### PR TITLE
Implement DPP toggle_cce 

### DIFF
--- a/inc/dm_bss.h
+++ b/inc/dm_bss.h
@@ -44,14 +44,14 @@ public:
      * @param vs_ie Vendor specific IE to add
      * @return true if the IE was added successfully, false if out of bounds
      */
-    bool add_vendor_ie(struct ieee80211_vs_ie *vs_ie);
+    bool add_vendor_ie(const struct ieee80211_vs_ie *vs_ie);
 
     /**
      * @brief Remove a vendor specific IE from the BSS. If the IE is not present, this function will return without error.
      * 
      * @param vs_ie Vendor specific IE to remove
      */
-    void remove_vendor_ie(struct ieee80211_vs_ie *vs_ie);
+    void remove_vendor_ie(const struct ieee80211_vs_ie *vs_ie);
 
     dm_bss_t(em_bss_info_t *bss);
     dm_bss_t(const dm_bss_t& bss);

--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -41,11 +41,12 @@ using send_encap_dpp_func = std::function<bool(em_encap_dpp_t*, size_t, em_dpp_c
 using send_act_frame_func = std::function<bool(uint8_t*, uint8_t *, size_t, unsigned int)>;
 
 /**
-* @brief Set the CCE IEs in the beacon and probe response frames
-* 
-* @param bool Whether to enable or disable the inclusion of CCE IEs in the beacon and probe response frames
-* @return bool true if successful, false otherwise
-*/
+ * @brief Set the CCE IEs in the beacon and probe response frames
+ * 
+ * @param bool Whether to enable or disable the inclusion of CCE IEs in the beacon and probe response frames
+ * @return bool true if successful, false otherwise
+ * @note If the operation fails, all CCE IEs are removed before the function exits
+ */
 using toggle_cce_func = std::function<bool(bool)>;
 
 /**
@@ -80,16 +81,6 @@ public:
                         send_act_frame_func send_action_frame, get_backhaul_sta_info_func backhaul_sta_info_func, get_1905_info_func ieee1905_info_func,
                         can_onboard_additional_aps_func can_onboard_func);
     virtual ~ec_configurator_t(); // Destructor
-
-    /**
-     * @brief Set the CCE IEs in the beacon and probe response frames
-     * 
-     * @param bool Whether to enable or disable the inclusion of CCE IEs in the beacon and probe response frames
-     * @return bool true if successful, false otherwise
-     */
-    toggle_cce_func m_toggle_cce = {
-        [](bool enable) -> bool { return false; }
-    };
 
     /**
      * @brief Start the EC configurator onboarding process for an enrollee

--- a/inc/ec_pa_configurator.h
+++ b/inc/ec_pa_configurator.h
@@ -25,7 +25,8 @@ public:
         send_encap_dpp_func send_prox_encap_dpp_msg,
         send_act_frame_func send_action_frame,
         get_backhaul_sta_info_func get_sta_info_func,
-        get_1905_info_func ieee1905_info_func
+        get_1905_info_func ieee1905_info_func,
+        toggle_cce_func toggle_cce_fn
     ) : ec_configurator_t(
             mac_addr,
             send_chirp_notification,
@@ -34,7 +35,8 @@ public:
             get_sta_info_func,
             ieee1905_info_func,
             {}
-        ) { }
+        ),
+        m_toggle_cce(toggle_cce_fn) { }
 
 
     /**
@@ -116,6 +118,15 @@ public:
      * @return bool true if successful, false otherwise
      */
     bool process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len) override;
+
+    /**
+     * @brief Set the CCE IEs in the beacon and probe response frames
+     * 
+     * @param bool Whether to enable or disable the inclusion of CCE IEs in the beacon and probe response frames
+     * @return bool true if successful, false otherwise
+     * @note If the operation fails, all CCE IEs are removed before the function exits
+     */
+    toggle_cce_func m_toggle_cce;
 
 private:
     // Private member variables go here

--- a/inc/em.h
+++ b/inc/em.h
@@ -91,6 +91,15 @@ public:
     bool is_matching_freq_band(em_freq_band_t *band);
     void set_al_type(bool is_al_mac) {m_is_al_em = is_al_mac;}
 
+    /**
+     * @brief Set the CCE IEs in the beacon and probe response frames
+     * 
+     * @param bool Whether to enable or disable the inclusion of CCE IEs in the beacon and probe response frames
+     * @return bool true if successful, false otherwise
+     * @note If the operation fails, all CCE IEs are removed before the function exits
+     */
+    bool toggle_cce(bool enable);
+
 	em_mgr_t *get_mgr() { return m_mgr; }
     ec_manager_t& get_ec_mgr() { return *m_ec_manager; }
 

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -75,7 +75,7 @@ public:
      * 
      * @param log_name [in] The string to use when logging
      * @param type [in] The subdoc type
-     * @return int 0 if encode fails, -1 if send fails, 1 if both succeed.
+     * @return int 1 if successful, 0 if encode fails, -1 if send fails, -2 if unimplemented
      */
     int refresh_onewifi_subdoc(const char *log_name, const webconfig_subdoc_type_t type) override;
 

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -71,6 +71,15 @@ public:
     void input_listener();
 
     /**
+     * @brief Refresh the OneWifi subdoc with current information + provided data and send to OneWifi
+     * 
+     * @param log_name [in] The string to use when logging
+     * @param type [in] The subdoc type
+     * @return int 0 if encode fails, -1 if send fails, 1 if both succeed.
+     */
+    int refresh_onewifi_subdoc(const char *log_name, const webconfig_subdoc_type_t type) override;
+
+    /**
      * @brief Send an action frame
      * 
      * @param dest_mac The destination MAC address

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -70,6 +70,18 @@ public:
     static void *mgr_input_listen(void *arg);
 
     /**
+     * @brief Refresh the OneWifi subdoc with current information + provided data and send to OneWifi
+     * 
+     * @param log_name [in] The string to use when logging
+     * @param type [in] The subdoc type
+     * @return int 0 if encode fails, -1 if send fails, 1 if both succeed.
+     */
+    virtual int refresh_onewifi_subdoc(const char *log_name, const webconfig_subdoc_type_t type) {
+        printf("refresh_onewifi_subdoc not implemented\n");
+        return 0;
+    }
+
+    /**
      * @brief Send an action frame. Optional to implement.
      * 
      * @param dest_mac The destination MAC address

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -74,11 +74,11 @@ public:
      * 
      * @param log_name [in] The string to use when logging
      * @param type [in] The subdoc type
-     * @return int 0 if encode fails, -1 if send fails, 1 if both succeed.
+     * @return int 1 if successful, 0 if encode fails, -1 if send fails, -2 if unimplemented
      */
     virtual int refresh_onewifi_subdoc(const char *log_name, const webconfig_subdoc_type_t type) {
         printf("refresh_onewifi_subdoc not implemented\n");
-        return 0;
+        return -2;
     }
 
     /**

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -598,6 +598,14 @@ void em_agent_t::handle_500ms_tick()
     m_orch->handle_timeout();
 }
 
+int em_agent_t::refresh_onewifi_subdoc(const char * log_name, const webconfig_subdoc_type_t type)
+{
+    wifi_bus_desc_t *desc = get_bus_descriptor();
+    ASSERT_NOT_NULL(desc, false, "%s:%d descriptor is null\n", __func__, __LINE__);
+    
+    return m_data_model.refresh_onewifi_subdoc(desc, &m_bus_hdl, log_name, type);
+}
+
 bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, unsigned int frequency) {
 
     wifi_bus_desc_t *desc = get_bus_descriptor();

--- a/src/dm/dm_bss.cpp
+++ b/src/dm/dm_bss.cpp
@@ -404,7 +404,7 @@ int dm_bss_t::parse_bss_id_from_key(const char *key, em_bss_id_t *id)
     return 0;
 }
 
-bool dm_bss_t::add_vendor_ie(struct ieee80211_vs_ie *vs_ie)
+bool dm_bss_t::add_vendor_ie(const struct ieee80211_vs_ie *vs_ie)
 {
     // Fetch full length from the IE
     unsigned int vs_ie_len = offsetof(struct ieee80211_vs_ie, vs_oui) + vs_ie->vs_len;
@@ -421,7 +421,7 @@ bool dm_bss_t::add_vendor_ie(struct ieee80211_vs_ie *vs_ie)
     return true;
 }
 
-void dm_bss_t::remove_vendor_ie(struct ieee80211_vs_ie *vs_ie)
+void dm_bss_t::remove_vendor_ie(const struct ieee80211_vs_ie *vs_ie)
 {
     size_t vs_ie_len = offsetof(struct ieee80211_vs_ie, vs_oui) + vs_ie->vs_len;
     if (m_bss_info.vendor_elements_len < vs_ie_len) {
@@ -442,7 +442,7 @@ void dm_bss_t::remove_vendor_ie(struct ieee80211_vs_ie *vs_ie)
             curr_ie_head += curr_ie_len;
             continue;
         }
-        if (memcmp(curr_ie_head, reinterpret_cast<uint8_t*>(vs_ie), curr_ie_len) != 0) {
+        if (memcmp(curr_ie_head, reinterpret_cast<const uint8_t*>(vs_ie), curr_ie_len) != 0) {
             // Didn't find the IE, skip 
             curr_ie_head += curr_ie_len;
             continue;

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -3139,12 +3139,7 @@ int em_configuration_t::handle_encrypted_settings()
     get_mgr()->io_process(em_bus_event_type_m2ctrl_configuration, reinterpret_cast<unsigned char *> (&radioconfig), sizeof(radioconfig));
     set_state(em_state_agent_owconfig_pending);
     if (get_service_type() == em_service_type_agent) {
-        get_ec_mgr().upgrade_to_onboarded_proxy_agent(
-            [this](bool enable) {
-                printf("Toggle CCE: %s\n", enable ? "true" : "false");
-                return 0;  // Added return value
-            }
-        );
+        get_ec_mgr().upgrade_to_onboarded_proxy_agent();
     }
     return ret;
 }

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -13,6 +13,7 @@ ec_manager_t::ec_manager_t(
     get_backhaul_sta_info_func get_bsta_info,
     get_1905_info_func get_1905_info,
     can_onboard_additional_aps_func can_onboard,
+    toggle_cce_func toggle_cce, 
     bool m_is_controller
 ) : m_is_controller(m_is_controller),
     m_stored_chirp_fn(send_chirp),
@@ -24,7 +25,7 @@ ec_manager_t::ec_manager_t(
     m_stored_mac_addr(mac_addr),
     m_configurator(nullptr),
     m_enrollee(nullptr),
-    m_stored_toggle_cce_fn(nullptr) {
+    m_toggle_cce_fn(toggle_cce) {
     
     if (m_is_controller) {
         m_configurator = std::unique_ptr<ec_configurator_t>(
@@ -90,7 +91,7 @@ bool ec_manager_t::handle_recv_gas_pub_action_frame(ec_gas_frame_base_t *frame, 
     return false;
 }
 
-bool ec_manager_t::upgrade_to_onboarded_proxy_agent(toggle_cce_func toggle_cce)
+bool ec_manager_t::upgrade_to_onboarded_proxy_agent()
 {
     if (m_is_controller) {
         // Only an enrollee agent can be upgraded to a proxy agent
@@ -114,8 +115,7 @@ bool ec_manager_t::upgrade_to_onboarded_proxy_agent(toggle_cce_func toggle_cce)
     m_enrollee.reset();
     
     // Create a new proxy agent configurator
-    m_configurator = std::unique_ptr<ec_pa_configurator_t>(new ec_pa_configurator_t(enrollee_mac, m_stored_chirp_fn, m_stored_encap_dpp_fn, m_stored_action_frame_fn, m_get_bsta_info_fn, m_get_1905_info_fn));
-    m_configurator->m_toggle_cce = toggle_cce;
+    m_configurator = std::unique_ptr<ec_pa_configurator_t>(new ec_pa_configurator_t(enrollee_mac, m_stored_chirp_fn, m_stored_encap_dpp_fn, m_stored_action_frame_fn, m_get_bsta_info_fn, m_get_1905_info_fn, m_toggle_cce_fn));
     printf("%s:%d: Upgraded enrollee agent to proxy agent\n", __func__, __LINE__);
     return true;
 }


### PR DESCRIPTION
As described in EasyMesh R6, Section 5.3.1, proxy agents must be able to advertise the CCE IE in their Beacon and Probe Response frames. The main addition of this PR is `em_t::toggle_cce(bool enable)`, which adds or removes DPP IEs to BSSs to advertise the CCE IE.

Currently, the IEs are added to every BSS found in `em_t::m_data_model`. 

I considered splitting `toggle_cce` into 2 separate functions (`enable_cce` and `disable_cce`), but I decided to stick with `toggle_cce` as it integrates more smoothly into existing code. 

Requesting review from @bcarlson-dev.