### PR TITLE
Adds the ability to add/remove vendor IEs via EasyMesh and abstracts webconfig south-bound refresh. 

### DIFF
--- a/inc/dm_bss.h
+++ b/inc/dm_bss.h
@@ -20,6 +20,7 @@
 #define DM_BSS_H
 
 #include "em_base.h"
+#include "ieee80211.h"
 
 class dm_bss_t {
 public:
@@ -36,6 +37,21 @@ public:
 
 	bool match_criteria(char *criteria);
 	static int parse_bss_id_from_key(const char *key, em_bss_id_t *id);
+
+    /**
+     * @brief Add a vendor specific IE to the BSS
+     * 
+     * @param vs_ie Vendor specific IE to add
+     * @return true if the IE was added successfully, false if out of bounds
+     */
+    bool add_vendor_ie(struct ieee80211_vs_ie *vs_ie);
+
+    /**
+     * @brief Remove a vendor specific IE from the BSS. If the IE is not present, this function will return without error.
+     * 
+     * @param vs_ie Vendor specific IE to remove
+     */
+    void remove_vendor_ie(struct ieee80211_vs_ie *vs_ie);
 
     dm_bss_t(em_bss_info_t *bss);
     dm_bss_t(const dm_bss_t& bss);

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -296,6 +296,18 @@ public:
     em_t *get_em() { return m_em; }
     void clone_hash_maps(dm_easy_mesh_t& obj);
 
+    static inline webconfig_subdoc_type_t get_subdoc_vap_type_for_freq(em_freq_band_t band) {
+        if (band == em_freq_band_24) return webconfig_subdoc_type_vap_24G;
+        if (band == em_freq_band_5) return webconfig_subdoc_type_vap_5G;
+        return webconfig_subdoc_type_vap_6G;
+    }
+
+    static inline webconfig_subdoc_type_t get_subdoc_radio_type_for_freq(em_freq_band_t band) {
+        if (band == em_freq_band_24) return webconfig_subdoc_type_radio_24G;
+        if (band == em_freq_band_5) return webconfig_subdoc_type_radio_5G;
+        return webconfig_subdoc_type_radio_6G;
+    }
+
 	void reset();
     int init();
     void deinit();

--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -49,6 +49,21 @@ public:
     int analyze_set_policy(em_bus_event_t *evt, wifi_bus_desc_t *desc, bus_handle_t *bus_hdl);
     int analyze_beacon_report(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 
+    /**
+     * @brief Refresh the OneWifi subdoc with current information + provided data and send to OneWifi
+     * 
+     * @param desc The wifi bus descriptor
+     * @param bus_hdl The bus handle
+     * @param logname The string to use when logging
+     * @param type The subdoc type
+     * @param m2_cfg The m2ctrl radio config (optional/NULLable)
+     * @param policy_config The policy config (optional/NULLable)
+     * @return int 0 if encode fails, -1 if send fails, 1 if both succeed.
+     */
+    int refresh_onewifi_subdoc(wifi_bus_desc_t *desc, bus_handle_t *bus_hdl, const char* logname,
+                               webconfig_subdoc_type_t type, m2ctrl_radioconfig *m2_cfg=NULL, 
+                               em_policy_cfg_params_t *policy_config=NULL);
+
     static webconfig_error_t webconfig_dummy_apply(webconfig_subdoc_t *doc, webconfig_subdoc_data_t *data);
     dm_easy_mesh_agent_t();
     ~dm_easy_mesh_agent_t();  

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2235,6 +2235,11 @@ typedef struct {
     bool    multi_bssid;
     bool    transmitted_bssid;
     em_eht_operations_bss_t eht_ops;
+
+    // Extra vendor information elements for the BSS
+    // @note Don't manually allocate, use the helper functions to add/remove elements 
+    unsigned char vendor_elements[WIFI_AP_MAX_VENDOR_IE_LEN];
+    size_t vendor_elements_len;
 } em_bss_info_t;
 
 typedef struct {

--- a/inc/ieee80211.h
+++ b/inc/ieee80211.h
@@ -1132,6 +1132,15 @@ struct ieee80211_csa_ie {
     uint8_t         csa_count;              /* Channel Switch Count */
 } __attribute__((packed));
 
+struct ieee80211_vs_ie{
+    uint8_t         vs_ie;         /* IEEE80211_ELEMID_VENDOR */
+    uint8_t         vs_len;
+    uint8_t         vs_oui[3];     /* Vendor OUI */
+    uint8_t         vs_type;       /* Vendor Specific type */
+    uint8_t         vs_subtype;    /* Vendor Specific sub-type (required for some devices, can be 0) */
+    uint8_t         payload[0];    /* Vendor Specific Payload */
+} __attribute__((packed));
+
 /*
  * Note the min acceptable CSA count is used to guard against
  * malicious CSA injection in station mode.  Defining this value

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -206,31 +206,14 @@ void dm_easy_mesh_agent_t::translate_onewifi_dml_data (char *str)
 
 int dm_easy_mesh_agent_t::analyze_m2ctrl_configuration(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl)
 {
-    em_event_t bus;
-    webconfig_external_easymesh_t dev_data;
-    webconfig_subdoc_type_t type;
-    webconfig_apply_data_t temp;
-    webconfig_t config;
-    static char *webconfig_easymesh_raw_data_ptr;
-    dm_easy_mesh_agent_t  dm = *this;
-    raw_data_t l_bus_data;
-    unsigned int index = 0, i = 0;
     m2ctrl_radioconfig *radioconfig;
     m2ctrl_radioconfig m2ctrl;
-	em_freq_band_t freq_band;
 	mac_addr_str_t mac_str;
 
     radioconfig = (m2ctrl_radioconfig *)evt->u.raw_buff;
-	freq_band = radioconfig->freq;
-	if (freq_band == em_freq_band_24) {
-		type = webconfig_subdoc_type_vap_24G;
-	} else if (radioconfig->freq == em_freq_band_5) {
-		type = webconfig_subdoc_type_vap_5G;
-	} else {
-		type = webconfig_subdoc_type_vap_6G;
-	}
+
 	m2ctrl.noofbssconfig = radioconfig->noofbssconfig;
-	for (i = 0; i < radioconfig->noofbssconfig; i++) {
+	for (unsigned int i = 0; i < radioconfig->noofbssconfig; i++) {
 		memcpy(m2ctrl.ssid[i], radioconfig->ssid[i], sizeof(m2ctrl.ssid[i]));
 		m2ctrl.authtype[i] = radioconfig->authtype[i];
 		memcpy(m2ctrl.password[i], radioconfig->password[i], sizeof(m2ctrl.password[i]));
@@ -240,39 +223,7 @@ int dm_easy_mesh_agent_t::analyze_m2ctrl_configuration(em_bus_event_t *evt, wifi
 		printf("%s:%d New configuration SSID=%s  passphrase=%s haultype=%d radiomac=%s\n",__func__, __LINE__,m2ctrl.ssid[i], m2ctrl.password[i], m2ctrl.haultype[i],mac_str);
 	}
 
-    webconfig_proto_easymesh_init(&dev_data, &dm, &m2ctrl, NULL, get_num_radios, set_num_radios,
-                                get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
-                                get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-                                get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
-
-    config.initializer = webconfig_initializer_onewifi;
-    config.apply_data =  webconfig_dummy_apply;
-
-    if (webconfig_init(&config) != webconfig_error_none) {
-        printf( "[%s]:%d Init WiFi Web Config  fail\n",__func__,__LINE__);
-        return 0;
-    }
-
-    if ((webconfig_easymesh_encode(&config, &dev_data, type, &webconfig_easymesh_raw_data_ptr )) == webconfig_error_none) {
-        printf("%s:%d Private subdoc encode success %s\n",__func__, __LINE__,webconfig_easymesh_raw_data_ptr);
-    } else {
-        printf("%s:%d Private subdoc encode fail\n",__func__, __LINE__);
-        return 0;
-    }
-    memset(&l_bus_data, 0, sizeof(raw_data_t));
-
-    l_bus_data.data_type    = bus_data_type_string;
-    l_bus_data.raw_data.bytes   = webconfig_easymesh_raw_data_ptr;
-    l_bus_data.raw_data_len = strlen(webconfig_easymesh_raw_data_ptr);
-
-    if (desc->bus_set_fn(bus_hdl, "Device.WiFi.WebConfig.Data.Subdoc.South", &l_bus_data)== 0) {
-        printf("%s:%d private subdoc send successfull\n",__func__, __LINE__);
-    } else {
-        printf("%s:%d private subdoc send fail\n",__func__, __LINE__);
-        return -1;
-    }
-
-    return 1;
+    return refresh_onewifi_subdoc(desc, bus_hdl, "Private", get_subdoc_vap_type_for_freq(radioconfig->freq), &m2ctrl, NULL);
 }    
 
 int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *pcmd[])
@@ -450,16 +401,7 @@ int dm_easy_mesh_agent_t::analyze_channel_pref_query(em_bus_event_t *evt, em_cmd
 
 int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl)
 {
-	em_event_t bus;
-	webconfig_external_easymesh_t dev_data;
-	webconfig_subdoc_type_t type;
-	webconfig_apply_data_t temp;
-	webconfig_t config;
-	static char *webconfig_easymesh_raw_data_ptr;
-	dm_easy_mesh_agent_t  dm = *this;
-	raw_data_t l_bus_data;
 	unsigned int index = 0, i = 0, noofopclass = 0, j = 0, k = 0, l = 0;
-	mac_addr_str_t mac_str;
 	op_class_channel_sel *channel_sel;
 	em_op_class_info_t *dm_op_class;
 	em_tx_power_limit_t	*tx_power_limit;
@@ -472,19 +414,11 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
 	spatial_reuse_req = (em_spatial_reuse_req_t*) &channel_sel->spatial_reuse_req;
     eht_ops = (em_eht_operations_t*) &channel_sel->eht_ops;
 
-	noofopclass = dm.get_num_op_class();
-
-	if (channel_sel->freq_band == em_freq_band_24) {
-		type = webconfig_subdoc_type_radio_24G;
-	} else if (channel_sel->freq_band == em_freq_band_5) {
-		type = webconfig_subdoc_type_radio_5G;
-	} else {
-		type = webconfig_subdoc_type_radio_6G;
-	}
+	noofopclass = this->get_num_op_class();
 
 	//TODO Select the right op class and number and configure
 	for (i = 0; i < noofopclass; i++) {
-		dm_op_class = dm.get_op_class_info(i);
+		dm_op_class = this->get_op_class_info(i);
 		if ((memcmp(&dm_op_class->id.ruid, &channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) && 
 			(dm_op_class->id.type == channel_sel->op_class_info[0].id.type)) {
 			dm_op_class->channel =  channel_sel->op_class_info[0].channels[0];
@@ -493,21 +427,21 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
 		}
 	}
 	if (i == noofopclass) {
-		dm_op_class = dm.get_op_class_info(i);
+		dm_op_class = this->get_op_class_info(i);
 		memcpy(dm_op_class, &channel_sel->op_class_info[i], sizeof(em_op_class_info_t));
 		dm_op_class->channel = channel_sel->op_class_info[0].channels[0];
 		dm_op_class->op_class = channel_sel->op_class_info[0].op_class;
 		noofopclass++;
 	}
-	dm.set_num_op_class(noofopclass);
+	this->set_num_op_class(noofopclass);
     
 	if(tx_power_limit->tx_power_eirp != 0) {
-		dm_radio_t* radio = dm.get_radio(tx_power_limit->ruid);
+		dm_radio_t* radio = this->get_radio(tx_power_limit->ruid);
 		em_radio_info_t* radio_info = radio->get_radio_info();
 		radio_info->transmit_power_limit = tx_power_limit->tx_power_eirp;
 	}
 
-    dm_radio_t* radio = dm.get_radio(spatial_reuse_req->ruid);
+    dm_radio_t* radio = this->get_radio(spatial_reuse_req->ruid);
     em_radio_info_t* radio_info = radio->get_radio_info();
     radio_info->bss_color = spatial_reuse_req->bss_color;
     radio_info->hesiga_spatial_reuse_value15_allowed = spatial_reuse_req->hesiga_spatial_reuse_value15_allowed;
@@ -524,8 +458,8 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     bool found_radio = false;
     bool found_bss = false;
     for (i = 0; i < eht_ops->radios_num; i++) {
-        for (j = 0; j < dm.get_num_radios(); j++) {
-            if (memcmp(eht_ops->radios[i].ruid, dm.m_radio[j].m_radio_info.id.mac, sizeof(mac_address_t)) == 0) {
+        for (j = 0; j < this->get_num_radios(); j++) {
+            if (memcmp(eht_ops->radios[i].ruid, this->m_radio[j].m_radio_info.id.mac, sizeof(mac_address_t)) == 0) {
                 found_radio = true;
                 break;
             }
@@ -537,8 +471,8 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
         found_radio = false;
 
         for(k = 0; k < eht_ops->radios[i].bss_num; k++) {
-            for(l = 0; l < dm.get_num_bss(); l++) {
-                if (memcmp(eht_ops->radios[i].bss, dm.m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t)) == 0) {
+            for(l = 0; l < this->get_num_bss(); l++) {
+                if (memcmp(eht_ops->radios[i].bss, this->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t)) == 0) {
                     found_bss = true;
                     break;
                 }
@@ -548,44 +482,11 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
                 }
             }
             found_bss = false;
-            memcpy(&dm.m_bss[j].get_bss_info()->eht_ops, &eht_ops->radios[i].bss[k], sizeof(em_eht_operations_bss_t));
+            memcpy(&this->m_bss[j].get_bss_info()->eht_ops, &eht_ops->radios[i].bss[k], sizeof(em_eht_operations_bss_t));
         }
     }
 #endif 
-    webconfig_proto_easymesh_init(&dev_data, &dm, NULL, NULL, get_num_radios, set_num_radios,
-            get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
-            get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
-
-	config.initializer = webconfig_initializer_onewifi;
-	config.apply_data =	 webconfig_dummy_apply;
-
-	if (webconfig_init(&config) != webconfig_error_none) {
-		printf( "[%s]:%d Init WiFi Web Config  fail\n",__func__,__LINE__);
-		return 0;
-	}
-
-	if ((webconfig_easymesh_encode(&config, &dev_data, type, &webconfig_easymesh_raw_data_ptr )) == webconfig_error_none) {
-		printf("%s:%d Radio subdoc encode success %s\n",__func__, __LINE__,webconfig_easymesh_raw_data_ptr);
-	} else {
-		printf("%s:%d Radio subdoc encode fail\n",__func__, __LINE__);
-		return 0;
-	}
-	memset(&l_bus_data, 0, sizeof(raw_data_t));
-
-	l_bus_data.data_type	= bus_data_type_string;
-	l_bus_data.raw_data.bytes	= webconfig_easymesh_raw_data_ptr;
-	l_bus_data.raw_data_len = strlen(webconfig_easymesh_raw_data_ptr);
-
-	if (desc->bus_set_fn(bus_hdl, "Device.WiFi.WebConfig.Data.Subdoc.South", &l_bus_data)== 0) {
-		printf("%s:%d Radio subdoc send successfull\n",__func__, __LINE__);
-	}
-	else {
-		printf("%s:%d Radio subdoc send fail\n",__func__, __LINE__);
-		return -1;
-	}
-
-	return 1;
+    return refresh_onewifi_subdoc(desc, bus_hdl, "Radio", get_subdoc_radio_type_for_freq(channel_sel->freq_band));
 }
 
 int dm_easy_mesh_agent_t::analyze_sta_link_metrics(em_bus_event_t *evt, em_cmd_t *pcmd[])
@@ -813,23 +714,22 @@ int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcm
 
 int dm_easy_mesh_agent_t::analyze_set_policy(em_bus_event_t *evt, wifi_bus_desc_t *desc, bus_handle_t *bus_hdl)
 {
-    unsigned int num = 0;
+    em_policy_cfg_params_t *policy_cfg = (em_policy_cfg_params_t *)evt->u.raw_buff;
+
+    return refresh_onewifi_subdoc(desc, bus_hdl, "Policy", webconfig_subdoc_type_em_config, NULL, policy_cfg);
+}
+
+int dm_easy_mesh_agent_t::refresh_onewifi_subdoc(wifi_bus_desc_t *desc, bus_handle_t *bus_hdl, const char* logname, webconfig_subdoc_type_t type, m2ctrl_radioconfig *m2_cfg, em_policy_cfg_params_t *policy_config)
+{
+
     webconfig_external_easymesh_t ext_data;
-    webconfig_subdoc_type_t type;
-    webconfig_t config;
-    static char *webconfig_easymesh_raw_data_ptr;
-    raw_data_t l_bus_data;
-    em_policy_cfg_params_t *policy_cfg;
-
-    policy_cfg = (em_policy_cfg_params_t *)evt->u.raw_buff;
-
-    type = webconfig_subdoc_type_em_config;
-
-    webconfig_proto_easymesh_init(&ext_data, NULL, NULL, policy_cfg, get_num_radios, set_num_radios,
+    
+    webconfig_proto_easymesh_init(&ext_data, this, m2_cfg, policy_config, get_num_radios, set_num_radios,
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
         get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
         get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
 
+    webconfig_t config;
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
 
@@ -838,12 +738,16 @@ int dm_easy_mesh_agent_t::analyze_set_policy(em_bus_event_t *evt, wifi_bus_desc_
         return 0;
     }
 
+    char *webconfig_easymesh_raw_data_ptr;
+
     if ((webconfig_easymesh_encode(&config, &ext_data, type, &webconfig_easymesh_raw_data_ptr )) == webconfig_error_none) {
-        printf("%s:%d Policy subdoc encode success\n", __func__, __LINE__);
+        printf("%s:%d %s subdoc encode success %s\n", __func__, __LINE__, logname, webconfig_easymesh_raw_data_ptr);
     } else {
-        printf("%s:%d Policy subdoc encode failure\n", __func__, __LINE__);
+        printf("%s:%d %s subdoc encode failure\n", __func__, __LINE__, logname);
         return 0;
     }
+
+    raw_data_t l_bus_data;
 
     memset(&l_bus_data, 0, sizeof(raw_data_t));
 
@@ -853,11 +757,11 @@ int dm_easy_mesh_agent_t::analyze_set_policy(em_bus_event_t *evt, wifi_bus_desc_
         l_bus_data.raw_data_len = strlen(webconfig_easymesh_raw_data_ptr);
     }
 
-    if (desc->bus_set_fn(bus_hdl, "Device.WiFi.WebConfig.Data.Subdoc.South", &l_bus_data)== 0) {
-        printf("%s:%d Policy subdoc send successfull\n", __func__, __LINE__);
+    if (desc->bus_set_fn(bus_hdl, WIFI_WEBCONFIG_DOC_DATA_SOUTH, &l_bus_data)== 0) {
+        printf("%s:%d %s subdoc send successfull\n", __func__, __LINE__, logname);
     }
     else {
-        printf("%s:%d Policy subdoc send fail\n", __func__, __LINE__);
+        printf("%s:%d %s subdoc send fail\n", __func__, __LINE__, logname);
         return -1;
     }
 

--- a/src/dm/dm_bss.cpp
+++ b/src/dm/dm_bss.cpp
@@ -154,6 +154,25 @@ int dm_bss_t::decode(const cJSON *obj, void *parent_id)
     if ((tmp = cJSON_GetObjectItem(obj, "TransmittedBSSID")) != NULL) {
         m_bss_info.transmitted_bssid = cJSON_IsTrue(tmp);
     }
+    
+    const char* vendor_ies = NULL;
+    if ((tmp = cJSON_GetObjectItem(obj, "ExtraVendorIEs")) != NULL && (vendor_ies = cJSON_GetStringValue(tmp)) != NULL) {
+        m_bss_info.vendor_elements_len = strlen(vendor_ies);
+
+        unsigned int element;
+        unsigned int i;
+        for (i = 0; i < sizeof(m_bss_info.vendor_elements); i++) {
+            // Make sure we have two characters for a valid hex number.
+            if (2 * i + 2 > m_bss_info.vendor_elements_len)
+                break;
+            if (sscanf(vendor_ies + 2 * i, "%02x", &element) == 1) {
+                m_bss_info.vendor_elements[i] = (unsigned char)element;
+            } else {
+                break;
+            }
+        }
+        m_bss_info.vendor_elements_len = i;
+    }
 
     return 0;
 
@@ -232,6 +251,15 @@ void dm_bss_t::encode(cJSON *obj, bool summary)
     // Add the array to the object
     cJSON_AddItemToObject(obj, "BackhaulAKMsAllowed", backhaul_akmsArray);
 
+    // Add vendor elements (ExtraVendorIEs) as hex string
+    char vendor_ies[2 * m_bss_info.vendor_elements_len + 1] = "";
+    if (m_bss_info.vendor_elements_len > 0) {
+        for (unsigned int i = 0; i < m_bss_info.vendor_elements_len; i++) {
+            snprintf(vendor_ies + 2 * i, 3, "%02x", m_bss_info.vendor_elements[i]);
+        }
+    }
+    cJSON_AddStringToObject(obj, "ExtraVendorIEs", vendor_ies);
+
 }
 
 void dm_bss_t::operator = (const dm_bss_t& obj)
@@ -266,6 +294,8 @@ void dm_bss_t::operator = (const dm_bss_t& obj)
     this->m_bss_info.r2_disallowed = obj.m_bss_info.r2_disallowed;
     this->m_bss_info.multi_bssid = obj.m_bss_info.multi_bssid;
     this->m_bss_info.transmitted_bssid = obj.m_bss_info.transmitted_bssid;
+    memcpy(this->m_bss_info.vendor_elements, obj.m_bss_info.vendor_elements, sizeof(this->m_bss_info.vendor_elements));
+    this->m_bss_info.vendor_elements_len = obj.m_bss_info.vendor_elements_len;
 }
 
 
@@ -302,6 +332,8 @@ bool dm_bss_t::operator == (const dm_bss_t& obj)
     ret += !(this->m_bss_info.r2_disallowed == obj.m_bss_info.r2_disallowed);
     ret += !(this->m_bss_info.multi_bssid == obj.m_bss_info.multi_bssid);
     ret += !(this->m_bss_info.transmitted_bssid == obj.m_bss_info.transmitted_bssid);
+    ret += (memcmp(this->m_bss_info.vendor_elements, obj.m_bss_info.vendor_elements, sizeof(this->m_bss_info.vendor_elements)) != 0);
+    ret += !(this->m_bss_info.vendor_elements_len == obj.m_bss_info.vendor_elements_len);
 
     if (ret > 0)
         return false;
@@ -363,6 +395,67 @@ int dm_bss_t::parse_bss_id_from_key(const char *key, em_bss_id_t *id)
    
 
     return 0;
+}
+
+bool dm_bss_t::add_vendor_ie(struct ieee80211_vs_ie *vs_ie)
+{
+    // Fetch full length from the IE
+    unsigned int vs_ie_len = offsetof(struct ieee80211_vs_ie, vs_oui) + vs_ie->vs_len;
+
+    if ((m_bss_info.vendor_elements_len + vs_ie_len) > sizeof(m_bss_info.vendor_elements)) {
+        printf("%s:%d: Vendor IE length exceeds the maximum limit\n", __func__, __LINE__);
+        return false;
+    }
+
+    // Copy the IE to the BSS
+    memcpy(m_bss_info.vendor_elements + m_bss_info.vendor_elements_len, vs_ie, vs_ie_len);
+    m_bss_info.vendor_elements_len += vs_ie_len;
+    printf("Successfully added Vendor IE of length %d to BSS\n", vs_ie_len);
+    return true;
+}
+
+void dm_bss_t::remove_vendor_ie(struct ieee80211_vs_ie *vs_ie)
+{
+    size_t vs_ie_len = offsetof(struct ieee80211_vs_ie, vs_oui) + vs_ie->vs_len;
+    if (m_bss_info.vendor_elements_len < vs_ie_len) {
+        // The IE is not present in the BSS, return true since it's technically removed
+        return;
+    }
+
+    // Find the IE in the BSS
+    uint8_t* curr_ie_head = m_bss_info.vendor_elements;
+    uint8_t* end = m_bss_info.vendor_elements + m_bss_info.vendor_elements_len;
+    while (curr_ie_head < end) {
+        struct ieee80211_vs_ie* curr_ie = reinterpret_cast<struct ieee80211_vs_ie*>(curr_ie_head);
+        size_t curr_ie_len = offsetof(struct ieee80211_vs_ie, vs_oui) + curr_ie->vs_len;
+
+        // If the current IE is not the same length as the IE we're looking for, skip it
+        if (vs_ie_len != vs_ie_len) {
+            curr_ie_head += curr_ie_len;
+            continue;
+        }
+        if (memcmp(curr_ie_head, reinterpret_cast<uint8_t*>(vs_ie), curr_ie_len) != 0) {
+            // Didn't find the IE, skip 
+            curr_ie_head += curr_ie_len;
+            continue;
+        }
+
+        // Found the IE, remove it by shifting the rest of the IEs back
+
+        // Clear the current IE that is being removed
+        memset(curr_ie_head, 0, curr_ie_len);
+
+        // Shift the rest of the IEs back
+        uint8_t* next_ie_head = curr_ie_head + curr_ie_len;
+        long int remaining_len = end - next_ie_head;
+        memmove(curr_ie_head, next_ie_head, static_cast<size_t>(remaining_len));
+        m_bss_info.vendor_elements_len -= curr_ie_len;
+
+        // Make sure to clear the rest of the buffer after the last IE
+        uint8_t* last_byte = m_bss_info.vendor_elements + m_bss_info.vendor_elements_len;
+        memset(last_byte, 0, static_cast<size_t>(end - last_byte));
+        return;
+    }
 }
 
 dm_bss_t::dm_bss_t(em_bss_info_t *bss)


### PR DESCRIPTION
- Adds methods, structs, and members to easily add and remove vendor IEs to a BSS
- Abstracts the `webconfig_proto_easymesh_init`, `webconfig_easymesh_encode` and `bus_set_fn` for sending current EasyMesh data model over the south bound interface into a separate method for easier use. (for example, when updating the IEs).

**Depends on OneWifi [PR #206](https://github.com/rdkcentral/OneWifi/pull/206)**

This has been tested with the correct OneWifi version and works when applying this patch and waiting for an action frame to be received (or just sending one to it). This was the easiest way to do asynchronous testing in the current version of the **agent** in my imagination but the core code could be moved else where the reviewer has a better idea.  
[vs_test.patch](https://github.com/user-attachments/files/19237935/vs_test.patch)

@amarnathhullur I am adding you as a reviewer since this deals with `webconfig` and while it does work as expected, appears to mostly be calling the same code and has feature parity with the master branch, I want to make sure I am not missing anything.
