### PR TITLE
RDKBACCL-620 : Observing seg fault in ctrl

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -44,7 +44,7 @@ class em_t;
 
 class dm_easy_mesh_t {
 public:
-    webconfig_subdoc_data_t m_wifi_data;
+    webconfig_subdoc_data_t *m_wifi_data = NULL;
 	unsigned int m_num_preferences;
 	em_interface_preference_t	m_preference[EM_MAX_PLATFORMS];
 	unsigned int	m_num_interfaces;

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -1811,8 +1811,13 @@ rdk_wifi_radio_t *dm_easy_mesh_t::get_radio_data(em_interface_t *interface)
 	unsigned int i;
 	rdk_wifi_radio_t *radio;
 
-	for (i = 0; i < m_wifi_data.u.decoded.num_radios; i++) {
-		radio = &m_wifi_data.u.decoded.radios[i];
+	if ( m_wifi_data == NULL )
+        {
+              printf("%s:%d: m_wifi_data is not initialized \n",__func__,__LINE__);
+              return NULL;
+        }
+	for (i = 0; i < m_wifi_data->u.decoded.num_radios; i++) {
+		radio = &m_wifi_data->u.decoded.radios[i];
 
 		if (strncmp(radio->name, interface->name, strlen(radio->name)) == 0) {
 			return radio;


### PR DESCRIPTION
Reason for change:  observed seg fault in ctrl when we do wifi reset in cli.
Attached below errors,
================================================================= ==227897==ERROR: AddressSanitizer: stack-overflow on address 0x007fe834db70 (pc 0x00556abbd32c bp 0x007fe86c6ef0 sp 0x007fe834db70 T0)
    #0 0x556abbd32c in em_cmd_t::init(dm_easy_mesh_t*) ../../../git/src/ctrl/../../src/cmd/em_cmd.cpp:188
    #1 0x556abc0f14 in em_cmd_t::em_cmd_t(em_cmd_type_t, em_cmd_params_t, dm_easy_mesh_t&) ../../../git/src/ctrl/../../src/cmd/em_cmd.cpp:807
    #2 0x556abc2920 in em_cmd_t::clone_for_next() ../../../git/src/ctrl/../../src/cmd/em_cmd.cpp:227
    #3 0x556abd914c in dm_easy_mesh_ctrl_t::analyze_reset(em_bus_event_t*, em_cmd_t**) ../../../git/src/ctrl/../../src/ctrl/dm_easy_mesh_ctrl.cpp:284
    #4 0x556ac09914 in em_ctrl_t::handle_reset(em_bus_event_t*) ../../../git/src/ctrl/../../src/ctrl/em_ctrl.cpp:308
    #5 0x556ab30780 in em_mgr_t::start() ../../../git/src/ctrl/../../src/em/em_mgr.cpp:415
    #6 0x556ab15b78 in main ../../../git/src/ctrl/../../src/ctrl/em_ctrl.cpp:780
    #7 0x7faeb3b22c  (/lib/libc.so.6+0x2b22c)
    #8 0x7faeb3b308 in __libc_start_main (/lib/libc.so.6+0x2b308)
    #9 0x556ab17cec in _start (/usr/ccsp/EasyMesh/onewifi_em_ctrl+0x32dcec)SUMMARY: AddressSanitizer: stack-overflow ../../../git/src/ctrl/../../src/cmd/em_cmd.cpp:188 in em_cmd_t::init(dm_easy_mesh_t*)
Test Procedure: Not observed this crash in ctrl
Risks: Low