### PR TITLE
Fixes constant "bss_color" notes and aligns "em_spatial_reuse_rprt_t" with EM specification

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -978,7 +978,7 @@ typedef struct {
 typedef struct {
     mac_address_t ruid;
     unsigned char reserved1 : 1;
-    unsigned char partial_bss_color : 2;
+    unsigned char partial_bss_color : 1;
     unsigned char bss_color : 6;
     unsigned char reserved2 : 3;
     unsigned char hesiga_spatial_reuse_value15_allowed : 1;


### PR DESCRIPTION
EasyMesh Specification 17.2.90: **Spatial Reuse Report TLV**

Partial BSS Color is **1** bit, not **2**. This also resolves all of the repeated :

```bash
g++ -I/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//inc -I/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//src/utils -I/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//src/util/ -I/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../../../halinterface/include -I/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../../../OneWifi//source/utils -I/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../../../OneWifi//include -I/include -I  -g -fPIC -o /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//src/cmd/em_cmd_onewifi_cb.o -c /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//src/cmd/em_cmd_onewifi_cb.cpp
In file included from /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//inc/em_cmd.h:22,
                 from /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//inc/em_cmd_onewifi_cb.h:22,
                 from /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//src/cmd/em_cmd_onewifi_cb.cpp:41:
/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/cli/../..//inc/em_base.h:978:16: note: offset of packed bit-field ‘<unnamed struct>::bss_color’ has changed in GCC 4.4
  978 | typedef struct {
      |

``` 
messages.


![Specification Screenshot](https://github.com/user-attachments/assets/8ec83c25-03cf-45b3-a4fe-d2d5f3ae4ec2)
