### PR TITLE
RDKBWIFI-6: Add trasnmit power limit tlv handle

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2113,6 +2113,7 @@ typedef struct {
     em_long_string_t    chip_vendor;
     bool    ap_metrics_wifi6;
     em_device_inventory_t inventory_info;
+    int     transmit_power_limit;
 } em_radio_info_t;
 
 typedef struct {

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -41,6 +41,7 @@ public:
     short create_cac_complete_report_tlv(unsigned char *buff);
     short create_cac_status_report_tlv(unsigned char *buff);
     short create_channel_pref_tlv_agent(unsigned char *buff);
+    short create_transmit_power_limit_tlv(unsigned char *buff);
 
     int send_channel_sel_request_msg();
     int send_channel_sel_response_msg(em_chan_sel_resp_code_type_t code, unsigned short msg_id);
@@ -53,7 +54,7 @@ public:
     int handle_channel_sel_rsp(unsigned char *buff, unsigned int len);
     int handle_operating_channel_rprt(unsigned char *buff, unsigned int len);
     int handle_channel_sel_req(unsigned char *buff, unsigned int len);
-    int handle_channel_pref_tlv(unsigned char *buff, unsigned int len);
+    int handle_channel_pref_tlv(unsigned char *buff, op_class_channel_sel *op_class);
     int handle_channel_pref_tlv_ctrl(unsigned char *buff, unsigned int len);
     int handle_op_channel_report(unsigned char *buff, unsigned int len);
 

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -424,9 +424,11 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
 	mac_addr_str_t mac_str;
 	op_class_channel_sel *channel_sel;
 	em_op_class_info_t *dm_op_class;
+	em_tx_power_limit_t	*tx_power_limit;
 
 	channel_sel = (op_class_channel_sel*) evt->u.raw_buff;
 	printf("%s:%d No of opclass=%d\n", __func__, __LINE__,channel_sel->num);
+	tx_power_limit = (em_tx_power_limit_t*) ((unsigned char *)evt->u.raw_buff + channel_sel->num * sizeof(em_op_class_info_t));
 
 	noofopclass = dm.get_num_op_class();
 	//TODO Select the right op class and number and configure
@@ -447,6 +449,13 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
 		noofopclass++;
 	}
 	dm.set_num_op_class(noofopclass);
+    
+	if(tx_power_limit->tx_power_eirp != 0) {
+		dm_radio_t* radio = dm.get_radio(tx_power_limit->ruid);
+		em_radio_info_t* radio_info = radio->get_radio_info();
+		radio_info->transmit_power_limit = tx_power_limit->tx_power_eirp;
+	}
+
 	dm.print_config();
 
     webconfig_proto_easymesh_init(&dev_data, &dm, NULL, get_num_radios, set_num_radios,

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -1472,6 +1472,7 @@ void dm_easy_mesh_t::print_config()
 {
     unsigned int i;
     mac_addr_str_t  ctrl_mac, ctrl_al_mac, agent_al_mac, radio_mac, mac_str;
+    int transmit_power_limit;
 
     dm_easy_mesh_t::macbytes_to_string(get_controller_interface_mac(), ctrl_mac);
     dm_easy_mesh_t::macbytes_to_string(get_ctrl_al_interface_mac(), ctrl_al_mac);
@@ -1504,8 +1505,10 @@ void dm_easy_mesh_t::print_config()
 
     for (i = 0;i < m_num_radios; i++) {
         dm_easy_mesh_t::macbytes_to_string(m_radio[i].get_radio_info()->id.mac, mac_str);
+        transmit_power_limit = m_radio[i].get_radio_info()->transmit_power_limit;
         printf("%s:%d:Radio Mac: %s \n", __func__, __LINE__, mac_str);
         printf("%s:%d:Radio Band: %d \n", __func__, __LINE__, m_radio[i].get_radio_info()->band);
+        printf("%s:%d:TransmitPowerLimit: %d \n", __func__, __LINE__, transmit_power_limit);
     }
 }
 

--- a/src/dm/dm_radio.cpp
+++ b/src/dm/dm_radio.cpp
@@ -128,6 +128,10 @@ int dm_radio_t::decode(const cJSON *obj, void *parent_id)
         m_radio_info.ap_metrics_wifi6 = cJSON_IsTrue(tmp);
     }
 
+    if ((tmp = cJSON_GetObjectItem(obj, "TransmitPowerLimit")) != NULL) {
+        m_radio_info.transmit_power_limit = tmp->valuedouble;;
+    }
+
     return 0;
 }
 
@@ -159,6 +163,7 @@ void dm_radio_t::encode(cJSON *obj, bool summary)
     cJSON_AddBoolToObject(obj, "AssociatedSTALinkMetricsInclusionPolicy", m_radio_info.associated_sta_link_mterics_inclusion_policy);
     cJSON_AddStringToObject(obj, "ChipsetVendor", m_radio_info.chip_vendor);
     cJSON_AddBoolToObject(obj, "APMetricsWiFi6", m_radio_info.ap_metrics_wifi6);
+    cJSON_AddNumberToObject(obj, "TransmitPowerLimit", m_radio_info.transmit_power_limit);
 }
 
 dm_orch_type_t dm_radio_t::get_dm_orch_type(const dm_radio_t& radio)
@@ -194,6 +199,7 @@ bool dm_radio_t::operator == (const dm_radio_t& obj) {
     ret += !(this->m_radio_info.associated_sta_link_mterics_inclusion_policy == obj.m_radio_info.associated_sta_link_mterics_inclusion_policy);
     ret += (memcmp(&this->m_radio_info.chip_vendor,&obj.m_radio_info.chip_vendor,sizeof(em_long_string_t)) != 0);
     //ret += !(this->m_radio_info.ap_metrics_wifi6 == obj.m_radio_info.ap_metrics_wifi6);
+    ret += !(this->m_radio_info.transmit_power_limit == obj.m_radio_info.transmit_power_limit);
 
     if (ret > 0)
         return false;
@@ -225,6 +231,7 @@ void dm_radio_t::operator = (const dm_radio_t& obj)
     this->m_radio_info.associated_sta_link_mterics_inclusion_policy = obj.m_radio_info.associated_sta_link_mterics_inclusion_policy;
     memcpy(&this->m_radio_info.chip_vendor,&obj.m_radio_info.chip_vendor,sizeof(em_long_string_t));
     //this->m_radio_info.ap_metrics_wifi6 = obj.m_radio_info.ap_metrics_wifi6;
+    this->m_radio_info.transmit_power_limit = obj.m_radio_info.transmit_power_limit;
 }
 
 dm_radio_t::dm_radio_t(em_radio_info_t *radio)


### PR DESCRIPTION
This change adds transmit power limit tlv support in controller and agent. The value of transmit power limit is received correctly on the agent side through the channel selection request message.