### PR TITLE
DPP EasyConnect: General bug fixes and improvements until `process_proxy_encap_dpp_msg`

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -191,7 +191,7 @@ typedef union {
         uint8_t reserved : 6;   // Bits 2-7
     } __attribute__((packed));  // Anonymous struct
     uint8_t byte;
-} ec_dpp_capabilities_t;
+} __attribute__((packed)) ec_dpp_capabilities_t;
 
 typedef union {
     struct {
@@ -204,7 +204,7 @@ typedef union {
         uint8_t reserved : 7;   // Bits 1-7
     } __attribute__((packed));
     uint8_t byte; // Used to access the entire byte
-}  ec_dpp_reconfig_flags_t;
+}  __attribute__((packed)) ec_dpp_reconfig_flags_t;
 
 
 typedef enum {

--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -38,7 +38,7 @@ using send_encap_dpp_func = std::function<bool(em_encap_dpp_t*, size_t, em_dpp_c
  * @param frequency The frequency to send the frame on (0 for current frequency)
  * @return true if successful, false otherwise
  */
-using send_act_frame_func = std::function<bool(uint8_t*, uint8_t *, size_t, unsigned int)>;
+using send_act_frame_func = std::function<bool(uint8_t*, uint8_t *, size_t, unsigned int, unsigned int)>;
 
 /**
  * @brief Set the CCE IEs in the beacon and probe response frames
@@ -216,6 +216,14 @@ public:
      */
     virtual bool handle_proxied_conn_status_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) {
         return true;
+    }
+
+    inline void teardown_connection(const std::string& mac) {
+        auto conn = m_connections.find(mac);
+        if (conn == m_connections.end()) return;
+        auto &c_ctx = conn->second;
+        ec_crypto::free_connection_ctx(&c_ctx);
+        ec_crypto::free_ephemeral_context(&c_ctx.eph_ctx, c_ctx.nonce_len, c_ctx.digest_len);
     }
 
     inline std::string get_mac_addr() { return m_mac_addr; };

--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -36,6 +36,7 @@ using send_encap_dpp_func = std::function<bool(em_encap_dpp_t*, size_t, em_dpp_c
  * @param action_frame The action frame to send
  * @param action_frame_len The length of the action frame
  * @param frequency The frequency to send the frame on (0 for current frequency)
+ * @param wait The time to wait on the channel after sending the frame (0 for no wait)
  * @return true if successful, false otherwise
  */
 using send_act_frame_func = std::function<bool(uint8_t*, uint8_t *, size_t, unsigned int, unsigned int)>;

--- a/inc/ec_crypto.h
+++ b/inc/ec_crypto.h
@@ -58,7 +58,7 @@ public:
      * @param boot_key The bootstrapping key to use as a basis
      * @return bool true if successful, false otherwise
      */
-    static bool init_persistent_ctx(ec_connection_context_t& c_ctx, const SSL_KEY *boot_key);
+    static bool init_connection_ctx(ec_connection_context_t& c_ctx, const SSL_KEY *boot_key);
 
     /**
      * @brief Compute the hash of the provided buffer
@@ -323,6 +323,28 @@ public:
         if (ctx->bk) rand_zero_free(ctx->bk, static_cast<size_t> (digest_len));
 
         rand_zero(reinterpret_cast<uint8_t*>(ctx), sizeof(ec_ephemeral_context_t));
+    }
+
+    static inline void free_connection_ctx(ec_connection_context_t* ctx) {
+        if (!ctx) return;
+
+        if (ctx->boot_data.resp_pub_boot_key) EC_POINT_free(ctx->boot_data.resp_pub_boot_key);
+        if (ctx->boot_data.init_pub_boot_key) EC_POINT_free(ctx->boot_data.init_pub_boot_key);
+        if (ctx->boot_data.resp_priv_boot_key) BN_free(ctx->boot_data.resp_priv_boot_key);
+        if (ctx->boot_data.init_priv_boot_key) BN_free(ctx->boot_data.init_priv_boot_key);
+        if (ctx->boot_data.responder_boot_key) em_crypto_t::free_key(const_cast<SSL_KEY*>(ctx->boot_data.responder_boot_key));
+        if (ctx->boot_data.initiator_boot_key) em_crypto_t::free_key(const_cast<SSL_KEY*>(ctx->boot_data.initiator_boot_key));
+
+        if (ctx->group) EC_GROUP_free(const_cast<EC_GROUP*>(ctx->group));
+        if (ctx->order) BN_free(ctx->order);
+        if (ctx->prime) BN_free(ctx->prime);
+        if (ctx->bn_ctx) BN_CTX_free(ctx->bn_ctx);
+        if (ctx->C_signing_key) em_crypto_t::free_key(ctx->C_signing_key);
+        if (ctx->ppk) EC_POINT_free(ctx->ppk);
+        if (ctx->net_access_key) em_crypto_t::free_key(ctx->net_access_key);
+        if (ctx->connector) rand_zero_free(const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(ctx->connector)), strlen(ctx->connector));
+
+        rand_zero(reinterpret_cast<uint8_t*>(ctx), sizeof(ec_connection_context_t));
     }
 
 // START: Connector methods

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -11,7 +11,7 @@ class ec_ctrl_configurator_t : public ec_configurator_t {
 public:
     ec_ctrl_configurator_t(std::string mac_addr, send_chirp_func send_chirp_notification, send_encap_dpp_func send_prox_encap_dpp_msg,
         get_backhaul_sta_info_func backhaul_sta_info_func, get_1905_info_func ieee1905_info_func, can_onboard_additional_aps_func can_onboard_func) :
-        ec_configurator_t(mac_addr, send_chirp_notification, send_prox_encap_dpp_msg, {}, backhaul_sta_info_func, ieee1905_info_func, can_onboard_func), m_enrollee_successfully_onboarded{}
+        ec_configurator_t(mac_addr, send_chirp_notification, send_prox_encap_dpp_msg, {}, backhaul_sta_info_func, ieee1905_info_func, can_onboard_func)
         {};
         // No MAC address needed for controller configurator
 
@@ -98,7 +98,7 @@ private:
      * @brief Maps Enrollee MAC (as string) to onboarded status. True if onboarded (now a Proxy Agent), false if still onboarding / onboarding failed.
      * 
      */
-    std::unordered_map<std::string, bool> m_enrollee_successfully_onboarded;
+    std::unordered_map<std::string, bool> m_enrollee_successfully_onboarded = {};
 };
 
 #endif // EC_CTRL_CONFIGURATOR_H

--- a/inc/ec_enrollee.h
+++ b/inc/ec_enrollee.h
@@ -71,6 +71,11 @@ public:
      */
     bool handle_config_response(uint8_t *buff, unsigned int len, uint8_t sa[ETH_ALEN]);
 
+    inline void teardown_connection() {
+        ec_crypto::free_connection_ctx(&m_c_ctx);
+        ec_crypto::free_ephemeral_context(&m_c_ctx.eph_ctx, m_c_ctx.nonce_len, m_c_ctx.digest_len);
+    }
+
     inline std::string get_mac_addr() { return m_mac_addr; };
 
     // Disable copy construction and assignment

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -42,7 +42,7 @@ public:
     bool handle_recv_ec_action_frame(ec_frame_t* frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN]);
 
 
-    bool handle_recv_gas_pub_action_frame(ec_gas_frame_base_t *, size_t, uint8_t[ETH_ALEN]);
+    bool handle_recv_gas_pub_action_frame(ec_gas_frame_base_t * frame, size_t len, uint8_t src_mac[ETH_ALEN]);
 
     /**
      * @brief Start the EC configurator onboarding

--- a/inc/ec_util.h
+++ b/inc/ec_util.h
@@ -279,7 +279,7 @@ public:
      * @param hash_len [out] The length of the hash
      * @return bool true if successful, false otherwise
      */
-    static bool parse_dpp_chirp_tlv(em_dpp_chirp_value_t* chirp_tlv,  uint16_t chirp_tlv_len, mac_addr_t *mac, uint8_t **hash, uint8_t *hash_len);
+    static bool parse_dpp_chirp_tlv(em_dpp_chirp_value_t* chirp_tlv,  uint16_t chirp_tlv_len, mac_addr_t *mac, uint8_t **hash, uint16_t *hash_len);
 
     /**
      * @brief Creates and allocates a DPP Chirp Value TLV
@@ -289,11 +289,13 @@ public:
      * @param mac_present [in] The address of the Enrollee Multi-AP Agent 
      * @param hash_validity [in] Establish/purge any DPP authentication state pertaining to the hash value in this TLV (0 = purge, 1 = establish)
      * @param dest_mac [in] The destination mac address (0 if not present)
+     * @param hash [in] The hash value (NULL if not present)
+     * @param hash_len [in] The length of the hash value (0 if not present)
      * @return em_dpp_chirp_value_t* The heap allocated DPP Chirp Value TLV, NULL if failed
      * 
      * @warning The `em_dpp_chirp_value_t` must be freed by the caller
      */
-    static std::pair<em_dpp_chirp_value_t*, uint16_t> create_dpp_chirp_tlv(bool mac_present, bool hash_validity, mac_addr_t dest_mac);
+    static std::pair<em_dpp_chirp_value_t*, uint16_t> create_dpp_chirp_tlv(bool mac_present, bool hash_validity, mac_addr_t dest_mac = NULL, uint8_t* hash = NULL, uint16_t hash_len = 0);
 
     /**
      * @brief Parse an Encap DPP TLV

--- a/inc/em.h
+++ b/inc/em.h
@@ -33,6 +33,8 @@
 #include "dm_easy_mesh.h"
 #include "em_sm.h"
 
+#include "util.h"
+
 class em_mgr_t;
 
 class em_t : 
@@ -101,7 +103,8 @@ public:
     bool toggle_cce(bool enable);
 
 	em_mgr_t *get_mgr() { return m_mgr; }
-    ec_manager_t& get_ec_mgr() { return *m_ec_manager; }
+
+    ec_manager_t& get_ec_mgr();
 
     void orch_execute(em_cmd_t *pcmd);
     em_orch_state_t get_orch_state() { return m_orch_state; }
@@ -135,7 +138,7 @@ public:
     em_ieee_1905_security_cap_t *get_ieee_1905_security_cap() { return m_data_model->get_ieee_1905_security_cap(); }
     em_device_info_t    *get_device_info() { return m_data_model->get_device_info(); }
 
-    unsigned char *get_peer_mac() { return (m_service_type == em_service_type_ctrl) ? m_data_model->get_agent_al_interface_mac():m_data_model->get_ctrl_al_interface_mac(); }
+    unsigned char *get_peer_mac() { return (m_service_type == em_service_type_ctrl) ? m_data_model->get_agent_al_interface_mac():m_data_model->get_controller_interface_mac(); }
 
     bool has_at_least_one_associated_sta() { return get_data_model()->has_at_least_one_associated_sta(); }
     dm_sta_t *find_sta(mac_address_t sta_mac, bssid_t bssid);

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -86,9 +86,10 @@ public:
      * @param action_frame The action frame to send
      * @param action_frame_len The length of the action frame
      * @param frequency The frequency to send the frame on (0 for current frequency)
+     * @param wait_time_ms The time to dwell on the frequency before switching back to the original frequency (0 for no wait)
      * @return true if successful, false otherwise
      */
-    bool send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, unsigned int frequency=0) override;
+    bool send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, unsigned int frequency=0, unsigned int wait_time_ms=0) override;
 
     /**
      * @brief Try to create a default EasymeshCfg.json file if one does not exist.

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -60,7 +60,7 @@ public:
      * 
      * @return Pointer to the physical AL node.
      */
-    em_t *get_phy_al_em();
+    em_t *get_phy_al_node();
 
     void nodes_listener();
     int reset_listeners();
@@ -88,9 +88,10 @@ public:
      * @param action_frame The action frame to send
      * @param action_frame_len The length of the action frame
      * @param frequency The frequency to send the frame on (0 for current frequency)
+     * @param wait_time_ms The time to dwell on the frequency before switching back to the original frequency (0 for no wait)
      * @return true if successful, false otherwise
      */
-    virtual bool send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, unsigned int frequency=0) {
+    virtual bool send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, unsigned int frequency=0, unsigned int wait_time_ms=0) {
         printf("send_action_frame not implemented\n");
         return false;
     }

--- a/inc/ieee80211.h
+++ b/inc/ieee80211.h
@@ -1138,7 +1138,7 @@ struct ieee80211_vs_ie{
     uint8_t         vs_oui[3];     /* Vendor OUI */
     uint8_t         vs_type;       /* Vendor Specific type */
     uint8_t         vs_subtype;    /* Vendor Specific sub-type (required for some devices, can be 0) */
-    uint8_t         payload[0];    /* Vendor Specific Payload */
+    uint8_t         payload[];    /* Vendor Specific Payload */
 } __attribute__((packed));
 
 /*

--- a/inc/util.h
+++ b/inc/util.h
@@ -60,6 +60,23 @@ void add_milliseconds(struct timespec *ts, long milliseconds);
 char *get_date_time_rfc3399(char *buff, unsigned int len);
 void print_hex_dump(unsigned int length, uint8_t *buffer, easymesh_dbg_type_t module=EM_STDOUT);
 
+
+/**
+ * @brief Captures and prints the current call stack to stderr
+ * 
+ * This function uses backtrace() to capture the current execution stack frames
+ * and backtrace_symbols() to convert the addresses to human-readable strings.
+ * The stack trace is printed to stderr with each frame on a separate line.
+ * 
+ * @note This implementation is Unix/Linux-specific and relies on execinfo.h,
+ *       which is not part of the C++ standard library. On other platforms,
+ *       alternative implementations would be required.
+ * 
+ * @note The stack trace information may be limited depending on compilation
+ *       flags. For best results, compile with debugging information (-g).
+ */
+void print_stacktrace();
+
 /**
  * Converts a MAC address to its string representation
  * 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -327,8 +327,9 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
         return;
     }
     const size_t full_frame_length = evt->data_len;
-    const size_t mgmt_hdr_len      = offsetof(struct ieee80211_mgmt, u);
-    ieee80211_mgmt *mgmt_frame     = (ieee80211_mgmt *)evt->u.raw_buff;
+    const size_t mgmt_hdr_len = offsetof(struct ieee80211_mgmt, u);
+    ieee80211_mgmt *mgmt_frame = (ieee80211_mgmt *)evt->u.raw_buff;
+
     mac_addr_str_t dest_mac;
     dm_easy_mesh_t::macbytes_to_string(mgmt_frame->da, dest_mac);
     em_t *dest_node = (em_t *)hash_map_get(g_agent.m_em_map, dest_mac);
@@ -336,10 +337,76 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
         printf("%s:%d: no node found for MAC '%s'\n", __func__, __LINE__, dest_mac);
         return;
     }
+    em_t *al_node = get_al_node();
+    if (!al_node) {
+        printf("%s:%d: no AL node present\n", __func__, __LINE__);
+        return;
+    }
+
     auto gas_frame_base = (ec_gas_frame_base_t *)evt->u.raw_buff + mgmt_hdr_len;
-    if (!dest_node->m_ec_manager->handle_recv_gas_pub_action_frame(
-            gas_frame_base, full_frame_length - mgmt_hdr_len, mgmt_frame->sa)) {
-        printf("%s:%d: EC manager failed to handle GAS frame!\n", __func__, __LINE__);
+
+    bool is_wfa_ec_gas = false;
+
+    switch (gas_frame_base->action) {
+    case dpp_gas_action_type_t::dpp_gas_initial_req: {
+        printf("%s:%d: Received GAS Initial Request\n", __func__, __LINE__);
+        ec_gas_initial_request_frame_t *gas_initial_req_frame =
+            (ec_gas_initial_request_frame_t *)gas_frame_base;
+        uint8_t *ap_proto_id = gas_initial_req_frame->ape_id;
+        if (ap_proto_id[0] == 0xDD) {
+            // Vendor specific GAS frame
+            if (memcmp(ap_proto_id, DPP_GAS_CONFIG_REQ_PROTO_ID,
+                       sizeof(DPP_GAS_CONFIG_REQ_PROTO_ID)) == 0) {
+                // DPP GAS frame
+                is_wfa_ec_gas = true;
+            }
+        }
+        break;
+    }
+    case dpp_gas_action_type_t::dpp_gas_initial_resp: {
+        printf("%s:%d: Received GAS Initial Response\n", __func__, __LINE__);
+        ec_gas_initial_response_frame_t *gas_initial_resp_frame =
+            (ec_gas_initial_response_frame_t *)gas_frame_base;
+        uint8_t *ap_proto_id = gas_initial_resp_frame->ape_id;
+        if (ap_proto_id[0] == 0xDD) {
+            // Vendor specific GAS frame
+            if (memcmp(ap_proto_id, DPP_GAS_CONFIG_REQ_PROTO_ID,
+                       sizeof(DPP_GAS_CONFIG_REQ_PROTO_ID)) == 0) {
+                // DPP GAS frame
+                is_wfa_ec_gas = true;
+            }
+        }
+        break;
+    }
+    case dpp_gas_action_type_t::dpp_gas_comeback_req:
+        printf("%s:%d: Received GAS Comeback Request\n", __func__, __LINE__);
+        // TODO: handle comeback request
+        break;
+    case dpp_gas_action_type_t::dpp_gas_comeback_resp:
+        printf("%s:%d: Received GAS Comeback Response\n", __func__, __LINE__);
+        // TODO: handle comeback response
+        break;
+    default:
+        printf("%s:%d: Received unknown GAS action type '0x%x'\n", __func__, __LINE__,
+               gas_frame_base->action);
+        return;
+    }
+
+    if (is_wfa_ec_gas) {
+        printf("%s:%d: Received WFA EC GAS frame\n", __func__, __LINE__);
+        bool dest_al_same = (memcmp(dest_node->get_radio_interface_mac(),
+                                    get_al_node()->get_radio_interface_mac(), ETH_ALEN) != 0);
+
+        if (!dest_al_same && !(m_data_model.get_colocated())) {
+            // DPP GAS Frame not sent to same radio as AL node, let's ignore it.
+            // We don't ignore it if this co-located since the AL-node will be the same as the controller (eth0)
+            // so if we ignore it, no packets will ever get through
+            return;
+        }
+        if (!dest_node->m_ec_manager->handle_recv_gas_pub_action_frame(
+                gas_frame_base, full_frame_length - mgmt_hdr_len, mgmt_frame->sa)) {
+            printf("%s:%d: EC manager failed to handle GAS frame!\n", __func__, __LINE__);
+        }
     }
 }
 
@@ -367,7 +434,7 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
 
     mac_addr_str_t dest_mac_str;
     dm_easy_mesh_t::macbytes_to_string(mgmt_frame->da, dest_mac_str);
-
+    printf("Dest Mac Str: %s\n", dest_mac_str);
     em_t* dest_radio_node = static_cast<em_t*>(hash_map_get(g_agent.m_em_map, dest_mac_str));
     if (dest_radio_node == NULL) {
         // printf("No radio node found for dest mac %s\n", dest_mac_str);
@@ -381,9 +448,18 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
     auto ec_frame = reinterpret_cast<ec_frame_t*>(evt->u.raw_buff + mgmt_hdr_len);
 
     switch (oui_type) {
-    case DPP_OUI_TYPE:
-        dest_radio_node->m_ec_manager->handle_recv_ec_action_frame(ec_frame, full_action_frame_len, mgmt_frame->sa);
+    case DPP_OUI_TYPE: {
+	em_t* al_node = get_al_node();
+	bool dest_al_same = (memcmp(dest_radio_node->get_radio_interface_mac(), get_al_node()->get_radio_interface_mac(), ETH_ALEN) != 0);
+
+	if (!dest_al_same && !(m_data_model.get_colocated()))
+		// DPP Action Frame not sent to same radio as AL node, let's ignore it.
+		// We don't ignore it if this co-located since the AL-node will be the same as the controller (eth0) 
+		// so if we ignore it, no packets will ever get through
+		break;
+        al_node->get_ec_mgr().handle_recv_ec_action_frame(ec_frame, full_action_frame_len, mgmt_frame->sa);
         break;
+    }
     default:
         break;
     }
@@ -606,7 +682,7 @@ int em_agent_t::refresh_onewifi_subdoc(const char * log_name, const webconfig_su
     return m_data_model.refresh_onewifi_subdoc(desc, &m_bus_hdl, log_name, type);
 }
 
-bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, unsigned int frequency) {
+bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, unsigned int frequency, unsigned int wait_time_ms) {
 
     wifi_bus_desc_t *desc = get_bus_descriptor();
     ASSERT_NOT_NULL(desc, false, "%s:%d descriptor is null\n", __func__, __LINE__);
@@ -620,6 +696,10 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
     act_frame_params->ap_index = 0;
     memcpy(act_frame_params->dest_addr, dest_mac, ETH_ALEN);
     act_frame_params->frequency = frequency;
+
+    //TODO: Disabled until halinterace, rdk-wifi-hal, OneWifi PRs are merged
+    //act_frame_params->wait_time_ms = wait_time_ms;
+
     act_frame_params->frame_len = action_frame_len;
     memcpy(act_frame_params->frame_data, action_frame, action_frame_len);
 
@@ -629,9 +709,16 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
     raw_act_frame.raw_data_len = sizeof(action_frame_params_t) + action_frame_len;
     raw_act_frame.data_type = bus_data_type_bytes;
 
+    static int test_idx = act_frame_params->ap_index+1;
+    char path[100] = {0};
+    snprintf(path, sizeof(path), "Device.WiFi.AccessPoint.%d.RawFrame.Mgmt.Action.Tx", test_idx);
+    
+    printf("%s:%d Sending Action frame to path: %s\n", __func__, __LINE__, path);
     // Send the action frame
-    if (desc->bus_set_fn(&m_bus_hdl, "Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx", &raw_act_frame) != 0) {
-        printf("%s:%d bus set failed\n", __func__, __LINE__);
+    bus_error_t rc;
+    if ((rc = desc->bus_set_fn(&m_bus_hdl, path,  &raw_act_frame)) != 0) {
+        if (rc == bus_error_destination_not_found) test_idx--;
+        printf("%s:%d bus set failed (%d)\n", __func__, __LINE__, rc);
         free(act_frame_params);
         return false;
     }
@@ -969,8 +1056,6 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 			return NULL;
 		}
 		break;
-        case em_msg_type_chirp_notif:
-
 		case em_msg_type_autoconf_wsc:
 			if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
                 	len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_radio_id(&ruid) == false) {
@@ -1151,6 +1236,10 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case em_msg_type_beacon_metrics_query:
             break;
 
+        case em_msg_type_proxied_encap_dpp:
+        case em_msg_type_chirp_notif:
+            em = al_em;
+            break;
         default:
             printf("%s:%d: Frame: %d not handled in agent\n", __func__, __LINE__, htons(cmdu->type));
             assert(0);
@@ -1261,7 +1350,7 @@ bool em_agent_t::try_start_dpp_onboarding()  {
         return false;
     }
 
-    em_t* al_node = get_phy_al_em();
+    em_t* al_node = get_al_node();
     ASSERT_NOT_NULL(al_node, false, "%s:%d: al_node is null\n", __func__, __LINE__);
 
     uint8_t* al_mac = al_node->get_radio_interface_mac();

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -750,7 +750,11 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
                 em = static_cast<em_t *> (hash_map_get_next(m_em_map, em));
             }
             break;
-
+        case em_msg_type_chirp_notif:
+        case em_msg_type_proxied_encap_dpp:
+            // TODO: Add more types and might have to work on addressing more
+	        em = al_em;
+	        break;
         default:
             printf("%s:%d: Frame: 0x%04x not handled in controller\n", __func__, __LINE__, htons(cmdu->type));
             assert(0);

--- a/src/dm/dm_bss.cpp
+++ b/src/dm/dm_bss.cpp
@@ -255,7 +255,6 @@ void dm_bss_t::encode(cJSON *obj, bool summary)
     // Add the array to the object
     cJSON_AddItemToObject(obj, "BackhaulAKMsAllowed", backhaul_akmsArray);
 
-    printf("Encoding %ld vendor elements\n", m_bss_info.vendor_elements_len);
     // Add vendor elements (ExtraVendorIEs) as hex string
     char vendor_ies[2 * m_bss_info.vendor_elements_len + 1] = {0};
     if (m_bss_info.vendor_elements_len > 0) {

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -260,7 +260,7 @@ em_t *em_mgr_t::get_al_node()
     return (found == true) ? em:NULL;	
 }
 
-em_t *em_mgr_t::get_phy_al_em()
+em_t *em_mgr_t::get_phy_al_node()
 {
     // al_node is the fake ("_al") node
     em_t* al_node = get_al_node();

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -251,8 +251,8 @@ em_tlv_t *em_msg_t::get_tlv(em_tlv_type_t type)
         if (tlv->type == type) {
             return tlv; 
         }
-        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + ntohs(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     return NULL;

--- a/src/em/prov/easyconnect/ec_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_configurator.cpp
@@ -74,11 +74,11 @@ bool ec_configurator_t::onboard_enrollee(ec_data_t *bootstrapping_data)
     c_ctx.boot_data.init_pub_boot_key = em_crypto_t::get_pub_key_point(c_ctx.boot_data.initiator_boot_key);
 
 
-    if (c_ctx.boot_data.resp_priv_boot_key == NULL) {
+    if (c_ctx.boot_data.resp_pub_boot_key == NULL) {
         printf("%s:%d Could not get responder bootstrap public key\n", __func__, __LINE__);
         return false;
     }
 
     printf("Configurator MAC: %s\n", m_mac_addr.c_str());
-    return ec_crypto::init_persistent_ctx(c_ctx, c_ctx.boot_data.responder_boot_key);
+    return ec_crypto::init_connection_ctx(c_ctx, c_ctx.boot_data.responder_boot_key);
 }

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -2,6 +2,7 @@
 #include "ec_ctrl_configurator.h"
 
 #include "ec_util.h"
+#include "util.h"
 
 #include <memory>
 
@@ -14,8 +15,8 @@ ec_manager_t::ec_manager_t(
     get_1905_info_func get_1905_info,
     can_onboard_additional_aps_func can_onboard,
     toggle_cce_func toggle_cce, 
-    bool m_is_controller
-) : m_is_controller(m_is_controller),
+    bool is_controller
+) : m_is_controller(is_controller),
     m_stored_chirp_fn(send_chirp),
     m_stored_encap_dpp_fn(send_encap_dpp),
     m_stored_action_frame_fn(send_action_frame),
@@ -26,9 +27,10 @@ ec_manager_t::ec_manager_t(
     m_configurator(nullptr),
     m_enrollee(nullptr),
     m_toggle_cce_fn(toggle_cce) {
-    
+	
+    printf("EC Manager created with MAC: %s\n", mac_addr.c_str());  
     if (m_is_controller) {
-        m_configurator = std::unique_ptr<ec_configurator_t>(
+        m_configurator = std::unique_ptr<ec_ctrl_configurator_t>(
             new ec_ctrl_configurator_t(mac_addr, send_chirp, send_encap_dpp, get_bsta_info, get_1905_info, can_onboard)
         );
     } else {
@@ -48,26 +50,41 @@ bool ec_manager_t::handle_recv_ec_action_frame(ec_frame_t *frame, size_t len, ui
         printf("%s:%d: frame validation failed\n", __func__, __LINE__);
         return false;
     }
+    bool did_succeed = false;
     switch (frame->frame_type) {
         case ec_frame_type_presence_announcement:
-            return m_configurator->handle_presence_announcement(frame, len, src_mac);
+            did_succeed = m_configurator->handle_presence_announcement(frame, len, src_mac);
+            break;
         case ec_frame_type_auth_req:
-            return m_enrollee->handle_auth_request(frame, len, src_mac);
+            did_succeed = m_enrollee->handle_auth_request(frame, len, src_mac);
+            break;
         case ec_frame_type_auth_rsp:
-            return m_configurator->handle_auth_response(frame, len, src_mac);
+            did_succeed = m_configurator->handle_auth_response(frame, len, src_mac);
+            break;
         case ec_frame_type_auth_cnf:
-            return m_enrollee->handle_auth_confirm(frame, len, src_mac);
+            did_succeed = m_enrollee->handle_auth_confirm(frame, len, src_mac);
+            break;
         case ec_frame_type_cfg_result:
-            return m_configurator->handle_cfg_result(frame, len, src_mac);
+            did_succeed = m_configurator->handle_cfg_result(frame, len, src_mac);
             break;
         case ec_frame_type_conn_status_result:
-            return m_configurator->handle_connection_status_result(frame, len, src_mac);
+            did_succeed = m_configurator->handle_connection_status_result(frame, len, src_mac);
             break;
         default:
             printf("%s:%d: frame type (%d) not handled\n", __func__, __LINE__, frame->frame_type);
             break;
     }
-    return true;
+    if (!did_succeed) {
+        // Teardown connection because of failure
+        if (m_configurator) {
+            std::string mac = util::mac_to_string(src_mac);
+            m_configurator->teardown_connection(mac);
+        }
+        if (m_enrollee) {
+            m_enrollee->teardown_connection();
+        }
+    }
+    return did_succeed;
 }
 
 bool ec_manager_t::handle_recv_gas_pub_action_frame(ec_gas_frame_base_t *frame, size_t len, uint8_t source_addr[ETH_ALEN]) {
@@ -76,11 +93,14 @@ bool ec_manager_t::handle_recv_gas_pub_action_frame(ec_gas_frame_base_t *frame, 
         return false;
     }
     printf("%s:%d: Got a GAS frame with %02x action!\n", __func__, __LINE__, frame->action);
+    bool did_succeed = false;
     switch (static_cast<dpp_gas_action_type_t>(frame->action)) {
         case dpp_gas_initial_req:
-            return m_configurator->handle_cfg_request(reinterpret_cast<uint8_t*>(frame), static_cast<unsigned int>(len), source_addr);
+            did_succeed = m_configurator->handle_cfg_request(reinterpret_cast<uint8_t*>(frame), static_cast<unsigned int>(len), source_addr);
+            break;
         case dpp_gas_initial_resp:
-            return m_enrollee->handle_config_response(reinterpret_cast<uint8_t*>(frame), static_cast<unsigned int>(len), source_addr);
+            did_succeed = m_enrollee->handle_config_response(reinterpret_cast<uint8_t*>(frame), static_cast<unsigned int>(len), source_addr);
+            break;
         case dpp_gas_comeback_req:
         case dpp_gas_comeback_resp:
         default:
@@ -88,7 +108,17 @@ bool ec_manager_t::handle_recv_gas_pub_action_frame(ec_gas_frame_base_t *frame, 
             printf("%s:%d: unhandled DPP GAS action type=%02x\n", __func__, __LINE__, frame->action);
             break;
     }
-    return false;
+    if (!did_succeed) {
+        // Teardown connection because of failure
+        if (m_configurator) {
+            std::string mac = util::mac_to_string(source_addr);
+            m_configurator->teardown_connection(mac);
+        }
+        if (m_enrollee) {
+            m_enrollee->teardown_connection();
+        }
+    }
+    return did_succeed;
 }
 
 bool ec_manager_t::upgrade_to_onboarded_proxy_agent()

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -32,11 +32,30 @@
 #include <algorithm>
 #include <sstream>
 
+#include <cstdlib>
+#include <execinfo.h>
+
 
 #include "util.h"
 
 extern "C" {
     extern char *__progname;
+}
+
+void util::print_stacktrace() {
+    // Get the stack trace (Unix/Linux implementation)
+    const int max_frames = 100;
+    void* callstack[max_frames];
+    int frames = backtrace(callstack, max_frames);
+    char** symbols = backtrace_symbols(callstack, frames);
+    
+    // Print the stack trace
+    fprintf(stderr, "Stack trace:\n");
+    for (int i = 0; i < frames; i++) {
+        fprintf(stderr, "%s\n", symbols[i]);
+    }
+    
+    free(symbols);
 }
 
 char *util::get_date_time_rfc3399(char *buff, unsigned int len)


### PR DESCRIPTION
**NOTE: These commits are separated for the ease of the reviewer. They do not function independently and will be squashed before merging.**

This fixes several bugs in EasyMesh + EasyConnect DPP, allowing for an Enrollee to announce it's presence, the Proxy Agent to handle those action frames correctly, forwarding them to the controller who verifies against the local `DPPURI.json` file's public key hash. If that verification is successful, it will generate an authentication request and attempt to send it back to the proxy agent. At this point it still crashes due to `ec_manager_t`  pointer corruption. This should not be an issue for existing operation of `unified-wifi-mesh` because it only occurs under very specific circumstances that are not allowed in the current codebase. For example, the out-of-band transfer of the `DPPURI.json` file to the controller must be performed for this crash to occur. That cannot happen by accident.

Here are some pertinent sections of logs to demonstrate it working (until the bad point):

### Controller
```shell
process_chirp_notification:25: Connection context not found for enrollee MAC 94:18:65:5c:e7:ac. Has the DPP URI been given? <----------- Chirp Notification is received without DPPURI given via TUI.
handle_dpp_chirp_notif:506: Failed to process chirp notification
decode:66: Decoding DPP <-------------- DPP URI is given via the TUI
ORCH: Start DPP
ORCH: DPP:
	DPP: Version: 2
	DPP: MAC Address: 94:18:65:5c:e7:ac
	DPP: Freqs:
		Freq: 2467
Configurator MAC: d8:3a:dd:74:f1:46
Successfully initialized persistent context with params:
	NID: 415
	Digest Length: 32
	Nonce Length: 128
	Prime (Length: 32):
  0000  ff ff ff ff 00 00 00 01 00 00 00 00 00 00 00 00  ................
  0010  00 00 00 00 ff ff ff ff ff ff ff ff ff ff ff ff  ................
create_auth_request:894 Enter <--------------- Verification has occurred and succeeded, the auth request will now be created
Key K_1:
  0000  5e 9a 7f 9d a2 83 83 91 22 d5 2b 98 2e cf 7a 21  ^.......".+...z!
  0010  3d c0 18 5c 56 33 96 3b 1f 99 f9 14 db 96 b4 35  =..\V3.;.......5
/home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/ctrl/../..//inc/ec_manager.h:130:59: runtime error: member access within misaligned address 0x918383a29d7f9a5e for type 'struct ec_configurator_t', which requires 8 byte alignment
0x918383a29d7f9a5e: note: pointer points here
<memory cannot be printed>
AddressSanitizer:DEADLYSIGNAL
=================================================================
==69801==ERROR: AddressSanitizer: SEGV on unknown address 0x30708453aff34b (pc 0x00555ab909a4 bp 0x007f94dee500 sp 0x007f94dee500 T2)
==69801==The signal is caused by a READ memory access.
    #0 0x555ab909a4 in ec_manager_t::process_proxy_encap_dpp_msg(em_encap_dpp_t*, unsigned short, em_dpp_chirp_value_t*, unsigned short) /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/ctrl/../..//inc/ec_manager.h:130
    #1 0x555ab88ff4 in em_provisioning_t::handle_proxy_encap_dpp(unsigned char*, unsigned int) /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/ctrl/../..//src/em/prov/em_provisioning.cpp:549
    #2 0x555ab88060 in em_provisioning_t::process_msg(unsigned char*, unsigned int) /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/ctrl/../..//src/em/prov/em_provisioning.cpp:457
    #3 0x555aa8b440 in em_t::proto_process(unsigned char*, unsigned int) /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/agent/../..//src/em/em.cpp:294
    #4 0x555aa8fe2c in em_t::proto_run() /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/agent/../..//src/em/em.cpp:491
    #5 0x555aa906c8 in em_t::em_func(void*) /home/bcarlson/rdkb_easymesh/unified-wifi-mesh/build/agent/../..//src/em/em.cpp:513
    #6 0x7f9b36ee2c in start_thread nptl/pthread_create.c:442
    #7 0x7f9b3d7ad8 in thread_start ../sysdeps/unix/sysv/linux/aarch64/clone.S:79
``` 

### Proxy Agent (Co-located)
```shell
mgmt_action_frame_cb:842 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
68
  0000  d0 00 00 00 d8 3a dd 74 f1 48 94 18 65 5c e7 ac  .....:.t.H..e\..
  0010  d8 3a dd 74 f1 48 00 00 04 09 50 6f 9a 1a 01 0d  .:.t.H....Po....
  0020  02 10 20 00 18 8a 32 d7 c8 78 24 85 1e 9d 07 11  .. ...2..x$.....
  0030  e1 2b 73 f0 c4 3a 4b 9c 6b af c8 57 a0 ec e3 58  .+s..:K.k..W...X
  0040  57 d5 ff ac                                      W...
handle_recv_wfa_action_frame:433: Received WFA action frame: Full Length: 68, VS Action Data Length: 39
Dest Mac Str: d8:3a:dd:74:f1:48
send_chirp_notif_msg:170: Sending CHIRP NOTIFICATION <---------- A presence announcement was received and we're sending the corresponding chirp notification.
send_chirp_notif_msg:174: Peer MAC: d8:3a:dd:74:f1:46, AL MAC: d8:3a:dd:74:f1:46
mgmt_action_frame_cb:842 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
68
  0000  d0 00 00 00 d8 3a dd 74 f1 48 94 18 65 5c e7 ac  .....:.t.H..e\..
  0010  d8 3a dd 74 f1 48 00 00 04 09 50 6f 9a 1a 01 0d  .:.t.H....Po....
  0020  02 10 20 00 18 8a 32 d7 c8 78 24 85 1e 9d 07 11  .. ...2..x$.....
  0030  e1 2b 73 f0 c4 3a 4b 9c 6b af c8 57 a0 ec e3 58  .+s..:K.k..W...X
  0040  57 d5 ff ac                                      W...
handle_recv_wfa_action_frame:433: Received WFA action frame: Full Length: 68, VS Action Data Length: 39
Dest Mac Str: d8:3a:dd:74:f1:48
send_chirp_notif_msg:170: Sending CHIRP NOTIFICATION
send_chirp_notif_msg:174: Peer MAC: d8:3a:dd:74:f1:46, AL MAC: d8:3a:dd:74:f1:46
process_proxy_encap_dpp_msg:231: Chirp TLV Hash: 188a32d7c87824851e9d0711e12b73f0c43a4b9c6bafc857a0ece35857d5ffac 
^
|
|
Due to an addressing issue because the co-located agent has the same AL MAC as the controller, this `process_proxy_encap_dpp_msg` is called which does work and does print the hash that we sent (although it doesn't matter here).
```

### Enrollee Agent
```shell
read_bootstrap_data_from_file:778: DPP URI JSON: {
	"URI":	{
		"V":	2,
		"M":	"94:18:65:5c:e7:ac",
		"C":	"81/12",
		"K":	"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8T6g1Tl016shEkbwYQvjv6Xv+ZMsW0zsVs2XCDPRVoPqzCzR9lpC90rVGQ44GqOylLkg6sNEUDexM2n2RZNb7A=="
	}
}
read_bootstrap_data_from_file:802: Successfully read DPP URI JSON from file <----- DPPURI.json is read for bootstrapping data.
try_start_dpp_onboarding:1302: DPP bootstrapping data generated successfully
Enrollee MAC: 94:18:65:5c:e7:ac
Successfully initialized persistent context with params:
	NID: 415
	Digest Length: 32
	Nonce Length: 128
	Prime (Length: 32):
  0000  ff ff ff ff 00 00 00 01 00 00 00 00 00 00 00 00  ................
  0010  00 00 00 00 ff ff ff ff ff ff ff ff ff ff ff ff  ................
try_start_dpp_onboarding:1307: DPP onboarding started successfully
send_result:133: write error on socket, err:88
create_presence_announcement:593 Enter
send_action_frame:649 Sending Action frame to path: Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx <--------------- Presence Announcements are sent on different frequencies, only one of which actually hits the Proxy Agent
send_action_frame:649 Sending Action frame to path: Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx
send_action_frame:649 Sending Action frame to path: Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx
orch_transient:53: Canceling comd: dev_init because time limit exceeded
cancel_command:180: Setting em:94:18:65:5c:e7:ac State set to cancel
send_action_frame:649 Sending Action frame to path: Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx
send_action_frame:649 Sending Action frame to path: Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx
send_action_frame:649 Sending Action frame to path: Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx
send_action_frame:649 Sending Action frame to path: Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx
send_action_frame:649 Sending Action frame to path: Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx
```