### PR TITLE
RDKBACCL-583 : Observing seg fault issue in CLI GUI

### DIFF
--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -312,6 +312,7 @@ int dm_easy_mesh_t::encode_config_reset(em_subdoc_info_t *subdoc, const char *ke
 	em_long_string_t	interface_str;
 	const char *preference[5] = {"First Preference", "Second Preference", "Third Preference", "Fourth Preference", "Fifth Preference"};
 	unsigned int i;
+	m_num_interfaces = sizeof(preference)/sizeof(*preference);
 
     if ((parent_obj = cJSON_CreateObject()) == NULL) {
         printf("%s:%d: Could not create parent object\n", __func__, __LINE__);


### PR DESCRIPTION
Reason for change:  Observing seg fault isse  when we execute "wifi reset" command in New Cli GUI.
Attached BT below,
(gdb) bt
#0  0x0000007faf5dc850 in ?? () from /lib/libc.so.6
#1  0x0000007faf4d28cc in ?? () from /usr/lib/libcjson.so.1
#2  0x0000007faf4d29a0 in ?? () from /usr/lib/libcjson.so.1
#3  0x0000007faf4d424c in cJSON_AddStringToObject () from /usr/lib/libcjson.so.1
#4  0x0000007faf709a9c in dm_easy_mesh_t::encode_config_reset (this=this@entry=0x7f76c65668, subdoc=subdoc@entry=0x7f76c64668, 
    key=key@entry=0x7f76c64520 "wfa-dataelements:Reset") at ../../../../git/src/cli/libs/../../../src/dm/dm_easy_mesh.cpp:347
#5  0x0000007faf70a31c in dm_easy_mesh_t::encode_config (this=this@entry=0x7f76c65668, subdoc=subdoc@entry=0x7f76c64668, 
    str=str@entry=0x7faf717e77 "Reset") at ../../../../git/src/cli/libs/../../../src/dm/dm_easy_mesh.cpp:294
#6  0x0000007faf703330 in em_cli_t::get_reset_tree (this=<optimized out>, platform=<optimized out>)
    at ../../../../git/src/cli/libs/../../../src/cli/libs/em_cli.cpp:82
#7  0x0000007faf7034f8 in get_reset_tree (platform=<optimized out>) at ../../../../git/src/cli/libs/../../../src/cli/libs/em_cli.cpp:356
#8  0x0000000000551ac8 in _cgo_15a569cc374f_Cfunc_get_reset_tree (v=0x40006059e8)
    at /usr/src/debug/unified-wifi-mesh-cli/gitAUTOINC+713ee7cfc1-r0/build-tmp/go-build2941847200/b001/cgo-gcc-prolog:252
#9  0x000000000046530c in runtime.asmcgocall () at /usr/lib/go/src/runtime/asm_arm64.s:973
#10 0x00000040000021a0 in ?? ()
Backtrace stopped: not enough registers or memory available to unwind further
(gdb) 
 Test Procedure: Not observed crash in cli
Risks: Low