### PR TITLE
RDKB-56802: Populate almac address, colocated mode and mesh backhaul

### DIFF
--- a/inc/dm_device.h
+++ b/inc/dm_device.h
@@ -59,6 +59,7 @@ public:
     dm_orch_type_t get_dm_orch_type(const dm_device_t& device);
 
     static int parse_device_id_from_key(const char *key, em_device_id_t *id);
+    int update_easymesh_json_cfg(bool colocated_mode);
 
     dm_device_t(em_device_info_t *dev);
     dm_device_t(const dm_device_t& dev);

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -166,6 +166,7 @@ extern "C"
 #define EM_AGENT_PATH   "agent"
 #define EM_CTRL_PATH    "ctrl"
 #define EM_CLI_PATH "cli"
+#define EM_CFG_FILE "/nvram/EasymeshCfg.json"
 
 #define EM_MAX_SSID_LEN                33 
 #define EM_MAX_WIFI_PASSWORD_LEN       65 

--- a/src/dm/dm_device.cpp
+++ b/src/dm/dm_device.cpp
@@ -357,6 +357,40 @@ int dm_device_t::parse_device_id_from_key(const char *key, em_device_id_t *id)
 
 }
 
+int dm_device_t::update_easymesh_json_cfg(bool colocated_mode)
+{
+	mac_addr_str_t mac_str;
+
+	// Create a JSON object
+	cJSON *root = cJSON_CreateObject();
+
+	dm_easy_mesh_t::macbytes_to_string((unsigned char *)m_device_info.backhaul_mac.mac, mac_str);
+	cJSON_AddStringToObject(root, "AL_MAC_ADDR", (char*)mac_str);
+	cJSON_AddNumberToObject(root, "Colocated_mode", (int)colocated_mode);
+	//Configuring Mesh Backhaul with default SSID and KeyPassphrase
+ 	//TBD: This file to be updated with the configuration used for mesh_backhaul
+	cJSON_AddStringToObject(root, "Backhaul_SSID", "mesh_backhaul");
+	cJSON_AddStringToObject(root, "Backhaul_KeyPassphrase", "test-backhaul");
+
+	// Convert the JSON object to a string
+	char *jsonString = cJSON_Print(root);
+
+	// Write the JSON string to a file
+	FILE *file = fopen(EM_CFG_FILE, "w");
+	if (file == NULL) {
+		printf("%s:%d Could not open file:%s for writing\n", __func__, __LINE__, EM_CFG_FILE);
+		cJSON_Delete(root);
+		free(jsonString);
+		return -1;
+	}
+
+	fprintf(file, "%s", jsonString);
+	fclose(file);
+	cJSON_Delete(root);
+	free(jsonString);
+	return 0;
+}
+
 dm_device_t::dm_device_t(em_device_info_t *dev)
 {
     memcpy(&m_device_info, dev, sizeof(em_device_info_t));

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1431,7 +1431,7 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 
     dm = new dm_easy_mesh_t();
     dm->init();
-    //printf("%s:%d: Created data model for net_id: %s mac: %s, coloc:%d\n", __func__, __LINE__, net_id, mac_str, colocated);
+    printf("%s:%d: Created data model for net_id: %s mac: %s, coloc:%d\n", __func__, __LINE__, net_id, mac_str, colocated);
     dm->set_colocated(colocated);
 
     dev = dm->get_device();
@@ -1441,6 +1441,8 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 		dev->m_device_info.id.media = dm->m_network.m_net_info.media;
 		memcpy(dev->m_device_info.backhaul_mac.mac, al_mac, sizeof(mac_address_t));
 		dev->m_device_info.backhaul_mac.media = dm->m_network.m_net_info.media;
+		//Update the easymesh configuration file
+		dev->update_easymesh_json_cfg(colocated);
 	}
     dev->m_device_info.profile = profile;
 	dm->set_channels_list(op_class, EM_MAX_PRE_SET_CHANNELS);


### PR DESCRIPTION
EasymeshCfg.json file in nvram is populated as part of WiFi reset in colocated agent.