### PR TITLE
EM 5.4.3 Proxy Agent Encap DPP TLV handling

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -56,6 +56,8 @@ extern "C"
 #define MAC2STR(x) static_cast<unsigned int>((x)[0]), static_cast<unsigned int>((x)[1]), static_cast<unsigned int>((x)[2]), \
                    static_cast<unsigned int>((x)[3]), static_cast<unsigned int>((x)[4]), static_cast<unsigned int>((x)[5])
 
+static const uint8_t BROADCAST_MAC_ADDR[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
 // EasyConnect 8.3.2
 static const uint8_t DPP_GAS_CONFIG_REQ_APE[3] = {0x6c, 0x08, 0x00};
 static const uint8_t DPP_GAS_CONFIG_REQ_PROTO_ID[7] = {0xDD, 0x05, 0x50, 0x6F, 0x9A ,0x1A, 0x01};

--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -87,7 +87,8 @@ typedef enum  {
     ec_frame_type_private_peer_intro_notify,
     ec_frame_type_private_peer_intro_update,
     // 24-255 : Reserved
-    ec_frame_type_reserved = 0xFF, // work around 
+    // XXX: Note: 255 is "reserved" in EasyConnect spec, but used by EasyMesh
+    ec_frame_type_easymesh = 255,
 } ec_frame_type_t;
 
 // As defined by EasyConnect 8.1 Table 29

--- a/src/em/prov/easyconnect/ec_pa_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_pa_configurator.cpp
@@ -33,7 +33,7 @@ bool ec_pa_configurator_t::handle_cfg_request(uint8_t *buff, unsigned int len, u
     // Configuration Request frame and shall set the Enrollee MAC Address Present field to one, include the Enrollee's MAC
     // address in the Destination STA MAC Address field, set the DPP Frame Indicator field to one and the Frame Type field to
     // 255, and send the message to the Multi-AP Controller.
-    auto [encap_dpp_tlv, encap_dpp_tlv_len] = ec_util::create_encap_dpp_tlv(true, sa, static_cast<ec_frame_type_t>(ec_frame_type_reserved), buff, len);
+    auto [encap_dpp_tlv, encap_dpp_tlv_len] = ec_util::create_encap_dpp_tlv(true, sa, static_cast<ec_frame_type_t>(ec_frame_type_easymesh), buff, len);
     ASSERT_NOT_NULL(encap_dpp_tlv, false, "%s:%d: Could not create Encap DPP TLV!\n", __func__, __LINE__);
     bool sent = m_send_prox_encap_dpp_msg(encap_dpp_tlv, encap_dpp_tlv_len, nullptr, 0);
     if (!sent) {

--- a/src/em/prov/easyconnect/ec_pa_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_pa_configurator.cpp
@@ -79,6 +79,86 @@ bool ec_pa_configurator_t::process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv
 
     bool did_finish = false;
 
+    // Pre-processing according to EM spec 5.4.3 Page 43
+    // If a Proxy Agent receives a Proxied Encap DPP message from the Multi-AP Controller, it shall extract the DPP frame from
+    // the Encapsulated Frame field of the 1905 Encap DPP TLV and:
+
+    // 1. If the 1905 Encap DPP TLV DPP Frame Indicator bit field is set to one and the Frame Type field is set to 255, the
+    // Proxy Agent shall decapsulate the DPP Configuration Response frame from the TLV and send it to the Enrollee Multi-
+    // AP Agent using a GAS frame as described in [18]
+    if (encap_tlv->dpp_frame_indicator && ec_frame_type == ec_frame_type_t::ec_frame_type_easymesh) {
+        if (!encap_tlv->enrollee_mac_addr_present) {
+            printf("%s:%d: Cannot forward DPP Configuration Result to Enrollee, MAC addr not present!\n", __func__, __LINE__);
+            return false;
+        }
+        bool sent = m_send_action_frame(dest_mac, encap_frame, encap_frame_len, 0);
+        if (!sent) {
+            printf("%s:%d: Failed to forward DPP Configuration Result to Enrollee '" MACSTRFMT "'\n", __func__, __LINE__, MAC2STR(dest_mac));
+        }
+        free(encap_frame);
+        return sent;
+    }
+
+    // 2. If the 1905 Encap DPP TLV DPP Frame Indicator bit field is set to one and the Frame Type field set to a value other
+    // than 255, the Proxy Agent shall discard the message
+    // 3. If the 1905 Encap DPP TLV DPP Frame Indicator bit field is set to zero and the Frame Type field set to 255, the Proxy
+    // Agent shall discard the message
+    if ((encap_tlv->dpp_frame_indicator && ec_frame_type != ec_frame_type_t::ec_frame_type_easymesh) ||
+        (!encap_tlv->dpp_frame_indicator && ec_frame_type == ec_frame_type_t::ec_frame_type_easymesh)) {
+            printf("%s:%d: Invalid Encap DPP fields, discarding message. DPP Frame Indicator=%d, DPP frame type=%d\n", __func__, __LINE__, encap_tlv->dpp_frame_indicator, ec_frame_type);
+            free(encap_frame);
+            return true;
+    }
+    // 4. If the 1905 Encap DPP TLV DPP Frame Indicator bit field is set to zero and the Frame Type field is set to a valid
+    // value, the Proxy Agent shall process the message following the procedures described in sections 5.3.4 or 5.3.10.
+    // Case 4 --  see next pile of text
+
+    // EasyMesh R6 5.4.3 Page 42
+    // If a Proxy Agent receives a Proxied Encap DPP message from the Controller, it shall extract the DPP frame from the
+    // Encapsulated Frame field of the 1905 Encap DPP TLV. If the DPP Frame Indicator field value is zero, and if the Frame
+    // Type field is not equal to zero or 15, then:
+    if ((ec_frame_type != ec_frame_type_t::ec_frame_type_auth_req && ec_frame_type != ec_frame_type_t::ec_frame_type_recfg_auth_req)) {
+        // 1. If the DPP Frame Indicator bit field in the 1905 Encap DPP TLV is set to zero and the Enrollee MAC Address Present
+        // bit is set to one, then the Proxy Agent shall send the frame as a unicast Public Action frame to the Enrollee MAC
+        // address
+        if (!encap_tlv->dpp_frame_indicator && encap_tlv->enrollee_mac_addr_present) {
+            bool sent = m_send_action_frame(dest_mac, encap_frame, encap_frame_len, 0);
+            if (!sent) {
+                printf("%s:%d: Failed to send non-DPP unicast action frame to '" MACSTRFMT "'\n", __func__, __LINE__, MAC2STR(dest_mac));
+            }
+            free(encap_frame);
+            return sent;
+        }
+        // 2. If the DPP Frame Indicator bit field in the 1905 Encap DPP TLV is set to zero and the Enrollee MAC Address Present
+        // bit is set to zero, then the Proxy Agent shall send the frame as a broadcast Public Action frame
+        else if (!encap_tlv->dpp_frame_indicator && !encap_tlv->enrollee_mac_addr_present) {
+            bool sent = m_send_action_frame(const_cast<uint8_t *>(BROADCAST_MAC_ADDR), encap_frame, encap_frame_len, 0);
+            if (!sent) {
+                printf("%s:%d: Failed to sent non-DPP broadcast action frame!\n", __func__, __LINE__);
+            }
+            free(encap_frame);
+            return sent;
+        }
+        // 3. If the DPP Frame Indicator bit field in the 1905 Encap DPP TLV is set to one and the Enrollee MAC Address Present
+        // bit is set to one, then the Proxy Agent shall send the frame as a unicast GAS frame to the Enrollee MAC address
+        else if (encap_tlv->dpp_frame_indicator && encap_tlv->enrollee_mac_addr_present) {
+            bool sent = m_send_action_frame(dest_mac, encap_frame, encap_frame_len, 0);
+            if (!sent) {
+                printf("%s:%d: Sent DPP unicast GAS frame to '" MACSTRFMT "'\n", __func__, __LINE__, MAC2STR(dest_mac));
+            }
+            free(encap_frame);
+            return sent;
+        }
+        // 4. If the DPP Frame Indicator bit field in the 1905 Encap DPP TLV is set to one and the Enrollee MAC Address Present
+        // bit is set to zero, then the Proxy Agent shall discard the message
+        else if (encap_tlv->dpp_frame_indicator && !encap_tlv->enrollee_mac_addr_present) {
+            printf("%s:%d: Proxied Encap DPP Message with DPP Frame Indicator set, but Enrollee MAC Addr Present false! Discarding.\n", __func__, __LINE__);
+            free(encap_frame);
+            return true;
+        }
+    }
+
+    // Handlers for frame types 0, 15 "ec_frame_type_auth_req" and "ec_frame_type_recfg_auth_req"
     switch (ec_frame_type) {
         case ec_frame_type_auth_req: {
             if (chirp_tlv == NULL || chirp_tlv_len == 0) {
@@ -104,12 +184,6 @@ bool ec_pa_configurator_t::process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv
             // Will be compared against incoming presence announcement hash and mac-addr
             m_stored_recfg_auth_frames.push_back(encap_frame_vec); 
             did_finish = true;
-            break;
-        }
-        case ec_frame_type_auth_cnf:
-        case ec_frame_type_recfg_auth_cnf: {
-            // Send the recevied frame to the enrollee agent
-            did_finish = m_send_action_frame(dest_mac, encap_frame, encap_frame_len, 0);
             break;
         }
         default:


### PR DESCRIPTION
**NOTE**: This assumes that `OneWifi` correctly sends an action frame to the broadcast address if that's what's given as the destination address. Need to confirm.