### PR TITLE
Fix some SIGSEGV discovered when using the TUI

### DIFF
--- a/src/cli/main.go
+++ b/src/cli/main.go
@@ -636,6 +636,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "c":
 			netNode := C.get_node_from_node_ctr(m.displayedNetNode, C.uint(m.tree.Cursor()))
+			if netNode == nil {
+				break
+			}
 			if uint(C.can_collapse_node(netNode)) == 1 {
 
 				tmp := m.displayedNetNode
@@ -652,6 +655,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "e":
 			netNode := C.get_node_from_node_ctr(m.displayedNetNode, C.uint(m.tree.Cursor()))
+			if netNode == nil {
+				break
+			}
 			if (uint(C.can_expand_node(netNode))) == 1 {
 
 				tmp := m.displayedNetNode

--- a/src/em/em_net_node.cpp
+++ b/src/em/em_net_node.cpp
@@ -524,6 +524,8 @@ em_network_node_t *em_net_node_t::get_node_from_node_ctr(em_network_node_t *tree
     bool found_match = false;
     unsigned int i;
 
+    if (tree == NULL) return NULL;
+
     if (tree->display_info.node_ctr == node_display_ctr) {
         return tree;
     } else {


### PR DESCRIPTION
If the currently selected tree in the TUI is NULL, then editing it via `'e'` or `'c'` will segfault, as the tree being passed to `get_node_from_node_ctr` will be `NULL` and immediately dereferenced. This is fixed in a9dc6afeabfc2bff14b2b0faae3ddd05f8a9e519

We also need to check the validity of the tree node returned by `get_node_from_node_ctr` when called from the Go TUI. This is fixed in 84b83864d3d440c9f98fb9945fc2ebf84f31f946. Now, instead of crashing, attempting to edit an empty tree in the TUI just does nothing.