### PR TITLE
webconfig external proto changes for channel scanning

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -194,16 +194,16 @@ public:
 	dm_policy_t *get_policy(unsigned int index) { return &m_policy[index]; }
     dm_policy_t& get_policy_by_ref(unsigned int index) { return m_policy[index]; }
 
-	unsigned int get_num_scan_results() { return m_num_scan_results; }
+    unsigned int get_num_scan_results() { return m_num_scan_results; }
     static unsigned int get_num_scan_results(void *dm) { return ((dm_easy_mesh_t *)dm)->get_num_scan_results(); }
-	void set_num_scan_results(unsigned int num) { m_num_scan_results = num; }
+    void set_num_scan_results(unsigned int num) { m_num_scan_results = num; }
     static void set_num_scan_results(void *dm, unsigned int num) { return ((dm_easy_mesh_t *)dm)->set_num_scan_results(num); }
-	dm_scan_result_t *get_scan_result(unsigned int index) { return &m_scan_result[index]; }
+    dm_scan_result_t *get_scan_result(unsigned int index) { return &m_scan_result[index]; }
     em_scan_result_t *get_scan_result_info(unsigned int index) { return m_scan_result[index].get_scan_result(); }
     static em_scan_result_t *get_scan_result_info(void *dm, unsigned int index) { return ((dm_easy_mesh_t *)dm)->get_scan_result_info(index); }
     dm_scan_result_t& get_scan_result_by_ref(unsigned int index) { return m_scan_result[index]; }
-	dm_scan_result_t *find_matching_scan_result(em_scan_result_id_t *id);
-	void remove_scan_result_by_index(unsigned int index);
+    dm_scan_result_t *find_matching_scan_result(em_scan_result_id_t *id);
+    void remove_scan_result_by_index(unsigned int index);
 
     unsigned int get_num_ap_mld() { return m_num_ap_mld; }
     static unsigned int get_num_ap_mld(void *dm) { return ((dm_easy_mesh_t *)dm)->get_num_ap_mld(); }

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -195,8 +195,12 @@ public:
     dm_policy_t& get_policy_by_ref(unsigned int index) { return m_policy[index]; }
 
 	unsigned int get_num_scan_results() { return m_num_scan_results; }
+    static unsigned int get_num_scan_results(void *dm) { return ((dm_easy_mesh_t *)dm)->get_num_scan_results(); }
 	void set_num_scan_results(unsigned int num) { m_num_scan_results = num; }
+    static void set_num_scan_results(void *dm, unsigned int num) { return ((dm_easy_mesh_t *)dm)->set_num_scan_results(num); }
 	dm_scan_result_t *get_scan_result(unsigned int index) { return &m_scan_result[index]; }
+    em_scan_result_t *get_scan_result_info(unsigned int index) { return m_scan_result[index].get_scan_result(); }
+    static em_scan_result_t *get_scan_result_info(void *dm, unsigned int index) { return ((dm_easy_mesh_t *)dm)->get_scan_result_info(index); }
     dm_scan_result_t& get_scan_result_by_ref(unsigned int index) { return m_scan_result[index]; }
 	dm_scan_result_t *find_matching_scan_result(em_scan_result_id_t *id);
 	void remove_scan_result_by_index(unsigned int index);

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -185,7 +185,7 @@ void dm_easy_mesh_agent_t::translate_onewifi_dml_data (char *str)
     webconfig_proto_easymesh_init(&ext, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
             get_num_scan_results, set_num_scan_results, get_scan_result_info);
     
     config.initializer = webconfig_initializer_onewifi;
@@ -289,7 +289,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_private_cb(em_bus_event_t *evt, em_cmd
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, 
-			get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
             get_num_scan_results, set_num_scan_results, get_scan_result_info);
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -334,7 +334,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
             get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
@@ -381,7 +381,7 @@ void dm_easy_mesh_agent_t::translate_onewifi_stats_data(char *str)
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
             get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
@@ -525,9 +525,9 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     }
 #endif 
     webconfig_proto_easymesh_init(&dev_data, &dm, NULL, NULL, get_num_radios, set_num_radios,
-			get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
-			get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
+            get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
             get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
 	config.initializer = webconfig_initializer_onewifi;
@@ -578,7 +578,7 @@ int dm_easy_mesh_agent_t::analyze_sta_link_metrics(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
             get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -185,7 +185,8 @@ void dm_easy_mesh_agent_t::translate_onewifi_dml_data (char *str)
     webconfig_proto_easymesh_init(&ext, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
     
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -240,7 +241,8 @@ int dm_easy_mesh_agent_t::analyze_m2ctrl_configuration(em_bus_event_t *evt, wifi
     webconfig_proto_easymesh_init(&dev_data, &dm, &m2ctrl, NULL, get_num_radios, set_num_radios,
                                 get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
                                 get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-                                get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+                                get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+                                get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -287,7 +289,8 @@ int dm_easy_mesh_agent_t::analyze_onewifi_private_cb(em_bus_event_t *evt, em_cmd
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, 
-			get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
     if (webconfig_init(&config) != webconfig_error_none) {
@@ -331,7 +334,8 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -377,7 +381,8 @@ void dm_easy_mesh_agent_t::translate_onewifi_stats_data(char *str)
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -522,7 +527,8 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     webconfig_proto_easymesh_init(&dev_data, &dm, NULL, NULL, get_num_radios, set_num_radios,
 			get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
 			get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
 	config.initializer = webconfig_initializer_onewifi;
 	config.apply_data =	 webconfig_dummy_apply;
@@ -572,7 +578,8 @@ int dm_easy_mesh_agent_t::analyze_sta_link_metrics(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+			get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+            get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -727,7 +734,8 @@ int dm_easy_mesh_agent_t::analyze_set_policy(em_bus_event_t *evt, wifi_bus_desc_
     webconfig_proto_easymesh_init(&ext_data, NULL, NULL, policy_cfg, get_num_radios, set_num_radios,
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
         get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-        get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac);
+        get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
+        get_num_scan_results, set_num_scan_results, get_scan_result_info);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -790,7 +798,7 @@ int dm_easy_mesh_agent_t::analyze_beacon_report(em_bus_event_t *evt, em_cmd_t *p
     webconfig_proto_easymesh_init(&extdata, &dm, NULL, NULL, NULL, NULL,
         NULL, NULL, NULL, NULL,
         NULL, NULL, get_radio_info, NULL, get_bss_info, NULL,
-        NULL, NULL, get_sta_info, put_sta_info, NULL);
+        NULL, NULL, get_sta_info, put_sta_info, NULL, NULL, NULL, NULL);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;


### PR DESCRIPTION
webconfig external proto changes for channel scanning

Reason for change: webconfig external proto changes to support channel scanning translation for easymesh
Test Procedure: Ensure both onewifi and agent builds are successful
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>