### PR TITLE
build/cli/makefile: fix run target

### DIFF
--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -105,10 +105,10 @@ clean:
 
 #
 # Run target: "make -f Makefile.Linux run" to execute the application
-#             You will need to add $(VARIABLE_NAME) for any command line parameters 
+#             You will need to add $(RUNARGS) for any command line parameters
 #             that you defined earlier in this file.
 # 
 
 run:
-	./$(PROGRAM) 
+	LD_LIBRARY_PATH=$(INSTALLDIR)/lib $(PROGRAM) $(RUNARGS)
 


### PR DESCRIPTION
Fixes the `run` target in the CLI `makefile`

Fixes both path to target binary `em_onewifi_cli` and also includes `LD_LIBRARY_PATH` as the dependent `libemcli.so` library is placed in `install/lib/` as opposed to `/usr/*/lib/` or the system `$PATH`

Also adds `RUNARGS` to be able to pass arguments to the CLI binary.

Example invocation if running on a pi:
```sh
make run RUNARGS=rpi
```