### PR TITLE
Fix crash issues with channel scanning

### DIFF
--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1372,6 +1372,9 @@ void dm_easy_mesh_list_t::put_scan_result(const char *key, const dm_scan_result_
 		}
 
 		if (found_neighbor == false) {
+			if (res->m_scan_result.num_neighbors >= EM_MAX_NEIGHORS) {
+				return;
+			}
 			nbr = &res->m_scan_result.neighbor[res->m_scan_result.num_neighbors];
 			memcpy(nbr, &scan_result->m_scan_result.neighbor[0], sizeof(em_neighbor_t));
 			res->m_scan_result.num_neighbors++;


### PR DESCRIPTION
Fix crash issues with channel scanning

Reason for change: Added check for max number of neighbors before updating the results to fix buffer overflow.
Test Procedure: Ensure channel scan results are received in agent side and then to controller cli upon request for channel scan without any crash.
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>