### PR TITLE
Bug fix for SSID update in local and remote agent

### DIFF
--- a/src/cmd/em_cmd_set_ssid.cpp
+++ b/src/cmd/em_cmd_set_ssid.cpp
@@ -50,10 +50,11 @@ em_cmd_set_ssid_t::em_cmd_set_ssid_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
 	memset((unsigned char *)&m_orch_desc[0], 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
 
     m_orch_op_idx = 0;
-    m_num_orch_desc = 2;
+    m_num_orch_desc = 3;
     m_orch_desc[0].op = dm_orch_type_db_cfg;
     m_orch_desc[1].op = dm_orch_type_em_update;
     m_orch_desc[1].submit = true;
+    m_orch_desc[2].op = dm_orch_type_net_ssid_update;
 
     strncpy(m_name, "set_ssid", strlen("set_ssid") + 1);
     m_svc = em_service_type_ctrl;


### PR DESCRIPTION
Fix for the following bugs: 
1. Check why local agent is not applying ssid
2. Check why UI is not showing the updated ssid