### PR TITLE
Removed "pedantic" flags when building

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -41,7 +41,7 @@ INCLUDEDIRS = \
 
 $(info The value of VARIABLE is $(ONEWIFI_HAL_INTF_HOME))
 
-CXXFLAGS += $(INCLUDEDIRS) -g -DEASY_MESH_NODE -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++11 -fsanitize=address -fsanitize=undefined #-Werror -O2
+CXXFLAGS += $(INCLUDEDIRS) -g -DEASY_MESH_NODE -Wall -Wextra -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++11 -fsanitize=address -fsanitize=undefined #-Werror -O2
 LDFLAGS += $(LIBDIRS) $(LIBS) -fsanitize=address -fsanitize=undefined
 LIBDIRS = \
 	-L$(INSTALLDIR)/lib \

--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -33,7 +33,7 @@ INCLUDEDIRS = \
     	-I$(ONEWIFI_EM_HOME)/src/util_crypto \
 	-I$(WIFI_CJSON) \
 
-CXXFLAGS += $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++11 -fsanitize=address -fsanitize=undefined #-Werror -O2
+CXXFLAGS += $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++11 -fsanitize=address -fsanitize=undefined #-Werror -O2
 LDFLAGS += $(LIBDIRS) $(LIBS) -fsanitize=address -fsanitize=undefined
 LIBDIRS = \
 	-L$(INSTALLDIR)/lib \


### PR DESCRIPTION
Removes the `-pedantic` and `-Wpedantic` flags from the build options.

These can be useful but given we are compiling a C++ project against two ANSI C projects, it will often result in many many warnings that **cannot** be resolved, either within those projects (`OneWifi`, `rdk-wifi-hal`) or within `em_base.h` which must include compatible C code for `OneWifi`. Having these just shows warnings that can't be fixed by `unified-wifi-mesh`.

```
/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/ctrl/../../../OneWifi//include/wifi_base.h:290:24: warning: ISO C++ forbids zero-size array ‘frame_data’ [-Wpedantic]
  290 |     uint8_t frame_data[0];
```