### PR TITLE
RDKBACCL-664 : Observing segfalt issue in easymesh agent

### DIFF
--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -746,6 +746,11 @@ int dm_easy_mesh_agent_t::refresh_onewifi_subdoc(wifi_bus_desc_t *desc, bus_hand
         printf("%s:%d %s subdoc encode failure\n", __func__, __LINE__, logname);
         return 0;
     }
+ 
+    if (webconfig_easymesh_raw_data_ptr == NULL) {
+        printf("%s:%d webconfig_easymesh_raw_data_ptr is NULL \n", __func__, __LINE__);
+        return 0;
+    }
 
     raw_data_t l_bus_data;
 


### PR DESCRIPTION
Reason for change:  observing segfault in agent when we execute wifi reset .
Added BT below,
[Current thread is 1 (LWP 511241)]
(gdb) bt
   #0  0x0000007faea6b724 in rbusValue_GetV () from /usr/lib/librbus.so.0
#1  0x0000007faea5f270 in rbusValue_appendToMessage () from /usr/lib/librbus.so.0
#2  0x0000007faea638c0 in rbus_set () from /usr/lib/librbus.so.0
#3  0x0000000000445778 in bus_set (handle=<optimized out>, name=0x456c6f "Device.WiFi.WebConfig.Data.Subdoc.South", data=0x7fdcda5d20)
    at ../../../git/src/agent/../../OneWifi/source/platform/rdkb/bus.c:1086
#4  0x000000000042f134 in dm_easy_mesh_agent_t::analyze_set_policy (this=this@entry=0x481160 <g_agent+344>, evt=evt@entry=0x7f9c008c24, 
    desc=desc@entry=0x8e2390 <g_bus>, bus_hdl=bus_hdl@entry=0x50d320 <g_agent+574232>)
    at ../../../git/src/agent/../../src/agent/dm_easy_mesh_agent.cpp:856
#5  0x000000000043369c in em_agent_t::handle_set_policy (this=0x481008 <g_agent>, evt=0x7f9c008c24)
    at ../../../git/src/agent/../../src/agent/em_agent.cpp:434
#6  0x000000000040da00 in em_mgr_t::start (this=this@entry=0x481008 <g_agent>) at ../../../git/src/agent/../../src/em/em_mgr.cpp:421
#7  0x00000000004094d4 in main (argc=<optimized out>, argv=<optimized out>) at ../../../git/src/agent/../../src/agent/em_agent.cpp:1237 
Test Procedure: no core formed
Risks: Low