### PR TITLE
Fix SSL deprecation warnings

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -296,7 +296,13 @@ typedef struct {
 #define ASSERT_EQUALS(x, y, ret, errMsg, ...) ASSERT_TRUE(x == y, ret, errMsg, ## __VA_ARGS__)
 #define ASSERT_NOT_EQUALS(x, y, ret, errMsg, ...) ASSERT_FALSE(x == y, ret, errMsg, ## __VA_ARGS__)
 
-
+#ifndef SSL_KEY
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#define SSL_KEY EC_KEY
+#else
+#define SSL_KEY EVP_PKEY
+#endif
+#endif
 
 typedef enum {
     ec_session_type_cfg,
@@ -382,7 +388,7 @@ typedef struct {
     /*
         The protocol key of the Enrollee is used as Network Access key (netAccessKey) later in the DPP Configuration and DPP Introduction protocol
     */  
-    EC_KEY *net_access_key;
+   SSL_KEY *net_access_key;
 
     /* TODO: 
     Add (if needed):
@@ -394,15 +400,6 @@ typedef struct {
 
     ec_ephemeral_context_t eph_ctx;
 } ec_connection_context_t;
-
-
-
-/*
-REMOVED:
-    -k1, k2, ke. These are only generated once per device per authentication session (and it should be that way)
-        unsigned char responder_nonce[SHA512_DIGEST_LENGTH/2];
-    unsigned char enrollee_nonce[SHA512_DIGEST_LENGTH/2];
-*/
 
 typedef struct {
 
@@ -417,13 +414,18 @@ typedef struct {
         - If this is the Controller, then this key is stored on the Controller. 
         - If this is the Enrollee, then this key is required for "mutual authentication" and must be recieved via an out-of-band mechanism from the controller.
     */
-    const EC_KEY *initiator_boot_key; 
+    const SSL_KEY *initiator_boot_key; 
     /*
     Responder/Enrollee bootstrapping key. (REQUIRED)
         - If this is the Controller, then this key was recieved out-of-band from the Enrollee in the DPP URI
         - If this is the Enrollee, then this key is stored locally.
     */
-    const EC_KEY *responder_boot_key;
+    const SSL_KEY *responder_boot_key;
+    
+    // B_I, B_R
+    EC_POINT *init_pub_boot_key, *resp_pub_boot_key;
+    // b_I, b_R
+    BIGNUM *init_priv_boot_key, *resp_priv_boot_key;
 } ec_data_t;
 
 #ifdef __cplusplus

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -3061,6 +3061,14 @@ typedef struct {
 	em_cli_type_t	cli_type;
 } em_cli_params_t;
 
+#ifndef SSL_KEY
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#define SSL_KEY EC_KEY
+#else
+#define SSL_KEY EVP_PKEY
+#endif
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -292,12 +292,19 @@ public:
      * Creates an OpenSSL EC_KEY from a base64-encoded DER public key
      *
      * @param base64_der_pubkey Null-terminated string containing the base64-encoded DER public key
-     * @return EC_KEY* on success, NULL on failure
+     * @return SSL_KEY* on success, NULL on failure
      *
      * @note The returned EC_KEY must be freed by the caller using EC_KEY_free()
      * @note This function assumes the input is a valid base64-encoded DER format EC public key
      */
-    static EC_KEY* create_ec_key_from_base64_der(const char* base64_der_pubkey);
+    static SSL_KEY* create_ec_key_from_base64_der(const char* base64_der_pubkey);
+
+
+    static EC_GROUP* get_key_group(const SSL_KEY* key);
+    static BIGNUM* get_priv_key_bn(const SSL_KEY* key);
+    static EC_POINT* get_pub_key_point(const SSL_KEY* key, EC_GROUP* key_group=NULL);
+    static SSL_KEY* generate_ec_key(int nid);
+    static void free_key(SSL_KEY* key);
 
 
     static inline uint8_t generate_iv(unsigned char *iv, unsigned int len) { if (!RAND_bytes(iv, static_cast<int>(len))) { return 0; } else { return 1; } }

--- a/src/dm/dm_dpp.cpp
+++ b/src/dm/dm_dpp.cpp
@@ -135,17 +135,20 @@ void dm_dpp_t::encode(cJSON *obj)
 }
 
 
-bool ec_pub_keys_equal(const EC_KEY* key1, const EC_KEY* key2) {
+bool ec_pub_keys_equal(const SSL_KEY* key1, const SSL_KEY* key2) {
     if (!key1 || !key2) return false;
     
-    const EC_POINT* point1 = EC_KEY_get0_public_key(key1);
-    const EC_POINT* point2 = EC_KEY_get0_public_key(key2);
+    const EC_POINT* point1 = em_crypto_t::get_pub_key_point(key1);
+    const EC_POINT* point2 = em_crypto_t::get_pub_key_point(key2);
     
     if (!point1 || !point2) return false;
     
-    // Compare just the public points
-    const EC_GROUP* group = EC_KEY_get0_group(key1);
-    return (EC_POINT_cmp(group, point1, point2, NULL) == 0);
+    const EC_GROUP* group1 = em_crypto_t::get_key_group(key1);
+    const EC_GROUP* group2 = em_crypto_t::get_key_group(key2);
+
+    if (EC_GROUP_cmp(group1, group2, NULL) != 0) return false;
+
+    return (EC_POINT_cmp(group1, point1, point2, NULL) == 0);
 }
 
 bool dm_dpp_t::operator == (const dm_dpp_t& obj)

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -59,16 +59,6 @@
 #include <sstream>
 #include <string>
 
-/**
- * @paragraph Versions of OpenSSL greater than 1.1 are currently not supported.
- *            This is due to the fact that OpenSSL made significant changes with thread-safety 
- *            in version 3.0+ which does not work well with the current multi-threaded nature
- *            of unified-wifi-mesh. The OpenSSL support that exists here is valid, however when enabled,
- *            certain race conditions appear that are not present prior to version 3.0.
- */
-#ifndef OPENSSL_VERSION_NUMBER
-#define OPENSSL_VERSION_NUMBER 0x10100000L
-#endif
 
 // Initialize the static member variables
 // From RFC 3526
@@ -108,22 +98,12 @@ em_crypto_t::em_crypto_t() {
             exit(1);
         }
     });
-    m_crypto_info.dh = DH_new();
 }
-
-/*static void print_key(const char* label, const uint8_t* key, uint16_t len) {
-    printf("%s (%d bytes): ", label, len);
-    for(int i = 0; i < len; i++) {
-        printf("%02X", key[i]);
-    }
-    printf("\n");
-}*/ //unused function
 
 int em_crypto_t::init()
 {
 
     BIGNUM *priv_key = NULL, *pub_key = NULL;
-	//DH *dh = NULL;
 
     RAND_bytes(m_crypto_info.e_nonce, sizeof(em_nonce_t));
     uuid_generate(m_crypto_info.e_uuid);
@@ -142,6 +122,7 @@ int em_crypto_t::init()
     if (!g) { goto bail; }
 
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
+    DH *dh = NULL;
     if (NULL == (dh = DH_new())) {
         goto bail;
     }
@@ -444,7 +425,7 @@ uint8_t em_crypto_t::platform_cipher_encrypt(const EVP_CIPHER *cipher_type, uint
     EVP_CIPHER_CTX _ctx;
 #endif
     EVP_CIPHER_CTX *ctx;
-    int             len = static_cast<int> (plain_len + AES_BLOCK_SIZE - 1), final_len = 0;
+    int len = static_cast<int> (plain_len + AES_BLOCK_SIZE - 1), final_len = 0;
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_init(&_ctx);
@@ -603,6 +584,9 @@ uint8_t em_crypto_t::platform_compute_shared_secret(uint8_t **shared_secret, uin
         return 0;
     }
 
+    *shared_secret = NULL;
+    *shared_secret_len = 0;
+
     if (remote_pub_len == 0 || local_priv_len == 0) {
         printf("%s:%d Invalid key lengths: remote_pub_len=%d, local_priv_len=%d\n", __func__, __LINE__,
                remote_pub_len, local_priv_len);
@@ -629,108 +613,13 @@ uint8_t em_crypto_t::platform_compute_shared_secret(uint8_t **shared_secret, uin
         return 1;
     }
 
-    free(*shared_secret);
+    if (*shared_secret != NULL) OPENSSL_free(*shared_secret);
     *shared_secret = NULL;
     *shared_secret_len = 0;
     printf("%s:%d Internal failed\n", __func__, __LINE__);
     return 0;
 }
 
-char *em_crypto_t::base64_encode(const uint8_t *input, size_t length, size_t *output_length) {
-    BIO *bio, *b64;
-	//BUF_MEM *bufferPtr;
-
-    // Create a base64 filter BIO and a memory BIO
-    b64 = BIO_new(BIO_f_base64());
-    bio = BIO_new(BIO_s_mem());
-    bio = BIO_push(b64, bio);  // Chain them together
-
-    // Disable newlines in the output
-    BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL);
-    
-    // Write data through the BIO chain
-    BIO_write(bio, input, static_cast<int> (length));
-    BIO_flush(bio);
-
-    // Extract the encoded data
-
-    size_t temp_out_length = 0;
-    char* data_ptr = NULL;
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    BIO_get_mem_ptr(bio, &bufferPtr);
-    temp_out_length = bufferPtr->length;
-    data_ptr = bufferPtr->data; 
-#elif OPENSSL_VERSION_NUMBER < 0x30000000L
-    const BUF_MEM *bptr;
-    BIO_get_mem_ptr(bio, &bptr);
-    temp_out_length = bptr->length;
-    data_ptr = bptr->data;
-#else
-    temp_out_length = static_cast<size_t> (BIO_get_mem_data(bio, &data_ptr));
-#endif
-
-    // Allocate and copy the encoded data
-    char* result = static_cast<char*> (malloc(temp_out_length + 1));
-    memcpy(result, data_ptr, temp_out_length);
-    result[temp_out_length] = '\0';
-
-    if (output_length) {
-        *output_length = temp_out_length;
-    }
-    BIO_free_all(bio);
-    return result;
-}
-
-uint8_t* em_crypto_t::base64_decode(const char* input, size_t length, size_t* output_length) {
-    BIO *bio, *b64;
-    unsigned char* result;
-
-    result = static_cast<unsigned char*> (malloc(length));
-    bio = BIO_new_mem_buf(input, -1);
-    b64 = BIO_new(BIO_f_base64());
-    bio = BIO_push(b64, bio);
-
-    BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
-    *output_length = static_cast<size_t> (BIO_read(bio, result, static_cast<int> (length)));
-
-    // Free the BIO chain
-    BIO_free_all(bio);
-
-    return result;
-}
-
-
-EC_KEY* em_crypto_t::create_ec_key_from_base64_der(const char* base64_der_pubkey) 
-{
-
-    if (!base64_der_pubkey) {
-        printf("%s:%d NULL parameter\n", __func__, __LINE__);
-        return NULL;
-    }
-    uint8_t key[1024];
-    int len = 1024;
-    
-    memset(key, 0, static_cast<size_t> (len));
-
-    if ((len = EVP_DecodeBlock(key, const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(base64_der_pubkey)), static_cast<int> (strlen(base64_der_pubkey)))) < 0) {
-        printf("%s:%d Failed to decode base 64 public key\n", __func__, __LINE__);
-        return NULL;
-    }
-
-    const unsigned char *ptr = key;
-    EC_KEY *ec_key = d2i_EC_PUBKEY(NULL, &ptr, len);
-
-    if (ec_key == NULL) {
-        printf("%s:%d Failed to create EC key from DER\n", __func__, __LINE__);
-        return NULL;
-    }
-
-    EC_KEY_set_conv_form(ec_key, POINT_CONVERSION_COMPRESSED);
-    EC_KEY_set_asn1_flag(ec_key, OPENSSL_EC_NAMED_CURVE);
-
-    return ec_key;
-}
 
 void em_crypto_t::cleanup_bignums(BIGNUM *p, BIGNUM *g, BIGNUM *priv, BIGNUM *pub) {
     BN_clear_free(p);
@@ -864,3 +753,283 @@ uint8_t em_crypto_t::compute_secret_internal(BIGNUM *p, BIGNUM *g, BIGNUM *bn_pr
 }
 #endif
 
+char *em_crypto_t::base64_encode(const uint8_t *input, size_t length, size_t *output_length) {
+    BIO *bio, *b64;
+
+    // Create a base64 filter BIO and a memory BIO
+    b64 = BIO_new(BIO_f_base64());
+    bio = BIO_new(BIO_s_mem());
+    bio = BIO_push(b64, bio);  // Chain them together
+
+    // Disable newlines in the output
+    BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL);
+    
+    // Write data through the BIO chain
+    BIO_write(bio, input, static_cast<int> (length));
+    BIO_flush(bio);
+
+    // Extract the encoded data
+
+    size_t temp_out_length = 0;
+    char* data_ptr = NULL;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    BUF_MEM *bufferPtr;
+    BIO_get_mem_ptr(bio, &bufferPtr);
+    temp_out_length = bufferPtr->length;
+    data_ptr = bufferPtr->data; 
+#elif OPENSSL_VERSION_NUMBER < 0x30000000L
+    const BUF_MEM *bptr;
+    BIO_get_mem_ptr(bio, &bptr);
+    temp_out_length = bptr->length;
+    data_ptr = bptr->data;
+#else
+    temp_out_length = static_cast<size_t> (BIO_get_mem_data(bio, &data_ptr));
+#endif
+
+    // Allocate and copy the encoded data
+    char* result = static_cast<char*> (malloc(temp_out_length + 1));
+    memcpy(result, data_ptr, temp_out_length);
+    result[temp_out_length] = '\0';
+
+    if (output_length) {
+        *output_length = temp_out_length;
+    }
+    BIO_free_all(bio);
+    return result;
+}
+
+uint8_t* em_crypto_t::base64_decode(const char* input, size_t length, size_t* output_length) {
+    BIO *bio, *b64;
+    unsigned char* result;
+
+    result = static_cast<unsigned char*> (malloc(length));
+    bio = BIO_new_mem_buf(input, -1);
+    b64 = BIO_new(BIO_f_base64());
+    bio = BIO_push(b64, bio);
+
+    BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
+    *output_length = static_cast<size_t> (BIO_read(bio, result, static_cast<int> (length)));
+
+    // Free the BIO chain
+    BIO_free_all(bio);
+
+    return result;
+}
+
+SSL_KEY* em_crypto_t::create_ec_key_from_base64_der(const char* base64_der_pubkey) 
+{
+
+    if (!base64_der_pubkey) {
+        printf("%s:%d NULL parameter\n", __func__, __LINE__);
+        return NULL;
+    }
+    uint8_t key[1024];
+    int len = 1024;
+    
+    memset(key, 0, static_cast<size_t> (len));
+
+    if ((len = EVP_DecodeBlock(key, const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(base64_der_pubkey)), static_cast<int> (strlen(base64_der_pubkey)))) < 0) {
+        printf("%s:%d Failed to decode base 64 public key\n", __func__, __LINE__);
+        return NULL;
+    }
+
+    const unsigned char *ptr = key;
+#if OPENSSL_VERSION_NUMBER < 0x30000000L 
+    EC_KEY *ec_key = d2i_EC_PUBKEY(NULL, &ptr, len);
+    if (ec_key == NULL) {
+        printf("%s:%d Failed to create EC key from DER\n", __func__, __LINE__);
+        return NULL;
+    }
+
+    EC_KEY_set_conv_form(ec_key, POINT_CONVERSION_COMPRESSED);
+    EC_KEY_set_asn1_flag(ec_key, OPENSSL_EC_NAMED_CURVE);
+
+    return ec_key;
+#else
+    EVP_PKEY* pkey = d2i_PUBKEY(NULL, &ptr, len);
+
+    if (!pkey) {
+        printf("%s:%d Failed to create EVP_PKEY from DER\n", __func__, __LINE__);
+        return NULL;
+    }
+    return pkey;
+#endif
+
+}
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+EC_GROUP *em_crypto_t::get_key_group(const SSL_KEY *key)
+{
+    // key = EVP_PKEY
+    if (EVP_PKEY_get_id(key) != EVP_PKEY_EC) {
+        return NULL;
+    }
+
+    EC_GROUP* group = NULL;
+    
+    // Get the EC group from the key
+    if (EVP_PKEY_get_group_name(key, NULL, 0, NULL) <= 0) return NULL;
+    
+    char group_name[64];
+    size_t group_name_len = 0;
+    if (EVP_PKEY_get_group_name(key, group_name, sizeof(group_name), &group_name_len) <= 0) return NULL;
+    
+    // Create a group from the name
+    group = EC_GROUP_new_by_curve_name(OBJ_txt2nid(group_name));
+    if (!group) return NULL;
+
+    return group;
+}
+
+BIGNUM *em_crypto_t::get_priv_key_bn(const SSL_KEY *key)
+{
+    // Check if the key is an EC key
+    if (EVP_PKEY_get_id(key) != EVP_PKEY_EC) {
+        return NULL;
+    }
+    BIGNUM *priv = NULL;
+    
+    if (!EVP_PKEY_get_bn_param(key, OSSL_PKEY_PARAM_PRIV_KEY, &priv)) {
+        return NULL;
+    }
+
+    return priv;
+}
+
+EC_POINT *em_crypto_t::get_pub_key_point(const SSL_KEY *key, EC_GROUP* key_group)
+{
+    // Check if the key is an EC key
+    if (EVP_PKEY_get_id(key) != EVP_PKEY_EC) {
+        return NULL;
+    }
+
+    // Use the existing method to get the group
+    EC_GROUP* group = key_group;
+    bool free_group = false;
+    if (group == NULL){
+        group = get_key_group(key);
+        free_group = true;
+    }
+    if (!group) return NULL;
+    
+    EC_POINT* point = NULL;
+    BIGNUM *x = BN_new(), *y = BN_new();
+    
+    if (!x || !y) {
+        goto cleanup;
+    }
+    
+    // Extract the X and Y coordinates
+    if (!EVP_PKEY_get_bn_param(key, OSSL_PKEY_PARAM_EC_PUB_X, &x) ||
+        !EVP_PKEY_get_bn_param(key, OSSL_PKEY_PARAM_EC_PUB_Y, &y)) {
+        goto cleanup;
+    }
+    
+    // Create an EC_POINT from the coordinates
+    point = EC_POINT_new(group);
+    if (!point) goto cleanup;
+    
+    if (!EC_POINT_set_affine_coordinates(group, point, x, y, NULL)) {
+        EC_POINT_free(point);
+        point = NULL;
+    }
+    
+cleanup:
+
+    if (x) BN_free(x);
+    if (y) BN_free(y);
+    if (group && free_group) EC_GROUP_free(group);
+    
+    return point;
+}
+
+SSL_KEY *em_crypto_t::generate_ec_key(int nid)
+{
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *param_ctx = NULL;
+
+    // Create a parameter generation context for the curve
+    param_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+    if (!param_ctx) return NULL;
+
+    // Initialize the parameter generation
+    if (EVP_PKEY_paramgen_init(param_ctx) <= 0) {
+        EVP_PKEY_CTX_free(param_ctx);
+        return NULL;
+    }
+
+    // Set the curve name parameter
+    if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(param_ctx, nid) <= 0) {
+        EVP_PKEY_CTX_free(param_ctx);
+        return NULL;
+    }
+
+    // Generate the parameters
+    if (EVP_PKEY_paramgen(param_ctx, &pkey) <= 0) {
+        EVP_PKEY_CTX_free(param_ctx);
+        return NULL;
+    }
+    EVP_PKEY_CTX_free(param_ctx);
+
+    // Generate the key pair
+    EVP_PKEY_CTX *key_ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    if (!key_ctx) {
+        EVP_PKEY_free(pkey);
+        return NULL;
+    }
+    
+    if (EVP_PKEY_keygen_init(key_ctx) <= 0) {
+        EVP_PKEY_CTX_free(key_ctx);
+        EVP_PKEY_free(pkey);
+        return NULL;
+    }
+    
+    EVP_PKEY *key = NULL;
+    if (EVP_PKEY_keygen(key_ctx, &key) <= 0) {
+        EVP_PKEY_CTX_free(key_ctx);
+        EVP_PKEY_free(pkey);
+        return NULL;
+    }
+    
+    EVP_PKEY_CTX_free(key_ctx);
+    EVP_PKEY_free(pkey);
+    
+    return key;
+}
+void em_crypto_t::free_key(SSL_KEY *key)
+{
+    EVP_PKEY_free(key);
+}
+#else
+EC_GROUP *em_crypto_t::get_key_group(const SSL_KEY *key)
+{
+    // key = EC_KEY
+    return const_cast<EC_GROUP*>(EC_KEY_get0_group(key));
+}
+BIGNUM *em_crypto_t::get_priv_key_bn(const SSL_KEY *key)
+{
+    return const_cast<BIGNUM*>(EC_KEY_get0_private_key(key));
+}
+
+EC_POINT *em_crypto_t::get_pub_key_point(const SSL_KEY *key, __attribute__((unused)) EC_GROUP* key_group)
+{
+    return const_cast<EC_POINT*>(EC_KEY_get0_public_key(key));
+}
+SSL_KEY *em_crypto_t::generate_ec_key(int nid)
+{
+    SSL_KEY *proto_key = EC_KEY_new_by_curve_name(nid);
+    if (proto_key == NULL) return NULL;
+
+    if (EC_KEY_generate_key(proto_key) == 0) {
+        EC_KEY_free(proto_key);
+        return NULL;
+    }
+    return proto_key;
+}
+
+void em_crypto_t::free_key(SSL_KEY *key)
+{
+    EC_KEY_free(key);
+}
+#endif

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -2,6 +2,7 @@
 
 #include "ec_util.h"
 #include "ec_crypto.h"
+#include "em_crypto.h"
 #include "util.h"
 #include "cjson/cJSON.h"
 #include "cjson_util.h"
@@ -13,6 +14,19 @@ ec_enrollee_t::ec_enrollee_t(std::string mac_addr, send_act_frame_func send_acti
 
 ec_enrollee_t::~ec_enrollee_t()
 {
+    if (m_boot_data.resp_priv_boot_key) {
+        BN_free(m_boot_data.resp_priv_boot_key);
+    }
+    if (m_boot_data.resp_pub_boot_key) {
+        EC_POINT_free(m_boot_data.resp_pub_boot_key);
+    }
+    if (m_boot_data.init_priv_boot_key) {
+        BN_free(m_boot_data.init_priv_boot_key);
+    }
+    if (m_boot_data.init_pub_boot_key) {
+        EC_POINT_free(m_boot_data.init_pub_boot_key);
+    }
+    ec_crypto::free_ephemeral_context(&m_eph_ctx, m_p_ctx.nonce_len, m_p_ctx.digest_len);
 }
 
 bool ec_enrollee_t::start(bool do_reconfig, ec_data_t* boot_data)
@@ -20,8 +34,15 @@ bool ec_enrollee_t::start(bool do_reconfig, ec_data_t* boot_data)
     memset(&m_boot_data, 0, sizeof(ec_data_t));
     memcpy(&m_boot_data, boot_data, sizeof(ec_data_t));
 
+    // Not all of these will be present but it is better to compute them now.
+    m_boot_data.resp_priv_boot_key = em_crypto_t::get_priv_key_bn(m_boot_data.responder_boot_key);
+    m_boot_data.resp_pub_boot_key = em_crypto_t::get_pub_key_point(m_boot_data.responder_boot_key);
+
+    m_boot_data.init_priv_boot_key= em_crypto_t::get_priv_key_bn(m_boot_data.initiator_boot_key);    
+    m_boot_data.init_pub_boot_key = em_crypto_t::get_pub_key_point(m_boot_data.initiator_boot_key);
+
     // Baseline test to ensure the bootstrapping key is present
-    if (EC_KEY_get0_public_key(m_boot_data.responder_boot_key) == NULL) {
+    if (m_boot_data.resp_pub_boot_key == NULL) {
         printf("%s:%d Could not get responder bootstrap public key\n", __func__, __LINE__);
         return false;
     }
@@ -107,10 +128,9 @@ Authentication Request frame without replying to it.
 
     // START Crypto in EasyConnect 6.3.3
     // Compute the M.x
-    const BIGNUM *priv_resp_boot_key = EC_KEY_get0_private_key(m_boot_data.responder_boot_key);
-    ASSERT_NOT_NULL(priv_resp_boot_key, false, "%s:%d failed to get responder bootstrapping private key\n", __func__, __LINE__);
+    ASSERT_NOT_NULL(m_boot_data.resp_priv_boot_key, false, "%s:%d failed to get responder bootstrapping private key\n", __func__, __LINE__);
 
-    m_eph_ctx.m = ec_crypto::compute_ec_ss_x(m_p_ctx, priv_resp_boot_key, m_eph_ctx.public_init_proto_key);
+    m_eph_ctx.m = ec_crypto::compute_ec_ss_x(m_p_ctx, m_boot_data.resp_priv_boot_key, m_eph_ctx.public_init_proto_key);
     const BIGNUM *bn_inputs[1] = { m_eph_ctx.m };
     // Compute the "first intermediate key" (k1)
     if (ec_crypto::compute_hkdf_key(m_p_ctx, m_eph_ctx.k1, m_p_ctx.digest_len, "first intermediate key", bn_inputs, 1, NULL, 0) == 0) {
@@ -254,8 +274,8 @@ bool ec_enrollee_t::handle_auth_confirm(ec_frame_t *frame, size_t len, uint8_t s
     // Get P_I.x, P_R.x, B_I.x, and B_R.x
     BIGNUM* P_I_x = ec_crypto::get_ec_x(m_p_ctx, m_eph_ctx.public_init_proto_key);
     BIGNUM* P_R_x = ec_crypto::get_ec_x(m_p_ctx, m_eph_ctx.public_resp_proto_key);
-    BIGNUM* B_I_x = ec_crypto::get_ec_x(m_p_ctx, EC_KEY_get0_public_key(m_boot_data.initiator_boot_key));
-    BIGNUM* B_R_x = ec_crypto::get_ec_x(m_p_ctx, EC_KEY_get0_public_key(m_boot_data.responder_boot_key));
+    BIGNUM* B_I_x = ec_crypto::get_ec_x(m_p_ctx, m_boot_data.resp_pub_boot_key);
+    BIGNUM* B_R_x = ec_crypto::get_ec_x(m_p_ctx, m_boot_data.init_pub_boot_key);
 
     if (P_I_x == NULL || P_R_x == NULL || B_R_x == NULL) {
         printf("%s:%d: Failed to get x-coordinates of P_I, P_R, and B_R\n", __func__, __LINE__);
@@ -475,15 +495,12 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_auth_response(ec_status_code_
     printf("Key K_2:\n");
     util::print_hex_dump(m_p_ctx.digest_len, m_eph_ctx.k2);
 
-    const BIGNUM* b_R = EC_KEY_get0_private_key(m_boot_data.responder_boot_key);
-    ASSERT_NOT_NULL_FREE2(b_R, {}, frame, attribs, "%s:%d failed to get responder bootstrapping private key\n", __func__, __LINE__);
+    ASSERT_NOT_NULL_FREE2(m_boot_data.resp_priv_boot_key, {}, frame, attribs, "%s:%d failed to get responder bootstrapping private key\n", __func__, __LINE__);
 
     // Compute L.x
     if (m_eph_ctx.is_mutual_auth){
-        const EC_POINT* B_I = EC_KEY_get0_public_key(m_boot_data.initiator_boot_key);
-        if (B_I != NULL){
-            m_eph_ctx.l = ec_crypto::calculate_Lx(m_p_ctx, b_R, m_eph_ctx.priv_resp_proto_key, B_I);
-            EC_POINT_free(const_cast<EC_POINT*>(B_I));
+        if (m_boot_data.init_pub_boot_key != NULL){
+            m_eph_ctx.l = ec_crypto::calculate_Lx(m_p_ctx, m_boot_data.resp_priv_boot_key, m_eph_ctx.priv_resp_proto_key, m_boot_data.init_pub_boot_key);
         }
     }
 
@@ -491,7 +508,6 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_auth_response(ec_status_code_
         printf("%s:%d failed to compute L.x\n", __func__, __LINE__);
         free(attribs);
         free(frame);
-        if (b_R) BN_free(const_cast<BIGNUM*>(b_R));
         return {};
     }
     
@@ -507,8 +523,8 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_auth_response(ec_status_code_
     // Compute R-auth = H(I-nonce | R-nonce | PI.x | PR.x | [ BI.x | ] BR.x | 0)
     BIGNUM* P_I_x = ec_crypto::get_ec_x(m_p_ctx, m_eph_ctx.public_init_proto_key);
     BIGNUM* P_R_x = ec_crypto::get_ec_x(m_p_ctx, m_eph_ctx.public_resp_proto_key);
-    BIGNUM* B_I_x = ec_crypto::get_ec_x(m_p_ctx, EC_KEY_get0_public_key(m_boot_data.initiator_boot_key));
-    BIGNUM* B_R_x = ec_crypto::get_ec_x(m_p_ctx, EC_KEY_get0_public_key(m_boot_data.responder_boot_key));
+    BIGNUM* B_I_x = ec_crypto::get_ec_x(m_p_ctx, m_boot_data.init_pub_boot_key);
+    BIGNUM* B_R_x = ec_crypto::get_ec_x(m_p_ctx, m_boot_data.resp_pub_boot_key);
 
     if (P_I_x == NULL || P_R_x == NULL || B_R_x == NULL) {
         printf("%s:%d: Failed to get x-coordinates of P_I, P_R, and B_R\n", __func__, __LINE__);


### PR DESCRIPTION
- Fixes OpenSSL deprecation warnings by abstracting out specific function implementations for different versions.
- Additionally made various adjustments for more memory safety and performance