### PR TITLE
RDKBWIFI-5: Add TID-to-Link Mapping Policy TLV and related data model

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -81,6 +81,7 @@ AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
 
 AGENT_OBJECTS = $(AGENT_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 

--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -59,6 +59,7 @@ CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/cli/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
 
 CLI_OBJECTS = $(CLI_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -34,6 +34,7 @@
 #include "dm_cac_comp.h"
 #include "dm_ap_mld.h"
 #include "dm_bsta_mld.h"
+#include "dm_tid_to_link.h"
 #include "webconfig_external_proto.h"
 
 class em_t;
@@ -66,6 +67,7 @@ public:
     unsigned int    m_num_ap_mld;
     dm_ap_mld_t     m_ap_mld[EM_MAX_AP_MLD];
     dm_bsta_mld_t   m_bsta_mld;
+    dm_tid_to_link_t m_tid_to_link;
 
 public:
     int init();

--- a/inc/dm_tid_to_link.h
+++ b/inc/dm_tid_to_link.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DM_TID_TO_LINK_H
+#define DM_TID_TO_LINK_H
+
+#include "em_base.h"
+
+class dm_tid_to_link_t {
+public:
+    em_tid_to_link_info_t    m_tid_to_link_info;
+
+public:
+    int init() { memset(&m_tid_to_link_info, 0, sizeof(em_tid_to_link_info_t)); return 0; }
+    em_tid_to_link_info_t *get_tid_to_link_info() { return &m_tid_to_link_info; }
+    int decode(const cJSON *obj, void *parent_id);
+    void encode(cJSON *obj);
+
+    bool operator == (const dm_tid_to_link_t& obj);
+    void operator = (const dm_tid_to_link_t& obj);
+
+    dm_tid_to_link_t(em_tid_to_link_info_t *tid_to_link_info);
+    dm_tid_to_link_t(const dm_tid_to_link_t& tid_to_link);
+    dm_tid_to_link_t();
+    ~dm_tid_to_link_t();
+};
+
+#endif

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -539,6 +539,7 @@ typedef enum {
     em_tlv_type_wifi7_agent_cap = 0xdf,
     em_tlv_type_ap_mld_config = 0xe0,
     em_tlv_type_bsta_mld_config = 0xe1,
+    em_tlv_type_tid_to_link_map_policy = 0xe6,
     em_tlv_eht_operations = 0xe7,
 } em_tlv_type_t;
 
@@ -2065,6 +2066,27 @@ typedef struct {
 } em_bsta_mld_info_t;
 
 typedef struct {
+    bool  add_remove;
+    mac_address_t  sta_mld_mac_addr;
+    bool  direction;
+    bool  default_link_map;
+    bool  map_switch_time_present;
+    bool  expected_dur_present;
+    bool  link_map_size;
+    unsigned char  link_map_presence_ind;
+    unsigned char  expected_dur[3];
+    unsigned char tid_to_link_map;
+} em_tid_to_link_map_info_t;
+
+typedef struct {
+    bool  is_bsta_config;
+    mac_address_t  mld_mac_addr;
+    bool  tid_to_link_map_neg;
+    unsigned char  num_mapping;
+    em_tid_to_link_map_info_t  tid_to_link_mapping[EM_MAX_AP_MLD];
+} em_tid_to_link_info_t;
+
+typedef struct {
     em_interface_t  id;
 	mac_address_t dev_id;
     em_long_string_t net_id;
@@ -2187,6 +2209,33 @@ typedef struct {
     unsigned char num_affiliated_bsta;
     em_affiliated_bsta_mld_t affiliated_bsta_mld[0];
 } __attribute__((__packed__)) em_bsta_mld_config_t;
+
+typedef struct {
+    unsigned char add_remove : 1;
+    unsigned char reserved4 : 7;
+    mac_addr_t sta_mld_mac_addr;
+    unsigned char direction : 2;
+    unsigned char default_link_mapping : 1;
+    unsigned char map_switch_time_present : 1;
+    unsigned char exp_dur_present : 1;
+    unsigned char link_map_size : 1;
+    unsigned char reserved5 : 2;
+    unsigned char link_map_presence_ind;
+    unsigned char expected_duration[3];
+    unsigned char tid_to_link_map[0];
+    unsigned char reserved6[7];
+} __attribute__((__packed__)) em_tid_to_link_mapping_t;
+
+typedef struct {
+    unsigned char is_bsta_config : 1;
+    unsigned char reserved1 : 7;
+    mac_addr_t mld_mac_addr;
+    unsigned char tid_to_link_map_negotiation : 1;
+    unsigned char reserved2 : 7;
+    unsigned char reserved3[22];
+    unsigned char num_mapping;
+    em_tid_to_link_mapping_t tid_to_link_mapping[0];
+} __attribute__((__packed__)) em_tid_to_link_map_policy_t;
 
 typedef struct {
     em_nonce_t  e_nonce;  

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -36,6 +36,7 @@ class em_configuration_t {
     short create_client_assoc_event_tlv(unsigned char *buff, mac_address_t sta, bssid_t bssid, bool assoc);
     int create_ap_mld_config_tlv(unsigned char *buff);
     int create_bsta_mld_config_tlv(unsigned char *buff);
+    int create_tid_to_link_map_policy_tlv(unsigned char *buff);
 
     int send_topology_response_msg(unsigned char *dst);
     int send_topology_notification_by_client(mac_address_t sta, bssid_t bssid, bool assoc);

--- a/src/dm/dm_tid_to_link.cpp
+++ b/src/dm/dm_tid_to_link.cpp
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <linux/filter.h>
+#include <netinet/ether.h>
+#include <netpacket/packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include "dm_tid_to_link.h"
+#include "dm_easy_mesh.h"
+#include "dm_easy_mesh_ctrl.h"
+
+int dm_tid_to_link_t::decode(const cJSON *obj, void *parent_id)
+{
+    //TODO: needs to be implemnented
+
+    return 0;
+}
+
+void dm_tid_to_link_t::encode(cJSON *obj)
+{
+    //TODO: needs to be implemnented
+}
+
+void dm_tid_to_link_t::operator = (const dm_tid_to_link_t& obj)
+{
+    this->m_tid_to_link_info.is_bsta_config = obj.m_tid_to_link_info.is_bsta_config;
+    memcpy(&this->m_tid_to_link_info.mld_mac_addr,&obj.m_tid_to_link_info.mld_mac_addr,sizeof(mac_address_t));
+    this->m_tid_to_link_info.tid_to_link_map_neg = obj.m_tid_to_link_info.tid_to_link_map_neg;
+    this->m_tid_to_link_info.num_mapping = obj.m_tid_to_link_info.num_mapping;
+    memcpy(&this->m_tid_to_link_info.tid_to_link_mapping,&obj.m_tid_to_link_info.tid_to_link_mapping,sizeof(em_tid_to_link_map_info_t));
+}
+
+bool dm_tid_to_link_t::operator == (const dm_tid_to_link_t& obj)
+{
+	int ret = 0;
+
+    ret += !(this->m_tid_to_link_info.is_bsta_config == obj.m_tid_to_link_info.is_bsta_config);
+    ret += (memcmp(&this->m_tid_to_link_info.mld_mac_addr,&obj.m_tid_to_link_info.mld_mac_addr,sizeof(mac_address_t)) != 0);
+    ret += !(this->m_tid_to_link_info.tid_to_link_map_neg == obj.m_tid_to_link_info.tid_to_link_map_neg);
+    ret += !(this->m_tid_to_link_info.num_mapping == obj.m_tid_to_link_info.num_mapping);
+    ret += (memcmp(&this->m_tid_to_link_info.tid_to_link_mapping,&obj.m_tid_to_link_info.tid_to_link_mapping,sizeof(em_tid_to_link_map_info_t)) != 0);
+
+    if (ret > 0)
+        return false;
+    else
+        return true;
+}
+
+dm_tid_to_link_t::dm_tid_to_link_t(em_tid_to_link_info_t *tid_to_link_info)
+{
+    memcpy(&m_tid_to_link_info, tid_to_link_info, sizeof(em_tid_to_link_info_t));
+}
+
+dm_tid_to_link_t::dm_tid_to_link_t(const dm_tid_to_link_t& tid_to_link)
+{
+    memcpy(&m_tid_to_link_info, &tid_to_link.m_tid_to_link_info, sizeof(em_tid_to_link_info_t));
+}
+
+dm_tid_to_link_t::dm_tid_to_link_t()
+{
+
+}
+
+dm_tid_to_link_t::~dm_tid_to_link_t()
+{
+
+}

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -373,6 +373,7 @@ void em_msg_t::topo_resp()
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_bss_conf_rep, (m_profile > em_profile_type_2) ? mandatory:bad, "17.2.75 of Wi-Fi Easy Mesh 5.0", 17);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_mld_config, optional, "17.2.96 of Wi-Fi Easy Mesh 6.0", 64);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_bsta_mld_config, optional, "17.2.97 of Wi-Fi Easy Mesh 6.0", 64);
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_tid_to_link_map_policy, optional, "17.2.97 of Wi-Fi Easy Mesh 6.0", 64);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_device_bridging_cap, optional, "table 6-11 of IEEE-1905-1", 11);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_non1905_neigh_list, optional, "table 6-14 of IEEE-1905-1", 15);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_1905_neigh_list, optional, "table 6-15 of IEEE-1905-1", 15);


### PR DESCRIPTION
This change also cover the following EasyMesh v.6 requirement:

If a Multi-AP Agent sends a 1905 Topology Response message (extended) and
the Multi-AP Agent has received one or more TID-to-Link Mappings (see section 20.2.8),
the Multi-AP Agent shall include those TID-to-Link Mappings in one or
more TID-to-Link Mapping Policy TLVs.