### PR TITLE
RDKB-59209: EM App - Fix channel scan issues

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -177,7 +177,7 @@ public:
     dm_scan_result_t *get_next_scan_result(dm_scan_result_t *scan_result) { return m_data_model_list.get_next_scan_result(scan_result); }
     dm_scan_result_t *get_scan_result(const char *key) { return m_data_model_list.get_scan_result(key); }
     void remove_scan_result(const char *key) { m_data_model_list.remove_scan_result(key); }
-    void put_scan_result(const char *key, const dm_scan_result_t *scan_result) { m_data_model_list.put_scan_result(key, scan_result); }
+    void put_scan_result(const char *key, const dm_scan_result_t *scan_result, unsigned int index) { m_data_model_list.put_scan_result(key, scan_result, index); }
 
 	void init_network_topology();
     void update_network_topology();

--- a/inc/dm_easy_mesh_list.h
+++ b/inc/dm_easy_mesh_list.h
@@ -101,7 +101,7 @@ public:
     dm_scan_result_t *get_next_scan_result(dm_scan_result_t *scan_result);
     dm_scan_result_t *get_scan_result(const char *key);
     void remove_scan_result(const char *key);
-    void put_scan_result(const char *key, const dm_scan_result_t *scan_result);
+    void put_scan_result(const char *key, const dm_scan_result_t *scan_result, unsigned int index);
 
     dm_easy_mesh_list_t();
     ~dm_easy_mesh_list_t();

--- a/inc/dm_scan_result_list.h
+++ b/inc/dm_scan_result_list.h
@@ -54,7 +54,7 @@ public:
     virtual dm_scan_result_t *get_next_scan_result(dm_scan_result_t *scan_result) = 0;
     virtual dm_scan_result_t *get_scan_result(const char *key) = 0;
     virtual void remove_scan_result(const char *key) = 0;
-    virtual void put_scan_result(const char *key, const dm_scan_result_t *scan_result) = 0;
+    virtual void put_scan_result(const char *key, const dm_scan_result_t *scan_result, unsigned int index) = 0;
 };
 
 #endif

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -72,7 +72,6 @@ extern "C"
 #define EM_MAX_RADIO_PER_AGENT         4
 #define EM_MAX_TRAFFIC_SEP_SSID        8
 #define EM_MAX_FREQ_RECORDS_PER_RADIO  8
-#define EM_MAX_CHANNELS   30
 #define MAP_INVENTORY_ITEM_LEN  64
 #define MAX_MCS  6
 #define MAP_AP_ROLE_MAX 2
@@ -81,7 +80,7 @@ extern "C"
 #define EM_MAX_STA_PER_BSS         128
 #define EM_MAX_STA_PER_STEER_POLICY        16 
 #define EM_MAX_STA_PER_AGENT       (EM_MAX_RADIO_PER_AGENT * EM_MAX_STA_PER_BSS)
-#define EM_MAX_NEIGHORS		16
+#define EM_MAX_NEIGHBORS	16
 #define EM_MAX_CHANNEL_SCAN_RPRT_MSG_LEN		166
 #define EM_MAX_CLIENT_MARKER    5
 
@@ -694,7 +693,7 @@ typedef struct {
     unsigned char util;
     unsigned char noise;
 	unsigned short num_neighbors;
-	em_neighbor_t	neighbor[EM_MAX_NEIGHORS];
+	em_neighbor_t	neighbor[EM_MAX_NEIGHBORS];
     unsigned int  aggr_scan_duration;
     unsigned char scan_type;
 } em_scan_result_t;

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -485,9 +485,7 @@ void em_agent_t::handle_channel_scan_result(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num;
 
-    if (m_orch->is_cmd_type_in_progress(evt->type) == true) {
-        printf("scan results in progress\n");
-    } else if ((num = m_data_model.analyze_scan_result(evt, pcmd)) == 0) {
+    if ((num = m_data_model.analyze_scan_result(evt, pcmd)) == 0) {
         printf("scan results failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
 		;

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -1830,8 +1830,8 @@ int dm_easy_mesh_ctrl_t::update_tables(dm_easy_mesh_t *dm)
     }
 
 	if (dm->db_cfg_type_is_set(db_cfg_type_scan_result_list_delete)) {
-        for (i = 0; i < dm->get_num_scan_results(); i++) {
-            scan_result = dm->get_scan_result(i);
+        while (dm->get_num_scan_results() > 0) {
+            scan_result = dm->get_scan_result(0);
             criteria = dm->db_cfg_type_get_criteria(db_cfg_type_scan_result_list_delete);
 			// first delect self
 			res.result = scan_result->get_scan_result();

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1316,7 +1316,7 @@ void dm_easy_mesh_list_t::remove_scan_result(const char *key)
     sta->m_sta_info.num_beacon_meas_report--;
 }
 
-void dm_easy_mesh_list_t::put_scan_result(const char *key, const dm_scan_result_t *scan_result)
+void dm_easy_mesh_list_t::put_scan_result(const char *key, const dm_scan_result_t *scan_result, unsigned int index)
 {
 	em_scan_result_id_t	id;
 	dm_easy_mesh_t	*dm;
@@ -1362,17 +1362,17 @@ void dm_easy_mesh_list_t::put_scan_result(const char *key, const dm_scan_result_
 
 			if (memcmp(nbr->bssid, bssid, sizeof(mac_address_t)) == 0) {
 				found_neighbor = true;
-				memcpy(nbr, &scan_result->m_scan_result.neighbor[0], sizeof(em_neighbor_t));
+				memcpy(nbr, &scan_result->m_scan_result.neighbor[index], sizeof(em_neighbor_t));
 				break;
 			}
 		}
 
 		if (found_neighbor == false) {
-			if (res->m_scan_result.num_neighbors >= EM_MAX_NEIGHORS) {
+			if (res->m_scan_result.num_neighbors >= EM_MAX_NEIGHBORS) {
 				return;
 			}
 			nbr = &res->m_scan_result.neighbor[res->m_scan_result.num_neighbors];
-			memcpy(nbr, &scan_result->m_scan_result.neighbor[0], sizeof(em_neighbor_t));
+			memcpy(nbr, &scan_result->m_scan_result.neighbor[index], sizeof(em_neighbor_t));
 			res->m_scan_result.num_neighbors++;
 		}
 	}

--- a/src/dm/dm_scan_result_list.cpp
+++ b/src/dm/dm_scan_result_list.cpp
@@ -111,7 +111,6 @@ int dm_scan_result_list_t::set_config(db_client_t& db_client, dm_scan_result_t& 
 	res.result = scan_result.get_scan_result();
 	res.index = scan_result_self_index;
 	update_db(db_client, (op = get_dm_orch_type(db_client, scan_result, scan_result_self_index)), &res);
-	update_list(scan_result, scan_result_self_index, op);
 
 	for (i = 0; i < scan_result.m_scan_result.num_neighbors; i++) {
 		res.result = scan_result.get_scan_result();
@@ -180,7 +179,7 @@ void dm_scan_result_list_t::update_list(const dm_scan_result_t& scan_result, uns
 
     switch (op) {
         case dm_orch_type_db_insert:
-            put_scan_result(key, &scan_result);
+            put_scan_result(key, &scan_result, index);
             break;
 
         case dm_orch_type_db_update:

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -311,7 +311,11 @@ short em_channel_t::create_channel_scan_res_tlv(unsigned char *buff, unsigned in
 	memcpy(tmp, reinterpret_cast<unsigned char *> (&param), sizeof(unsigned short));
 	len += static_cast<short unsigned int> (sizeof(unsigned short));
 	tmp += sizeof(unsigned short);
-	
+
+	if (scan_res->m_scan_result.num_neighbors > EM_MAX_NEIGHBORS) {
+		scan_res->m_scan_result.num_neighbors = EM_MAX_NEIGHBORS;
+	}
+
 	for (i = 0; i < scan_res->m_scan_result.num_neighbors; i++) {
 		nbr = &scan_res->m_scan_result.neighbor[i];
 
@@ -1829,6 +1833,10 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
 	memcpy(&scan_res->m_scan_result.num_neighbors, tmp, sizeof(unsigned short));
 	scan_res->m_scan_result.num_neighbors = htons(scan_res->m_scan_result.num_neighbors);	
 	tmp += sizeof(unsigned short);		
+
+	if (scan_res->m_scan_result.num_neighbors > EM_MAX_NEIGHBORS) {
+		scan_res->m_scan_result.num_neighbors = EM_MAX_NEIGHBORS;
+	}
 
     for (i = 0; i < scan_res->m_scan_result.num_neighbors; i++) {
         nbr = &scan_res->m_scan_result.neighbor[i];


### PR DESCRIPTION
RDKB-59209: EM App - Fix channel scan issues

Reason for change: 1) Fix typo in EM_MAX_NEIGHBORS and added check for max number of neighbors to avoid buffer overflow.
2) Fix the issue with deleting the scan results database on controller restart. Replaced for loop with while to ensure all entries are deleted properly.
3) When multiple scan results are received in agent, only one scan result is processed. Modified handle_channel_scan_result to fix this issue.
4) Updated proper scanner mac in analyze_scan_result function
5) Fix warning - EM_MAX_CHANNELS redefined
6) Update put_scan_result function to use index value as current implementation always updates index 0 and cause duplicate scan results and  override the scan results.

Test Procedure: Ensure channel scan results are received in agent side and then to controller cli upon request for channel scan.
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>