### PR TITLE
em_printf log function to print time, date, function and line number …

### DIFF
--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -58,6 +58,7 @@ public:
 
     static void *mgr_nodes_listen(void *arg);
     static void *mgr_input_listen(void *arg);
+    static void em_printf(const char *func_name, int line_num, const char *msg_format, ...);
 
     virtual em_t *find_em_for_msg_type(unsigned char *data, unsigned int len, em_t *al_em) = 0;
     virtual int data_model_init(const char *data_model_path) = 0;

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2820,7 +2820,7 @@ int em_configuration_t::handle_autoconfig_search(unsigned char *buff, unsigned i
 
         return -1;
     }
-    printf("%s:%d: autoconfig rsp send success\n", __func__, __LINE__);
+    em_mgr_t::em_printf(__func__, __LINE__, "autoconfig_resp send successful");
     set_state(em_state_ctrl_wsc_m1_pending);
 
     return 0;
@@ -2961,8 +2961,8 @@ void em_configuration_t::handle_state_config_none()
         printf("%s:%d: failed, err:%d\n", __func__, __LINE__, errno);
         return;
     }
-
-    printf("%s:%d: autoconfig_search send successful\n", __func__, __LINE__);
+    
+    em_mgr_t::em_printf(__func__, __LINE__, "autoconfig_search send successful");
     set_state(em_state_agent_autoconfig_rsp_pending);
 
     return;

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -19,6 +19,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <time.h>
+#include <stdarg.h>
 #include <errno.h>
 #include <assert.h>
 #include <signal.h>
@@ -358,6 +360,25 @@ int em_mgr_t::init(const char *data_model_path)
 
     orch_init();
     return data_model_init(data_model_path);
+}
+
+void em_mgr_t::em_printf(const char *func_name, int line_num, const char *msg_format, ...)
+{
+    time_t now = time(NULL);
+    struct tm *tm_info = localtime(&now);
+
+    printf("%02d/%02d/%04d %02d:%02d:%02d - ",
+            tm_info->tm_mday, tm_info->tm_mon + 1, tm_info->tm_year + 1900,
+            tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec);
+
+    printf("[%s:%d] - ", func_name, line_num);
+
+    va_list args;
+    va_start(args, msg_format);
+    vprintf(msg_format, args);
+    va_end(args);
+
+    printf("\n");
 }
 
 em_mgr_t::em_mgr_t()


### PR DESCRIPTION
…along with string.

Example to call em_printf: em_mgr_t::em_printf(__func__, __LINE__, "autoconfig_resp send successful");