### PR TITLE
Added GitHub Action for testing build before merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,82 @@
+name: Build Check on ARM64
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  Build:
+
+    runs-on: ubuntu-latest  # Host OS for the container
+
+    steps:
+    - name: Checkout current repository
+      uses: actions/checkout@v4
+      with:
+        path: 'unified-wifi-mesh'
+
+    - name: Clone OneWiFi repository
+      run: |
+        mkdir -p easymesh_project
+        git clone https://github.com/rdkcentral/OneWifi.git easymesh_project/OneWifi
+        mv unified-wifi-mesh easymesh_project/unified-wifi-mesh
+
+    - name: Set up dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential \
+                                cmake \
+                                python3 \
+                                python3-pip \
+                                git \
+                                vim \
+                                libev-dev \
+                                libjansson-dev \
+                                zlib1g-dev \
+                                libnl-3-dev \
+                                libnl-genl-3-dev \
+                                libnl-route-3-dev \
+                                libavro-dev \
+                                libcjson1 libcjson-dev \
+                                libssl-dev \
+                                uuid-dev \
+                                libmysqlcppconn-dev \
+                                libreadline-dev \
+                                iptables \
+                                mariadb-server \
+                                gnupg \
+                                file \
+
+    - name: Setup OneWiFi
+      working-directory: easymesh_project/OneWifi
+      run: |
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git config --global user.name "${{ github.actor }}"
+        make -f build/linux/makefile setup
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+
+    - name: Build OneWiFi
+      working-directory: easymesh_project/OneWifi
+      run: |
+        make -f build/linux/makefile all
+
+    - name: Build unified-wifi-mesh controller
+      working-directory: easymesh_project/unified-wifi-mesh/build/ctrl
+      run: |
+        make clean
+        make all
+
+    - name: Build unified-wifi-mesh agent
+      working-directory: easymesh_project/unified-wifi-mesh/build/agent
+      run: |
+        make clean
+        make all
+
+    - name: Build unified-wifi-mesh CLI
+      working-directory: easymesh_project/unified-wifi-mesh/build/cli
+      run: |
+        make clean
+        make all


### PR DESCRIPTION
Unfortunately, you won't see the effect of the GitHub action in this PR since the file has to be in the repository's main branch before it can take effect, but I tested it on my fork, and it works.  You should be able to see my GitHub Actions page to see this:

https://github.com/bcarlson-dev/unified-wifi-mesh/actions

**Notes**:
- Currently, this runs in x86 Ubuntu. It is possible to run a Docker image inside GitHub actions that emulates Arm64, but that is very slow, which is not necessarily a good idea (given my next point). 
- GitHub Actions has different tiers for using their runners depending on your organization's plan. I have linked the tier page so you can reference it based on `rdkbcentral`s plan.
- A self-hosted runner can easily be set up and replaced in this yaml file without any changes. This would require a device (Raspberry Pi in our case) to be plugged in somewhere and constantly connected to the internet. A self-hosted runner would not have usage limits and would likely be the best way forward, but CableLabs should not be hosting that runner. 


[GitHub Actions Tiers](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions)