### PR TITLE
Draft: WIP: GAS frame handling for DPP

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -42,6 +42,7 @@ extern "C"
 
 #define DPP_OUI_TYPE 0x1A
 #define DPP_MAX_EN_CHANNELS 4
+static const uint8_t WFA_DPP_OUI[3] = {0x50, 0x6F, 0x9A};
 
 // As defined by EasyConnect 8.2.1 Table 35
 typedef enum  {

--- a/inc/ec_session.h
+++ b/inc/ec_session.h
@@ -28,6 +28,9 @@
 #include <functional>
 #include <vector>
 
+// forward decl
+struct ieee80211_mgmt;
+
 #define EC_FRAME_BASE_SIZE (offsetof(ec_frame_t, attributes))
 
 class ec_session_t {
@@ -161,6 +164,20 @@ public:
      * @return int 0 if successful, -1 otherwise
      */
     int handle_recv_ec_action_frame(ec_frame_t* frame, size_t len);
+
+    /**
+     * @brief Handles a GAS DPP frame.
+     *
+     * @param frame The full GAS frame
+     * @param frame_len The length in bytes of `frame`
+     * @return 0 if OK, -1 otherwise
+     */
+    int handle_recv_gas_action_frame(ieee80211_mgmt *frame, size_t frame_len);
+
+    int handle_gas_initial_req(ieee80211_mgmt *, size_t);
+    int handle_gas_initial_resp(ieee80211_mgmt *, size_t);
+    int handle_gas_comeback_req(ieee80211_mgmt *, size_t);
+    int handle_gas_comeback_resp(ieee80211_mgmt *, size_t);
 
     /**
      * @brief Construct an EC session

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -51,6 +51,7 @@ class em_agent_t : public em_mgr_t {
     void handle_action_frame(struct ieee80211_mgmt *frame);
     void handle_public_action_frame(struct ieee80211_mgmt *frame);
     void handle_vendor_public_action_frame(struct ieee80211_mgmt *frame);
+    void handle_gas_public_action_frame(em_bus_event_t *evt);
     void handle_btm_request_action_frame(em_bus_event_t *evt);
     void handle_recv_wfa_action_frame(em_bus_event_t *evt);
     void handle_btm_response_action_frame(em_bus_event_t *evt);

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2569,7 +2569,8 @@ typedef enum {
     em_bus_event_type_get_mld_config,
     em_bus_event_type_mld_reconfig,
     em_bus_event_type_beacon_report,
-    em_bus_event_type_recv_wfa_action_frame
+    em_bus_event_type_recv_wfa_action_frame,
+    em_bus_even_type_recv_gas_action_frame
 } em_bus_event_type_t;
 
 typedef struct {

--- a/src/em/prov/easyconnect/ec_session.cpp
+++ b/src/em/prov/easyconnect/ec_session.cpp
@@ -23,6 +23,7 @@
 #include "ec_util.h"
 #include "em.h"
 #include "aes_siv.h"
+#include "ieee80211.h"
 
 std::pair<uint8_t*, uint16_t> ec_session_t::create_auth_request()
 {
@@ -507,6 +508,62 @@ int ec_session_t::handle_recv_ec_action_frame(ec_frame_t *frame, size_t len)
             break;
     }
     return 0;
+}
+
+int ec_session_t::handle_gas_initial_req(ieee80211_mgmt *frame, size_t frame_len)
+{
+    // TODO: implement from Configurator POV
+    (void)frame;
+    (void)frame_len;
+    printf("%s:%d: called!\n", __func__, __LINE__);
+    return -1;
+}
+
+int ec_session_t::handle_gas_initial_resp(ieee80211_mgmt *frame, size_t frame_len)
+{
+    // TODO implement from Enrollee POV
+    (void)frame;
+    (void)frame_len;
+    printf("%s:%d: called!\n", __func__, __LINE__);
+    return -1;
+}
+
+int ec_session_t::handle_gas_comeback_req(ieee80211_mgmt *frame, size_t frame_len)
+{
+    // TODO implement from Configurator POV
+    (void)frame;
+    (void)frame_len;
+    printf("%s:%d: called!\n", __func__, __LINE__);
+    return -1;
+}
+
+int ec_session_t::handle_gas_comeback_resp(ieee80211_mgmt *frame, size_t frame_len)
+{
+    // TODO implement from Enrollee POV
+    (void)frame;
+    (void)frame_len;
+    printf("%s:%d: called!\n", __func__, __LINE__);
+    return -1;
+}
+
+int ec_session_t::handle_recv_gas_action_frame(ieee80211_mgmt *frame, size_t frame_len)
+{
+    const auto &action_type = frame->u.action.u.public_action.action;
+    switch (action_type) {
+    case WLAN_PA_GAS_INITIAL_REQ:
+        return handle_gas_initial_req(frame, frame_len);
+    case WLAN_PA_GAS_INITIAL_RESP:
+        return handle_gas_initial_resp(frame, frame_len);
+    case WLAN_PA_GAS_COMEBACK_REQ:
+        return handle_gas_comeback_req(frame, frame_len);
+    case WLAN_PA_GAS_COMEBACK_RESP:
+        return handle_gas_comeback_resp(frame, frame_len);
+    default:
+        printf("%s:%d: unknown GAS frame action type=%d\n", action_type);
+        break;
+    }
+    // not handled -- unknown type
+    return -1;
 }
 
 ec_session_t::ec_session_t(std::function<int(em_dpp_chirp_value_t*, size_t)> send_chirp_notification,


### PR DESCRIPTION
@bcarlson-dev I'd like to get your take on this before going further. What's your take on my current impl of forwarding GAS frames to `ec_session` to handle? I imagine we could add another `std::function<(...)>`, like `send_gas_response`, that's bound to an implementation in `em_provisioning`, but a bit unsure on how to handle states and such.

For example, in `ec_session::handle_gas_initial_req`, we'll need to know if we're the Configurator or Enrollee, if Enrollee just ignore, and if Configurator, read relevant information and craft a reply and send it back to Enrollee via aforementioned hypothetical `send_gas_response` function pointer, but TMK that's all encapsulated within `em_provisioning` itself. Also unsure on the best way to proceed for _sending_ GAS frames, from the Enrollee's PoV. Thoughts?