### PR TITLE
Remove dependency of OneWifi to be referred as generic

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -28,16 +28,16 @@ INCLUDEDIRS = \
 	-I$(ONEWIFI_EM_HOME)/inc \
 	-I$(ONEWIFI_EM_HOME)/src/utils \
 	-I$(ONEWIFI_HAL_INTF_HOME) \
-	-I$(ONEWIFI_HOME)/generic/source/utils \
-	-I$(ONEWIFI_HOME)/generic/include \
+	-I$(ONEWIFI_HOME)/source/utils \
+	-I$(ONEWIFI_HOME)/include \
     	-I$(ONEWIFI_BUS_LIB_HOME)/inc \
-    	-I$(ONEWIFI_HOME)/generic/lib/log \
-    	-I$(ONEWIFI_HOME)/generic/lib/ds \
-    	-I$(ONEWIFI_HOME)/generic/source/platform/linux \
-    	-I$(ONEWIFI_HOME)/generic/source/platform/common \
-    	-I$(ONEWIFI_HOME)/generic/source/platform/linux/he_bus/inc \
+    	-I$(ONEWIFI_HOME)/lib/log \
+    	-I$(ONEWIFI_HOME)/lib/ds \
+    	-I$(ONEWIFI_HOME)/source/platform/linux \
+    	-I$(ONEWIFI_HOME)/source/platform/common \
+    	-I$(ONEWIFI_HOME)/source/platform/linux/he_bus/inc \
         -I$(ONEWIFI_EM_HOME)/src/util_crypto \
-        -I$(ONEWIFI_HOME)/generic/source/ccsp
+        -I$(ONEWIFI_HOME)/source/ccsp
 
 $(info The value of VARIABLE is $(ONEWIFI_HAL_INTF_HOME))
 
@@ -45,14 +45,14 @@ CXXFLAGS = $(INCLUDEDIRS) -g -DEASY_MESH_NODE
 LDFLAGS = $(LIBDIRS) $(LIBS) 
 LIBDIRS = \
 	-L$(INSTALLDIR)/lib \
-    -L$(ONEWIFI_HOME)/generic/install/lib/
+    -L$(ONEWIFI_HOME)/install/lib/
 
 LIBS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwebconfig -lhebus
 
-GENERIC_SOURCES = $(ONEWIFI_HOME)/generic/source/utils/collection.c \
+GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c \
 	$(ONEWIFI_EM_SRC)/util_crypto/aes_siv.c \
-    	$(ONEWIFI_HOME)/generic/lib/common/util.c \
-    	$(ONEWIFI_HOME)/generic/source/platform/linux/bus.c \
+    	$(ONEWIFI_HOME)/lib/common/util.c \
+    	$(ONEWIFI_HOME)/source/platform/linux/bus.c \
 
 AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
 	$(wildcard $(ONEWIFI_EM_SRC)/em/config/*.cpp) \

--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -29,8 +29,8 @@ INCLUDEDIRS = \
 	-I$(ONEWIFI_EM_HOME)/src/utils \
 	-I$(ONEWIFI_EM_HOME)/src/util/ \
 	-I$(ONEWIFI_HAL_INTF_HOME) \
-	-I$(ONEWIFI_HOME)/generic/source/utils \
-	-I$(ONEWIFI_HOME)/generic/include \
+	-I$(ONEWIFI_HOME)/source/utils \
+	-I$(ONEWIFI_HOME)/include \
     -I$(RBUS_HOME)/include \
 	-I$(WIFI_CJSON) \
 
@@ -41,7 +41,7 @@ LIBDIRS = \
 
 LIBS = -lm -lpthread -ldl -lcjson -lreadline
 
-GENERIC_SOURCES = $(ONEWIFI_HOME)/generic/source/utils/collection.c
+GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c
 
 CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/cli/*.cpp) \
 	$(wildcard $(ONEWIFI_EM_SRC)/cmd/*.cpp) \

--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -28,8 +28,8 @@ INCLUDEDIRS = \
 	-I$(ONEWIFI_EM_HOME)/inc \
 	-I$(ONEWIFI_EM_HOME)/src/utils \
 	-I$(ONEWIFI_HAL_INTF_HOME)/ \
-	-I$(ONEWIFI_HOME)/generic/source/utils \
-	-I$(ONEWIFI_HOME)/generic/include \
+	-I$(ONEWIFI_HOME)/source/utils \
+	-I$(ONEWIFI_HOME)/include \
     	-I$(RBUS_HOME)/include \
     	-I$(ONEWIFI_EM_HOME)/src/util_crypto \
 	-I$(WIFI_CJSON) \
@@ -41,7 +41,7 @@ LIBDIRS = \
 
 LIBS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lmysqlcppconn
 
-GENERIC_SOURCES = $(ONEWIFI_HOME)/generic/source/utils/collection.c \
+GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c \
 	$(ONEWIFI_EM_SRC)/util_crypto/aes_siv.c \
 
 CTRL_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \

--- a/build/makefile.inc
+++ b/build/makefile.inc
@@ -23,9 +23,9 @@ PLATFORM = $(shell uname -a)
 BASE = $(shell pwd)
 
 ONEWIFI_EM_HOME = $(BASE)/../../
-ONEWIFI_HOME = $(BASE)/../../../
+ONEWIFI_HOME = $(BASE)/../../../OneWifi/
 ONEWIFI_HAL_INTF_HOME = $(BASE)/../../../halinterface/include
-ONEWIFI_BUS_LIB_HOME = $(ONEWIFI_HOME)/generic/lib/bus
+ONEWIFI_BUS_LIB_HOME = $(ONEWIFI_HOME)/lib/bus
 ONEWIFI_EM_SRC = $(ONEWIFI_EM_HOME)/src
 INSTALLDIR = $(ONEWIFI_EM_HOME)/install
 OBJDIR = obj


### PR DESCRIPTION
Makefile changes to remove OneWifi being referred as generic. This enables we can clone OneWifi as is without renaming it to be cloned as generic.