### PR TITLE
`em_agent_t` creates an EasymeshCfg.json if one does not exist.

### DIFF
--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -28,6 +28,8 @@
 #include "em_simulator.h"
 #include "bus.h"
 
+#include <string>
+
 class em_cmd_agent_t;
 
 class em_agent_t : public em_mgr_t {
@@ -76,6 +78,16 @@ public:
      * @return true if successful, false otherwise
      */
     bool send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, unsigned int frequency=0) override;
+
+    /**
+     * @brief Try to create a default EasymeshCfg.json file if one does not exist.
+     * 
+     * A default EasymeshCfg.json file only contains the `AL_MAC_ADDR` and `Colocated_mode` fields.
+     * 
+     * @param interface The interface to use for filling the `AL_MAC_ADDR` field
+     * @return true if successful or if the file already exists, false otherwise
+     */
+    bool try_create_default_em_cfg(std::string interface);
 
     int data_model_init(const char *data_model_path);
     bool is_data_model_initialized() { return true; }


### PR DESCRIPTION
- Allows OneWifi to run in non-colocated, non-onboarded instance. 
- Generated when `--interface=` is present in calling of `onewifi_em_agent`
    * Example: `sudo ./onewifi_em_agent --interface=wlan0` or `sudo ./onewifi_em_agent --interface=eth0`
- Additionally added occasional output when bus refuses to connect.

**NOTE:** This currently exposes a segfault present in OneWifi that is due to the `Colocated : 0` state with a wireless al mac interface:

To reproduce, run (in appropriate directories):
```bash
$ sudo mv /nvram/EasymeshCfg.json /nvram/EasymeshCfg-bak.json 
$ sudo ./onewifi_em_agent --interface=wlan0
# Interrrupt (Ctrl + C)
$ sudo ./OneWifi -c
# SEGFAULT
```

The `eth0` generated `EasymeshCfg.json` file will work as expected:

```bash
$ sudo rm -f /nvram/EasymeshCfg.json
$ sudo ./onewifi_em_agent --interface=eth0
# Interrrupt (Ctrl + C)
$ sudo ./OneWifi -c
# CONTINUES AND SUCCEEDS
```

GDB Output of OneWifi SEFAULT with `wlan0` `EasymeshCfg.json`
```gdb
Thread 1 "OneWifi" received signal SIGSEGV, Segmentation fault.
0x00000055556470fc in configure_vap_name_basedon_colocated_mode (ifname=0x7fffffefa8 "wlan0", colocated_mode=0)
    at /home/bcarlson/rdkb_easymesh/OneWifi/../rdk-wifi-hal/src/wifi_hal_nl80211_utils.c:4177
4177	                strcpy((char *)interface_index_map[index].vap_name, "mesh_sta_");
(gdb) bt
#0  0x00000055556470fc in configure_vap_name_basedon_colocated_mode (ifname=0x7fffffefa8 "wlan0", colocated_mode=0)
    at /home/bcarlson/rdkb_easymesh/OneWifi/../rdk-wifi-hal/src/wifi_hal_nl80211_utils.c:4177
#1  0x000000555560d3c0 in wifi_hal_getHalCapability (hal=0x55558149af <g_wifi_mgr+38039>)
    at /home/bcarlson/rdkb_easymesh/OneWifi/../rdk-wifi-hal/src/wifi_hal.c:266
#2  0x00000055555b1744 in init_wifi_hal () at /home/bcarlson/rdkb_easymesh/OneWifi//source/core/wifi_mgr.c:105
#3  0x00000055555b1de8 in init_wifimgr () at /home/bcarlson/rdkb_easymesh/OneWifi//source/core/wifi_mgr.c:232
#4  0x00000055555b2218 in main (argc=2, argv=0x7ffffff448)
    at /home/bcarlson/rdkb_easymesh/OneWifi//source/core/wifi_mgr.c:337
(gdb) l
4172	    wifi_interface_info_t *interface = NULL;
4173	    for (index = 0; index < get_sizeof_interfaces_index_map(); index++) {
4174	        if (strncmp(interface_index_map[index].interface_name, ifname, strlen(ifname)) == 0) {
4175	            switch (colocated_mode) {
4176	            case 0:
4177	                strcpy((char *)interface_index_map[index].vap_name, "mesh_sta_");
4178	                concat_band_to_vap_name((char *)interface_index_map[index].vap_name,
4179	                    interface_index_map[index].rdk_radio_index);
4180	                break;
4181	            case 1:
(gdb) l -
4162	        break;
4163	    default:
4164	        wifi_hal_error_print("%s:%d: Invalid rdk_radio_index:%d for vap_name:%s\n", __func__,
4165	            __LINE__, rdk_radio_index, vap_name);
4166	    }
4167	}
4168
4169	int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode)
4170	{
4171	    unsigned int index = 0;
(gdb) quit

```
 