### PR TITLE
RDKBWIFI-12 Fix for using network order byte of em_tlv_type_profile.

### DIFF
--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -1021,7 +1021,7 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
 
         } else {
             found_profile = true;
-			memcpy(&profile, tlv->value, tlv->len);
+			memcpy(&profile, tlv->value, ntohs(tlv->len));
             break; 
         }
     }


### PR DESCRIPTION
It looks like tlv->len is already converted into network bytes order (htons). Using this member in host architecture seems require converting it back into host bytes order (ntohs). Without that could be observed undefined behaviour (in it case memory corruption and segfault). 