### PR TITLE
Added generic hash algorithm and cipher methods along with documentation and static/inline optimizations

### DIFF
--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -163,22 +163,22 @@ public:
     int compute_secret(unsigned char **secret, unsigned short *secret_len, 
         unsigned char *remote_pub, unsigned short pub_len, 
         unsigned char *local_priv, unsigned short priv_len) { 
-            return m_crypto.platform_compute_shared_secret(secret, secret_len, remote_pub, pub_len, local_priv, priv_len); 
+            return em_crypto_t::platform_compute_shared_secret(secret, secret_len, remote_pub, pub_len, local_priv, priv_len); 
     }
 
     int compute_digest(unsigned char num, unsigned char **addr, unsigned int *len, unsigned char *digest) {
-        return m_crypto.platform_SHA256(num, addr, len, digest); 
+        return em_crypto_t::platform_SHA256(num, addr, len, digest); 
     }
 
     int compute_kdk(unsigned char *key, unsigned short keylen, 
         unsigned char num_elem, unsigned char **addr, 
         unsigned int *len, unsigned char *hmac) {
-            return m_crypto.platform_hmac_SHA256(key, keylen, num_elem, addr, len, hmac);
+            return em_crypto_t::platform_hmac_SHA256(key, keylen, num_elem, addr, len, hmac);
     }
 
     int derive_key(unsigned char *key, unsigned char *label_prefix, unsigned int label_prefix_len, 
         char *label, unsigned char *res, unsigned int res_len) {
-            return m_crypto.wps_key_derivation_function(key, label_prefix, label_prefix_len, label, res, res_len);
+            return em_crypto_t::wps_key_derivation_function(key, label_prefix, label_prefix_len, label, res, res_len);
     }
 
     int compute_keys(unsigned char *remote_pub, unsigned short pub_len, unsigned char *local_priv, unsigned short priv_len);

--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -45,12 +45,8 @@ public:
     static uint8_t g_dh1536_p[];
 
     int init();
-    em_crypto_info_t *get_crypto_info() { return &m_crypto_info; }
-    uint8_t get_shared_key(uint8_t **shared_secret, uint16_t *shared_secret_len, uint8_t *remote_pub, uint16_t remote_pub_len, uint8_t *local_priv, uint16_t local_priv_len);
-    uint8_t platform_hmac_SHA256(uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *hmac);
-    uint8_t platform_SHA256(uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest);
-    void _I4B (const uint32_t *memory_pointer, uint8_t **packet_ppointer);
-    uint8_t wps_key_derivation_function(uint8_t *key, uint8_t *label_prefix, uint32_t label_prefix_len, char *label, uint8_t *res, uint32_t res_len);
+
+    static uint8_t get_shared_key(uint8_t **shared_secret, uint16_t *shared_secret_len, uint8_t *remote_pub, uint16_t remote_pub_len, uint8_t *local_priv, uint16_t local_priv_len);
 
     /**
      * @brief Computes an HMAC hash using OpenSSL for multiple input elements
@@ -188,38 +184,43 @@ public:
     static uint8_t platform_compute_shared_secret(uint8_t **shared_secret, uint16_t *shared_secret_len,
         uint8_t *remote_pub, uint16_t remote_pub_len,
         uint8_t *local_priv, uint8_t local_priv_len);
-    unsigned int get_e_uuid(unsigned char *uuid) { memcpy(uuid, (unsigned char *)&m_crypto_info.e_uuid, sizeof(uuid_t)); return sizeof(uuid_t); }
-    unsigned int get_r_uuid(unsigned char *uuid) { memcpy(uuid, (unsigned char *)&m_crypto_info.r_uuid, sizeof(uuid_t)); return sizeof(uuid_t); }
-    unsigned int get_e_nonce(unsigned char *nonce) { memcpy(nonce, (unsigned char *)&m_crypto_info.e_nonce, sizeof(em_nonce_t)); return sizeof(em_nonce_t); }
-    unsigned int get_r_nonce(unsigned char *nonce) { memcpy(nonce, (unsigned char *)&m_crypto_info.r_nonce, sizeof(em_nonce_t)); return sizeof(em_nonce_t); }
 
-    unsigned char *get_e_nonce() { return (unsigned char *)&m_crypto_info.e_nonce; }
-    unsigned char *get_r_nonce() { return (unsigned char *)&m_crypto_info.r_nonce; }
+    static inline uint8_t generate_iv(unsigned char *iv, unsigned int len) { if (!RAND_bytes(iv, len)) { return 0; } else { return 1; } }
 
-    void set_e_uuid(unsigned char *uuid, unsigned int len) { memcpy((unsigned char *)&m_crypto_info.e_uuid, uuid, len); }
-    void set_r_uuid(unsigned char *uuid, unsigned int len) { memcpy((unsigned char *)&m_crypto_info.r_uuid, uuid, len); }
-    void set_e_nonce(unsigned char *nonce, unsigned int len) { memcpy((unsigned char *)&m_crypto_info.e_nonce, nonce, len); }
-    void set_r_nonce(unsigned char *nonce, unsigned int len) { memcpy((unsigned char *)&m_crypto_info.r_nonce, nonce, len); }
+    // START: Object getters and setters
+    inline em_crypto_info_t *get_crypto_info() { return &m_crypto_info; }
 
-    unsigned char *get_e_public() { return m_crypto_info.e_pub; }
-    unsigned int get_e_public_len() { return m_crypto_info.e_pub_len; }
-    unsigned char *get_e_private() { return m_crypto_info.e_priv; }
-    unsigned int get_e_private_len() { return m_crypto_info.e_priv_len; }
-    unsigned char *get_r_public() { return m_crypto_info.r_pub; }
-    unsigned int get_r_public_len() { return m_crypto_info.r_pub_len; }
-    unsigned char *get_r_private() { return m_crypto_info.r_priv; }
-    unsigned int get_r_private_len() { return m_crypto_info.r_priv_len; }
+    inline unsigned int get_e_uuid(unsigned char *uuid) { memcpy(uuid, (unsigned char *)&m_crypto_info.e_uuid, sizeof(uuid_t)); return sizeof(uuid_t); }
+    inline unsigned int get_r_uuid(unsigned char *uuid) { memcpy(uuid, (unsigned char *)&m_crypto_info.r_uuid, sizeof(uuid_t)); return sizeof(uuid_t); }
+    inline unsigned int get_e_nonce(unsigned char *nonce) { memcpy(nonce, (unsigned char *)&m_crypto_info.e_nonce, sizeof(em_nonce_t)); return sizeof(em_nonce_t); }
+    inline unsigned int get_r_nonce(unsigned char *nonce) { memcpy(nonce, (unsigned char *)&m_crypto_info.r_nonce, sizeof(em_nonce_t)); return sizeof(em_nonce_t); }
 
-    uint8_t generate_iv(unsigned char *iv, unsigned int len) { if (!RAND_bytes(iv, len)) { return 0; } else { return 1; } }
+    inline unsigned char *get_e_nonce() { return (unsigned char *)&m_crypto_info.e_nonce; }
+    inline unsigned char *get_r_nonce() { return (unsigned char *)&m_crypto_info.r_nonce; }
 
-    void set_e_public(unsigned char *pub, unsigned int len) { memcpy(m_crypto_info.e_pub, pub, len); }
-    void set_r_public(unsigned char *pub, unsigned int len) { memcpy(m_crypto_info.r_pub, pub, len); }
+    inline void set_e_uuid(unsigned char *uuid, unsigned int len) { memcpy((unsigned char *)&m_crypto_info.e_uuid, uuid, len); }
+    inline void set_r_uuid(unsigned char *uuid, unsigned int len) { memcpy((unsigned char *)&m_crypto_info.r_uuid, uuid, len); }
+    inline void set_e_nonce(unsigned char *nonce, unsigned int len) { memcpy((unsigned char *)&m_crypto_info.e_nonce, nonce, len); }
+    inline void set_r_nonce(unsigned char *nonce, unsigned int len) { memcpy((unsigned char *)&m_crypto_info.r_nonce, nonce, len); }
 
-    unsigned char *get_e_mac() { return m_crypto_info.e_mac; }
-    unsigned char *get_r_mac() { return m_crypto_info.r_mac; }
+    inline unsigned char *get_e_public() { return m_crypto_info.e_pub; }
+    inline unsigned int get_e_public_len() { return m_crypto_info.e_pub_len; }
+    inline unsigned char *get_e_private() { return m_crypto_info.e_priv; }
+    inline unsigned int get_e_private_len() { return m_crypto_info.e_priv_len; }
+    inline unsigned char *get_r_public() { return m_crypto_info.r_pub; }
+    inline unsigned int get_r_public_len() { return m_crypto_info.r_pub_len; }
+    inline unsigned char *get_r_private() { return m_crypto_info.r_priv; }
+    inline unsigned int get_r_private_len() { return m_crypto_info.r_priv_len; }
 
-    void set_e_mac(unsigned char *mac) { memcpy(m_crypto_info.e_mac, mac, sizeof(mac_address_t)); }
-    void set_r_mac(unsigned char *mac) { memcpy(m_crypto_info.r_mac, mac, sizeof(mac_address_t)); }
+    inline void set_e_public(unsigned char *pub, unsigned int len) { memcpy(m_crypto_info.e_pub, pub, len); }
+    inline void set_r_public(unsigned char *pub, unsigned int len) { memcpy(m_crypto_info.r_pub, pub, len); }
+
+    inline unsigned char *get_e_mac() { return m_crypto_info.e_mac; }
+    inline unsigned char *get_r_mac() { return m_crypto_info.r_mac; }
+
+    inline void set_e_mac(unsigned char *mac) { memcpy(m_crypto_info.e_mac, mac, sizeof(mac_address_t)); }
+    inline void set_r_mac(unsigned char *mac) { memcpy(m_crypto_info.r_mac, mac, sizeof(mac_address_t)); }
+
     em_crypto_t();
     ~em_crypto_t() {}
 };

--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -186,6 +186,7 @@ public:
         uint8_t *local_priv, uint8_t local_priv_len);
 
     static inline uint8_t generate_iv(unsigned char *iv, unsigned int len) { if (!RAND_bytes(iv, len)) { return 0; } else { return 1; } }
+    static inline uint8_t generate_nonce(em_nonce_t nonce) { if (!RAND_bytes(nonce, sizeof(em_nonce_t))) { return 0; } else { return 1; } }
 
     // START: Object getters and setters
     inline em_crypto_info_t *get_crypto_info() { return &m_crypto_info; }

--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -51,9 +51,140 @@ public:
     uint8_t platform_SHA256(uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest);
     void _I4B (const uint32_t *memory_pointer, uint8_t **packet_ppointer);
     uint8_t wps_key_derivation_function(uint8_t *key, uint8_t *label_prefix, uint32_t label_prefix_len, char *label, uint8_t *res, uint32_t res_len);
-    uint8_t platform_aes_decrypt(uint8_t *key, uint8_t *iv, uint8_t *data, uint32_t data_len);
-    uint8_t platform_aes_encrypt(uint8_t *key, uint8_t *iv, uint8_t *plain, uint32_t plain_len, uint8_t *cipher_text, uint32_t *cipher_len);
-    EVP_PKEY* create_dh_pkey(BIGNUM *p, BIGNUM *g, BIGNUM *bn_priv, BIGNUM *bn_pub);
+
+    /**
+     * @brief Computes an HMAC hash using OpenSSL for multiple input elements
+     *
+     * This function calculates an HMAC hash using a specified hashing algorithm and key,
+     * supporting multiple input elements. It's compatible with different OpenSSL versions
+     * (pre-1.1.0, 1.1.0+, and 3.0.0+) through conditional compilation.
+     *
+     * @param hashing_algo The OpenSSL message digest algorithm to use (e.g., EVP_sha256())
+     * @param key         Pointer to the key used for HMAC calculation
+     * @param keylen      Length of the key in bytes
+     * @param num_elem    Number of elements to be hashed
+     * @param addr        Array of pointers to input data elements
+     * @param len         Array of lengths corresponding to each input element
+     * @param hmac        Output buffer where the computed HMAC will be stored
+     *
+     * @return uint8_t    Returns 1 on success, 0 on failure
+     *
+     * @note The hmac buffer must be pre-allocated with sufficient space for the output
+     *       (32 bytes for SHA-256)
+     */
+    static uint8_t platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *hmac);
+
+    /**
+    * @brief Convenience wrapper to compute HMAC-SHA256 hash for multiple input elements
+    *
+    * @param key      Key used for HMAC calculation
+    * @param keylen   Length of the key in bytes  
+    * @param num_elem Number of elements to hash
+    * @param addr     Array of pointers to input data elements
+    * @param len      Array of lengths for each input element
+    * @param hmac     Output buffer for computed HMAC
+    *
+    * @return 1 on success, 0 on failure
+    */
+    inline static uint8_t platform_hmac_SHA256(uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *hmac) {
+        return platform_hmac_hash(EVP_sha256(), key, keylen, num_elem, addr, len, hmac);
+    }
+    
+    /**
+    * @brief Computes a cryptographic hash of multiple input elements using OpenSSL
+    *
+    * @param hashing_algo OpenSSL message digest algorithm to use (e.g., EVP_sha256())
+    * @param num_elem     Number of elements to hash
+    * @param addr         Array of pointers to input data elements  
+    * @param len          Array of lengths for each input element
+    * @param digest       Output buffer for computed hash value
+    *
+    * @return 1 on success, 0 on failure
+    */
+    static uint8_t platform_hash(const EVP_MD * hashing_algo, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest);
+
+    /**
+    * @brief Convenience wrapper to compute SHA-256 hash for multiple input elements
+    *
+    * @param num_elem Number of elements to hash
+    * @param addr     Array of pointers to input data elements
+    * @param len      Array of lengths for each input element  
+    * @param digest   Output buffer for computed hash
+    * 
+    * @return 1 on success, 0 on failure
+    */
+    inline static uint8_t platform_SHA256(uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest) {
+        return platform_hash(EVP_sha256(), num_elem, addr, len, digest);
+    }
+    
+
+
+    static void _I4B (const uint32_t *memory_pointer, uint8_t **packet_ppointer);
+    static uint8_t wps_key_derivation_function(uint8_t *key, uint8_t *label_prefix, uint32_t label_prefix_len, char *label, uint8_t *res, uint32_t res_len);
+
+    /**
+    * @brief Decrypts data using OpenSSL cipher in place
+    *
+    * @param cipher_type Type of cipher to use (e.g., EVP_aes_256_cbc())
+    * @param key        Decryption key
+    * @param iv         Initialization vector
+    * @param data       Buffer containing ciphertext, also used for plaintext output
+    * @param data_len   Length of input ciphertext
+    *
+    * @return 1 on success, 0 on failure
+    * 
+    * @note Padding is disabled. Input length must be multiple of block size.
+    */
+    static uint8_t platform_cipher_decrypt(const EVP_CIPHER *cipher_type, uint8_t *key, uint8_t *iv, uint8_t *data, uint32_t data_len);
+
+    /**
+    * @brief Encrypts data using OpenSSL cipher in place
+    *
+    * @param cipher_type Type of cipher to use (e.g., EVP_aes_256_cbc())
+    * @param key        Encryption key
+    * @param iv         Initialization vector
+    * @param plain      Input plaintext buffer
+    * @param plain_len  Length of input plaintext
+    * @param cipher     Output buffer for ciphertext
+    * @param cipher_len Output parameter for length of ciphertext
+    *
+    * @return 1 on success, 0 on failure
+    *
+    * @note Padding is disabled. Input length must be multiple of block size.
+    */
+    static uint8_t platform_cipher_encrypt(const EVP_CIPHER *cipher_type, uint8_t *key, uint8_t *iv, uint8_t *plain, uint32_t plain_len, uint8_t *cipher_text, uint32_t *cipher_len);
+
+    /**
+    * @brief Decrypts data using AES-128 in CBC mode (in-place)
+    *
+    * @param key      128-bit AES key
+    * @param iv       Initialization vector
+    * @param data     Data to decrypt (overwritten with plaintext)
+    * @param data_len Length of data
+    *
+    * @return 1 on success, 0 on failure
+    */
+    static inline uint8_t platform_aes_128_cbc_decrypt(uint8_t *key, uint8_t *iv, uint8_t *data, uint32_t data_len) {
+        return platform_cipher_decrypt(EVP_aes_128_cbc(), key, iv, data, data_len);
+    }
+    
+    /**
+    * @brief Encrypts data using AES-128 in CBC mode
+    *
+    * @param key         128-bit AES key
+    * @param iv          Initialization vector
+    * @param plain       Input plaintext
+    * @param plain_len   Length of plaintext
+    * @param cipher_text Output ciphertext buffer
+    * @param cipher_len  Output ciphertext length
+    *
+    * @return 1 on success, 0 on failure
+    */
+    static inline uint8_t platform_aes_128_cbc_encrypt(uint8_t *key, uint8_t *iv, uint8_t *plain, uint32_t plain_len, uint8_t *cipher_text, uint32_t *cipher_len) {
+        return platform_cipher_encrypt(EVP_aes_128_cbc(), key, iv, plain, plain_len, cipher_text, cipher_len);
+    }
+
+    static EVP_PKEY* create_dh_pkey(BIGNUM *p, BIGNUM *g, BIGNUM *bn_priv, BIGNUM *bn_pub);
     static uint8_t platform_compute_shared_secret(uint8_t **shared_secret, uint16_t *shared_secret_len,
         uint8_t *remote_pub, uint16_t remote_pub_len,
         uint8_t *local_priv, uint8_t local_priv_len);

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2186,7 +2186,7 @@ int em_configuration_t::handle_encrypted_settings()
     memset(&ev,0,sizeof(em_event_t));
     // first decrypt the encrypted m2 data
 
-    if (get_crypto()->platform_aes_128_cbc_decrypt(m_key_wrap_key, m_m2_encrypted_settings, plain, plain_len) != 1) {
+    if (em_crypto_t::platform_aes_128_cbc_decrypt(m_key_wrap_key, m_m2_encrypted_settings, plain, plain_len) != 1) {
         printf("%s:%d: platform decrypt failed\n", __func__, __LINE__);
         return 0;
     }
@@ -2308,7 +2308,7 @@ unsigned int em_configuration_t::create_encrypted_settings(unsigned char *buff, 
     len += (sizeof(data_elem_attr_t) + size);
     tmp += (sizeof(data_elem_attr_t) + size);
 
-    if (get_crypto()->generate_iv(iv, AES_BLOCK_SIZE) != 1) {
+    if (em_crypto_t::generate_iv(iv, AES_BLOCK_SIZE) != 1) {
         printf("%s:%d: iv generate failed\n", __func__, __LINE__);
         return 0;
     }
@@ -2318,7 +2318,7 @@ unsigned int em_configuration_t::create_encrypted_settings(unsigned char *buff, 
     plain_len = len + (AES_BLOCK_SIZE - len%AES_BLOCK_SIZE);
     
     // encrypt the m2 data
-    if (get_crypto()->platform_aes_128_cbc_encrypt(m_key_wrap_key, iv, plain, plain_len, buff + AES_BLOCK_SIZE, &cipher_len) != 1) {
+    if (em_crypto_t::platform_aes_128_cbc_encrypt(m_key_wrap_key, iv, plain, plain_len, buff + AES_BLOCK_SIZE, &cipher_len) != 1) {
         printf("%s:%d: platform encrypt failed\n", __func__, __LINE__);
         return 0;
     }
@@ -2342,7 +2342,7 @@ unsigned int em_configuration_t::create_authenticator(unsigned char *buff)
     //printf( "%s:%d m2 addr:%s::length:%d,\n", __func__, __LINE__, addr[1], length[1]);
     //dm_easy_mesh_t::print_hex_dump(length[1], addr[1]);
 
-    if (get_crypto()->platform_hmac_SHA256(m_auth_key, WPS_AUTHKEY_LEN, 2, addr, length, hash) != 1) {
+    if (em_crypto_t::platform_hmac_SHA256(m_auth_key, WPS_AUTHKEY_LEN, 2, addr, length, hash) != 1) {
         printf("%s:%d: Authenticator create failed\n", __func__, __LINE__);
         return -1;
     }

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2186,7 +2186,7 @@ int em_configuration_t::handle_encrypted_settings()
     memset(&ev,0,sizeof(em_event_t));
     // first decrypt the encrypted m2 data
 
-    if (get_crypto()->platform_aes_decrypt(m_key_wrap_key, m_m2_encrypted_settings, plain, plain_len) != 1) {
+    if (get_crypto()->platform_aes_128_cbc_decrypt(m_key_wrap_key, m_m2_encrypted_settings, plain, plain_len) != 1) {
         printf("%s:%d: platform decrypt failed\n", __func__, __LINE__);
         return 0;
     }
@@ -2318,7 +2318,7 @@ unsigned int em_configuration_t::create_encrypted_settings(unsigned char *buff, 
     plain_len = len + (AES_BLOCK_SIZE - len%AES_BLOCK_SIZE);
     
     // encrypt the m2 data
-    if (get_crypto()->platform_aes_encrypt(m_key_wrap_key, iv, plain, plain_len, buff + AES_BLOCK_SIZE, &cipher_len) != 1) {
+    if (get_crypto()->platform_aes_128_cbc_encrypt(m_key_wrap_key, iv, plain, plain_len, buff + AES_BLOCK_SIZE, &cipher_len) != 1) {
         printf("%s:%d: platform encrypt failed\n", __func__, __LINE__);
         return 0;
     }

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -343,7 +343,7 @@ bail:
     return 0;
 }
 
-uint8_t em_crypto_t::platform_SHA256(uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest)
+uint8_t em_crypto_t::platform_hash(const EVP_MD * hashing_algo, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest)
 {  
     EVP_MD_CTX   *ctx;
     unsigned int  mac_len;
@@ -361,7 +361,7 @@ uint8_t em_crypto_t::platform_SHA256(uint8_t num_elem, uint8_t **addr, uint32_t 
     EVP_MD_CTX_init(ctx);
 #endif
 
-    if (!EVP_DigestInit_ex(ctx, EVP_sha256(), NULL)) {
+    if (!EVP_DigestInit_ex(ctx, hashing_algo, NULL)) {
         res = 0;
     }
 
@@ -388,7 +388,7 @@ uint8_t em_crypto_t::platform_SHA256(uint8_t num_elem, uint8_t **addr, uint32_t 
 
     return res;
 }
-uint8_t em_crypto_t::platform_hmac_SHA256(uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr,
+uint8_t em_crypto_t::platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr,
         uint32_t *len, uint8_t *hmac)
 {
     //em_util_info_print(EM_CONF," %s:%d\n",__func__,__LINE__);
@@ -421,7 +421,7 @@ uint8_t em_crypto_t::platform_hmac_SHA256(uint8_t *key, uint32_t keylen, uint8_t
     if (pkey == NULL) {
         goto bail;
     }
-    if (EVP_DigestSignInit(ctx, NULL, EVP_sha256(), NULL, pkey) != 1) {
+    if (EVP_DigestSignInit(ctx, NULL, hashing_algo, NULL, pkey) != 1) {
         goto bail;
     }
 
@@ -433,7 +433,7 @@ uint8_t em_crypto_t::platform_hmac_SHA256(uint8_t *key, uint32_t keylen, uint8_t
         goto bail;
     }
 #else
-    if (HMAC_Init_ex(ctx, key, keylen, EVP_sha256(), NULL) != 1) {
+    if (HMAC_Init_ex(ctx, key, keylen, hashing_algo, NULL) != 1) {
         goto bail;
     }
 

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -795,7 +795,7 @@ uint8_t em_crypto_t::platform_compute_shared_secret(uint8_t **shared_secret, uin
     if (EVP_PKEY_derive(pkey_ctx, NULL, &secret_len) != 1 || secret_len == 0) {
         goto bail;
     }
-    *shared_secret = malloc(secret_len);
+    *shared_secret = (uint8_t*) malloc(secret_len);
     if (EVP_PKEY_derive(pkey_ctx, *shared_secret, &secret_len) != 1) {
         goto bail;
     }

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -848,8 +848,9 @@ em_t::em_t(em_interface_t *ruid, em_freq_band_t band, dm_easy_mesh_t *dm, em_pro
     m_sm.init_sm(type);
 	m_orch_state = em_orch_state_idle;
     m_cmd = NULL;
-    RAND_bytes(get_crypto_info()->e_nonce, sizeof(em_nonce_t));
-    RAND_bytes(get_crypto_info()->r_nonce, sizeof(em_nonce_t));
+
+    em_crypto_t::generate_nonce(get_crypto_info()->e_nonce);
+    em_crypto_t::generate_nonce(get_crypto_info()->r_nonce);
     m_data_model = dm;
 }
 


### PR DESCRIPTION
- Added a generic `em_crypto::platform_hash` function that takes any OpenSSL hashing algorithm
- Added a generic `em_crypto::platform_cipher_decrypt`/`em_crypto::platform_cipher_encrypt` to take any OpenSSL cipher
- Added a generic `em_crypto::platform_hmac_hash` (although that's a bit redundant) function that takes any OpenSSL hashing algo
- Added documentation
- Made functions in `em_crypto` that should be `static` or `inline` their correct designation.

More improvements to the `em_crypto` class can be done in a separate PR.