### PR TITLE
Change to build unified-easy-mesh with upstream OneWifi

### DIFF
--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -28,7 +28,7 @@ INCLUDEDIRS = \
 	-I$(ONEWIFI_EM_HOME)/inc \
 	-I$(ONEWIFI_EM_HOME)/src/utils \
 	-I$(ONEWIFI_EM_HOME)/src/util/ \
-	-I$(ONEWIFI_HAL_INTF_HOME)/generic \
+	-I$(ONEWIFI_HAL_INTF_HOME) \
 	-I$(ONEWIFI_HOME)/generic/source/utils \
 	-I$(ONEWIFI_HOME)/generic/include \
     -I$(RBUS_HOME)/include \

--- a/build/makefile.inc
+++ b/build/makefile.inc
@@ -24,7 +24,7 @@ BASE = $(shell pwd)
 
 ONEWIFI_EM_HOME = $(BASE)/../../
 ONEWIFI_HOME = $(BASE)/../../../
-ONEWIFI_HAL_INTF_HOME = $(BASE)/../../../halinterface
+ONEWIFI_HAL_INTF_HOME = $(BASE)/../../../halinterface/include
 ONEWIFI_BUS_LIB_HOME = $(ONEWIFI_HOME)/generic/lib/bus
 ONEWIFI_EM_SRC = $(ONEWIFI_EM_HOME)/src
 INSTALLDIR = $(ONEWIFI_EM_HOME)/install


### PR DESCRIPTION
Path changes in makefile to be compatible with upstream OneWifi code on github