### PR TITLE
RDKB-59209: EM App - Channel scan changes

### DIFF
--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2622,7 +2622,6 @@ void dm_easy_mesh_t::update_scan_results(em_scan_result_t *scan_result)
 
     strncpy(id->net_id, netid, strlen(netid) + 1);
 	memcpy(id->dev_mac, get_agent_al_interface_mac(), sizeof(mac_address_t));
-	memcpy(id->scanner_mac, get_radio_by_ref(0).get_radio_interface_mac(), sizeof(mac_address_t));
     id->scanner_type = em_scanner_type_radio;
 
     dm_scan_result_t *res = find_matching_scan_result(id);

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -288,7 +288,7 @@ short em_channel_t::create_channel_scan_res_tlv(unsigned char *buff, unsigned in
     dm = get_data_model();
 	scan_res = dm->get_scan_result(index);
 
-	memcpy(res->ruid, get_radio_interface_mac(), sizeof(mac_address_t));	
+	memcpy(res->ruid, scan_res->m_scan_result.id.scanner_mac, sizeof(mac_address_t));
 	memcpy(&res->op_class, &scan_res->m_scan_result.id.op_class, sizeof(unsigned char));
 	memcpy(&res->channel, &scan_res->m_scan_result.id.channel, sizeof(unsigned char));
 	res->scan_status = scan_res->m_scan_result.scan_status;


### PR DESCRIPTION
Fix crash issues with channel scanning

Reason for change: Modified the ruid based on scanner mac from onewifi. 
Test Procedure: Ensure channel scan results are received in agent side and then to controller cli upon request for channel scan. Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>