### PR TITLE
EC 6.4.2 DPP Configuration Object creation + send from Enrollee, GAS frame helpers

### DIFF
--- a/inc/cjson_util.h
+++ b/inc/cjson_util.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2025 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ #ifndef __CJSON_UTIL__
+ #define __CJSON_UTIL__ 
+
+ #include "cjson/cJSON.h"
+
+ namespace cjson_utils {
+
+    /**
+     * @brief Get the size, in bytes, of a cJSON JSON string.
+     * 
+     * @param json The JSON instance to get the size of.
+     * @return size_t The size / length of the JSON instance, in bytes.
+     */
+    static inline size_t get_cjson_blob_size(const cJSON *const json) {
+        size_t len = 0UL;
+        if (json != NULL) {
+            char *s = cJSON_Print(json);
+            if (s) {
+                len = strlen(s);
+                free(s);
+            }
+        }
+        return len;
+    }
+ }
+
+
+ #endif // __CJSON_UTIL__
+

--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -222,20 +222,22 @@ typedef struct {
 } __attribute__((packed)) ec_gas_frame_base_t;
 
 typedef struct {
+    ec_gas_frame_base_t base;
     uint8_t ape[3];
     uint8_t ape_id[7];
     uint16_t query_len;
     uint8_t query[];
-} ec_gas_initial_request_frame_t;
+} __attribute__((packed)) ec_gas_initial_request_frame_t;
 
 typedef struct {
+    ec_gas_frame_base_t base;
     uint16_t status_code;
     uint16_t gas_comeback_delay;
     uint8_t ape[3];
     uint8_t ape_id[7];
     uint16_t resp_len;
     uint8_t resp[];
-} ec_gas_initial_response_frame_t;
+} __attribute__((packed)) ec_gas_initial_response_frame_t;
 
 // Used to avoid many many if-not-null checks
 #define ASSERT_FALSE(x, ret, errMsg, ...) \

--- a/src/em/prov/easyconnect/ec_util.cpp
+++ b/src/em/prov/easyconnect/ec_util.cpp
@@ -95,9 +95,8 @@ bool ec_util::validate_frame(const ec_frame_t *frame)
 }
 
 
-
-uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, size_t* non_wrapped_len, bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs)
-{
+uint8_t *ec_util::add_wrapped_data_attr(uint8_t *frame, size_t frame_len, uint8_t* frame_attribs, size_t* non_wrapped_len, 
+bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs) {
     siv_ctx ctx;
 
     // Initialize AES-SIV context
@@ -138,7 +137,7 @@ uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attrib
             return NULL;
         }
         siv_encrypt(&ctx, wrap_attribs, &wrapped_attrib->data[AES_BLOCK_SIZE], wrapped_len, wrapped_attrib->data, 2,
-            frame, sizeof(ec_frame_t),
+            frame, frame_len,
             frame_attribs, *non_wrapped_len);
     } else {
         siv_encrypt(&ctx, wrap_attribs, &wrapped_attrib->data[AES_BLOCK_SIZE], wrapped_len, wrapped_attrib->data, 0);
@@ -151,6 +150,12 @@ uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attrib
     free(wrap_attribs);
 
     return ret_frame_attribs;
+
+}
+
+uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, size_t* non_wrapped_len, bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs)
+{
+    return add_wrapped_data_attr(reinterpret_cast<uint8_t*>(frame), sizeof(ec_frame_t), frame_attribs, non_wrapped_len, use_aad, key, create_wrap_attribs);
 }
 
 std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t* wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key)
@@ -319,16 +324,20 @@ std::pair<em_encap_dpp_t*, uint16_t> ec_util::create_encap_dpp_tlv(bool dpp_fram
 
 ec_frame_t *ec_util::copy_attrs_to_frame(ec_frame_t *frame, uint8_t *attrs, size_t attrs_len)
 {
-    size_t new_len = EC_FRAME_BASE_SIZE + attrs_len;
-    ec_frame_t* new_frame = reinterpret_cast<ec_frame_t *>(realloc(reinterpret_cast<uint8_t*>(frame), new_len));
-    if (new_frame == NULL) {
-        printf("%s:%d unable to realloc memory\n", __func__, __LINE__);
-        return NULL; 
+    return reinterpret_cast<ec_frame_t*>(copy_attrs_to_frame(
+        reinterpret_cast<uint8_t*>(frame), sizeof(ec_frame_t), attrs, attrs_len
+    ));
+}
+
+uint8_t *ec_util::copy_attrs_to_frame(uint8_t *frame, size_t frame_base_size, uint8_t *attrs, size_t attrs_len) {
+    size_t new_len = frame_base_size + attrs_len;
+    uint8_t *new_frame = reinterpret_cast<uint8_t *>(realloc(frame, new_len));
+    if (new_frame == nullptr) {
+        printf("%s:%d: unable to realloc\n", __func__, __LINE__);
+        return nullptr;
     }
-    memcpy(new_frame->attributes, attrs, attrs_len);
-
+    memcpy(new_frame + frame_base_size, attrs, attrs_len);
     return new_frame;
-
 }
 
 std::string ec_util::hash_to_hex_string(const uint8_t *hash, size_t hash_len) {


### PR DESCRIPTION
Enrollee only ATM

@bcarlson-dev This needs to be rebased onto `main` but putting up as draft to hopefully discuss what we ought to do for Configuration Request Object creation (see: `4.4 DPP Configuration Request Object` in EasyConnect and `Table 5. DPP Configuration Request object` in EasyMesh), since we need fairly in-depth radio configuration information which `ec_enrollee.h` obviously doesn't have. I was thinking either a bound std::function to _some_ `em_t` which can just return a cJSON object potentially, or maybe a callback bound to some OneWifi call that gets radio info? Unsure what the "right" approach would be and I'd appreciate your thoughts