### PR TITLE
RDKBACCL-540: Observing segfault issue in em_ctrl when we tried to do reset command in em_cli prompt

### DIFF
--- a/src/dm/dm_network_ssid.cpp
+++ b/src/dm/dm_network_ssid.cpp
@@ -248,7 +248,9 @@ em_haul_type_t dm_network_ssid_t::haul_type_from_string(em_string_t str)
         type = em_haul_type_configurator;
     } else {
         type = em_haul_type_max;
-    }	
+    }
+
+    return type; 
 }
 
 dm_network_ssid_t::dm_network_ssid_t(em_network_ssid_info_t *net_ssid)


### PR DESCRIPTION
Reason for change: "haul_type_from_string() " api is not returning the type value .
Test Procedure: reset command is passed in cli
Risks: Low