### PR TITLE
RDKBWIFI-5: Implementation of AP MLD Configuration TLV and AP MLD data model

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -79,6 +79,7 @@ AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
 	$(ONEWIFI_EM_SRC)/dm/dm_sta.cpp \
 	$(ONEWIFI_EM_SRC)/dm/dm_radio_cap.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
 
 AGENT_OBJECTS = $(AGENT_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 

--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -57,6 +57,7 @@ CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/cli/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_sta.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_radio_cap.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
 
 CLI_OBJECTS = $(CLI_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 

--- a/inc/dm_ap_mld.h
+++ b/inc/dm_ap_mld.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DM_AP_MLD_H
+#define DM_AP_MLD_H
+
+#include "em_base.h"
+
+class dm_ap_mld_t {
+public:
+    em_ap_mld_info_t    m_ap_mld_info;
+
+public:
+    int init() { memset(&m_ap_mld_info, 0, sizeof(em_ap_mld_info_t)); return 0; }
+    em_ap_mld_info_t *get_ap_mld_info() { return &m_ap_mld_info; }
+    int decode(const cJSON *obj, void *parent_id);
+    void encode(cJSON *obj);
+
+    bool operator == (const dm_ap_mld_t& obj);
+    void operator = (const dm_ap_mld_t& obj);
+
+    dm_ap_mld_t(em_ap_mld_info_t *ap_mld_info);
+    dm_ap_mld_t(const dm_ap_mld_t& ap_mld);
+    dm_ap_mld_t();
+    ~dm_ap_mld_t();
+};
+
+#endif

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -32,6 +32,7 @@
 #include "dm_op_class.h"
 #include "dm_radio_cap.h"
 #include "dm_cac_comp.h"
+#include "dm_ap_mld.h"
 #include "webconfig_external_proto.h"
 
 class em_t;
@@ -61,6 +62,8 @@ public:
     unsigned int	m_db_cfg_type;
     em_t *m_em;
     bool    m_colocated;
+    unsigned int    m_num_ap_mld;
+    dm_ap_mld_t     m_ap_mld[EM_MAX_AP_MLD];
 
 public:
     int init();
@@ -157,6 +160,13 @@ public:
     dm_bss_t *get_bss(unsigned int index) { return &m_bss[index]; }
     dm_bss_t *get_bss_index(mac_address_t radio, mac_address_t bss, bool *new_bss);
     dm_bss_t& get_bss_by_ref(unsigned int index) { return m_bss[index]; }
+
+    unsigned int get_num_ap_mld() { return m_num_ap_mld; }
+    static unsigned int get_num_ap_mld(void *dm) { return ((dm_easy_mesh_t *)dm)->get_num_ap_mld(); }
+    void set_num_ap_mld(unsigned int num) { m_num_ap_mld = num; }
+    static void set_num_ap_mld(void *dm, unsigned int num) { ((dm_easy_mesh_t *)dm)->set_num_ap_mld(num); }
+    dm_ap_mld_t *get_ap_mld(unsigned int index) { return &m_ap_mld[index]; }
+    dm_ap_mld_t& get_ap_mld_by_ref(unsigned int index) { return m_ap_mld[index]; }
 
     dm_dpp_t *get_dpp() { return &m_dpp; }
 

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -122,6 +122,7 @@
 #define EM_MAX_AKMS     10
 #define EM_MAX_HAUL_TYPES   3
 #define EM_MAX_OPCLASS  64
+#define EM_MAX_AP_MLD   64
 
 #define EM_MAX_CMD  16
 
@@ -367,6 +368,10 @@ typedef enum {
     em_msg_type_agent_list = 0x8035,
     em_msg_type_anticipated_channel_usage_rprt,
     em_msg_type_qos_mgmt_notif,
+    em_msg_type_ap_mld_config_req = 0x8044,
+    em_msg_type_ap_mld_config_resp,
+    em_msg_type_bsta_mld_config_req,
+    em_msg_type_bsta_mld_config_resp,
 } em_msg_type_t;
 
 typedef enum {
@@ -519,6 +524,8 @@ typedef enum {
     em_tlv_type_qos_mgmt_policy = 0xdb,
     em_tlv_type_qos_mgmt_desc = 0xdc,
     em_tlv_type_ctrl_cap = 0xdd,
+    em_tlv_type_ap_mld_config = 0xe0,
+    em_tlv_type_bsta_mld_config = 0xe1,
 } em_tlv_type_t;
 
 typedef struct {
@@ -1923,6 +1930,26 @@ typedef struct {
 } em_bss_info_t;
 
 typedef struct {
+    bool  mac_addr_valid;
+    bool  link_id_valid;
+    em_interface_t  ruid;
+    mac_address_t  mac_addr;
+    unsigned char  link_id;
+} em_affiliated_ap_info_t;
+
+typedef struct {
+    bool  mac_addr_valid;
+    ssid_t  ssid;
+    mac_address_t  mac_addr;
+    bool  str;
+    bool  nstr;
+    bool  emlsr;
+    bool  emlmr;
+    unsigned char  num_affiliated_ap;
+    em_affiliated_ap_info_t  affiliated_ap[EM_MAX_AP_MLD];
+} em_ap_mld_info_t;
+
+typedef struct {
     em_interface_t  id;
 	mac_address_t dev_id;
     em_long_string_t net_id;
@@ -1983,6 +2010,41 @@ typedef struct {
     unsigned char num_radios;
     em_radio_rprt_t radio_rprt[0];
 } __attribute__((__packed__)) em_bss_config_rprt_t;
+
+typedef struct {
+    unsigned char ssid_len;
+    char ssid[0];
+} __attribute__((__packed__)) em_ap_mld_ssids_t;
+
+typedef struct {
+    unsigned char affiliated_mac_addr_valid : 1;
+    unsigned char link_id_valid : 1;
+    unsigned char reseverd1 : 6;
+    em_radio_id_t ruid;
+    mac_addr_t affiliated_mac_addr;
+    unsigned char link_id;
+    unsigned char reserved2[18];
+} __attribute__((__packed__)) em_affiliated_ap_mld_t;
+
+typedef struct {
+    unsigned char ap_mld_mac_addr_valid : 1;
+    unsigned char reserved1 : 7;
+    em_ap_mld_ssids_t ssids[0];
+    mac_addr_t ap_mld_mac_addr;
+    unsigned char str : 1;
+    unsigned char nstr : 1;
+    unsigned char emlsr : 1;
+    unsigned char emlmr : 1;
+    unsigned char reseverd2 : 4;
+    unsigned char reserved3[20];
+    unsigned char num_affiliated_ap;
+    em_affiliated_ap_mld_t affiliated_ap_mld[0];
+} __attribute__((__packed__)) em_ap_mld_t;
+
+typedef struct {
+    unsigned char num_ap_mld;
+    em_ap_mld_t ap_mld[0];
+} __attribute__((__packed__)) em_ap_mld_config_t;
 
 typedef struct {
     em_nonce_t  e_nonce;  

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -34,6 +34,7 @@ class em_configuration_t {
     int	create_bss_config_rprt_tlv(unsigned char *buff);
     int create_device_info_type_tlv(unsigned char *buff);
     short create_client_assoc_event_tlv(unsigned char *buff, mac_address_t sta, bssid_t bssid, bool assoc);
+    int create_ap_mld_config_tlv(unsigned char *buff);
 
     int send_topology_response_msg(unsigned char *dst);
     int send_topology_notification_by_client(mac_address_t sta, bssid_t bssid, bool assoc);

--- a/src/dm/dm_ap_mld.cpp
+++ b/src/dm/dm_ap_mld.cpp
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <linux/filter.h>
+#include <netinet/ether.h>
+#include <netpacket/packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include "dm_ap_mld.h"
+#include "dm_easy_mesh.h"
+#include "dm_easy_mesh_ctrl.h"
+
+int dm_ap_mld_t::decode(const cJSON *obj, void *parent_id)
+{
+    //TODO: needs to be implemnented
+
+    return 0;
+}
+
+void dm_ap_mld_t::encode(cJSON *obj)
+{
+    //TODO: needs to be implemnented
+}
+
+void dm_ap_mld_t::operator = (const dm_ap_mld_t& obj)
+{
+    this->m_ap_mld_info.mac_addr_valid = obj.m_ap_mld_info.mac_addr_valid;
+    memcpy(&this->m_ap_mld_info.ssid,&obj.m_ap_mld_info.ssid,sizeof(ssid_t));
+    memcpy(&this->m_ap_mld_info.mac_addr ,&obj.m_ap_mld_info.mac_addr,sizeof(mac_address_t));
+    this->m_ap_mld_info.str = obj.m_ap_mld_info.str;
+    this->m_ap_mld_info.nstr = obj.m_ap_mld_info.nstr;
+    this->m_ap_mld_info.emlsr = obj.m_ap_mld_info.emlsr;
+    this->m_ap_mld_info.emlmr = obj.m_ap_mld_info.emlmr;
+    this->m_ap_mld_info.num_affiliated_ap = obj.m_ap_mld_info.num_affiliated_ap;
+    memcpy(&this->m_ap_mld_info.affiliated_ap,&obj.m_ap_mld_info.affiliated_ap,sizeof(em_affiliated_ap_info_t));
+}
+
+
+bool dm_ap_mld_t::operator == (const dm_ap_mld_t& obj)
+{
+	int ret = 0;
+
+    ret += !(this->m_ap_mld_info.mac_addr_valid == obj.m_ap_mld_info.mac_addr_valid);
+    ret += (memcmp(&this->m_ap_mld_info.ssid,&obj.m_ap_mld_info.ssid,sizeof(ssid_t)) != 0);
+    ret += (memcmp(&this->m_ap_mld_info.mac_addr,&obj.m_ap_mld_info.mac_addr,sizeof(mac_address_t)) != 0);
+    ret += !(this->m_ap_mld_info.str == obj.m_ap_mld_info.str);
+    ret += !(this->m_ap_mld_info.nstr == obj.m_ap_mld_info.nstr);
+    ret += !(this->m_ap_mld_info.emlsr == obj.m_ap_mld_info.emlsr);
+    ret += !(this->m_ap_mld_info.emlmr == obj.m_ap_mld_info.emlmr);
+    ret += !(this->m_ap_mld_info.num_affiliated_ap == obj.m_ap_mld_info.num_affiliated_ap);
+    ret += (memcmp(&this->m_ap_mld_info.affiliated_ap,&obj.m_ap_mld_info.affiliated_ap,sizeof(em_affiliated_ap_info_t)) != 0);
+
+    if (ret > 0)
+        return false;
+    else
+        return true;
+}
+
+dm_ap_mld_t::dm_ap_mld_t(em_ap_mld_info_t *ap_mld_info)
+{
+    memcpy(&m_ap_mld_info, ap_mld_info, sizeof(em_ap_mld_info_t));
+}
+
+dm_ap_mld_t::dm_ap_mld_t(const dm_ap_mld_t& ap_mld)
+{
+    memcpy(&m_ap_mld_info, &ap_mld.m_ap_mld_info, sizeof(em_ap_mld_info_t));
+}
+
+dm_ap_mld_t::dm_ap_mld_t()
+{
+
+}
+
+dm_ap_mld_t::~dm_ap_mld_t()
+{
+
+}

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2020,6 +2020,7 @@ dm_easy_mesh_t::dm_easy_mesh_t()
     m_num_radios = 0;
 	m_num_opclass = 0;
 	m_num_bss = 0;
+    m_num_ap_mld = 0;
 	m_db_cfg_type = db_cfg_type_none;
     m_colocated = false;
 }

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -371,6 +371,7 @@ void em_msg_t::topo_resp()
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_associated_clients, optional, "17.2.5 of Wi-Fi Easy Mesh 5.0", 20);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_profile, (m_profile > em_profile_type_1) ? mandatory:bad, "17.2.47 of Wi-Fi Easy Mesh 5.0", 4);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_bss_conf_rep, (m_profile > em_profile_type_2) ? mandatory:bad, "17.2.75 of Wi-Fi Easy Mesh 5.0", 17);
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_mld_config, optional, "17.2.96 of Wi-Fi Easy Mesh 6.0", 64);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_device_bridging_cap, optional, "table 6-11 of IEEE-1905-1", 11);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_non1905_neigh_list, optional, "table 6-14 of IEEE-1905-1", 15);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_1905_neigh_list, optional, "table 6-15 of IEEE-1905-1", 15);


### PR DESCRIPTION
Changes also cover the following EasyMesh v.6 requirement:

If a Multi-AP Agent sends a 1905 Topology Response message (extended) and the Multi-AP Agent is operating one or more AP MLDs, the Multi-AP Agent shall include one Agent AP MLD Configuration TLV for each AP MLD that it is operating.