### PR TITLE
Add Channel Support in EM APP

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -197,6 +197,8 @@ public:
 	dm_scan_result_t *create_new_scan_result(em_scan_result_id_t *id);
 	unsigned int	get_num_scan_results() { return hash_map_count(m_scan_result_map); }
 	dm_scan_result_t *get_scan_result(unsigned int index);
+    void update_scan_results(em_scan_result_t *scan_result);
+    static void update_scan_results(void *dm, em_scan_result_t *scan_result) { ((dm_easy_mesh_t *)dm)->update_scan_results(scan_result); }
 
     unsigned int get_num_ap_mld() { return m_num_ap_mld; }
     static unsigned int get_num_ap_mld(void *dm) { return ((dm_easy_mesh_t *)dm)->get_num_ap_mld(); }

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -195,8 +195,12 @@ public:
     dm_policy_t& get_policy_by_ref(unsigned int index) { return m_policy[index]; }
 
 	unsigned int get_num_scan_results() { return m_num_scan_results; }
+    static unsigned int get_num_scan_results(void *dm) { return ((dm_easy_mesh_t *)dm)->get_num_scan_results(); }
 	void set_num_scan_results(unsigned int num) { m_num_scan_results = num; }
+    static void set_num_scan_results(void *dm, unsigned int num) { return ((dm_easy_mesh_t *)dm)->set_num_scan_results(num); }
 	dm_scan_result_t *get_scan_result(unsigned int index) { return &m_scan_result[index]; }
+    em_scan_result_t *get_scan_result_info(unsigned int index) { return m_scan_result[index].get_scan_result(); }
+    static em_scan_result_t *get_scan_result_info(void *dm, unsigned int index) { return ((dm_easy_mesh_t *)dm)->get_scan_result_info(index); }
     dm_scan_result_t& get_scan_result_by_ref(unsigned int index) { return m_scan_result[index]; }
 	dm_scan_result_t *find_matching_scan_result(em_scan_result_id_t *id);
 	void remove_scan_result_by_index(unsigned int index);

--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -44,6 +44,7 @@ public:
     int analyze_sta_link_metrics(em_bus_event_t *evt, em_cmd_t *pcmd[]);
     int analyze_btm_request_action_frame(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl);
     int analyze_btm_response_action_frame(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+    int analyze_scan_request(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl);
     int analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 
     static webconfig_error_t webconfig_dummy_apply(webconfig_subdoc_t *doc, webconfig_subdoc_data_t *data);

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -104,6 +104,7 @@ public:
     static void onewifi_cb(char *event_name, raw_data_t *data);
     static int assoc_stats_cb(char *event_name, raw_data_t *data);
     static int mgmt_action_frame_cb(char *event_name, raw_data_t *data);
+    static int channel_scan_cb(char *event_name, raw_data_t *data);
     void *get_assoc(void*);
     void io(void *data, bool input = true);
     bool agent_output(void *data);

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -185,7 +185,7 @@ void dm_easy_mesh_agent_t::translate_onewifi_dml_data (char *str)
     webconfig_proto_easymesh_init(&ext, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
     
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -243,8 +243,7 @@ int dm_easy_mesh_agent_t::analyze_m2ctrl_configuration(em_bus_event_t *evt, wifi
     webconfig_proto_easymesh_init(&dev_data, &dm, &m2ctrl, NULL, get_num_radios, set_num_radios,
                                 get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
                                 get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-                                get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
-                                get_num_scan_results, set_num_scan_results, get_scan_result_info);
+                                get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -294,7 +293,8 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, 
-            get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+            get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            update_scan_results);
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
     if (webconfig_init(&config) != webconfig_error_none) {
@@ -364,7 +364,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -410,7 +410,7 @@ void dm_easy_mesh_agent_t::translate_onewifi_stats_data(char *str)
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -555,7 +555,7 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     webconfig_proto_easymesh_init(&dev_data, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
 
 	config.initializer = webconfig_initializer_onewifi;
 	config.apply_data =	 webconfig_dummy_apply;
@@ -605,7 +605,7 @@ int dm_easy_mesh_agent_t::analyze_sta_link_metrics(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -769,18 +769,17 @@ int dm_easy_mesh_agent_t::analyze_btm_response_action_frame(em_bus_event_t *evt,
 int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     unsigned int num = 0;
-    dm_easy_mesh_agent_t  dm;
+    dm_easy_mesh_agent_t  dm = *this;
     em_cmd_t *tmp;
 
     webconfig_t config;
     webconfig_external_easymesh_t ext;
     webconfig_subdoc_type_t type = webconfig_subdoc_type_em_channel_stats;
 
-    webconfig_proto_easymesh_init(&ext, &dm, NULL, get_num_radios, set_num_radios,
+    webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
-            get_num_scan_results, set_num_scan_results, get_scan_result_info);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -831,7 +830,7 @@ int dm_easy_mesh_agent_t::analyze_set_policy(em_bus_event_t *evt, wifi_bus_desc_
     webconfig_proto_easymesh_init(&ext_data, NULL, NULL, policy_cfg, get_num_radios, set_num_radios,
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
         get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-        get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+        get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -894,7 +893,7 @@ int dm_easy_mesh_agent_t::analyze_beacon_report(em_bus_event_t *evt, em_cmd_t *p
     webconfig_proto_easymesh_init(&extdata, &dm, NULL, NULL, NULL, NULL,
         NULL, NULL, NULL, NULL,
         NULL, NULL, get_radio_info, NULL, get_bss_info, NULL,
-        NULL, NULL, get_sta_info, put_sta_info, NULL);
+        NULL, NULL, get_sta_info, put_sta_info, NULL, NULL);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -677,12 +677,10 @@ int dm_easy_mesh_agent_t::analyze_scan_request(em_bus_event_t *evt, wifi_bus_des
     dm_easy_mesh_t::macbytes_to_string(scan_req->ruid, radio_mac_str);
     printf("%s:%d: Radio: %s Num of Op Classes: %d\n", __func__, __LINE__, radio_mac_str, scan_req->num_op_classes);
 
-    scan_data.perform_fresh_scan = 1;
+    scan_data.perform_fresh_scan = true;
     scan_data.num_radios = 1;
 
-    for (int i = 0; i < 6; ++i) {
-        scan_data.ruid[i] = scan_req->ruid[i];
-    }
+    memcpy(scan_data.ruid, scan_req->ruid, sizeof(mac_address_t));
 
     scan_data.num_operating_classes = scan_req->num_op_classes;
     for (i = 0; i < scan_req->num_op_classes; i++) {

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -184,7 +184,8 @@ void dm_easy_mesh_agent_t::translate_onewifi_dml_data (char *str)
     webconfig_proto_easymesh_init(&ext, this, NULL, get_num_radios, set_num_radios, 
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
     
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -239,7 +240,8 @@ int dm_easy_mesh_agent_t::analyze_m2ctrl_configuration(em_bus_event_t *evt, wifi
     webconfig_proto_easymesh_init(&dev_data, &dm, &m2ctrl, get_num_radios, set_num_radios,
                                 get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
                                 get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-                                get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+                                get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+                                get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -285,7 +287,8 @@ int dm_easy_mesh_agent_t::analyze_onewifi_private_cb(em_bus_event_t *evt, em_cmd
     webconfig_proto_easymesh_init(&ext, &dm, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, 
-			get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
     if (webconfig_init(&config) != webconfig_error_none) {
@@ -329,7 +332,8 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&ext, &dm, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -375,7 +379,8 @@ void dm_easy_mesh_agent_t::translate_onewifi_stats_data(char *str)
     webconfig_proto_easymesh_init(&extdata, this, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -520,7 +525,8 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     webconfig_proto_easymesh_init(&dev_data, &dm, NULL, get_num_radios, set_num_radios,
 			get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
 			get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
 	config.initializer = webconfig_initializer_onewifi;
 	config.apply_data =	 webconfig_dummy_apply;
@@ -570,7 +576,8 @@ int dm_easy_mesh_agent_t::analyze_sta_link_metrics(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&extdata, this, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -659,6 +666,51 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
     return 1;
 }
 
+int dm_easy_mesh_agent_t::analyze_scan_request(em_bus_event_t *evt, wifi_bus_desc_t *desc, bus_handle_t *bus_hdl)
+{
+    unsigned i, j;
+    mac_addr_str_t radio_mac_str;
+    raw_data_t l_bus_data;
+    channel_scan_request_t scan_data;
+    em_scan_params_t *scan_req = (em_scan_params_t *)&evt->u.raw_buff;
+
+    dm_easy_mesh_t::macbytes_to_string(scan_req->ruid, radio_mac_str);
+    printf("%s:%d: Radio: %s Num of Op Classes: %d\n", __func__, __LINE__, radio_mac_str, scan_req->num_op_classes);
+
+    scan_data.perform_fresh_scan = 1;
+    scan_data.num_radios = 1;
+
+    for (int i = 0; i < 6; ++i) {
+        scan_data.ruid[i] = scan_req->ruid[i];
+    }
+
+    scan_data.num_operating_classes = scan_req->num_op_classes;
+    for (i = 0; i < scan_req->num_op_classes; i++) {
+        scan_data.operating_classes[i].operating_class = scan_req->op_class[i].op_class;
+        scan_data.operating_classes[i].num_channels = scan_req->op_class[i].num_channels;
+        printf("Op Class: %d ", scan_req->op_class[i].op_class);
+        printf("Channels: ");
+        for (j = 0; j < scan_req->op_class[i].num_channels; j++) {
+            scan_data.operating_classes[i].channels[j] = scan_req->op_class[i].channels[j];
+            printf("%d ", scan_req->op_class[i].channels[j]);
+        }
+        printf("\n");
+    }
+
+    l_bus_data.data_type = bus_data_type_bytes;
+    l_bus_data.raw_data.bytes = (void *)&scan_data;
+    l_bus_data.raw_data_len = sizeof(channel_scan_request_t);
+
+    if (desc->bus_set_fn(bus_hdl, "Device.WiFi.EM.ChannelScanRequest", &l_bus_data)== 0) {
+        printf("%s:%d Scan Req send successfull\n",__func__, __LINE__);
+    }
+    else {
+        printf("%s:%d Scan Req send failed\n",__func__, __LINE__);
+        return -1;
+    }
+    return 1;
+}
+
 int dm_easy_mesh_agent_t::analyze_btm_response_action_frame(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     //TODO: if callback would give for multiple entries or one by one
@@ -693,7 +745,35 @@ int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcm
     unsigned int num = 0;
     dm_easy_mesh_agent_t  dm;
     em_cmd_t *tmp;
-    
+
+    webconfig_t config;
+    webconfig_external_easymesh_t ext;
+    webconfig_subdoc_type_t type = webconfig_subdoc_type_em_channel_stats;
+
+    webconfig_proto_easymesh_init(&ext, &dm, NULL, get_num_radios, set_num_radios,
+            get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
+            get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
+
+    config.initializer = webconfig_initializer_onewifi;
+    config.apply_data =  webconfig_dummy_apply;
+
+    if (webconfig_init(&config) != webconfig_error_none) {
+        printf( "[%s]:%d Init WiFi Web Config  fail\n",__func__,__LINE__);
+        return 0;
+    }
+
+    if ((webconfig_easymesh_decode(&config, (char *)evt->u.raw_buff, &ext, &type)) == webconfig_error_none) {
+        printf("%s:%d analyze_scan_result subdoc decode success\n",__func__, __LINE__);
+    } else {
+        printf("%s:%d analyze_scan_result subdoc decode fail\n",__func__, __LINE__);
+    }
+
+    em_cmd_params_t *evt_param = NULL;
+    evt_param = &evt->params;
+    memcpy(evt_param->u.scan_params.ruid, get_radio_info(0)->intf.mac, sizeof(mac_address_t));
+
     pcmd[num] = new em_cmd_scan_result_t(evt->params, dm);
     tmp = pcmd[num];
     num++;

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -524,8 +524,6 @@ void em_agent_t::input_listener()
 int em_agent_t::channel_scan_cb(char *event_name, raw_data_t *data)
 {
     cJSON *json, *channel_stats_arr;
-    printf("%s:%d: Scan Results received\n", __func__, __LINE__);
-    //printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, (char *)data->raw_data.bytes);
 
     json = cJSON_Parse((const char *)data->raw_data.bytes);
     if (json != NULL) {

--- a/src/cli/main.go
+++ b/src/cli/main.go
@@ -174,7 +174,7 @@ func CreateEasyMeshCommands() map[string]EasyMeshCmd {
 		NeighborsListCmd: {
 			Title:                NeighborsListCmd,
 			LoadOrder:            5,
-			GetCommand:           "get_channel OneWifiMesh",
+			GetCommand:           "scan_result OneWifiMesh",
 			GetCommandEx:         "get_channel OneWifiMesh 2",
 			SetCommand:           "scan_channel OneWifiMesh",
 			Help:                 "",

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -91,6 +91,11 @@ dm_easy_mesh_t dm_easy_mesh_t::operator =(dm_easy_mesh_t const& obj)
 
     m_em = obj.m_em;
 
+    this->m_num_scan_results = obj.m_num_scan_results;
+    for (unsigned int i = 0; i < obj.m_num_scan_results; i++) {
+        memcpy(&m_scan_result[i], &obj.m_scan_result[i], sizeof(dm_scan_result_t));
+    }
+
     return *this;
 }
 

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -99,11 +99,6 @@ dm_easy_mesh_t dm_easy_mesh_t::operator =(dm_easy_mesh_t const& obj)
 
     m_em = obj.m_em;
 
-    this->m_num_scan_results = obj.m_num_scan_results;
-    for (unsigned int i = 0; i < obj.m_num_scan_results; i++) {
-        memcpy(&m_scan_result[i], &obj.m_scan_result[i], sizeof(dm_scan_result_t));
-    }
-
     return *this;
 }
 
@@ -2612,6 +2607,29 @@ dm_scan_result_t *dm_easy_mesh_t::find_matching_scan_result(em_scan_result_id_t 
 	}    
 
     return NULL;
+}
+
+void dm_easy_mesh_t::update_scan_results(em_scan_result_t *scan_result)
+{
+    const char *netid = "OneWifiMesh";
+    mac_addr_str_t mac_str, radio_str;
+
+    em_scan_result_id_t *id = &scan_result->id;
+
+    strncpy(id->net_id, netid, strlen(netid) + 1);
+	memcpy(id->dev_mac, get_agent_al_interface_mac(), sizeof(mac_address_t));
+	memcpy(id->scanner_mac, get_radio_by_ref(0).get_radio_interface_mac(), sizeof(mac_address_t));
+    id->scanner_type = em_scanner_type_radio;
+
+    dm_scan_result_t *res = find_matching_scan_result(id);
+
+    if (res) {
+        *res->get_scan_result() = *scan_result;
+    } else {
+        printf("%s:%d creating new scan result\n", __func__, __LINE__);
+        res = create_new_scan_result(id);
+        *res->get_scan_result() = *scan_result;
+    }
 }
 
 void dm_easy_mesh_t::reset_db_cfg_type(db_cfg_type_t type) 

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -285,7 +285,7 @@ short em_channel_t::create_channel_scan_res_tlv(unsigned char *buff, unsigned in
 	unsigned short param;
 	em_channel_scan_result_t *res = (em_channel_scan_result_t *)buff;
 
-    dm = get_data_model();
+    dm = get_current_cmd()->get_data_model();
 	scan_res = &dm->m_scan_result[index];
 
 	memcpy(res->ruid, get_radio_interface_mac(), sizeof(mac_address_t));	
@@ -438,13 +438,18 @@ int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
 	unsigned int i, start_idx = *last_index;
 	unsigned char time_len;
 
-    dm = get_data_model();
-
-    memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
+    if (get_current_cmd() == NULL) {
+        return -1;
+    }
+    dm = get_current_cmd()->get_data_model();
+    if (dm == NULL) {
+        return -1;
+    }
+    memcpy(tmp, get_data_model()->get_ctl_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
     len += sizeof(mac_address_t);
 
-    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    memcpy(tmp, get_data_model()->get_agent_al_interface_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
     len += sizeof(mac_address_t);
 
@@ -2010,7 +2015,13 @@ void em_channel_t::process_state()
 
 		case em_state_agent_channel_scan_result_pending:
             if (get_service_type() == em_service_type_agent) {
-				dm = get_data_model();
+                if (get_current_cmd() == NULL) {
+                    break;
+                }
+                dm = get_current_cmd()->get_data_model();
+                if (dm == NULL) {
+                    break;
+                }
 				while (last_index < dm->m_num_scan_results) {
                 	send_channel_scan_report_msg(&last_index);
 				}

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -438,18 +438,13 @@ int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
 	unsigned int i, start_idx = *last_index;
 	unsigned char time_len;
 
-    if (get_current_cmd() == NULL) {
-        return -1;
-    }
-    dm = get_current_cmd()->get_data_model();
-    if (dm == NULL) {
-        return -1;
-    }
-    memcpy(tmp, get_data_model()->get_ctl_mac(), sizeof(mac_address_t));
+    dm = get_data_model();
+
+    memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
     len += sizeof(mac_address_t);
 
-    memcpy(tmp, get_data_model()->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
     len += sizeof(mac_address_t);
 

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -1837,6 +1837,7 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
         tmp += sizeof(unsigned char);
 
         strncpy(nbr->ssid, (char *)tmp, ssid_len + 1);
+        nbr->ssid[ssid_len] = '\0';
         tmp += ssid_len;
 
         memcpy(&nbr->signal_strength, tmp, sizeof(unsigned char));


### PR DESCRIPTION
Add Channel Support in EM APP

Reason for change: Add Channel Support in EM APP. Added changes to trigger channel scan to onewifi based on request from controller. 
Also to sent the scan data back to controller upon receiving. 
Test Procedure: Ensure channel scan results are received in agent side and then to controller cli upon request for channel scan.
The namespace used for subscription - Device.WiFi.EM.ChannelScanReport 
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E rakhilpe001@gmail.com