### PR TITLE
Adds callbacks for retreiving bSTA info / 1905 layer info

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -56,6 +56,20 @@ extern "C"
 #define MAC2STR(x) static_cast<unsigned int>((x)[0]), static_cast<unsigned int>((x)[1]), static_cast<unsigned int>((x)[2]), \
                    static_cast<unsigned int>((x)[3]), static_cast<unsigned int>((x)[4]), static_cast<unsigned int>((x)[5])
 
+
+// For self-documenting code/runtime
+#define SPEC_TODO_NOT_FATAL(SPEC, VERSION, SECTION, TEXT) \
+    do { \
+        fprintf(stderr, "[TODO] Spec: %s v%s, Section: %s\nText: %s\n", SPEC, VERSION, SECTION, TEXT); \
+    } while (0)
+
+
+#define SPEC_TODO_FATAL(SPEC, VERSION, SECTION, TEXT) \
+    do { \
+        fprintf(stderr, "[TODO - FATAL] Spec: %s v%s, Section: %s\nText: %s\n", SPEC, VERSION, SECTION, TEXT); \
+        assert(false); \
+    } while (0)
+
 static const uint8_t BROADCAST_MAC_ADDR[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
 // EasyConnect 8.3.2

--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -57,13 +57,13 @@ using get_backhaul_sta_info_func = std::function<cJSON*(ec_connection_context_t 
 
 /**
  * @brief Creates a DPP Configuration Response object for the 1905.1 interface.
- *
+ * @return cJSON * on success, nullptr otherwise.
  */
 using get_1905_info_func = std::function<cJSON*(ec_connection_context_t *)>;
 
 /**
  * @brief Used to determine if an additional AP can be on-boarded or not.
- *
+ * @return True if additional APs can be on-boraded into the mesh, false otherwise.
  */
 using can_onboard_additional_aps_func = std::function<bool(void)>;
 
@@ -176,6 +176,16 @@ public:
      */
     virtual bool  process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len) = 0;
 
+    /**
+     * @brief Handle a proxied encapsulated DPP Configuration Request frame.
+     * 
+     * @param encap_frame The DPP Configuration Request frame from an Enrollee.
+     * @param encap_frame_len The length of the DPP Configuration Request frame.
+     * @param dest_mac The source MAC of this DPP Configuration Request frame (Enrollee).
+     * @return true on success, otherwise false.
+     * 
+     * @note: overridden by subclass.
+     */
     virtual bool handle_proxied_dpp_configuration_request(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) {
         return true;
     }

--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -48,6 +48,25 @@ using send_act_frame_func = std::function<bool(uint8_t*, uint8_t *, size_t, unsi
 */
 using toggle_cce_func = std::function<bool(bool)>;
 
+/**
+ * @brief Creates a DPP Configuration Response object for the backhaul STA interface.
+ * @param conn_ctx Optional connection context (not needed for Enrollee, needed for Configurator) -- pass nullptr if not needed.
+ * @return cJSON * on success, nullptr otherwise
+ */
+using get_backhaul_sta_info_func = std::function<cJSON*(ec_connection_context_t *)>;
+
+/**
+ * @brief Creates a DPP Configuration Response object for the 1905.1 interface.
+ *
+ */
+using get_1905_info_func = std::function<cJSON*(ec_connection_context_t *)>;
+
+/**
+ * @brief Used to determine if an additional AP can be on-boarded or not.
+ *
+ */
+using can_onboard_additional_aps_func = std::function<bool(void)>;
+
 class ec_configurator_t {
 public:
     /**
@@ -58,7 +77,8 @@ public:
      */
     // TODO: Add send_gas_frame functions
     ec_configurator_t(std::string mac_addr, send_chirp_func send_chirp_notification, send_encap_dpp_func send_prox_encap_dpp_msg, 
-                        send_act_frame_func send_action_frame);
+                        send_act_frame_func send_action_frame, get_backhaul_sta_info_func backhaul_sta_info_func, get_1905_info_func ieee1905_info_func,
+                        can_onboard_additional_aps_func can_onboard_func);
     virtual ~ec_configurator_t(); // Destructor
 
     /**
@@ -156,6 +176,10 @@ public:
      */
     virtual bool  process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len) = 0;
 
+    virtual bool handle_proxied_dpp_configuration_request(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) {
+        return true;
+    }
+
     inline std::string get_mac_addr() { return m_mac_addr; };
 
     // Disable copy construction and assignment
@@ -175,6 +199,12 @@ protected:
     send_encap_dpp_func m_send_prox_encap_dpp_msg;
 
     send_act_frame_func m_send_action_frame;
+
+    get_backhaul_sta_info_func m_get_backhaul_sta_info;
+
+    get_1905_info_func m_get_1905_info;
+
+    can_onboard_additional_aps_func m_can_onboard_additional_aps;
 
     // The connections to the Enrollees/Agents
     std::map<std::string, ec_connection_context_t> m_connections = {};

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -1,12 +1,16 @@
 #ifndef EC_CTRL_CONFIGURATOR_H
 #define EC_CTRL_CONFIGURATOR_H
 
-#include "ec_configurator.h" 
+#include "ec_configurator.h"
+
+// forward decl
+struct cJSON;
 
 class ec_ctrl_configurator_t : public ec_configurator_t {
 public:
-    ec_ctrl_configurator_t(std::string mac_addr, send_chirp_func send_chirp_notification, send_encap_dpp_func send_prox_encap_dpp_msg) :
-        ec_configurator_t(mac_addr, send_chirp_notification, send_prox_encap_dpp_msg, {}) {};
+    ec_ctrl_configurator_t(std::string mac_addr, send_chirp_func send_chirp_notification, send_encap_dpp_func send_prox_encap_dpp_msg,
+        get_backhaul_sta_info_func backhaul_sta_info_func, get_1905_info_func ieee1905_info_func, can_onboard_additional_aps_func can_onboard_func) :
+        ec_configurator_t(mac_addr, send_chirp_notification, send_prox_encap_dpp_msg, {}, backhaul_sta_info_func, ieee1905_info_func, can_onboard_func) {};
         // No MAC address needed for controller configurator
 
     /**
@@ -40,6 +44,8 @@ public:
      *     but the proxy agent + configurator does.
      */
     bool handle_auth_response(ec_frame_t *frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN]) override;
+
+    bool handle_proxied_dpp_configuration_request(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) override;
 
 private:
     // Private member variables can be added here

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -45,6 +45,16 @@ public:
      */
     bool handle_auth_response(ec_frame_t *frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN]) override;
 
+    /**
+     * @brief Handle a proxied encapsulated DPP Configuration Request frame.
+     * 
+     * @param encap_frame The DPP Configuration Request frame from an Enrollee.
+     * @param encap_frame_len The length of the DPP Configuration Request frame.
+     * @param dest_mac The source MAC of this DPP Configuration Request frame (Enrollee).
+     * @return true on success, otherwise false.
+     * 
+     * @note: overrides parent impl.
+     */
     bool handle_proxied_dpp_configuration_request(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) override;
 
 private:

--- a/inc/ec_enrollee.h
+++ b/inc/ec_enrollee.h
@@ -16,11 +16,13 @@ public:
      * Broadcasts 802.11 presence announcements, handles 802.11 frames from Proxy Agents and sends 802.11 responses to Proxy Agents.
      * 
      * @param mac_addr The MAC address of the device
+     * @param send_action_frame Callback for sending 802.11 action frames
+     * @param get_bsta_info Callback for getting backhaul STA info, used for building DPP Configuration Request JSON objects.
      * 
      * @note The default state of an enrollee is non-onboarding. All non-controller devices are started as (non-onboarding) enrollees 
      *      until they are told that they are on the network at which point they can be upgraded to a proxy agent.
      */
-    ec_enrollee_t(std::string mac_addr, send_act_frame_func send_action_frame);
+    ec_enrollee_t(std::string mac_addr, send_act_frame_func send_action_frame, get_backhaul_sta_info_func get_bsta_info);
     
     // Destructor
     ~ec_enrollee_t();
@@ -82,6 +84,13 @@ private:
      * @return true if successful, false otherwise
      */
     send_act_frame_func m_send_action_frame;
+
+    /**
+     * @brief Get backhaul station information to be JSON encoded and added to DPP Configuration Request frame.
+     *
+     * @return cJSON * on success, nullptr otherwise.
+     */
+    get_backhaul_sta_info_func m_get_bsta_info;
 
     // TODO: Send GAS Frame
 

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -27,7 +27,8 @@ public:
      * If the EasyMesh code is correctly implemented this should not be an issue.
      * 
      */
-    ec_manager_t(std::string mac_addr, send_chirp_func send_chirp, send_encap_dpp_func send_encap_dpp, send_act_frame_func send_action_frame, bool m_is_controller);
+    ec_manager_t(std::string mac_addr, send_chirp_func send_chirp, send_encap_dpp_func send_encap_dpp, send_act_frame_func send_action_frame, 
+        get_backhaul_sta_info_func get_bsta_info, get_1905_info_func get_1905_info, can_onboard_additional_aps_func can_onboard, bool m_is_controller);
     ~ec_manager_t();
 
     /**
@@ -136,6 +137,9 @@ private:
     send_chirp_func m_stored_chirp_fn;
     send_encap_dpp_func m_stored_encap_dpp_fn;
     send_act_frame_func m_stored_action_frame_fn;
+    get_backhaul_sta_info_func m_get_bsta_info_fn;
+    get_1905_info_func m_get_1905_info_fn;
+    can_onboard_additional_aps_func m_can_onboard_fn;
     std::string m_stored_mac_addr;
     
     std::unique_ptr<ec_configurator_t> m_configurator;

--- a/inc/ec_pa_configurator.h
+++ b/inc/ec_pa_configurator.h
@@ -23,12 +23,17 @@ public:
         std::string mac_addr,
         send_chirp_func send_chirp_notification,
         send_encap_dpp_func send_prox_encap_dpp_msg,
-        send_act_frame_func send_action_frame
+        send_act_frame_func send_action_frame,
+        get_backhaul_sta_info_func get_sta_info_func,
+        get_1905_info_func ieee1905_info_func
     ) : ec_configurator_t(
             mac_addr,
             send_chirp_notification,
             send_prox_encap_dpp_msg,
-            send_action_frame
+            send_action_frame,
+            get_sta_info_func,
+            ieee1905_info_func,
+            {}
         ) { }
 
 

--- a/inc/em_provisioning.h
+++ b/inc/em_provisioning.h
@@ -23,6 +23,7 @@
 #include "ec_manager.h"
 #include <memory>
 
+struct cJSON;
 class em_cmd_t;
 class em_provisioning_t {
 
@@ -58,11 +59,12 @@ class em_provisioning_t {
     virtual int send_frame(uint8_t *buff, unsigned int len, bool multicast = false) = 0;
     virtual int send_cmd(em_cmd_type_t type, em_service_type_t svc, uint8_t *buff, unsigned int len) = 0;
     virtual em_cmd_t *get_current_cmd() = 0;
+    virtual dm_easy_mesh_t *get_data_model() = 0;
 
 protected:
     int send_chirp_notif_msg(em_dpp_chirp_value_t *chirp, size_t chirp_len);
     int send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, size_t encap_dpp_len, em_dpp_chirp_value_t *chirp, size_t chirp_len);
-
+    cJSON *create_enrollee_bsta_list(ec_connection_context_t *conn_ctx);
 public:
     void    process_msg(uint8_t *data, unsigned int len);
     void    process_agent_state();

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1082,6 +1082,7 @@ em_t::em_t(em_interface_t *ruid, em_freq_band_t band, dm_easy_mesh_t *dm, em_mgr
     RAND_bytes(get_crypto_info()->r_nonce, sizeof(em_nonce_t));
     m_data_model = dm;
 	m_mgr = mgr;
+    em_service_type_t service_type = get_service_type();
 
     std::string mac_address = util::mac_to_string(get_peer_mac());
     m_ec_manager = std::unique_ptr<ec_manager_t>(new ec_manager_t(
@@ -1089,7 +1090,12 @@ em_t::em_t(em_interface_t *ruid, em_freq_band_t band, dm_easy_mesh_t *dm, em_mgr
         std::bind(&em_t::send_chirp_notif_msg, this, std::placeholders::_1, std::placeholders::_2),
         std::bind(&em_t::send_prox_encap_dpp_msg, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
         std::bind(&em_mgr_t::send_action_frame, mgr, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4), 
-        get_service_type() == em_service_type_ctrl
+        service_type == em_service_type_agent
+            ? std::bind(&em_t::create_enrollee_bsta_list, this, std::placeholders::_1)
+            : static_cast<std::function<cJSON*(ec_connection_context_t *)>>(nullptr),
+        nullptr,
+        nullptr,
+        service_type == em_service_type_ctrl
     ));
 }
 

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1092,7 +1092,12 @@ em_t::em_t(em_interface_t *ruid, em_freq_band_t band, dm_easy_mesh_t *dm, em_mgr
         std::bind(&em_mgr_t::send_action_frame, mgr, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4), 
         service_type == em_service_type_agent
             ? std::bind(&em_t::create_enrollee_bsta_list, this, std::placeholders::_1)
-            : static_cast<std::function<cJSON*(ec_connection_context_t *)>>(nullptr),
+            : static_cast<get_backhaul_sta_info_func>(nullptr),
+        // XXX: Bind these callbacks when implemented
+        // See: ec_configurator.h `get_1905_info_func` and `can_onboard_additional_aps_func`
+        // Depending on service type, will remain as nullptr,
+        // for instance, `ec_pa_configurator` will remain nullptr, so
+        // callsites should check for validity of the std::functions before calling.
         nullptr,
         nullptr,
         service_type == em_service_type_ctrl

--- a/src/em/prov/easyconnect/ec_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_configurator.cpp
@@ -5,11 +5,16 @@ ec_configurator_t::ec_configurator_t(
     std::string mac_addr,
     send_chirp_func send_chirp_notification,
     send_encap_dpp_func send_prox_encap_dpp_msg,
-    send_act_frame_func send_action_frame
-) : m_mac_addr(mac_addr),
+    send_act_frame_func send_action_frame,
+    get_backhaul_sta_info_func backhaul_sta_info_func,
+    get_1905_info_func ieee1905_info_func,
+    can_onboard_additional_aps_func can_onboard_func) : m_mac_addr(mac_addr),
     m_send_chirp_notification(send_chirp_notification),
     m_send_prox_encap_dpp_msg(send_prox_encap_dpp_msg),
-    m_send_action_frame(send_action_frame)
+    m_send_action_frame(send_action_frame),
+    m_get_backhaul_sta_info(backhaul_sta_info_func),
+    m_get_1905_info(ieee1905_info_func),
+    m_can_onboard_additional_aps(can_onboard_func)
 {
 }
 

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -617,6 +617,7 @@ cJSON *em_provisioning_t::create_enrollee_bsta_list(ec_connection_context_t *con
                 radioListObj, "RUID",
                 util::mac_to_string(radio->m_radio_info.id.ruid, "").c_str())) {
             printf("%s:%d: Could not add RUID to RadioList object!\n", __func__, __LINE__);
+            cJSON_Delete(radioListObj);
             cJSON_Delete(bsta_list_obj);
             return nullptr;
         }
@@ -654,7 +655,7 @@ cJSON *em_provisioning_t::create_enrollee_bsta_list(ec_connection_context_t *con
 
     if (!cJSON_AddStringToObject(bsta_list_obj, "channelList", channelList.c_str())) {
         printf("%s:%d: Could not add channelList to bSTAList object!\n", __func__, __LINE__);
-        cJSON_Delete(bsta_list_obj);
+        cJSON_Delete(b_sta_list_arr);
         return nullptr;
     }
     return b_sta_list_arr;


### PR DESCRIPTION
Implement DPP Configuration Request Object creation, creating bSTAList object on Enrollee

Begins parsing of DPP Configuration Frame on Controller

Also plugs memory leaks in Enrollee.

Configuration Request frame parsing / Configuration Response frame handling still TODO in Configurator, need callbacks first.

See EasyConnect 6.4.3.1 for auditing Configurator work, EasyMesh 5.3.2 Table 5 for auditing Enrollee `get_bsta_info` callback.

Note: `akm` is still hard-coded as there's nothing (currently) in the data model to expose this nor map it to a radio.