### PR TITLE
Fix for crash in EasyMesh Control when db init fails

### DIFF
--- a/src/db/db_client.cpp
+++ b/src/db/db_client.cpp
@@ -34,16 +34,25 @@ void *db_client_t::execute(const char *query)
         sql::Statement *stmt;
         sql::ResultSet *res;
 
-        //printf("%s:%d: Query: %s\n", __func__, __LINE__, query);
-        stmt = ((sql::Connection *)m_con)->createStatement();
-        res = stmt->executeQuery(query);
-        tmp = res; 
+        if (m_con) {
+            stmt = ((sql::Connection *)m_con)->createStatement();
+        } else {
+            printf("%s:%d: Query: %s m_con is NULL, exciting\n", __func__, __LINE__, query);
+            return tmp;
+        }
+
+        if (stmt) {
+            res = stmt->executeQuery(query);
+        } else {
+            printf("%s:%d: Query: %s stmt is NULL, exciting\n", __func__, __LINE__, query);
+            return tmp;
+        }
+        tmp = res;
         delete stmt;
 
     } catch (sql::SQLException &e) {
         //printf("%s:%d: Exception in executing query, error code:%d\n", __func__, __LINE__, e.getErrorCode());
     }
-
 
     return tmp;
 }


### PR DESCRIPTION
This commit introduces NULL check of m_con object pointer before dereferencing it to avoid the crash.
Test Procedure: Start EasyMesh controller and try to connect to db as root, db init fails. Run cli and provide command "reset eth0 pi4" to populate initial db table.

Change-Id: Iad7a8aed1d017370c8e88cedc62a85652d0de0b0