### PR TITLE
CI .yml: remove -j from OneWifi build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Build OneWiFi
       working-directory: easymesh_project/OneWifi
       run: |
-        make -j -f build/linux/makefile all
+        make -f build/linux/makefile all
 
     - name: Build unified-wifi-mesh controller
       working-directory: easymesh_project/unified-wifi-mesh/build/ctrl

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Build OneWiFi
       working-directory: easymesh_project/OneWifi
       run: |
-       make -j -f build/linux/makefile all
+       make -f build/linux/makefile all
 
     - name: Install GTest
       working-directory: easymesh_project/unified-wifi-mesh/


### PR DESCRIPTION
OneWifi "fails" to build with -j with exit code 2:
![image](https://github.com/user-attachments/assets/5ebe251d-278e-47f2-8827-0093ab76e4bf)


Ideally we want parallel builds eventually, but to not clog up CI, just remove `-j` here, for now.