### PR TITLE
em.cpp: forward provisioning msgs to em_provisioning::process_msg

### DIFF
--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -212,6 +212,18 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
             em_metrics_t::process_msg(data, len);
             break;
 
+        case em_msg_type_dpp_cce_ind:
+        case em_msg_type_proxied_encap_dpp:
+        case em_msg_type_direct_encap_dpp:
+        case em_msg_type_reconfig_trigger:
+        case em_msg_type_bss_config_req:
+        case em_msg_type_bss_config_rsp:
+        case em_msg_type_bss_config_res:
+        case em_msg_type_chirp_notif:
+        case em_msg_type_dpp_bootstrap_uri_notif:
+            em_provisioning_t::process_msg(data, len);
+            break;
+
         default:
             break;  
     }

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -429,7 +429,14 @@ void em_provisioning_t::process_msg(unsigned char *data, unsigned int len)
         case em_msg_type_bss_config_res:
             break;
 
+        case em_msg_type_chirp_notif:
+            break;
+
+        case em_msg_type_dpp_bootstrap_uri_notif:
+            break;
+
         default:
+            printf("%s:%d: unhandled message type %u\n", __func__, __LINE__, htons(cmdu->type));
             break;
     }
 }


### PR DESCRIPTION
Forwards provisioning messages (DPP, etc.) to `em_provisioning::process_msg`

Currently `em_provisioning::process_msg` just falls through to a `default:` case and logs. Actual message handlers and state machines still TODO. 

There is already a `create_cce_ind_msg` handler in `em_provisioning.cpp` but it's half-baked and needs work, hence why it is not called for that msg type.