### PR TITLE
Added Unit Test GitHub Action Workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,76 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  Unit-Tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout current repository
+      uses: actions/checkout@v4
+      with:
+        path: 'unified-wifi-mesh'
+
+    - name: Set up dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential \
+                            cmake \
+                            python3 \
+                            python3-pip \
+                            git \
+                            vim \
+                            libev-dev \
+                            libjansson-dev \
+                            zlib1g-dev \
+                            libnl-3-dev \
+                            libnl-genl-3-dev \
+                            libnl-route-3-dev \
+                            libavro-dev \
+                            libcjson1 libcjson-dev \
+                            libssl-dev \
+                            uuid-dev \
+                            libmysqlcppconn-dev \
+                            libreadline-dev \
+                            iptables \
+                            mariadb-server \
+                            gnupg \
+                            file \
+                            golang
+
+    - name: Clone OneWiFi repository
+      run: |
+        mkdir -p easymesh_project
+        git clone https://github.com/rdkcentral/OneWifi.git easymesh_project/OneWifi
+        mv unified-wifi-mesh easymesh_project/unified-wifi-mesh
+
+    - name: Setup OneWiFi
+      working-directory: easymesh_project/OneWifi
+      run: |
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git config --global user.name "${{ github.actor }}"
+        make -f build/linux/makefile setup
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+
+    - name: Build OneWiFi
+      working-directory: easymesh_project/OneWifi
+      run: |
+       make -f build/linux/makefile all
+
+    - name: Install GTest
+      working-directory: easymesh_project/unified-wifi-mesh/
+      timeout-minutes: 5 
+      run: |
+        make -j2 -C build/ctrl install_gtest
+
+    - name: Make test
+      working-directory: easymesh_project/unified-wifi-mesh/
+      timeout-minutes: 5 
+      run: |
+        make -j2 -C build/ctrl test
+


### PR DESCRIPTION
Adds an additional GitHub Action workflow to test whatever Unit Tests are present in the `tests` folder. 

This is currently just for unit tests (not end-to-end integration tests using OneWifi, the Agent, and the Controller) and these tests have limited coverage for critical atomic methods. Due to my current work, these only relate to EasyConnect and cryptography but the additional unit-testing files can be added to the "tests" folder in the future and this GitHub action will not need modification.