### PR TITLE
Add `default` case to `switch` where missing to reduce compilation noise

### DIFF
--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -236,6 +236,9 @@ int dm_easy_mesh_t::commit_config(em_cmd_t  *cmd)
                         m_num_radios++;
 
                         break;
+                    default:
+                        printf("%s:%d: unhandled case %d\n", __func__, __LINE__, cmd->get_orch_op());
+                        break;
                 }
             }
             break;

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -2019,6 +2019,9 @@ void em_channel_t::process_state()
                 set_state(em_state_agent_configured);
             }
 			break;
+        default:
+            printf("%s:%d: unhandled case %d\n", __func__, __LINE__, get_state());
+            break;
 
     }
 }
@@ -2043,6 +2046,9 @@ void em_channel_t::process_ctrl_state()
 		case em_state_ctrl_channel_scan_pending:
 			send_channel_scan_request_msg();
             break; 
+        default:
+            printf("%s:%d: unhandled case %d\n", __func__, __LINE__, get_state());
+            break;
     }
 }
 

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -3807,6 +3807,9 @@ void em_configuration_t::process_ctrl_state()
         case em_state_ctrl_ap_mld_config_pending:
             send_ap_mld_config_req_msg();
             break;
+        default:
+            printf("%s:%d: unhandled case %d\n", __func__, __LINE__, get_state());
+            break;
     }
 
 }

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -1008,6 +1008,9 @@ void em_metrics_t::process_ctrl_state()
         case em_state_ctrl_sta_link_metrics_pending:
             send_all_associated_sta_link_metrics_msg();
             break;
+        default:
+            printf("%s:%d: unhandled case %d\n", __func__, __LINE__, get_state());
+            break;
     }
 }
 


### PR DESCRIPTION
`-Wswitch` is enabled and spews out walls of text when compiling which makes for finding errors quite difficult during dev.

See:
![image](https://github.com/user-attachments/assets/e398a480-d912-4805-952e-f857644e0317)
![image](https://github.com/user-attachments/assets/f77f83b5-73c4-4fb9-b50c-e98592f5e391)
![image](https://github.com/user-attachments/assets/e0f7cdf7-614f-481e-88cc-9c8ac124d3ce)
![image](https://github.com/user-attachments/assets/37fcc1db-8a02-4206-a173-942f26d95ae8)
![image](https://github.com/user-attachments/assets/f9c9785a-81be-43a4-9af9-8548658af15a)

If this is done intentionally (no default case), feel free to close this PR.