### PR TITLE
Add Wi-Fi7 and EHT operations capability data models

### DIFF
--- a/inc/em.h
+++ b/inc/em.h
@@ -132,6 +132,8 @@ public:
     short create_vht_tlv(unsigned char *buff);
     short create_he_tlv(unsigned char *buff);
     short create_wifi6_tlv(unsigned char *buff);
+    short create_wifi7_tlv(unsigned char *buff);
+    short create_eht_operations_tlv(unsigned char *buff);
     short create_channelscan_tlv(unsigned char *buff);
     short create_prof_2_tlv(unsigned char *buff);
     short create_device_inventory_tlv(unsigned char *buff);

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -52,6 +52,7 @@
 #define EM_MAX_BSS_PER_RADIO           16
 #define EM_MAX_RADIO_PER_AGENT         4
 #define EM_MAX_TRAFFIC_SEP_SSID        8
+#define EM_MAX_FREQ_RECORDS_PER_RADIO  8
 #define EM_MAX_CHANNELS   30
 #define MAP_INVENTORY_ITEM_LEN  64
 #define MAX_MCS  6
@@ -524,8 +525,10 @@ typedef enum {
     em_tlv_type_qos_mgmt_policy = 0xdb,
     em_tlv_type_qos_mgmt_desc = 0xdc,
     em_tlv_type_ctrl_cap = 0xdd,
+    em_tlv_type_wifi7_agent_cap = 0xdf,
     em_tlv_type_ap_mld_config = 0xe0,
     em_tlv_type_bsta_mld_config = 0xe1,
+    em_tlv_eht_operations = 0xe7,
 } em_tlv_type_t;
 
 typedef struct {
@@ -1354,6 +1357,84 @@ typedef struct {
 } __attribute__((__packed__))em_ap_wifi6_cap_t;
 
 typedef struct {
+    em_radio_id_t ruid;
+    unsigned char freq_sep : 5;
+    unsigned char reserved : 3;
+} __attribute__((__packed__)) em_radio_wifi7_freq_record_t;
+
+typedef struct {
+    unsigned char num_records;
+    em_radio_wifi7_freq_record_t records[EM_MAX_FREQ_RECORDS_PER_RADIO];
+} __attribute__((__packed__)) em_radio_wifi7_freq_records_t;
+
+typedef struct {
+    unsigned char max_num_mlds;
+    unsigned char ap_max_links : 4;
+    unsigned char bsta_max_links : 4;
+    unsigned char tid_link_mapping_cap : 2;
+    unsigned char reserved1 : 6;
+    unsigned char reserved2[13];
+} __attribute__((__packed__)) em_radio_wifi7_cap_data_t;
+
+typedef struct {
+    em_radio_id_t ruid;
+    unsigned char reserved3[24];
+    unsigned char ap_str_support : 1;
+    unsigned char ap_nstr_support : 1;
+    unsigned char ap_emlsr_support : 1;
+    unsigned char ap_emlmr_support : 1;
+    unsigned char reserved4 : 4;
+    unsigned char bsta_str_support : 1;
+    unsigned char bsta_nstr_support : 1;
+    unsigned char bsta_emlrs_support : 1;
+    unsigned char bsta_emlmr_support : 1;
+    unsigned char reserved5 : 4;
+    em_radio_wifi7_freq_records_t ap_str;
+    em_radio_wifi7_freq_records_t ap_nstr;
+    em_radio_wifi7_freq_records_t ap_emlsr;
+    em_radio_wifi7_freq_records_t ap_emlmr;
+    em_radio_wifi7_freq_records_t bsta_str;
+    em_radio_wifi7_freq_records_t bsta_nstr;
+    em_radio_wifi7_freq_records_t bsta_emlsr;
+    em_radio_wifi7_freq_records_t bsta_emlmr;
+} __attribute__((__packed__)) em_radio_wifi7_radio_t;
+
+typedef struct {
+    em_radio_wifi7_cap_data_t cap_data;
+    unsigned char radios_num;
+    em_radio_wifi7_radio_t radios[EM_MAX_RADIO_PER_AGENT];
+} __attribute__((__packed__)) em_wifi7_agent_cap_t;
+
+typedef struct {
+    mac_address_t bssid;
+    unsigned char op_info_valid : 1;
+    unsigned char disabled_subchannel_valid : 1;
+    unsigned char default_pe_duration : 1;
+    unsigned char group_addr_bu_ind_limit : 1;
+    unsigned char group_addr_bu_ind_exp : 2;
+    unsigned char reserved1 : 2;
+    unsigned char eht_msc_nss_set[4];
+    unsigned char control;
+    unsigned char ccfs0;
+    unsigned char ccfs1;
+    unsigned char disabled_subchannel_bitmap[2];
+    unsigned char reserved2[16];
+} __attribute__((__packed__)) em_eht_operations_bss_t;
+
+typedef struct {
+    em_radio_id_t ruid;
+    unsigned char bss_num;
+    em_eht_operations_bss_t bss[EM_MAX_BSS_PER_RADIO];
+    unsigned char reserved[25];
+} __attribute__((__packed__)) em_eht_operations_radio_t;
+
+typedef struct {
+    unsigned char reserved[32];
+    unsigned char radios_num;
+    em_eht_operations_radio_t radios[EM_MAX_RADIO_PER_AGENT];
+} __attribute__((__packed__)) em_eht_operations_t;
+
+typedef struct {
     em_radio_id_t  ruid;
     unsigned char  boot_only : 1;
     unsigned char  scan_impact : 2;
@@ -1879,6 +1960,7 @@ typedef struct {
     em_long_string_t    vht_cap;
     em_long_string_t    he_cap;
     em_long_string_t    wifi6_cap;
+    em_long_string_t    wifi7_cap;
     em_long_string_t    cellular_data_pref;
     em_long_string_t    listen_interval;
     em_long_string_t    ssid;
@@ -1984,6 +2066,8 @@ typedef struct {
     em_ap_he_cap_t  he_cap;
     em_long_string_t    eht_cap;
     em_radio_wifi6_cap_data_t wifi6_cap;
+    em_wifi7_agent_cap_t wifi7_cap;
+    em_eht_operations_t eht_ops;
     em_radio_info_t ch_scan;
     em_ap_radio_advanced_cap_t radio_ad_cap;
     em_profile_2_ap_cap_t   prof_2_ap_cap;

--- a/inc/em_capability.h
+++ b/inc/em_capability.h
@@ -49,6 +49,8 @@ class em_capability_t {
     virtual short create_vht_tlv(unsigned char *buff) = 0;
     virtual short create_he_tlv(unsigned char *buff) = 0;
     virtual short create_wifi6_tlv(unsigned char *buff) = 0;
+    virtual short create_wifi7_tlv(unsigned char *buff) = 0;
+    virtual short create_eht_operations_tlv(unsigned char *buff) = 0;
     virtual short create_channelscan_tlv(unsigned char *buff) = 0;
     virtual short create_prof_2_tlv(unsigned char *buff) = 0;
     virtual short create_device_inventory_tlv(unsigned char *buff) = 0;

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -132,6 +132,24 @@ int em_capability_t::create_ap_cap_report_msg(unsigned char *buff)
     tmp += (sizeof(em_tlv_t) + sz);
     len += (sizeof(em_tlv_t) + sz);
 
+    // AP WiFi7 capabilities 17.2.95
+    tlv = (em_tlv_t *)tmp;
+    tlv->type = em_tlv_type_wifi7_agent_cap;
+    sz = create_wifi7_tlv(tlv->value);
+    tlv->len = htons(sz);
+
+    tmp += (sizeof(em_tlv_t) + sz);
+    len += (sizeof(em_tlv_t) + sz);
+
+    // AP EHT Operations 17.2.103
+    tlv = (em_tlv_t *)tmp;
+    tlv->type = em_tlv_eht_operations;
+    sz = create_eht_operations_tlv(tlv->value);
+    tlv->len = htons(sz);
+
+    tmp += (sizeof(em_tlv_t) + sz);
+    len += (sizeof(em_tlv_t) + sz);  
+
     // AP Channel Scan capabilities 17.2.38
     tlv = (em_tlv_t *)tmp;
     tlv->type = em_tlv_type_channel_scan_cap;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -604,6 +604,36 @@ short em_t::create_wifi6_tlv(unsigned char *buff)
     return len;
 }
 
+short em_t::create_wifi7_tlv(unsigned char *buff)
+{
+    short len = 0;
+    em_radio_cap_info_t* cap_info = get_data_model()->get_radio_cap(get_radio_interface_mac())->get_radio_cap_info();
+    em_wifi7_agent_cap_t *wifi7_cap = (em_wifi7_agent_cap_t *)buff;
+
+    if ((wifi7_cap == NULL) || (cap_info == NULL)) {
+        printf("%s:%d No data Found\n", __func__, __LINE__);
+        return 0;
+    }
+    memcpy(&wifi7_cap,&cap_info->wifi7_cap,sizeof(em_wifi7_agent_cap_t));
+    len = sizeof(em_wifi7_agent_cap_t);
+    return len;
+}
+
+short em_t::create_eht_operations_tlv(unsigned char *buff)
+{
+    short len = 0;
+    em_radio_cap_info_t* cap_info = get_data_model()->get_radio_cap(get_radio_interface_mac())->get_radio_cap_info();
+    em_eht_operations_t *eht_ops = (em_eht_operations_t *)buff;
+
+    if ((eht_ops == NULL) || (cap_info == NULL)) {
+        printf("%s:%d No data Found\n", __func__, __LINE__);
+        return 0;
+    }
+    memcpy(&eht_ops,&cap_info->eht_ops,sizeof(em_eht_operations_t));
+    len = sizeof(em_eht_operations_t);
+    return len;
+}
+
 short em_t::create_channelscan_tlv(unsigned char *buff)
 {
     short len = 0;


### PR DESCRIPTION
This patch adds Wi-Fi7 and EHT operations data models and includes them into ap capability report message according to EasyMesh spec v6.0:

"The Multi-AP Agent shall include one Wi-Fi 7 Agent Capabilities TLV and one EHT Operations TLV in the AP Capability Report"