### PR TITLE
Implemented DPP Chirp Notification Handling and other EC enhancements

### DIFF
--- a/inc/ec_session.h
+++ b/inc/ec_session.h
@@ -79,7 +79,23 @@ class ec_session_t {
 
 
     int compute_intermediate_key(bool is_first);
-    int set_auth_frame_wrapped_data(ec_frame_t *frame, unsigned int non_wrapped_len, bool do_init_auth);
+
+    /**
+     * @brief Add a wrapped data attribute to a frame
+     * 
+     * @param frame The frame to use as AAD. Can be NULL if no AAD is needed
+     * @param frame_attribs The attributes to add the wrapped data attribute to and to use as AAD
+     * @param non_wrapped_len The length of the non-wrapped attributes (`frame_attribs`, In/Out)
+     * @param use_aad Whether to use AAD in the encryption
+     * @param key The key to use for encryption
+     * @param create_wrap_attribs A function to create the attributes to wrap and their length. Memory is handled by function (see note)
+     * @return uint8_t* The new frame attributes with the wrapped data attribute added
+     * 
+     * @note The `create_wrap_attribs` function will allocate heap-memory which is freed inside the `add_wrapped_data_attr` function.
+     *     **The caller should not use statically allocated memory in `create_wrap_attribs` or free the memory returned by `create_wrap_attribs`.**
+     */
+    uint8_t* add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, uint16_t* non_wrapped_len, 
+        bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs);
     
     int hkdf(const EVP_MD *h, int skip, uint8_t *ikm, int ikmlen, 
             uint8_t *salt, int saltlen, uint8_t *info, int infolen, 
@@ -89,12 +105,11 @@ public:
     int init_session(ec_data_t* ec_data);
 
     /**
-     * @brief Create an authentication request frame in a pre-allocated buffer
+     * @brief Create an authentication request `ec_frame_t` with the necessary attributes 
      * 
-     * @param buff The buffer to store the frame
-     * @return int The length of the frame
+     * @return std::pair<uint8_t*, uint16_t> The buffer containing the `ec_frame_t` and the length of the frame
      */
-    int create_auth_req(uint8_t *buff);
+    std::pair<uint8_t*, uint16_t> create_auth_request();
 
     /**
      * @brief Handle a chirp notification TLV and output the authentication request frame (if necessary)
@@ -147,6 +162,12 @@ public:
      */
     int handle_recv_ec_action_frame(ec_frame_t* frame, size_t len);
 
+    /**
+     * @brief Construct an EC session
+     * 
+     * @param send_chirp_notification The function to send a chirp notification
+     * @param send_prox_encap_dpp_msg The function to send a proxied encapsulated DPP message
+     */
     ec_session_t( std::function<int(em_dpp_chirp_value_t*, size_t)> send_chirp_notification,
                    std::function<int(em_encap_dpp_t*, size_t, em_dpp_chirp_value_t*, size_t)> send_prox_encap_dpp_msg);
     ~ec_session_t();

--- a/inc/ec_util.h
+++ b/inc/ec_util.h
@@ -65,38 +65,45 @@ public:
     static ec_attribute_t *get_attrib(uint8_t *buff, uint16_t len, ec_attrib_id_t id);
 
     /**
-     * @brief Add an attribute to the buffer
+     * @brief Add an attribute to the buffer, (re)allocating the buffer if necessary
      * 
      * @param buff The buffer to add the attribute to
+     * @param buff_len The length of the buffer (in/out)
      * @param id The attribute ID
      * @param len The length of the data
      * @param data The attribute data
      * @return uint8_t* The buffer offset by the length of the attribute
+     * 
+     * @warning The buffer must be freed by the caller
      */
-    static uint8_t *add_attrib(uint8_t *buff, ec_attrib_id_t id, uint16_t len, uint8_t *data);
+    static uint8_t *add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t id, uint16_t len, uint8_t *data);
 
     /**
-     * @brief Add an attribute to the buffer
+     * @brief Add an attribute to the buffer, (re)allocating the buffer if necessary
      * 
      * @param buff The buffer to add the attribute to
      * @param id The attribute ID
      * @param val The uint8_t attribute value
      * @return uint8_t* The buffer offset by the length of the attribute
+     * 
+     * @warning The buffer must be freed by the caller
      */
-    static inline uint8_t* add_attrib(uint8_t *buff, ec_attrib_id_t id, uint8_t val) {
-        return add_attrib(buff, id, sizeof(uint8_t), (uint8_t *)&val);
+    static inline uint8_t* add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t id, uint8_t val) {
+        return add_attrib(buff, buff_len, id, sizeof(uint8_t), (uint8_t *)&val);
     }
 
     /**
-     * @brief Add an attribute to the buffer
+     * @brief Add an attribute to the buffer, (re)allocating the buffer if necessary
      * 
      * @param buff The buffer to add the attribute to
      * @param id The attribute ID
      * @param val The uint16_t attribute value
      * @return uint8_t* The buffer offset by the length of the attribute
+     * 
+     * @warning The buffer must be freed by the caller
      */
-    static inline uint8_t* add_attrib(uint8_t *buff, ec_attrib_id_t id, uint16_t val) {
-        return add_attrib(buff, id, sizeof(uint16_t), (uint8_t *)&val);
+    static inline uint8_t* add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t id, uint16_t val) {
+        return add_attrib(buff, buff_len, id, sizeof(uint16_t), (uint8_t *)&val);
     }
 
     /**

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -302,13 +302,6 @@ typedef enum {
 } em_freq_band_t;
 
 typedef struct {
-    unsigned int    bit_map;
-    mac_address_t   enrollee_mac;
-    unsigned char   hash_len;
-    unsigned char   hash_val[0];
-} __attribute__((__packed__)) em_chirp_t;
-
-typedef struct {
     unsigned char   channel[0];
 } __attribute__((__packed__)) em_channels_list_t;
 
@@ -612,13 +605,13 @@ typedef struct {
 }__attribute__((__packed__)) em_dpp_bootstrap_uri_t;
 
 typedef struct {
-    unsigned char frame_type;
-    unsigned short encap_frame_len;
-    mac_address_t dest_mac_addr[6];
     unsigned char enrollee_mac_addr_present : 1;
     unsigned char reserved : 1;
     unsigned char dpp_frame_indicator : 1;
     unsigned char content_type : 5;
+    mac_address_t dest_mac_addr;
+    unsigned char frame_type;
+    unsigned short encap_frame_len;
     unsigned char encap_frame[0];
 }__attribute__((__packed__)) em_encap_dpp_t;
 

--- a/inc/em_msg.h
+++ b/inc/em_msg.h
@@ -50,6 +50,53 @@ class em_msg_t {
     unsigned char *m_buff;
     unsigned int m_len;
 public:
+
+    /**
+     * @brief Add a value to the message
+     * 
+     * @param buff The buffer to add the item to
+     * @param len In/Out. The current length of the buffer. Updated with the new length
+     * @param element The element to add
+     * @param element_len The length of the element
+     * @return unsigned char* The new buffer pointer
+     */
+    static unsigned char* add_buff_element(unsigned char *buff, unsigned int *len, unsigned char *element, unsigned int element_len);
+
+    /**
+     * @brief Add a TLV to the message
+     * 
+     * @param buff The buffer to add the TLV to
+     * @param len In/Out. The current length of the buffer. Updated with the new length
+     * @param tlv_type The type of the TLV
+     * @param value The value of the TLV
+     * @param value_len The length of the value
+     * @return unsigned char* The new buffer pointer
+     */
+    static unsigned char* add_tlv(unsigned char *buff, unsigned int *len, em_tlv_type_t tlv_type, unsigned char *value, unsigned int value_len);
+
+    /**
+     * @brief Add an EOM TLV to the message
+     * 
+     * @param buff The buffer to add the TLV to
+     * @param len In/Out. The current length of the buffer. Updated with the new length
+     * @return unsigned char* The new buffer pointer
+     */
+    inline static unsigned char* add_eom_tlv(unsigned char *buff, unsigned int *len) {
+        return add_tlv(buff, len, em_tlv_type_eom, NULL, 0);
+    }
+
+    /**
+     * @brief Add a 1905 header to the message
+     * 
+     * @param buff The buffer to add the header to
+     * @param len In/Out. The current length of the buffer. Updated with the new length
+     * @param dst The destination MAC address
+     * @param src The source MAC address
+     * @param msg_type The message type
+     * @return unsigned char* The new buffer pointer
+     */
+    static unsigned char* add_1905_header(unsigned char *buff, unsigned int *len, mac_addr_t dst, mac_addr_t src, em_msg_type_t msg_type);
+
     unsigned int validate(char *errors[]);
     bool get_radio_id(mac_address_t *mac);
     bool get_bss_id(mac_address_t *mac);

--- a/inc/em_provisioning.h
+++ b/inc/em_provisioning.h
@@ -26,16 +26,20 @@
 class em_cmd_t;
 class em_provisioning_t {
 
-    int create_cce_ind_msg(unsigned char *buff);
-    int create_cce_ind_cmd(unsigned char *buff);
-    int create_chirp_notif_msg(unsigned char *buff, em_chirp_t *chirp, unsigned char *hash_val);
-    int create_bss_config_req_msg(unsigned char *buff);
-    int create_bss_config_rsp_msg(unsigned char *buff);
-    int create_bss_config_res_msg(unsigned char *buff);
-    int create_dpp_direct_encap_msg(unsigned char *buff, unsigned char *frame, unsigned short len);
+    int create_cce_ind_msg(uint8_t *buff);
+    int create_cce_ind_cmd(uint8_t *buff);
+    
+    int create_bss_config_req_msg(uint8_t *buff);
+    int create_bss_config_rsp_msg(uint8_t *buff);
+    int create_bss_config_res_msg(uint8_t *buff);
+    int create_dpp_direct_encap_msg(uint8_t *buff, uint8_t *frame, uint16_t len);
 
-    int handle_cce_ind_msg(unsigned char *buff, unsigned int len);
-    int handle_dpp_chirp_notif(unsigned char *buff, unsigned int len);
+    int handle_cce_ind_msg(uint8_t *buff, unsigned int len);
+    int handle_dpp_chirp_notif(uint8_t *buff, unsigned int len);
+    int handle_proxy_encap_dpp(uint8_t *buff, unsigned int len);
+
+    int send_chirp_notif_msg(em_dpp_chirp_value_t *chirp, size_t chirp_len);
+    int send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, size_t encap_dpp_len, em_dpp_chirp_value_t *chirp, size_t chirp_len);
     // states
     void handle_state_prov_none();
     void handle_state_prov();
@@ -50,15 +54,15 @@ class em_provisioning_t {
     virtual em_state_t get_state() = 0;
     virtual void set_state(em_state_t state) = 0;
     virtual char *get_radio_interface_name() = 0;
-    virtual unsigned char *get_peer_mac() = 0;
-    virtual unsigned char *get_al_interface_mac() = 0;
-    virtual unsigned char *get_radio_interface_mac() = 0;
-    virtual int send_frame(unsigned char *buff, unsigned int len, bool multicast = false) = 0;
-    virtual int send_cmd(em_cmd_type_t type, em_service_type_t svc, unsigned char *buff, unsigned int len) = 0;
+    virtual uint8_t *get_peer_mac() = 0;
+    virtual uint8_t *get_al_interface_mac() = 0;
+    virtual uint8_t *get_radio_interface_mac() = 0;
+    virtual int send_frame(uint8_t *buff, unsigned int len, bool multicast = false) = 0;
+    virtual int send_cmd(em_cmd_type_t type, em_service_type_t svc, uint8_t *buff, unsigned int len) = 0;
     virtual em_cmd_t *get_current_cmd() = 0;
 
 public:
-    void    process_msg(unsigned char *data, unsigned int len);
+    void    process_msg(uint8_t *data, unsigned int len);
     void    process_agent_state();
     void    process_ctrl_state();
 

--- a/src/em/prov/easyconnect/ec_session.cpp
+++ b/src/em/prov/easyconnect/ec_session.cpp
@@ -371,6 +371,10 @@ int ec_session_t::handle_chirp_notification(em_dpp_chirp_value_t *chirp_tlv, uin
 
 }
 
+int ec_session_t::handle_proxy_encap_dpp_tlv(em_encap_dpp_t *encap_tlv, uint8_t **out_frame) {
+
+}
+
 int ec_session_t::set_auth_frame_wrapped_data(ec_frame_t *frame, unsigned int non_wrapped_len, bool do_init_auth)
 {
     siv_ctx ctx;
@@ -448,7 +452,9 @@ int ec_session_t::handle_recv_ec_action_frame(ec_frame_t *frame, size_t len)
     return 0;
 }
 
-ec_session_t::ec_session_t()
+ec_session_t::ec_session_t(std::function<int(em_dpp_chirp_value_t*, size_t)> send_chirp_notification,
+                            std::function<int(em_encap_dpp_t*, size_t, em_dpp_chirp_value_t*, size_t)> send_prox_encap_dpp_msg)
+                            : m_send_chirp_notification(send_chirp_notification), m_send_prox_encap_dpp_msg(send_prox_encap_dpp_msg)
 {
     // Initialize member variables
     m_cfgrtr_ver = 0;

--- a/src/em/prov/easyconnect/ec_session.cpp
+++ b/src/em/prov/easyconnect/ec_session.cpp
@@ -24,89 +24,103 @@
 #include "em.h"
 #include "aes_siv.h"
 
-int ec_session_t::create_auth_req(uint8_t *buff)
+std::pair<uint8_t*, uint16_t> ec_session_t::create_auth_request()
 {
 
     EC_KEY *responder_boot_key, *initiator_boot_key;
-    unsigned int wrapped_len;
 
-    uint16_t attrib_len, chann_attr;;
-    uint8_t protocol_key_buff[1024];
+    ec_dpp_capabilities_t caps = {{
+        .enrollee = 0,
+        .configurator = 1
+    }};
 
     printf("%s:%d Enter\n", __func__, __LINE__);
 
+    uint8_t* buff = (uint8_t*) calloc(EC_FRAME_BASE_SIZE, 1);
+
     ec_frame_t    *frame = (ec_frame_t *)buff;
-
-    attrib_len = 0;
-
     frame->frame_type = ec_frame_type_auth_req;
 
     if (init_session(NULL) != 0) {
         m_activation_status = ActStatus_Failed;
         printf("%s:%d Failed to initialize session parameters\n", __func__, __LINE__);
-        return -1;
+        return std::make_pair<uint8_t*, uint16_t>(NULL, 0);
     }
 
     if (compute_intermediate_key(true) != 0) {
         m_activation_status = ActStatus_Failed;
         printf("%s:%d failed to generate key\n", __func__, __LINE__);
-        return -1;
+        return std::make_pair<uint8_t*, uint16_t>(NULL, 0);
     }
 
-    uint8_t* attribs = frame->attributes;
+    uint8_t* attribs = NULL;
+    uint16_t attrib_len = 0;
 
     // Responder Bootstrapping Key Hash
     if (compute_key_hash(m_data.responder_boot_key, m_params.responder_keyhash) < 1) {
         m_activation_status = ActStatus_Failed;
         printf("%s:%d unable to get x, y of the curve\n", __func__, __LINE__);
-        return -1;
+        return std::make_pair<uint8_t*, uint16_t>(NULL, 0);
     }
 
-    attribs = ec_util::add_attrib(attribs, ec_attrib_id_resp_bootstrap_key_hash, SHA256_DIGEST_LENGTH, m_params.responder_keyhash);
-    attrib_len += ec_util::get_ec_attr_size(SHA256_DIGEST_LENGTH);
+    attribs = ec_util::add_attrib(attribs, &attrib_len, ec_attrib_id_resp_bootstrap_key_hash, SHA256_DIGEST_LENGTH, m_params.responder_keyhash);
 
     // Initiator Bootstrapping Key Hash
     if (compute_key_hash(m_data.initiator_boot_key, m_params.initiator_keyhash) < 1) {
         m_activation_status = ActStatus_Failed;
         printf("%s:%d unable to get x, y of the curve\n", __func__, __LINE__);
-        return -1;
+        return std::make_pair<uint8_t*, uint16_t>(NULL, 0);
     }
 
-    attribs = ec_util::add_attrib(attribs, ec_attrib_id_init_bootstrap_key_hash, SHA256_DIGEST_LENGTH, m_params.initiator_keyhash);
-    attrib_len += ec_util::get_ec_attr_size(SHA256_DIGEST_LENGTH);
+    attribs = ec_util::add_attrib(attribs, &attrib_len, ec_attrib_id_init_bootstrap_key_hash, SHA256_DIGEST_LENGTH, m_params.initiator_keyhash);
 
     // Initiator Protocol Key
+    uint8_t protocol_key_buff[1024];
     BN_bn2bin((const BIGNUM *)m_params.x,
             &protocol_key_buff[BN_num_bytes(m_params.prime) - BN_num_bytes(m_params.x)]);
     BN_bn2bin((const BIGNUM *)m_params.y,
             &protocol_key_buff[2*BN_num_bytes(m_params.prime) - BN_num_bytes(m_params.x)]);
 
-    attribs = ec_util::add_attrib(attribs, ec_attrib_id_init_proto_key, 2*BN_num_bytes(m_params.prime), protocol_key_buff);
-    attrib_len += ec_util::get_ec_attr_size(2*BN_num_bytes(m_params.prime));
+    attribs = ec_util::add_attrib(attribs, &attrib_len, ec_attrib_id_init_proto_key, 2*BN_num_bytes(m_params.prime), protocol_key_buff);
 
     // Protocol Version
     if (m_cfgrtr_ver > 1) {
-        attribs = ec_util::add_attrib(attribs, ec_attrib_id_proto_version, m_cfgrtr_ver);
-        attrib_len += ec_util::get_ec_attr_size(sizeof(m_cfgrtr_ver));
+        attribs = ec_util::add_attrib(attribs, &attrib_len, ec_attrib_id_proto_version, m_cfgrtr_ver);
     }
 
     // Channel Attribute (optional)
     //TODO: REVISIT THIS
     if (m_data.ec_freqs[0] != 0){
         int base_freq = m_data.ec_freqs[0]; 
-        chann_attr = ec_util::freq_to_channel_attr(base_freq);
-        attribs = ec_util::add_attrib(attribs, ec_attrib_id_channel, sizeof(uint16_t), (uint8_t *)&chann_attr);
-        attrib_len += ec_util::get_ec_attr_size(sizeof(uint16_t));
+        uint16_t chann_attr = ec_util::freq_to_channel_attr(base_freq);
+        attribs = ec_util::add_attrib(attribs, &attrib_len, ec_attrib_id_channel, sizeof(uint16_t), (uint8_t *)&chann_attr);
     }
 
 
     // Wrapped Data (with Initiator Nonce and Initiator Capabilities)
-    wrapped_len = set_auth_frame_wrapped_data(frame, attrib_len, true);
-    attrib_len += ec_util::get_ec_attr_size(wrapped_len);
+    // EasyMesh 8.2.2 Table 36
+    attribs = add_wrapped_data_attr(frame, attribs, &attrib_len, true, m_params.k1, [&](){
+        uint8_t* wrap_attribs = NULL;
+        uint16_t wrapped_len = 0;
+        wrap_attribs = ec_util::add_attrib(wrap_attribs, &wrapped_len, ec_attrib_id_init_nonce, m_params.noncelen, m_params.initiator_nonce);
+        wrap_attribs = ec_util::add_attrib(wrap_attribs, &wrapped_len, ec_attrib_id_init_caps, caps.byte);
+        return std::make_pair(wrap_attribs, wrapped_len);
+    });
 
-    printf("%s:%d Exit\n", __func__, __LINE__);
+    // Add attributes to the frame
+    uint16_t new_len = EC_FRAME_BASE_SIZE + attrib_len;
+    buff = (uint8_t*) realloc(buff, new_len);
+    if (buff == NULL) {
+        m_activation_status = ActStatus_Failed;
+        printf("%s:%d unable to realloc memory\n", __func__, __LINE__);
+        return std::make_pair<uint8_t*, uint16_t>(NULL, 0);
+    }
+    frame = (ec_frame_t *)buff;
+    memcpy(frame->attributes, attribs, attrib_len);
 
-    return attrib_len;
+    free(attribs);
+
+    return std::make_pair(buff, new_len);
 
 }
 
@@ -137,7 +151,7 @@ int ec_session_t::create_pres_ann(uint8_t *buff)
     uint8_t* attribs = frame->attributes;
     uint16_t attrib_len = 0;
 
-    attribs = ec_util::add_attrib(attribs, ec_attrib_id_resp_bootstrap_key_hash, SHA256_DIGEST_LENGTH, resp_boot_key_chirp_hash);
+    attribs = ec_util::add_attrib(attribs, &attrib_len, ec_attrib_id_resp_bootstrap_key_hash, SHA256_DIGEST_LENGTH, resp_boot_key_chirp_hash);
     attrib_len += ec_util::get_ec_attr_size(SHA256_DIGEST_LENGTH); 
 
     return attrib_len;
@@ -326,6 +340,7 @@ int ec_session_t::init_session(ec_data_t* ec_data)
 
 int ec_session_t::handle_chirp_notification(em_dpp_chirp_value_t *chirp_tlv, uint8_t **out_frame)
 {
+    // TODO: Currently only handling controller side
 
     // Parse TLV
     bool mac_addr_present = chirp_tlv->mac_present;
@@ -351,22 +366,69 @@ int ec_session_t::handle_chirp_notification(em_dpp_chirp_value_t *chirp_tlv, uin
     memcpy(hash, data_ptr, hash_len);
 
     // Validate hash
-    if (compute_key_hash(m_data.responder_boot_key, m_params.responder_keyhash) < 1) {
+    // Compute the hash of the responder boot key 
+    uint8_t resp_boot_key_chirp_hash[SHA512_DIGEST_LENGTH];
+    if (compute_key_hash(m_data.responder_boot_key, resp_boot_key_chirp_hash, "chirp") < 1) {
         m_activation_status = ActStatus_Failed;
-        printf("%s:%d unable to get x, y of the curve\n", __func__, __LINE__);
+        printf("%s:%d unable to compute \"chirp\" responder bootstrapping key hash\n", __func__, __LINE__);
         return -1;
     }
 
-    if (memcmp(hash, m_params.responder_keyhash, hash_len) != 0) {
+    if (memcmp(hash, resp_boot_key_chirp_hash, hash_len) != 0) {
         // Hashes don't match, don't initiate DPP authentication
         *out_frame = NULL;
         printf("%s:%d: Chirp notification hash and DPP URI hash did not match! Stopping DPP!\n", __func__, __LINE__);
         return -1;
     }
 
-    // TODO: 
-    // create_auth_req(*out_frame);
+    auto [auth_frame, auth_frame_len] = create_auth_request();
+    if (auth_frame == NULL || auth_frame_len == 0) {
+        printf("%s:%d: Failed to create authentication request frame\n", __func__, __LINE__);
+        return -1;
+    }
 
+    // Create Auth Request Encap TLV: EasyMesh 5.3.4
+    em_encap_dpp_t* encap_dpp_tlv = (em_encap_dpp_t*)calloc(sizeof(em_encap_dpp_t) + auth_frame_len , 1);
+    if (encap_dpp_tlv == NULL) {
+        printf("%s:%d: Failed to allocate memory for Encap DPP TLV\n", __func__, __LINE__);
+        return -1;
+    }
+    encap_dpp_tlv->dpp_frame_indicator = 0;
+    encap_dpp_tlv->frame_type = 0; // DPP Authentication Request Frame
+    encap_dpp_tlv->enrollee_mac_addr_present = 1;
+
+    memcpy(encap_dpp_tlv->dest_mac_addr, mac, sizeof(mac_addr_t));
+    encap_dpp_tlv->encap_frame_len = auth_frame_len;
+    memcpy(encap_dpp_tlv->encap_frame, auth_frame, auth_frame_len);
+
+    free(auth_frame);
+
+    // Create Auth Request Chirp TLV: EasyMesh 5.3.4
+    size_t data_size = sizeof(mac_addr_t) + hash_len + sizeof(uint8_t);
+    em_dpp_chirp_value_t* chirp = (em_dpp_chirp_value_t*)calloc(sizeof(em_dpp_chirp_value_t) + data_size, 1);
+    if (chirp == NULL) {
+        printf("%s:%d: Failed to allocate memory for chirp TLV\n", __func__, __LINE__);
+        free(encap_dpp_tlv);
+        return -1;
+    }
+    chirp->mac_present = 1;
+    chirp->hash_valid = 1;
+
+    uint8_t* tmp = chirp->data;
+    memcpy(tmp, mac, sizeof(mac_addr_t));
+    tmp += sizeof(mac_addr_t);
+
+    *tmp = hash_len;
+    tmp++;
+
+    memcpy(tmp, hash, hash_len); 
+
+    // Send the encapsulated DPP message (with Encap TLV and Chirp TLV)
+    this->m_send_prox_encap_dpp_msg(encap_dpp_tlv, sizeof(em_encap_dpp_t) + auth_frame_len, chirp, sizeof(em_dpp_chirp_value_t) + data_size);
+
+    free(encap_dpp_tlv);
+    free(chirp);
+    
     return 0;
 
 }
@@ -375,19 +437,9 @@ int ec_session_t::handle_proxy_encap_dpp_tlv(em_encap_dpp_t *encap_tlv, uint8_t 
 
 }
 
-int ec_session_t::set_auth_frame_wrapped_data(ec_frame_t *frame, unsigned int non_wrapped_len, bool do_init_auth)
+uint8_t* ec_session_t::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, uint16_t* non_wrapped_len, bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs)
 {
     siv_ctx ctx;
-    
-    ec_attribute_t *attrib;
-    ec_dpp_capabilities_t caps = {{
-        .enrollee = 0,
-        .configurator = 1
-    }};
-    unsigned int wrapped_len = 0;
-    ec_attribute_t *wrapped_attrib;
-
-    uint8_t *key = do_init_auth ? m_params.k1 : m_params.ke;
 
     // Initialize AES-SIV context
     switch(m_params.digestlen) {
@@ -402,38 +454,43 @@ int ec_session_t::set_auth_frame_wrapped_data(ec_frame_t *frame, unsigned int no
             break;
         default:
             printf("%s:%d Unknown digest length\n", __func__, __LINE__);
-            return -1;
+            return NULL;
     }
 
-    uint8_t plain[512];
-    uint8_t* attribs = plain;
-
-    if (do_init_auth) {
-        attribs = ec_util::add_attrib(attribs, ec_attrib_id_init_nonce, m_params.noncelen, m_params.initiator_nonce);
-        wrapped_len += ec_util::get_ec_attr_size(m_params.noncelen); 
-
-        attribs = ec_util::add_attrib(attribs, ec_attrib_id_init_caps, caps.byte);
-        wrapped_len += ec_util::get_ec_attr_size(1);
-    } else {
-        attribs = ec_util::add_attrib(attribs, ec_attrib_id_init_auth_tag, m_params.digestlen, m_params.iauth);
-        wrapped_len += ec_util::get_ec_attr_size(m_params.digestlen);
-
-    }
+    // Use the provided function to create wrap_attribs and wrapped_len
+    auto [wrap_attribs, wrapped_len] = create_wrap_attribs();
 
     // Encapsulate the attributes in a wrapped data attribute
-    wrapped_attrib = (ec_attribute_t *)(frame->attributes + non_wrapped_len);
+    uint16_t wrapped_attrib_len = wrapped_len + AES_BLOCK_SIZE;
+    ec_attribute_t *wrapped_attrib = (ec_attribute_t *)calloc(sizeof(ec_attribute_t) + wrapped_attrib_len, 1); 
     wrapped_attrib->attr_id = ec_attrib_id_wrapped_data;
-    wrapped_attrib->length = wrapped_len + AES_BLOCK_SIZE;
+    wrapped_attrib->length = wrapped_attrib_len;
+    memset(wrapped_attrib->data, 0, wrapped_attrib_len);
 
-    // Encrypt the attributes
-    siv_encrypt(&ctx, plain, &wrapped_attrib->data[AES_BLOCK_SIZE], wrapped_len, wrapped_attrib->data, 2,
-            frame, sizeof(ec_frame_t), // Used for SIV (authentication)
-            frame->attributes, non_wrapped_len); // Used for SIV (authentication)
+    /**
+    * Encrypt attributes using SIV mode with two additional authenticated data (AAD) inputs:
+    * 1. The frame structure and 2. Non-wrapped attributes (per EasyMesh 6.3.1.4)
+    * The synthetic IV/tag is stored in the first AES_BLOCK_SIZE bytes of wrapped_attrib->data
+    */
+   if (use_aad) {
+        if (frame == NULL || frame_attribs == NULL || non_wrapped_len == NULL) {
+            printf("%s:%d: AAD input is NULL, AAD encryption failed!\n", __func__, __LINE__);
+            return NULL;
+        }
+        siv_encrypt(&ctx, wrap_attribs, &wrapped_attrib->data[AES_BLOCK_SIZE], wrapped_len, wrapped_attrib->data, 2,
+            frame, sizeof(ec_frame_t),
+            frame_attribs, *non_wrapped_len);
+    } else {
+        siv_encrypt(&ctx, wrap_attribs, &wrapped_attrib->data[AES_BLOCK_SIZE], wrapped_len, wrapped_attrib->data, 0);
+    }
 
-    //printf("%s:%d: Plain text:\n", __func__, __LINE__);
-    //util::print_hex_dump(noncelen, plain);
+    // Add the wrapped data attribute to the frame
+    uint8_t* ret_frame_attribs = ec_util::add_attrib(frame_attribs, non_wrapped_len, ec_attrib_id_wrapped_data, wrapped_attrib_len, (uint8_t *)wrapped_attrib);
 
-    return wrapped_len + AES_BLOCK_SIZE;
+
+    free(wrap_attribs);
+
+    return ret_frame_attribs;
 }
 
 int ec_session_t::handle_recv_ec_action_frame(ec_frame_t *frame, size_t len)


### PR DESCRIPTION
- Implemented the handling of DPP Chirp Notifications with the sending of the DPP Encap Messages in response.
- Added callable variables to `ec_session` to allow for exterior claling of send chirp and encap messages.
- Updated attribute methods to use heap allocation versus stack allocation.
- Replaced `set_auth_frame_wrapped_data` with a more universal `add_wrapped_data_attr`  which can be used whenever authentication is needed by having the caller provide their own key and attributes to wrap.
- Added static `em_msg_t` utilities to reduce the code duplication in Controller and Agent code (still not applied everywhere)