### PR TITLE
RDKBACCL-583 : Fixing seg fault issue in Ctrl

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -52,7 +52,7 @@ public:
     dm_network_t    m_network;
     dm_device_t     m_device;
     dm_ieee_1905_security_t m_ieee_1905_security;
-    unsigned int	m_num_net_ssids;
+    unsigned int	m_num_net_ssids = 0;
     dm_network_ssid_t   m_network_ssid[EM_MAX_NET_SSIDS];
     unsigned int    m_num_radios;
     dm_radio_t  m_radio[EM_MAX_BANDS];


### PR DESCRIPTION
Reason for change:  Observing seg fault issue  when we execute "wifi reset" command in New Cli GUI.
Attached errors below,
../../../git/inc/dm_easy_mesh.h:166:91: runtime error: index 5 out of bounds for type 'dm_network_ssid_t [4]' ================================================================= ==35317==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x007f99aff100 at pc 0x007f9fc31f08 bp 0x007fee4e68f0 sp 0x007fee4e6968 READ of size 1 at 0x007f99aff100 thread T0
    #0 0x7f9fc31f04 in __interceptor_strncmp ../../../../../../../../work-shared/gcc-11.3.0-r0/gcc-11.3.0/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:497
    #1 0x558d99978c in dm_easy_mesh_list_t::put_network_ssid(char const*, dm_network_ssid_t const*) ../../../git/src/ctrl/../../src/dm/dm_easy_mesh_list.cpp:824
    #2 0x558d9b266c in dm_network_ssid_list_t::set_config(db_client_t&, dm_network_ssid_t&, void*) ../../../git/src/ctrl/../../src/dm/dm_network_ssid_list.cpp:118
    #3 0x558d925ff4 in dm_easy_mesh_ctrl_t::update_tables(dm_easy_mesh_t*) ../../../git/src/ctrl/../../src/ctrl/dm_easy_mesh_ctrl.cpp:1771
    #4 0x558d9f508c in em_orch_ctrl_t::pre_process_orch_op(em_cmd_t*) ../../../git/src/ctrl/../../src/orch/em_orch_ctrl.cpp:284
    #5 0x558d9e9ce4 in em_orch_t::submit_commands(em_cmd_t**, unsigned int) ../../../git/src/ctrl/../../src/orch/em_orch.cpp:49
    #6 0x558d93f4a8 in em_ctrl_t::handle_reset(em_bus_event_t*) ../../../git/src/ctrl/../../src/ctrl/em_ctrl.cpp:310
    #7 0x558d86673c in em_mgr_t::start() ../../../git/src/ctrl/../../src/em/em_mgr.cpp:415
    #8 0x558d84bc38 in main ../../../git/src/ctrl/../../src/ctrl/em_ctrl.cpp:780
    #9 0x7f9e8fb22c  (/lib/libc.so.6+0x2b22c)
    #10 0x7f9e8fb308 in __libc_start_main (/lib/libc.so.6+0x2b308)
    #11 0x558d84ddac in _start (/usr/ccsp/EasyMesh/onewifi_em_ctrl+0x32ddac)
Test Procedure: Not observed this crash
Risks: Low