### PR TITLE
DPP EasyConnect: Fixed all non-deprecated warnings

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -47,11 +47,14 @@ extern "C"
 #define DPP_GAS_INITIAL_RESP 0x0B
 
 #define APEFMT "%02x,%02x,%02x"
-#define APE2STR(x) x[0], x[1], x[2]
+#define APE2STR(x) static_cast<unsigned int>((x)[0]), static_cast<unsigned int>((x)[1]), static_cast<unsigned int>((x)[2])
 #define APEIDFMT "%02x,%02x,%02x,%02x,%02x,%02x,%02x"
-#define APEID2STR(x) x[0], x[1], x[2], x[3], x[4], x[5], x[6]
+#define APEID2STR(x) static_cast<unsigned int>((x)[0]), static_cast<unsigned int>((x)[1]), static_cast<unsigned int>((x)[2]), \
+                     static_cast<unsigned int>((x)[3]), static_cast<unsigned int>((x)[4]), static_cast<unsigned int>((x)[5]), \
+                     static_cast<unsigned int>((x)[6])
 #define MACSTRFMT "%02x:%02x:%02x:%02x:%02x:%02x"
-#define MAC2STR(x) x[0], x[1], x[2], x[3], x[4], x[5]
+#define MAC2STR(x) static_cast<unsigned int>((x)[0]), static_cast<unsigned int>((x)[1]), static_cast<unsigned int>((x)[2]), \
+                   static_cast<unsigned int>((x)[3]), static_cast<unsigned int>((x)[4]), static_cast<unsigned int>((x)[5])
 
 // EasyConnect 8.3.2
 static const uint8_t DPP_GAS_CONFIG_REQ_APE[3] = {0x6c, 0x08, 0x00};
@@ -255,13 +258,24 @@ typedef struct {
  * @param ... Additional arguments for the format string
  */
 #define ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
-    if(x == NULL) { \
-        fprintf(stderr, errMsg, ## __VA_ARGS__); \
-        if (ptr1) free(ptr1); \
-        if (ptr2) free(ptr2); \
-        if (ptr3) free(ptr3); \
-        return ret; \
-    }
+    do { \
+        if(x == NULL) { \
+            fprintf(stderr, errMsg, ## __VA_ARGS__); \
+            void *_tmp1 = (ptr1); \
+            void *_tmp2 = (ptr2); \
+            void *_tmp3 = (ptr3); \
+            if (_tmp1) { \
+                free(_tmp1); \
+            } \
+            if (_tmp2) { \
+                free(_tmp2); \
+            } \
+            if (_tmp3) { \
+                free(_tmp3); \
+            } \
+            return ret; \
+        } \
+    } while (0)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 2 pointers and returns a value
@@ -295,8 +309,8 @@ typedef struct {
     const EVP_MD *hash_fcn;
     BIGNUM *prime;
     BN_CTX *bn_ctx;
-    int digest_len;
-    int nonce_len;
+    uint16_t digest_len;
+    uint16_t nonce_len;
     int nid;
 
 
@@ -392,7 +406,7 @@ typedef struct {
 
     // Baseline static, DPP URI data
     unsigned int version;
-    int  ec_freqs[DPP_MAX_EN_CHANNELS];
+    unsigned int  ec_freqs[DPP_MAX_EN_CHANNELS];
     mac_address_t   mac_addr;
     ec_session_type_t   type;
 

--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -67,7 +67,9 @@ public:
      * @param bool Whether to enable or disable the inclusion of CCE IEs in the beacon and probe response frames
      * @return bool true if successful, false otherwise
      */
-    toggle_cce_func m_toggle_cce;
+    toggle_cce_func m_toggle_cce = {
+        [](bool enable) -> bool { return false; }
+    };
 
     /**
      * @brief Start the EC configurator onboarding
@@ -162,9 +164,11 @@ public:
     ec_configurator_t& operator=(const ec_configurator_t&) = delete;
 
 protected:
-    ec_persistent_context_t m_p_ctx;
+    ec_persistent_context_t m_p_ctx = {};
 
-    ec_data_t m_boot_data;
+    ec_data_t m_boot_data = {};
+
+    std::string m_mac_addr;
 
     send_chirp_func m_send_chirp_notification;
 
@@ -172,10 +176,8 @@ protected:
 
     send_act_frame_func m_send_action_frame;
 
-    std::string m_mac_addr;
-
     // The connections to the Enrollees/Agents
-    std::map<std::string, ec_connection_context_t> m_connections;
+    std::map<std::string, ec_connection_context_t> m_connections = {};
 
     inline ec_connection_context_t* get_conn_ctx(const std::string& mac) {
         if (m_connections.find(mac) == m_connections.end()) {

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -50,11 +50,11 @@ private:
         .reserved = 0
     }};
 
-    std::pair<uint8_t*, uint16_t> create_auth_request(std::string enrollee_mac);
-    std::pair<uint8_t*, uint16_t> create_recfg_auth_request();
-    std::pair<uint8_t*, uint16_t> create_auth_confirm(std::string enrollee_mac, ec_status_code_t dpp_status, uint8_t* i_auth_tag);
-    std::pair<uint8_t*, uint16_t> create_recfg_auth_confirm(std::string enrollee_mac, ec_status_code_t dpp_status);
-    std::pair<uint8_t*, uint16_t> create_config_response();
+    std::pair<uint8_t*, size_t> create_auth_request(std::string enrollee_mac);
+    std::pair<uint8_t*, size_t> create_recfg_auth_request();
+    std::pair<uint8_t*, size_t> create_auth_confirm(std::string enrollee_mac, ec_status_code_t dpp_status, uint8_t* i_auth_tag);
+    std::pair<uint8_t*, size_t> create_recfg_auth_confirm(std::string enrollee_mac, ec_status_code_t dpp_status);
+    std::pair<uint8_t*, size_t> create_config_response();
 };
 
 #endif // EC_CTRL_CONFIGURATOR_H

--- a/inc/ec_enrollee.h
+++ b/inc/ec_enrollee.h
@@ -70,6 +70,17 @@ public:
 
 private:
 
+    std::string m_mac_addr;
+
+    /**
+     * @brief Send an action frame. Optional to implement.
+     * 
+     * @param dest_mac The destination MAC address
+     * @param action_frame The action frame to send
+     * @param action_frame_len The length of the action frame
+     * @param frequency The frequency to send the frame on (0 for current frequency)
+     * @return true if successful, false otherwise
+     */
     send_act_frame_func m_send_action_frame;
 
     // TODO: Send GAS Frame
@@ -80,21 +91,21 @@ private:
         .reserved = 0
     }};
 
-    std::pair<uint8_t*, uint16_t> create_presence_announcement();
-    std::pair<uint8_t*, uint16_t> create_recfg_presence_announcement();
-    std::pair<uint8_t*, uint16_t> create_auth_response(ec_status_code_t dpp_status, uint8_t init_proto_version);
-    std::pair<uint8_t*, uint16_t> create_recfg_auth_response(ec_status_code_t dpp_status);
-    std::pair<uint8_t*, uint16_t> create_config_request();
-    std::pair<uint8_t*, uint16_t> create_config_result(); 
+    std::pair<uint8_t*, size_t> create_presence_announcement();
+    std::pair<uint8_t*, size_t> create_recfg_presence_announcement();
+    std::pair<uint8_t*, size_t> create_auth_response(ec_status_code_t dpp_status, uint8_t init_proto_version);
+    std::pair<uint8_t*, size_t> create_recfg_auth_response(ec_status_code_t dpp_status);
+    std::pair<uint8_t*, size_t> create_config_request();
+    std::pair<uint8_t*, size_t> create_config_result(); 
 
-    ec_persistent_context_t m_p_ctx;
+    ec_persistent_context_t m_p_ctx = {};
 
     // Randomized and cleared at the end of the authentication/configuration process
-    ec_ephemeral_context_t m_eph_ctx;
+    ec_ephemeral_context_t m_eph_ctx = {};
 
-    ec_data_t m_boot_data;
+    ec_data_t m_boot_data = {};
 
-    std::string m_mac_addr;
+
 
 
 };

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -130,16 +130,17 @@ public:
 
 
 private:
-    std::unique_ptr<ec_configurator_t> m_configurator;
-    std::unique_ptr<ec_enrollee_t> m_enrollee;
     bool m_is_controller;
-
+    
     // Used to store the function pointers to instantiate objects again
     send_chirp_func m_stored_chirp_fn;
     send_encap_dpp_func m_stored_encap_dpp_fn;
     send_act_frame_func m_stored_action_frame_fn;
-    toggle_cce_func m_stored_toggle_cce_fn;
     std::string m_stored_mac_addr;
+    
+    std::unique_ptr<ec_configurator_t> m_configurator;
+    std::unique_ptr<ec_enrollee_t> m_enrollee;
+    toggle_cce_func m_stored_toggle_cce_fn;
 };
 
 #endif // EC_MANAGER_H

--- a/inc/ec_util.h
+++ b/inc/ec_util.h
@@ -69,7 +69,7 @@ public:
      * @param id The attribute ID
      * @return ec_attribute_t* The attribute if found, NULL otherwise
      */
-    static ec_attribute_t *get_attrib(uint8_t *buff, uint16_t len, ec_attrib_id_t id);
+    static ec_attribute_t *get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id);
 
     /**
      * @brief Add an attribute to the buffer, (re)allocating the buffer if necessary
@@ -83,7 +83,7 @@ public:
      * 
      * @warning The buffer must be freed by the caller
      */
-    static uint8_t *add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t id, uint16_t len, uint8_t *data);
+    static uint8_t *add_attrib(uint8_t *buff, size_t* buff_len, ec_attrib_id_t id, uint16_t len, uint8_t *data);
 
     /**
      * @brief Add an attribute to the buffer, (re)allocating the buffer if necessary
@@ -95,8 +95,8 @@ public:
      * 
      * @warning The buffer must be freed by the caller
      */
-    static inline uint8_t* add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t id, uint8_t val) {
-        return add_attrib(buff, buff_len, id, sizeof(uint8_t), const_cast<uint8_t *> (&val));
+    static inline uint8_t* add_attrib(uint8_t *buff, size_t* buff_len, ec_attrib_id_t id, uint8_t val) {
+        return add_attrib(buff, buff_len, id, sizeof(uint8_t), const_cast<uint8_t*>(&val));
     }
 
     /**
@@ -109,8 +109,8 @@ public:
      * 
      * @warning The buffer must be freed by the caller
      */
-    static inline uint8_t* add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t id, uint16_t val) {
-        return add_attrib(buff, buff_len, id, sizeof(uint16_t), reinterpret_cast<uint8_t *> (&val));
+    static inline uint8_t* add_attrib(uint8_t *buff, size_t* buff_len, ec_attrib_id_t id, uint16_t val) {
+        return add_attrib(buff, buff_len, id, sizeof(uint16_t), const_cast<uint8_t*>(reinterpret_cast<uint8_t*>(&val)));
     }
 
     /**
@@ -127,7 +127,7 @@ public:
             printf("%s:%d unable to allocate memory\n", __func__, __LINE__);
             return NULL;
         }
-        ec_frame_t    *frame = reinterpret_cast<ec_frame_t *> (buff);
+        ec_frame_t    *frame = reinterpret_cast<ec_frame_t*>(buff);
         init_frame(frame);
         frame->frame_type = type;
         return frame;
@@ -143,7 +143,7 @@ public:
      * 
      * @warning The frame must be freed by the caller
      */
-    static ec_frame_t* copy_attrs_to_frame(ec_frame_t *frame, uint8_t *attrs, uint16_t attrs_len);
+    static ec_frame_t* copy_attrs_to_frame(ec_frame_t *frame, uint8_t *attrs, size_t attrs_len);
 
     /**
      * @brief Validate an EC frame based on the WFA parameters
@@ -189,7 +189,7 @@ public:
      * 
      * @warning The `encap_frame` must be freed by the caller
      */
-    static bool parse_encap_dpp_tlv(em_encap_dpp_t* encap_tlv, uint16_t encap_tlv_len, mac_addr_t *dest_mac, uint8_t *frame_type, uint8_t** encap_frame, uint8_t *encap_frame_len);
+    static bool parse_encap_dpp_tlv(em_encap_dpp_t* encap_tlv, uint16_t encap_tlv_len, mac_addr_t *dest_mac, uint8_t *frame_type, uint8_t** encap_frame, uint16_t *encap_frame_len);
 
     /**
      * @brief Creates and allocates an Encap DPP TLV
@@ -201,7 +201,7 @@ public:
      * @param encap_frame_len [in] The length of the encapsulated frame
      * @return em_encap_dpp_t* The heap allocated Encap DPP TLV, NULL if failed 
      */
-    static std::pair<em_encap_dpp_t*, size_t> create_encap_dpp_tlv(bool dpp_frame_indicator, mac_addr_t dest_mac, ec_frame_type_t frame_type, uint8_t *encap_frame, uint8_t encap_frame_len);
+    static std::pair<em_encap_dpp_t*, uint16_t> create_encap_dpp_tlv(bool dpp_frame_indicator, mac_addr_t dest_mac, ec_frame_type_t frame_type, uint8_t *encap_frame, size_t encap_frame_len);
 
 
     /**
@@ -221,7 +221,7 @@ public:
      * @param data_len The length of the data in the attribute
      * @return size_t The size of the attribute
      */
-    static inline size_t get_ec_attr_size(size_t data_len) {
+    static inline size_t get_ec_attr_size(uint16_t data_len) {
         return offsetof(ec_attribute_t, data) + data_len;
     };
 
@@ -249,7 +249,7 @@ public:
      * @note The `create_wrap_attribs` function will allocate heap-memory which is freed inside the `add_wrapped_data_attr` function.
      *     **The caller should not use statically allocated memory in `create_wrap_attribs` or free the memory returned by `create_wrap_attribs`.**
      */
-    static uint8_t* add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, uint16_t* non_wrapped_len, 
+    static uint8_t* add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, size_t* non_wrapped_len, 
         bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs);
 
 
@@ -265,7 +265,7 @@ public:
      * 
      * @warning The caller is responsible for freeing the memory returned by this function
      */
-    static std::pair<uint8_t*, size_t> unwrap_wrapped_attrib(ec_attribute_t* wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key);
+    static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(ec_attribute_t* wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key);
 
     /**
      * @brief Convert a hash to a hex string

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -210,7 +210,7 @@ extern "C"
 #define 	EM_PARSE_ERR_NO_CHANGE	EM_PARSE_NO_ERR	- 4	
 
 #ifndef ETH_ALEN
-#define ETH_ALEN (6UL)
+#define ETH_ALEN 6
 #endif // ETH_ALEN
 
 typedef char em_interface_name_t[32];

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -189,17 +189,17 @@ public:
             return em_crypto_t::platform_compute_shared_secret(secret, secret_len, remote_pub, pub_len, local_priv, static_cast<uint8_t>(priv_len));
     }
 
-    int compute_digest(unsigned char num, unsigned char **addr, unsigned int *len, unsigned char *digest) {
+    int compute_digest(unsigned char num, unsigned char **addr, size_t *len, unsigned char *digest) {
         return em_crypto_t::platform_SHA256(num, addr, len, digest); 
     }
 
     int compute_kdk(unsigned char *key, unsigned short keylen, 
         unsigned char num_elem, unsigned char **addr, 
-        unsigned int *len, unsigned char *hmac) {
+        size_t *len, unsigned char *hmac) {
             return em_crypto_t::platform_hmac_SHA256(key, keylen, num_elem, addr, len, hmac);
     }
 
-    int derive_key(unsigned char *key, unsigned char *label_prefix, unsigned int label_prefix_len, 
+    int derive_key(unsigned char *key, unsigned char *label_prefix, size_t label_prefix_len, 
         char *label, unsigned char *res, unsigned int res_len) {
             return em_crypto_t::wps_key_derivation_function(key, label_prefix, label_prefix_len, label, res, res_len);
     }

--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -91,7 +91,7 @@ public:
      * @note The hmac buffer must be pre-allocated with sufficient space for the output
      *       (32 bytes for SHA-256)
      */
-    static uint8_t platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *hmac);
+    static uint8_t platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, size_t *len, uint8_t *hmac);
 
     /**
     * @brief Convenience wrapper to compute HMAC-SHA256 hash for multiple input elements
@@ -105,7 +105,7 @@ public:
     *
     * @return 1 on success, 0 on failure
     */
-    inline static uint8_t platform_hmac_SHA256(uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *hmac){
+    inline static uint8_t platform_hmac_SHA256(uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, size_t *len, uint8_t *hmac){
         return platform_hmac_hash(EVP_sha256(), key, keylen, num_elem, addr, len, hmac);
     }
     
@@ -120,7 +120,7 @@ public:
     *
     * @return 1 on success, 0 on failure
     */
-    static uint8_t platform_hash(const EVP_MD * hashing_algo, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest);
+    static uint8_t platform_hash(const EVP_MD * hashing_algo, uint8_t num_elem, uint8_t **addr, size_t *len, uint8_t *digest);
 
     /**
     * @brief Convenience wrapper to compute SHA-256 hash for multiple input elements
@@ -132,7 +132,7 @@ public:
     * 
     * @return 1 on success, 0 on failure
     */
-    inline static uint8_t platform_SHA256(uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest){
+    inline static uint8_t platform_SHA256(uint8_t num_elem, uint8_t **addr, size_t *len, uint8_t *digest){
         return platform_hash(EVP_sha256(), num_elem, addr, len, digest);
     }
     
@@ -157,7 +157,7 @@ public:
     * 
     * @return 1 on success, 0 on HMAC failure
     */
-    static uint8_t wps_key_derivation_function(uint8_t *key, uint8_t *label_prefix, uint32_t label_prefix_len, char *label, uint8_t *res, uint32_t res_len);
+    static uint8_t wps_key_derivation_function(uint8_t *key, uint8_t *label_prefix, size_t label_prefix_len, char *label, uint8_t *res, uint32_t res_len);
 
     /**
     * @brief Decrypts data using OpenSSL cipher in place

--- a/inc/util.h
+++ b/inc/util.h
@@ -92,7 +92,7 @@ int em_chan_to_freq(uint8_t op_class, uint8_t chan, const std::string& country="
  * @param region Two-letter region code (e.g., "US", "EU", "JP", "CN"). Empty string for global ranges only.
  * @return Returns pair of {operating_class, channel}. 
  */
-std::pair<uint8_t, uint8_t> em_freq_to_chan(int frequency, const std::string& region="");
+std::pair<uint8_t, uint8_t> em_freq_to_chan(unsigned int frequency, const std::string& region="");
 
 } // namespace util
 

--- a/src/dm/dm_dpp.cpp
+++ b/src/dm/dm_dpp.cpp
@@ -111,7 +111,7 @@ int dm_dpp_t::decode(const cJSON *obj, void *parent_id, void* user_info)
                 uint8_t channel = std::stoi(pair.substr(slash_pos + 1));
                 int freq = util::em_chan_to_freq(op_class, channel, std::string(country_code));
                 if (freq > 0) {
-                    m_dpp_info.ec_freqs[pair_idx] = freq;
+                    m_dpp_info.ec_freqs[pair_idx] = static_cast<unsigned int>(freq);
                     pair_idx++;
                 } else {
                     printf("%s:%d: Failed to convert channel to frequency (op class: %d, channel: %d)\n", __func__, __LINE__, op_class, channel);

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2362,7 +2362,7 @@ int em_configuration_t::compute_keys(unsigned char *remote_pub, unsigned short p
     unsigned char *secret;
     unsigned short secret_len;
     unsigned char  *addr[3];
-    unsigned int length[3];
+    size_t length[3];
     unsigned char  dhkey[SHA256_MAC_LEN];
     unsigned char  kdk  [SHA256_MAC_LEN];
     unsigned char keys[WPS_AUTHKEY_LEN + WPS_KEYWRAPKEY_LEN + WPS_EMSK_LEN];
@@ -2378,7 +2378,7 @@ int em_configuration_t::compute_keys(unsigned char *remote_pub, unsigned short p
     //util::print_hex_dump(secret_len, secret);
 
     addr[0] = secret;
-    length[0] = secret_len;
+    length[0] = (size_t) secret_len;
 
     if (compute_digest(1, addr, length, dhkey) != 1) {
         free(secret);
@@ -3252,13 +3252,13 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 int em_configuration_t::create_authenticator(unsigned char *buff)
 {
     unsigned char *addr[2];
-    unsigned int length[2];
+    size_t length[2];
     unsigned char hash[SHA256_MAC_LEN];
 
     addr[0] = m_m1_msg;
     addr[1] = m_m2_msg;
-    length[0] = static_cast<unsigned int> (m_m1_length);
-    length[1] = static_cast<unsigned int> (m_m2_length);
+    length[0] = m_m1_length;
+    length[1] = m_m2_length;
 
     //printf( "%s:%d m1 addr:%s::length:%d,\n", __func__, __LINE__, addr[0], length[0]);
     //util::print_hex_dump(length[0], addr[0]);

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -238,7 +238,7 @@ bail:
     return -1;
 }
 
-uint8_t em_crypto_t::platform_hash(const EVP_MD * hashing_algo, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *digest)
+uint8_t em_crypto_t::platform_hash(const EVP_MD * hashing_algo, uint8_t num_elem, uint8_t **addr, size_t *len, uint8_t *digest)
 {  
     EVP_MD_CTX   *ctx;
     unsigned int  mac_len;
@@ -283,7 +283,7 @@ uint8_t em_crypto_t::platform_hash(const EVP_MD * hashing_algo, uint8_t num_elem
 
     return res;
 }
-uint8_t em_crypto_t::platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, uint32_t *len, uint8_t *hmac)
+uint8_t em_crypto_t::platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *key, uint32_t keylen, uint8_t num_elem, uint8_t **addr, size_t *len, uint8_t *hmac)
 {
     //em_util_info_print(EM_CONF," %s:%d\n",__func__,__LINE__);
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -382,13 +382,13 @@ void em_crypto_t:: append_u32_net(const uint32_t *memory_pointer, uint8_t **pack
 #endif
 }
 
-uint8_t em_crypto_t:: wps_key_derivation_function(uint8_t *key, uint8_t *label_prefix, uint32_t label_prefix_len, char *label, uint8_t *res, uint32_t res_len)
+uint8_t em_crypto_t:: wps_key_derivation_function(uint8_t *key, uint8_t *label_prefix, size_t label_prefix_len, char *label, uint8_t *res, uint32_t res_len)
 {
     uint8_t i_buf[4];
     uint8_t key_bits[4];
 
     uint8_t   *addr[4];
-    uint32_t   len[4];
+    size_t   len[4];
 
     uint32_t i, iter;
 

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -15,7 +15,10 @@ ec_manager_t::ec_manager_t(
     m_stored_chirp_fn(send_chirp),
     m_stored_encap_dpp_fn(send_encap_dpp),
     m_stored_action_frame_fn(send_action_frame),
-    m_stored_mac_addr(mac_addr) {
+    m_stored_mac_addr(mac_addr),
+    m_configurator(nullptr),
+    m_enrollee(nullptr),
+    m_stored_toggle_cce_fn(nullptr) {
     
     if (m_is_controller) {
         m_configurator = std::unique_ptr<ec_configurator_t>(
@@ -63,9 +66,9 @@ bool ec_manager_t::handle_recv_gas_pub_action_frame(ec_gas_frame_base_t *frame, 
     printf("%s:%d: Got a GAS frame with %02x action!\n", __func__, __LINE__, frame->action);
     switch (static_cast<dpp_gas_action_type_t>(frame->action)) {
         case dpp_gas_initial_req:
-            return m_configurator->handle_cfg_request(reinterpret_cast<uint8_t *> (frame), static_cast<unsigned> (len), source_addr);
+            return m_configurator->handle_cfg_request(reinterpret_cast<uint8_t*>(frame), static_cast<unsigned int>(len), source_addr);
         case dpp_gas_initial_resp:
-            return m_enrollee->handle_config_response(reinterpret_cast<uint8_t *> (frame), static_cast<unsigned> (len), source_addr);
+            return m_enrollee->handle_config_response(reinterpret_cast<uint8_t*>(frame), static_cast<unsigned int>(len), source_addr);
         case dpp_gas_comeback_req:
         case dpp_gas_comeback_resp:
         default:

--- a/src/em/prov/easyconnect/ec_pa_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_pa_configurator.cpp
@@ -15,7 +15,7 @@ bool ec_pa_configurator_t::handle_presence_announcement(ec_frame_t *frame, size_
 bool ec_pa_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN])
 {
     // Encapsulate 802.11 frame into 1905 Encap DPP TLV and send to controller
-    auto [encap_dpp_tlv, encap_dpp_size] = ec_util::create_encap_dpp_tlv(false, src_mac, ec_frame_type_auth_rsp, (uint8_t*)frame, len);
+    auto [encap_dpp_tlv, encap_dpp_size] = ec_util::create_encap_dpp_tlv(false, src_mac, ec_frame_type_auth_rsp, reinterpret_cast<uint8_t*>(frame), len);
     ASSERT_NOT_NULL(encap_dpp_tlv, false, "%s:%d Failed to create Encap DPP TLV\n", __func__, __LINE__);
 
     // Only create and forward an Encap TLV
@@ -28,12 +28,12 @@ bool ec_pa_configurator_t::handle_cfg_request(uint8_t *buff, unsigned int len, u
 {
     printf("%s:%d: Rx'd a DPP Configuration Request from " MACSTRFMT "\n", __func__, __LINE__, MAC2STR(sa));
     uint8_t *p = buff;
-    ec_gas_frame_base_t *gas_frame_base = reinterpret_cast<ec_gas_frame_base_t *> (p);
+    ec_gas_frame_base_t *gas_frame_base = reinterpret_cast<ec_gas_frame_base_t *>(p);
     p += sizeof(ec_gas_frame_base_t);
-    ec_gas_initial_request_frame_t *gas_initial_request = reinterpret_cast<ec_gas_initial_request_frame_t *> (p);
+    ec_gas_initial_request_frame_t *gas_initial_request = reinterpret_cast<ec_gas_initial_request_frame_t *>(p);
     printf(
         "%s:%d: Got a DPP config request! category=%02x action=%02x dialog_token=%02x ape=" APEFMT
-        " ape_id=" APEIDFMT " query_len=%d\n",
+        " ape_id=" APEIDFMT " query_len=%u\n",
         __func__, __LINE__, gas_frame_base->action, gas_frame_base->category,
         gas_frame_base->dialog_token, APE2STR(gas_initial_request->ape),
         APEID2STR(gas_initial_request->ape_id), gas_initial_request->query_len);
@@ -62,9 +62,9 @@ bool ec_pa_configurator_t::process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv
     mac_addr_t dest_mac = {0};
     uint8_t frame_type = 0;
     uint8_t* encap_frame = NULL;
-    uint8_t encap_frame_len = 0;
+    uint16_t encap_frame_len = 0;
 
-    if (ec_util::parse_encap_dpp_tlv(encap_tlv, encap_tlv_len, &dest_mac, &frame_type, &encap_frame, &encap_frame_len) == false) {
+    if (!ec_util::parse_encap_dpp_tlv(encap_tlv, encap_tlv_len, &dest_mac, &frame_type, &encap_frame, &encap_frame_len)) {
         printf("%s:%d: Failed to parse Encap DPP TLV\n", __func__, __LINE__);
         return false;
     }
@@ -73,7 +73,7 @@ bool ec_pa_configurator_t::process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv
     uint8_t chirp_hash[255] = {0}; // Max hash length to avoid dynamic allocation
     uint8_t chirp_hash_len = 0;
 
-    ec_frame_type_t ec_frame_type = static_cast<ec_frame_type_t> (frame_type);
+    ec_frame_type_t ec_frame_type = static_cast<ec_frame_type_t>(frame_type);
 
     bool did_finish = false;
 
@@ -83,7 +83,7 @@ bool ec_pa_configurator_t::process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv
                 printf("%s:%d: Chirp TLV is empty\n", __func__, __LINE__);
                 break;
             }
-            if (ec_util::parse_dpp_chirp_tlv(chirp_tlv, chirp_tlv_len, &chirp_mac, reinterpret_cast<uint8_t**> (&chirp_hash), &chirp_hash_len) == false) {
+            if (!ec_util::parse_dpp_chirp_tlv(chirp_tlv, chirp_tlv_len, &chirp_mac, reinterpret_cast<uint8_t**>(&chirp_hash), &chirp_hash_len)) {
                 printf("%s:%d: Failed to parse DPP Chirp TLV\n", __func__, __LINE__);
                 break;
             }

--- a/src/em/prov/easyconnect/ec_util.cpp
+++ b/src/em/prov/easyconnect/ec_util.cpp
@@ -19,10 +19,10 @@ void ec_util::init_frame(ec_frame_t *frame)
     frame->crypto_suite = 0x01; // Section 3.3 (Currently only 0x01 is defined)
 }
 
-ec_attribute_t *ec_util::get_attrib(uint8_t *buff, uint16_t len, ec_attrib_id_t id)
+ec_attribute_t *ec_util::get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id)
 {
-    unsigned int total_len = 0;
-    ec_attribute_t *attrib = (ec_attribute_t *)buff;
+    size_t total_len = 0;
+    ec_attribute_t *attrib = reinterpret_cast<ec_attribute_t *>(buff);
 
     while (total_len < len) {
         if (attrib->attr_id == id) {
@@ -30,14 +30,14 @@ ec_attribute_t *ec_util::get_attrib(uint8_t *buff, uint16_t len, ec_attrib_id_t 
         }
 
         total_len += (get_ec_attr_size(attrib->length));
-        attrib = (ec_attribute_t *)((uint8_t*)attrib + get_ec_attr_size(attrib->length));
+        attrib = reinterpret_cast<ec_attribute_t *>(reinterpret_cast<uint8_t*>(attrib) + get_ec_attr_size(attrib->length));
     }
 
     return NULL;
 }
 
 
-uint8_t* ec_util::add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t id, uint16_t len, uint8_t *data)
+uint8_t* ec_util::add_attrib(uint8_t *buff, size_t* buff_len, ec_attrib_id_t id, uint16_t len, uint8_t *data)
 {
     if (data == NULL || len == 0) {
         fprintf(stderr, "Invalid input\n");
@@ -46,11 +46,11 @@ uint8_t* ec_util::add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t i
 
     
     // Add extra space for the new attribute
-    uint16_t new_len = *buff_len + get_ec_attr_size(len);
+    size_t new_len = *buff_len + get_ec_attr_size(len);
     // Original start pointer to use for realloc
     uint8_t* base_ptr = NULL;
     if (buff != NULL) base_ptr = buff - *buff_len;
-    if ((base_ptr = (uint8_t*)realloc(base_ptr, new_len)) == NULL) {
+    if ((base_ptr = reinterpret_cast<uint8_t*>(realloc(base_ptr, new_len))) == NULL) {
         fprintf(stderr, "Failed to realloc\n");
         return NULL;
     }
@@ -59,7 +59,7 @@ uint8_t* ec_util::add_attrib(uint8_t *buff, uint16_t* buff_len, ec_attrib_id_t i
     uint8_t* tmp = base_ptr + *buff_len;
 
     memset(tmp, 0, get_ec_attr_size(len));
-    ec_attribute_t *attr = (ec_attribute_t *)tmp;
+    ec_attribute_t *attr = reinterpret_cast<ec_attribute_t *>(tmp);
     // EC attribute id and length are in host byte order according to the spec (8.1)
     attr->attr_id = id;
     attr->length = len;
@@ -75,7 +75,8 @@ uint16_t ec_util::freq_to_channel_attr(unsigned int freq)
     auto op_chan = util::em_freq_to_chan(freq);
 
     auto [op_class, channel] = op_chan;
-    return ((channel << 8) | (0x00ff & op_class));
+    
+    return static_cast<uint16_t>((channel << 8) | (0x00ff & op_class));
 }
 
 bool ec_util::validate_frame(const ec_frame_t *frame)
@@ -95,7 +96,7 @@ bool ec_util::validate_frame(const ec_frame_t *frame)
 
 
 
-uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, uint16_t* non_wrapped_len, bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs)
+uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, size_t* non_wrapped_len, bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs)
 {
     siv_ctx ctx;
 
@@ -121,7 +122,7 @@ uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attrib
 
     // Encapsulate the attributes in a wrapped data attribute
     uint16_t wrapped_attrib_len = wrapped_len + AES_BLOCK_SIZE;
-    ec_attribute_t *wrapped_attrib = (ec_attribute_t *)calloc(sizeof(ec_attribute_t) + wrapped_attrib_len, 1); 
+    ec_attribute_t *wrapped_attrib = static_cast<ec_attribute_t *>(calloc(sizeof(ec_attribute_t) + wrapped_attrib_len, 1));
     wrapped_attrib->attr_id = ec_attrib_id_wrapped_data;
     wrapped_attrib->length = wrapped_attrib_len;
     memset(wrapped_attrib->data, 0, wrapped_attrib_len);
@@ -144,7 +145,7 @@ uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attrib
     }
 
     // Add the wrapped data attribute to the frame
-    uint8_t* ret_frame_attribs = ec_util::add_attrib(frame_attribs, non_wrapped_len, ec_attrib_id_wrapped_data, wrapped_attrib_len, (uint8_t *)wrapped_attrib);
+    uint8_t* ret_frame_attribs = ec_util::add_attrib(frame_attribs, non_wrapped_len, ec_attrib_id_wrapped_data, wrapped_attrib_len, reinterpret_cast<uint8_t *>(wrapped_attrib));
 
 
     free(wrap_attribs);
@@ -152,7 +153,7 @@ uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attrib
     return ret_frame_attribs;
 }
 
-std::pair<uint8_t*, size_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t* wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key)
+std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t* wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key)
 {
     siv_ctx ctx;
 
@@ -173,29 +174,29 @@ std::pair<uint8_t*, size_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t* wrapp
     // }
 
     uint8_t* wrapped_ciphertext = wrapped_attrib->data + AES_BLOCK_SIZE;
-    size_t wrapped_len = wrapped_attrib->length - AES_BLOCK_SIZE;
+    uint16_t wrapped_len = wrapped_attrib->length - AES_BLOCK_SIZE;
 
-    uint8_t* unwrap_attribs = (uint8_t*)calloc(wrapped_len, 1);
+    uint8_t* unwrap_attribs = new uint8_t[wrapped_len]();
     int result = -1;
     if (uses_aad) {
         if (frame == NULL) {
             printf("%s:%d: AAD input is NULL, AAD decryption failed!\n", __func__, __LINE__);
-            return std::pair<uint8_t*, size_t>(NULL, 0);
+            return std::pair<uint8_t*, uint16_t>(NULL, 0);
         }
         result = siv_decrypt(&ctx, wrapped_ciphertext, unwrap_attribs, wrapped_len, wrapped_attrib->data, 2,
             frame, sizeof(ec_frame_t),
-            frame->attributes, ((uint8_t*)wrapped_attrib) - frame->attributes); // Non-wrapped attributes
+            frame->attributes, (reinterpret_cast<uint8_t*>(wrapped_attrib) - frame->attributes)); // Non-wrapped attributes
     } else {
         result = siv_decrypt(&ctx, wrapped_ciphertext, unwrap_attribs, wrapped_len, wrapped_attrib->data, 0);
     }
 
     if (result < 0) {
         printf("%s:%d: Failed to decrypt and authenticate wrapped data\n", __func__, __LINE__);
-        free(unwrap_attribs);
-        return std::pair<uint8_t*, size_t>(NULL, 0);
+        delete[] unwrap_attribs;
+        return std::pair<uint8_t*, uint16_t>(NULL, 0);
     }
 
-    return std::pair<uint8_t*, size_t>(unwrap_attribs, wrapped_len);
+    return std::pair<uint8_t*, uint16_t>(unwrap_attribs, wrapped_len);
 }
 
 bool ec_util::parse_dpp_chirp_tlv(em_dpp_chirp_value_t* chirp_tlv, uint16_t chirp_tlv_len, mac_addr_t *mac, uint8_t **hash, uint8_t *hash_len)
@@ -205,16 +206,16 @@ bool ec_util::parse_dpp_chirp_tlv(em_dpp_chirp_value_t* chirp_tlv, uint16_t chir
         return false;
     }
 
-    uint16_t data_len = chirp_tlv_len - sizeof(em_dpp_chirp_value_t);
+    uint16_t data_len = chirp_tlv_len - static_cast<uint16_t>(sizeof(em_dpp_chirp_value_t));
     // Parse TLV
     bool mac_addr_present = chirp_tlv->mac_present;
     bool hash_valid = chirp_tlv->hash_valid;
 
     uint8_t *data_ptr = chirp_tlv->data;
-    if (mac_addr_present && data_len >= sizeof(mac_addr_t)) {
-        memcpy(*mac, data_ptr, sizeof(mac_addr_t));
-        data_ptr += sizeof(mac_addr_t);
-        data_len -= sizeof(mac_addr_t);
+    if (mac_addr_present && data_len >= ETH_ALEN) {
+        memcpy(*mac, data_ptr, ETH_ALEN);
+        data_ptr += ETH_ALEN;
+        data_len -= ETH_ALEN;
     }
 
     if (!hash_valid || data_len <= 0) {
@@ -226,21 +227,21 @@ bool ec_util::parse_dpp_chirp_tlv(em_dpp_chirp_value_t* chirp_tlv, uint16_t chir
     data_ptr++;
     if (data_len < *hash_len) {
         fprintf(stderr, "Invalid chirp tlv\n");
-        return NULL;
+        return false;
     }
     memcpy(*hash, data_ptr, *hash_len);
 
     return true;
 }
 
-bool ec_util::parse_encap_dpp_tlv(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, mac_addr_t *dest_mac, uint8_t *frame_type, uint8_t **encap_frame, uint8_t *encap_frame_len)
+bool ec_util::parse_encap_dpp_tlv(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, mac_addr_t *dest_mac, uint8_t *frame_type, uint8_t **encap_frame, uint16_t *encap_frame_len)
 {
     if (encap_tlv == NULL || encap_tlv_len == 0) {
         fprintf(stderr, "Invalid input\n");
         return false;
     }
 
-    uint16_t data_len = encap_tlv_len - sizeof(em_encap_dpp_t);
+    uint16_t data_len = encap_tlv_len - static_cast<uint16_t>(sizeof(em_encap_dpp_t));
     // Parse TLV
     bool mac_addr_present = encap_tlv->enrollee_mac_addr_present;
 
@@ -249,7 +250,7 @@ bool ec_util::parse_encap_dpp_tlv(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_
     if (mac_addr_present && data_len >= sizeof(mac_addr_t)) {
         memcpy(*dest_mac, data_ptr, sizeof(mac_addr_t));
         data_ptr += sizeof(mac_addr_t);
-        data_len -= sizeof(mac_addr_t);
+        data_len = static_cast<uint16_t>(data_len - sizeof(mac_addr_t));
     } else {
         memset(*dest_mac, 0, sizeof(mac_addr_t));
     }
@@ -264,7 +265,7 @@ bool ec_util::parse_encap_dpp_tlv(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_
     data_ptr++;
 
     // Get frame length
-    *encap_frame_len = htons(*((uint16_t *)data_ptr));
+    *encap_frame_len = htons(*reinterpret_cast<uint16_t *>(data_ptr));
     data_ptr += sizeof(uint16_t);
 
     if (data_len < *encap_frame_len) {
@@ -273,22 +274,26 @@ bool ec_util::parse_encap_dpp_tlv(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_
     }
 
     // Copy frame
-    *encap_frame = (uint8_t *)calloc(*encap_frame_len, 1);
+    *encap_frame = new uint8_t[*encap_frame_len]();
     ASSERT_NOT_NULL(*encap_frame, false, "Failed to allocate memory\n");
     memcpy(*encap_frame, data_ptr, *encap_frame_len);
 
     return true;
 }
 
-std::pair<em_encap_dpp_t*, size_t> ec_util::create_encap_dpp_tlv(bool dpp_frame_indicator, mac_addr_t dest_mac, ec_frame_type_t frame_type, uint8_t *encap_frame, uint8_t encap_frame_len)
+std::pair<em_encap_dpp_t*, uint16_t> ec_util::create_encap_dpp_tlv(bool dpp_frame_indicator, mac_addr_t dest_mac, ec_frame_type_t frame_type, uint8_t *encap_frame, size_t encap_frame_len)
 {
     size_t data_size = sizeof(em_encap_dpp_t) + sizeof(uint8_t) + sizeof(uint16_t) + encap_frame_len;
     if (dest_mac != NULL) {
         data_size += sizeof(mac_addr_t);
     }
     em_encap_dpp_t *encap_tlv = NULL;
+    if (encap_frame_len > UINT16_MAX) {
+        fprintf(stderr, "Encap frame too large\n");
+        return {};
+    }
 
-    if ((encap_tlv = (em_encap_dpp_t *)calloc(data_size, 1)) == NULL){
+    if ((encap_tlv = static_cast<em_encap_dpp_t *>(calloc(data_size, 1))) == NULL){
         fprintf(stderr, "Failed to allocate memory\n");
         return {};
     }
@@ -304,18 +309,18 @@ std::pair<em_encap_dpp_t*, size_t> ec_util::create_encap_dpp_tlv(bool dpp_frame_
     *data_ptr = frame_type;
     data_ptr++;
 
-    *((uint16_t *)data_ptr) = htons(encap_frame_len);
+    *reinterpret_cast<uint16_t *>(data_ptr) = htons(static_cast<uint16_t>(encap_frame_len));
     data_ptr += sizeof(uint16_t);
 
     memcpy(data_ptr, encap_frame, encap_frame_len);
 
-    return std::pair<em_encap_dpp_t*, size_t>(encap_tlv, data_size);
+    return std::pair<em_encap_dpp_t*, uint16_t>(encap_tlv, static_cast<uint16_t>(data_size));
 }
 
-ec_frame_t *ec_util::copy_attrs_to_frame(ec_frame_t *frame, uint8_t *attrs, uint16_t attrs_len)
+ec_frame_t *ec_util::copy_attrs_to_frame(ec_frame_t *frame, uint8_t *attrs, size_t attrs_len)
 {
-    uint16_t new_len = EC_FRAME_BASE_SIZE + attrs_len;
-    ec_frame_t* new_frame = (ec_frame_t *) realloc((uint8_t*)frame, new_len);
+    size_t new_len = EC_FRAME_BASE_SIZE + attrs_len;
+    ec_frame_t* new_frame = reinterpret_cast<ec_frame_t *>(realloc(reinterpret_cast<uint8_t*>(frame), new_len));
     if (new_frame == NULL) {
         printf("%s:%d unable to realloc memory\n", __func__, __LINE__);
         return NULL; 

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -345,7 +345,7 @@ int util::em_chan_to_freq(uint8_t op_class, uint8_t channel, const std::string& 
     return -1;
 }
 
-std::pair<uint8_t, uint8_t> util::em_freq_to_chan(int frequency, const std::string& region) {
+std::pair<uint8_t, uint8_t> util::em_freq_to_chan(unsigned int frequency, const std::string& region) {
     std::pair<uint8_t, uint8_t> global_result;
     
     for (const auto& range : frequency_ranges) {


### PR DESCRIPTION
- Added C++ style casts to appropriate places
- Used `new` and `delete` when allocated `uint8_t` arrays to reduce casts
- Reformatted some args to reduce casts
- Changed some size typing to reflect spec requirements:
    * attribute max size can be `uint16_t`
    * many attributes can be added into a `size_t` buffer (could be fragmented)