### PR TITLE
Association request frame body parsing changes.

### DIFF
--- a/inc/dm_sta.h
+++ b/inc/dm_sta.h
@@ -35,7 +35,7 @@ public:
     void operator = (const dm_sta_t& obj);
 
     static void parse_sta_bss_radio_from_key(const char *key, mac_address_t sta, bssid_t bssid, mac_address_t radio);
-    static void decode_sta_capabilty(dm_sta_t *sta);
+    static void decode_sta_capability(dm_sta_t *sta);
 
     dm_sta_t(em_sta_info_t *sta);
     dm_sta_t(const dm_sta_t& sta);

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -1882,6 +1882,7 @@ typedef struct {
     em_long_string_t    ext_supp_rates;
     em_long_string_t    supp_op_classes;
     em_long_string_t    ext_cap;
+    em_long_string_t    rm_cap;
     em_long_string_t    vendor_info[MAX_VENDOR_INFO];
 } em_sta_info_t;
 
@@ -2298,7 +2299,9 @@ typedef enum {
     tag_rsn_information = 48,
     tag_extended_supported_rates = 50,
     tag_supported_operating_classes = 59,
+    tag_rm_enabled_capability = 70,
     tag_extended_capabilities = 127,
+    tag_vht_capability = 191,
     tag_vendor_specific = 221,
 } tag_type_t;
 


### PR DESCRIPTION
Association request frame body parsing changes.

Reason for change: To parse tagged parameters from association request frame body and cli should print the values.
Test Procedure: Ensure frame body data is parsed properly.
Risks: Medium

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>