### PR TITLE
Assign explicit message type values

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -301,7 +301,7 @@ typedef enum {
 } em_tlv_requirement_t;
 
 typedef enum {
-    em_msg_type_topo_disc,
+    em_msg_type_topo_disc = 0x0000,
     em_msg_type_topo_notif,
     em_msg_type_topo_query,
     em_msg_type_topo_resp,
@@ -312,7 +312,8 @@ typedef enum {
     em_msg_type_autoconf_resp,
     em_msg_type_autoconf_wsc,
     em_msg_type_autoconf_renew,
-    em_msg_type_ap_cap_query = 0x8001,
+    em_msg_type_1905_ack = 0x8000,
+    em_msg_type_ap_cap_query,
     em_msg_type_ap_cap_rprt,
     em_msg_type_map_policy_config_req,
     em_msg_type_channel_pref_query,
@@ -363,10 +364,9 @@ typedef enum {
     em_msg_type_dpp_bootstrap_uri_notif,
     em_msg_type_anticipated_channel_pref,
     em_msg_type_failed_conn,
-    em_msg_type_agent_list,
+    em_msg_type_agent_list = 0x8035,
     em_msg_type_anticipated_channel_usage_rprt,
     em_msg_type_qos_mgmt_notif,
-    em_msg_type_1905_ack,
 } em_msg_type_t;
 
 typedef enum {


### PR DESCRIPTION
In the `em_msg_type_t` enum from `em_base.h`, it looks like `em_msg_type_1905_ack` is out of order, causing the compiler to assign it a value of `0x8038` when the spec says 1905 Ack should be `0x8000`. For reference, here is a screenshot of the spec highlighted in red:

![Screenshot 2024-11-12 at 12 14 21 PM](https://github.com/user-attachments/assets/6333155f-d414-47a1-a0f7-61aa69bb8ac6)

This doesn't present any symptoms/incorrect behavior because the codebase is internally consistent based on the values of this enum. If we test against devices running other EasyMesh implementations, we should expect to see conflicts when 1905 Ack is sent/received. 

This pull request fixes the 1905 Ack message value and explicitly assigns correct values to the rest of the enum members (in the hopes of avoiding future typos). 