### PR TITLE
RDKBWIFI-5: Add Associated STA MLD Configuration Report TLV and related data model

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -83,6 +83,7 @@ AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_assoc_sta_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
 
 AGENT_OBJECTS = $(AGENT_SOURCES:.cpp=.o)

--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -63,6 +63,7 @@ CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/cli/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_assoc_sta_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
 
 MAIN_SOURCE = $(ONEWIFI_EM_SRC)/cli/main.c

--- a/inc/dm_assoc_sta_mld.h
+++ b/inc/dm_assoc_sta_mld.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DM_ASSOC_STA_MLD_H
+#define DM_ASSOC_STA_MLD_H
+
+#include "em_base.h"
+
+class dm_assoc_sta_mld_t {
+public:
+    em_assoc_sta_mld_info_t    m_assoc_sta_mld_info;
+
+public:
+    int init() { memset(&m_assoc_sta_mld_info, 0, sizeof(em_assoc_sta_mld_info_t)); return 0; }
+    em_assoc_sta_mld_info_t *get_ap_mld_info() { return &m_assoc_sta_mld_info; }
+    int decode(const cJSON *obj, void *parent_id);
+    void encode(cJSON *obj);
+
+    bool operator == (const dm_assoc_sta_mld_t& obj);
+    void operator = (const dm_assoc_sta_mld_t& obj);
+
+    dm_assoc_sta_mld_t(em_assoc_sta_mld_info_t *ap_mld_info);
+    dm_assoc_sta_mld_t(const dm_assoc_sta_mld_t& ap_mld);
+    dm_assoc_sta_mld_t();
+    ~dm_assoc_sta_mld_t();
+};
+
+#endif

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -35,6 +35,7 @@
 #include "dm_cac_comp.h"
 #include "dm_ap_mld.h"
 #include "dm_bsta_mld.h"
+#include "dm_assoc_sta_mld.h"
 #include "dm_tid_to_link.h"
 #include "webconfig_external_proto.h"
 
@@ -70,6 +71,7 @@ public:
     unsigned int    m_num_ap_mld;
     dm_ap_mld_t     m_ap_mld[EM_MAX_AP_MLD];
     dm_bsta_mld_t   m_bsta_mld;
+    dm_assoc_sta_mld_t m_assoc_sta_mld;
     dm_tid_to_link_t m_tid_to_link;
 
 public:

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -545,6 +545,7 @@ typedef enum {
     em_tlv_type_wifi7_agent_cap = 0xdf,
     em_tlv_type_ap_mld_config = 0xe0,
     em_tlv_type_bsta_mld_config = 0xe1,
+    em_tlv_type_assoc_sta_mld_conf_rep = 0xe2,
     em_tlv_type_tid_to_link_map_policy = 0xe6,
     em_tlv_eht_operations = 0xe7,
     em_tlv_vendor_sta_metrics = 0xf1,
@@ -2082,6 +2083,22 @@ typedef struct {
 } em_bsta_mld_info_t;
 
 typedef struct {
+    mac_address_t  bssid;
+    mac_address_t  mac_addr;
+} em_affiliated_sta_info_t;
+
+typedef struct {
+    mac_address_t  mac_addr;
+    mac_address_t  ap_mld_mac_addr;
+    bool  str;
+    bool  nstr;
+    bool  emlsr;
+    bool  emlmr;
+    unsigned char  num_affiliated_sta;
+    em_affiliated_sta_info_t  affiliated_sta[EM_MAX_AP_MLD];
+} em_assoc_sta_mld_info_t;
+
+typedef struct {
     bool  add_remove;
     mac_address_t  sta_mld_mac_addr;
     bool  direction;
@@ -2238,6 +2255,25 @@ typedef struct {
     unsigned char num_affiliated_bsta;
     em_affiliated_bsta_mld_t affiliated_bsta_mld[0];
 } __attribute__((__packed__)) em_bsta_mld_config_t;
+
+typedef struct {
+    bssid_t bssid;
+    mac_addr_t affiliated_sta_mac_addr;
+    unsigned char reserved1[19];
+} __attribute__((__packed__)) em_affiliated_sta_mld_t;
+
+typedef struct {
+    mac_addr_t sta_mld_mac_addr;
+    mac_addr_t ap_mld_mac_addr;
+    unsigned char str : 1;
+    unsigned char nstr : 1;
+    unsigned char emlsr : 1;
+    unsigned char emlmr : 1;
+    unsigned char reseverd1 : 4;
+    unsigned char reserved2[18];
+    unsigned char num_affiliated_sta;
+    em_affiliated_sta_mld_t affiliated_sta_mld[0];
+} __attribute__((__packed__)) em_assoc_sta_mld_config_report_t;
 
 typedef struct {
     unsigned char add_remove : 1;

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -36,6 +36,7 @@ class em_configuration_t {
     short create_client_assoc_event_tlv(unsigned char *buff, mac_address_t sta, bssid_t bssid, bool assoc);
     int create_ap_mld_config_tlv(unsigned char *buff);
     int create_bsta_mld_config_tlv(unsigned char *buff);
+    int create_assoc_sta_mld_config_report_tlv(unsigned char *buff);
     int create_tid_to_link_map_policy_tlv(unsigned char *buff);
 
     int send_topology_response_msg(unsigned char *dst);

--- a/src/dm/dm_assoc_sta_mld.cpp
+++ b/src/dm/dm_assoc_sta_mld.cpp
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <linux/filter.h>
+#include <netinet/ether.h>
+#include <netpacket/packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include "dm_assoc_sta_mld.h"
+#include "dm_easy_mesh.h"
+#include "dm_easy_mesh_ctrl.h"
+
+int dm_assoc_sta_mld_t::decode(const cJSON *obj, void *parent_id)
+{
+    //TODO: needs to be implemnented
+
+    return 0;
+}
+
+void dm_assoc_sta_mld_t::encode(cJSON *obj)
+{
+    //TODO: needs to be implemnented
+}
+
+void dm_assoc_sta_mld_t::operator = (const dm_assoc_sta_mld_t& obj)
+{
+    memcpy(&this->m_assoc_sta_mld_info.mac_addr ,&obj.m_assoc_sta_mld_info.mac_addr,sizeof(mac_address_t));
+    memcpy(&this->m_assoc_sta_mld_info.ap_mld_mac_addr ,&obj.m_assoc_sta_mld_info.ap_mld_mac_addr,sizeof(mac_address_t));
+    this->m_assoc_sta_mld_info.str = obj.m_assoc_sta_mld_info.str;
+    this->m_assoc_sta_mld_info.nstr = obj.m_assoc_sta_mld_info.nstr;
+    this->m_assoc_sta_mld_info.emlsr = obj.m_assoc_sta_mld_info.emlsr;
+    this->m_assoc_sta_mld_info.emlmr = obj.m_assoc_sta_mld_info.emlmr;
+    this->m_assoc_sta_mld_info.num_affiliated_sta = obj.m_assoc_sta_mld_info.num_affiliated_sta;
+    memcpy(&this->m_assoc_sta_mld_info.affiliated_sta,&obj.m_assoc_sta_mld_info.affiliated_sta,sizeof(em_affiliated_sta_info_t));
+}
+
+bool dm_assoc_sta_mld_t::operator == (const dm_assoc_sta_mld_t& obj)
+{
+	int ret = 0;
+
+    ret += (memcmp(&this->m_assoc_sta_mld_info.mac_addr,&obj.m_assoc_sta_mld_info.mac_addr,sizeof(mac_address_t)) != 0);
+    ret += (memcmp(&this->m_assoc_sta_mld_info.ap_mld_mac_addr,&obj.m_assoc_sta_mld_info.ap_mld_mac_addr,sizeof(mac_address_t)) != 0);
+    ret += !(this->m_assoc_sta_mld_info.str == obj.m_assoc_sta_mld_info.str);
+    ret += !(this->m_assoc_sta_mld_info.nstr == obj.m_assoc_sta_mld_info.nstr);
+    ret += !(this->m_assoc_sta_mld_info.emlsr == obj.m_assoc_sta_mld_info.emlsr);
+    ret += !(this->m_assoc_sta_mld_info.emlmr == obj.m_assoc_sta_mld_info.emlmr);
+    ret += !(this->m_assoc_sta_mld_info.num_affiliated_sta == obj.m_assoc_sta_mld_info.num_affiliated_sta);
+    ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta,&obj.m_assoc_sta_mld_info.affiliated_sta,sizeof(em_affiliated_ap_info_t)) != 0);
+
+    if (ret > 0)
+        return false;
+    else
+        return true;
+}
+
+dm_assoc_sta_mld_t::dm_assoc_sta_mld_t(em_assoc_sta_mld_info_t *assoc_sta_mld_info)
+{
+    memcpy(&m_assoc_sta_mld_info, assoc_sta_mld_info, sizeof(em_assoc_sta_mld_info_t));
+}
+
+dm_assoc_sta_mld_t::dm_assoc_sta_mld_t(const dm_assoc_sta_mld_t& assoc_sta_mld)
+{
+    memcpy(&m_assoc_sta_mld_info, &assoc_sta_mld.m_assoc_sta_mld_info, sizeof(em_assoc_sta_mld_info_t));
+}
+
+dm_assoc_sta_mld_t::dm_assoc_sta_mld_t()
+{
+
+}
+
+dm_assoc_sta_mld_t::~dm_assoc_sta_mld_t()
+{
+
+}

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -373,6 +373,7 @@ void em_msg_t::topo_resp()
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_bss_conf_rep, (m_profile > em_profile_type_2) ? mandatory:bad, "17.2.75 of Wi-Fi Easy Mesh 5.0", 17);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_mld_config, optional, "17.2.96 of Wi-Fi Easy Mesh 6.0", 64);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_bsta_mld_config, optional, "17.2.97 of Wi-Fi Easy Mesh 6.0", 64);
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_assoc_sta_mld_conf_rep, optional, "17.2.98 of Wi-Fi Easy Mesh 6.0", 64);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_tid_to_link_map_policy, optional, "17.2.97 of Wi-Fi Easy Mesh 6.0", 64);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_device_bridging_cap, optional, "table 6-11 of IEEE-1905-1", 11);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_non1905_neigh_list, optional, "table 6-14 of IEEE-1905-1", 15);


### PR DESCRIPTION
This change also cover the following EasyMesh v.6 requirement:

If a Multi-AP Agent sends a 1905 Topology Response message (extended), the Multi-AP Agent shall include one Associated STA MLD Configuration Report TLV for each Client MLD and bSTA MLD that is associated.