### PR TITLE
Fix warning for controller

### DIFF
--- a/src/dm/dm_op_class.cpp
+++ b/src/dm/dm_op_class.cpp
@@ -45,7 +45,7 @@ int dm_op_class_t::decode(const cJSON *obj, void *parent_id)
     unsigned int i;
 
     memset(&m_op_class_info, 0, sizeof(em_op_class_info_t));
-    dm_op_class_t::parse_op_class_id_from_key((char *)parent_id, &m_op_class_info.id);
+    dm_op_class_t::parse_op_class_id_from_key(static_cast<char*>(parent_id), &m_op_class_info.id);
 	
     if ((tmp = cJSON_GetObjectItem(obj, "Class")) != NULL) {
         m_op_class_info.op_class = tmp->valuedouble;

--- a/src/dm/dm_op_class_list.cpp
+++ b/src/dm/dm_op_class_list.cpp
@@ -202,6 +202,9 @@ void dm_op_class_list_t::update_list(const dm_op_class_t& op_class, dm_orch_type
         case dm_orch_type_db_delete:
             remove_op_class(key);
             break;
+
+        default:
+            break;
     }
 }
 

--- a/src/dm/dm_policy_list.cpp
+++ b/src/dm/dm_policy_list.cpp
@@ -205,6 +205,9 @@ void dm_policy_list_t::update_list(const dm_policy_t& policy, dm_orch_type_t op)
         case dm_orch_type_db_delete:
             remove_policy(key);
             break;
+
+        default:
+            break;
     }
 }
 

--- a/src/dm/dm_sta_list.cpp
+++ b/src/dm/dm_sta_list.cpp
@@ -168,6 +168,9 @@ void dm_sta_list_t::update_list(const dm_sta_t& sta, dm_orch_type_t op)
         case dm_orch_type_db_delete:
             remove_sta(key);            
             break;
+
+        default:
+            break;
     }
 
 }

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -852,7 +852,7 @@ void em_configuration_t::handle_ap_vendor_operational_bss(unsigned char *value, 
 			memcpy(dm_bss->m_bss_info.id.bssid, bss->bssid, sizeof(mac_address_t));
 			memcpy(dm_bss->m_bss_info.ruid.mac, radio->ruid, sizeof(mac_address_t));
 			memcpy(dm_bss->m_bss_info.bssid.mac, bss->bssid, sizeof(mac_address_t));
-			dm_bss->m_bss_info.id.haul_type = (em_haul_type_t) bss->haultype;
+			dm_bss->m_bss_info.id.haul_type = static_cast<em_haul_type_t> (bss->haultype);
 			bss = reinterpret_cast<em_ap_vendor_operational_bss_t *>(reinterpret_cast<unsigned char *> (bss) + sizeof(em_ap_vendor_operational_bss_t));
 			all_bss_len += sizeof(em_ap_vendor_operational_bss_t);
 		}


### PR DESCRIPTION
Reason for change: 1) Added missing default case for switch statement 
2) Handled static type cast
Test Procedure: Checked and compared the warning before and after fix, observed around 200 warning is fixed. Also compared the run time logs for OneWifi, controller, agent with and without changes and did not observe any additional logs/error. Also checked the CLI and observed its working fine. 
Risks: Medium
Priority: P1