### PR TITLE
RDKBWIFI-5: Add Backhaul STA MLD Configuration TLV and related data model

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -80,6 +80,7 @@ AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
 	$(ONEWIFI_EM_SRC)/dm/dm_radio_cap.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
 
 AGENT_OBJECTS = $(AGENT_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 

--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -58,6 +58,7 @@ CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/cli/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_radio_cap.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
 
 CLI_OBJECTS = $(CLI_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 

--- a/inc/dm_bsta_mld.h
+++ b/inc/dm_bsta_mld.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DM_BSTA_MLD_H
+#define DM_BSTA_MLD_H
+
+#include "em_base.h"
+
+class dm_bsta_mld_t {
+public:
+    em_bsta_mld_info_t    m_bsta_mld_info;
+
+public:
+    int init() { memset(&m_bsta_mld_info, 0, sizeof(em_bsta_mld_info_t)); return 0; }
+    em_bsta_mld_info_t *get_ap_mld_info() { return &m_bsta_mld_info; }
+    int decode(const cJSON *obj, void *parent_id);
+    void encode(cJSON *obj);
+
+    bool operator == (const dm_bsta_mld_t& obj);
+    void operator = (const dm_bsta_mld_t& obj);
+
+    dm_bsta_mld_t(em_bsta_mld_info_t *ap_mld_info);
+    dm_bsta_mld_t(const dm_bsta_mld_t& ap_mld);
+    dm_bsta_mld_t();
+    ~dm_bsta_mld_t();
+};
+
+#endif

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -33,6 +33,7 @@
 #include "dm_radio_cap.h"
 #include "dm_cac_comp.h"
 #include "dm_ap_mld.h"
+#include "dm_bsta_mld.h"
 #include "webconfig_external_proto.h"
 
 class em_t;
@@ -64,6 +65,7 @@ public:
     bool    m_colocated;
     unsigned int    m_num_ap_mld;
     dm_ap_mld_t     m_ap_mld[EM_MAX_AP_MLD];
+    dm_bsta_mld_t   m_bsta_mld;
 
 public:
     int init();

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2039,6 +2039,25 @@ typedef struct {
 } em_ap_mld_info_t;
 
 typedef struct {
+    bool  mac_addr_valid;
+    em_interface_t  ruid;
+    mac_address_t  mac_addr;
+} em_affiliated_bsta_info_t;
+
+typedef struct {
+    bool  mac_addr_valid;
+    bool  ap_mld_mac_addr_valid;
+    mac_address_t  mac_addr;
+    mac_address_t  ap_mld_mac_addr;
+    bool  str;
+    bool  nstr;
+    bool  emlsr;
+    bool  emlmr;
+    unsigned char  num_affiliated_bsta;
+    em_affiliated_bsta_info_t  affiliated_bsta[EM_MAX_AP_MLD];
+} em_bsta_mld_info_t;
+
+typedef struct {
     em_interface_t  id;
 	mac_address_t dev_id;
     em_long_string_t net_id;
@@ -2136,6 +2155,30 @@ typedef struct {
     unsigned char num_ap_mld;
     em_ap_mld_t ap_mld[0];
 } __attribute__((__packed__)) em_ap_mld_config_t;
+
+typedef struct {
+    unsigned char affiliated_bsta_mac_addr_valid : 1;
+    unsigned char reseverd1 : 7;
+    em_radio_id_t ruid;
+    mac_addr_t affiliated_bsta_mac_addr;
+    unsigned char reserved2[19];
+} __attribute__((__packed__)) em_affiliated_bsta_mld_t;
+
+typedef struct {
+    unsigned char bsta_mld_mac_addr_valid : 1;
+    unsigned char ap_mld_mac_addr_valid : 1;
+    unsigned char reserved1 : 6;
+    mac_addr_t bsta_mld_mac_addr;
+    mac_addr_t ap_mld_mac_addr;
+    unsigned char str : 1;
+    unsigned char nstr : 1;
+    unsigned char emlsr : 1;
+    unsigned char emlmr : 1;
+    unsigned char reseverd2 : 4;
+    unsigned char reserved3[17];
+    unsigned char num_affiliated_bsta;
+    em_affiliated_bsta_mld_t affiliated_bsta_mld[0];
+} __attribute__((__packed__)) em_bsta_mld_config_t;
 
 typedef struct {
     em_nonce_t  e_nonce;  

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -35,6 +35,7 @@ class em_configuration_t {
     int create_device_info_type_tlv(unsigned char *buff);
     short create_client_assoc_event_tlv(unsigned char *buff, mac_address_t sta, bssid_t bssid, bool assoc);
     int create_ap_mld_config_tlv(unsigned char *buff);
+    int create_bsta_mld_config_tlv(unsigned char *buff);
 
     int send_topology_response_msg(unsigned char *dst);
     int send_topology_notification_by_client(mac_address_t sta, bssid_t bssid, bool assoc);

--- a/src/dm/dm_bsta_mld.cpp
+++ b/src/dm/dm_bsta_mld.cpp
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <linux/filter.h>
+#include <netinet/ether.h>
+#include <netpacket/packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include "dm_bsta_mld.h"
+#include "dm_easy_mesh.h"
+#include "dm_easy_mesh_ctrl.h"
+
+int dm_bsta_mld_t::decode(const cJSON *obj, void *parent_id)
+{
+    //TODO: needs to be implemnented
+
+    return 0;
+}
+
+void dm_bsta_mld_t::encode(cJSON *obj)
+{
+    //TODO: needs to be implemnented
+}
+
+void dm_bsta_mld_t::operator = (const dm_bsta_mld_t& obj)
+{
+    this->m_bsta_mld_info.mac_addr_valid = obj.m_bsta_mld_info.mac_addr_valid;
+    this->m_bsta_mld_info.ap_mld_mac_addr_valid = obj.m_bsta_mld_info.ap_mld_mac_addr_valid;
+    memcpy(&this->m_bsta_mld_info.mac_addr ,&obj.m_bsta_mld_info.mac_addr,sizeof(mac_address_t));
+    memcpy(&this->m_bsta_mld_info.ap_mld_mac_addr ,&obj.m_bsta_mld_info.ap_mld_mac_addr,sizeof(mac_address_t));
+    this->m_bsta_mld_info.str = obj.m_bsta_mld_info.str;
+    this->m_bsta_mld_info.nstr = obj.m_bsta_mld_info.nstr;
+    this->m_bsta_mld_info.emlsr = obj.m_bsta_mld_info.emlsr;
+    this->m_bsta_mld_info.emlmr = obj.m_bsta_mld_info.emlmr;
+    this->m_bsta_mld_info.num_affiliated_bsta = obj.m_bsta_mld_info.num_affiliated_bsta;
+    memcpy(&this->m_bsta_mld_info.affiliated_bsta,&obj.m_bsta_mld_info.affiliated_bsta,sizeof(em_affiliated_bsta_info_t));
+}
+
+
+bool dm_bsta_mld_t::operator == (const dm_bsta_mld_t& obj)
+{
+	int ret = 0;
+
+    ret += !(this->m_bsta_mld_info.mac_addr_valid == obj.m_bsta_mld_info.mac_addr_valid);
+    ret += !(this->m_bsta_mld_info.ap_mld_mac_addr_valid == obj.m_bsta_mld_info.ap_mld_mac_addr_valid);
+    ret += (memcmp(&this->m_bsta_mld_info.mac_addr,&obj.m_bsta_mld_info.mac_addr,sizeof(mac_address_t)) != 0);
+    ret += (memcmp(&this->m_bsta_mld_info.ap_mld_mac_addr,&obj.m_bsta_mld_info.ap_mld_mac_addr,sizeof(mac_address_t)) != 0);
+    ret += !(this->m_bsta_mld_info.str == obj.m_bsta_mld_info.str);
+    ret += !(this->m_bsta_mld_info.nstr == obj.m_bsta_mld_info.nstr);
+    ret += !(this->m_bsta_mld_info.emlsr == obj.m_bsta_mld_info.emlsr);
+    ret += !(this->m_bsta_mld_info.emlmr == obj.m_bsta_mld_info.emlmr);
+    ret += !(this->m_bsta_mld_info.num_affiliated_bsta == obj.m_bsta_mld_info.num_affiliated_bsta);
+    ret += (memcmp(&this->m_bsta_mld_info.affiliated_bsta,&obj.m_bsta_mld_info.affiliated_bsta,sizeof(em_affiliated_ap_info_t)) != 0);
+
+    if (ret > 0)
+        return false;
+    else
+        return true;
+}
+
+dm_bsta_mld_t::dm_bsta_mld_t(em_bsta_mld_info_t *bsta_mld_info)
+{
+    memcpy(&m_bsta_mld_info, bsta_mld_info, sizeof(em_bsta_mld_info_t));
+}
+
+dm_bsta_mld_t::dm_bsta_mld_t(const dm_bsta_mld_t& bsta_mld)
+{
+    memcpy(&m_bsta_mld_info, &bsta_mld.m_bsta_mld_info, sizeof(em_bsta_mld_info_t));
+}
+
+dm_bsta_mld_t::dm_bsta_mld_t()
+{
+
+}
+
+dm_bsta_mld_t::~dm_bsta_mld_t()
+{
+
+}

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -372,6 +372,7 @@ void em_msg_t::topo_resp()
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_profile, (m_profile > em_profile_type_1) ? mandatory:bad, "17.2.47 of Wi-Fi Easy Mesh 5.0", 4);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_bss_conf_rep, (m_profile > em_profile_type_2) ? mandatory:bad, "17.2.75 of Wi-Fi Easy Mesh 5.0", 17);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_mld_config, optional, "17.2.96 of Wi-Fi Easy Mesh 6.0", 64);
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_bsta_mld_config, optional, "17.2.97 of Wi-Fi Easy Mesh 6.0", 64);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_device_bridging_cap, optional, "table 6-11 of IEEE-1905-1", 11);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_non1905_neigh_list, optional, "table 6-14 of IEEE-1905-1", 15);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_1905_neigh_list, optional, "table 6-15 of IEEE-1905-1", 15);


### PR DESCRIPTION
This change also covers the following EasyMesh v.6 requirement:

If a Multi-AP Agent sends a 1905 Topology Response message (extended) and 
the Multi-AP Agent is operating a bSTA MLD, the Multi-AP Agent shall include 
one Backhaul STA MLD Configuration TLV.