### PR TITLE
RDKBACCL-618 : obsering incorrect mac address

### DIFF
--- a/install/bin/Reset.json
+++ b/install/bin/Reset.json
@@ -10,7 +10,9 @@
 					"rpi": "eth"
 				}, {
 					"sim": "ens"
-			}],
+				}, {
+					"bpi": "erouter"
+				}],
 			"List": []
 		},
         "NetworkSSIDList": [{

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -763,7 +763,14 @@ int dm_easy_mesh_t::decode_config_reset(em_subdoc_info_t *subdoc, const char *ke
 				}
 				m_num_preferences++;
 			}
-			
+
+			if ((obj = cJSON_GetObjectItem(preference_obj, "bpi")) != NULL) {
+                                strncpy(m_preference[m_num_preferences].platform, "bpi", strlen("bpi") + 1);
+                                if (strncmp(cJSON_GetStringValue(obj), "erouter", strlen("erouter")) == 0) {
+                                        m_preference[m_num_preferences].media = em_media_type_ieee8023ab;
+                                }
+                                m_num_preferences++;
+                        }
 		}
 	}
 
@@ -1683,7 +1690,7 @@ em_interface_t *dm_easy_mesh_t::get_prioritized_interface(const char *platform)
 
 	if (m_preference[i].media == em_media_type_ieee8023ab) {
 		for (i = 0; i < m_num_interfaces; i++) {
-			if ((strstr(m_interfaces[i].name, "eth") != NULL) || (strstr(m_interfaces[i].name, "ens") != NULL)) {
+			if ((strstr(m_interfaces[i].name, "eth") != NULL) || (strstr(m_interfaces[i].name, "ens") != NULL) || (strstr(m_interfaces[i].name, "erouter") != NULL)) {
 				found_match = true;
 				break;
 			}
@@ -1728,6 +1735,8 @@ int dm_easy_mesh_t::get_interfaces_list(em_interface_t interfaces[], unsigned in
             strncpy(interfaces[num].name, tmp->ifa_name, strlen(tmp->ifa_name) + 1);
 			if (strstr(tmp->ifa_name, "eth") != NULL) {
 				interfaces[num].media = em_media_type_ieee8023ab;
+			} else if (strstr(tmp->ifa_name, "erouter") != NULL) {
+                                interfaces[num].media = em_media_type_ieee8023ab;	
 			} else if (strstr(tmp->ifa_name, "ens") != NULL) {
 				interfaces[num].media = em_media_type_ieee8023ab;
 			} else if (strstr(tmp->ifa_name, "wlan") != NULL) {


### PR DESCRIPTION
Reason for change:  Adding bpi support to fetch proper erouter mac address for ctrl
Test Procedure: Able to see proper mac addr in ctrl 
"init_network_topology:1879: Root: 0e:e5:d7:73:c5:e5  added to network topology"
 Risks: Low