### PR TITLE
Read/Write Keypair PEM + DPP bootstrapping PEM saving

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -44,6 +44,7 @@ extern "C"
 // START: Hardcoded EasyConnect values
 #define DPP_VERSION 0x02
 #define DPP_URI_JSON_PATH "/nvram/DPPURI.json"
+#define DPP_BOOT_PEM_PATH "/nvram/DPPURI.pem"
 
 // The NID for generating the local responder keypair
 #define DPP_KEY_NID NID_X9_62_prime256v1

--- a/inc/ec_util.h
+++ b/inc/ec_util.h
@@ -548,22 +548,24 @@ public:
                                            std::string country_code = "US");
 
     /**
-     * @brief Read the bootstrapping data from a file
+     * @brief Read the bootstrapping data from a JSON file
      * 
      * @param boot_data [out] The DPP data to read into
-     * @param file_path [in] The path to the file to read from
+     * @param json_file_path [in] The path to the JSON file to read from
+     * @param pem_file_path [in] The path to the PEM file (for the private key) to read from. NULL if not needed (e.g. for initiator)
      * @return true The DPP boot data was read successfully, false otherwise
      */
-    static bool read_bootstrap_data_from_file(ec_data_t *boot_data, const std::string &file_path);
+    static bool read_bootstrap_data_from_files(ec_data_t *boot_data, const std::string &json_file_path, const std::optional<std::string> &pem_file_path = std::nullopt);
 
     /**
      * @brief Write the bootstrapping data to a file
      * 
      * @param boot_data [in] The DPP data to write
      * @param file_path [in] The path to the file to write to
+     * @param pem_file_path [in] The path to the PEM file (for the private key) to write to
      * @return true The DPP boot data was written successfully, false otherwise
      */
-    static bool write_bootstrap_data_to_file(ec_data_t *boot_data, const std::string &file_path);
+    static bool write_bootstrap_data_to_files(ec_data_t *boot_data, const std::string &file_path, const std::string &pem_file_path);
 
     /**
      * @brief Generate DPP bootstrapping data

--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -427,13 +427,69 @@ public:
                                                    const std::optional<std::vector<uint8_t>>& priv_key_bytes = std::nullopt,
                                                    const std::string& group_name = "P-256");
 
-
+    
+    /**
+     * @brief Get the group of the key
+     * 
+     * @param key The SSL_KEY object containing the key
+     * @return Pointer to the EC_GROUP object representing the key group
+     */
     static EC_GROUP* get_key_group(const SSL_KEY* key);
+
+    /**
+     * @brief Get the private key as a BIGNUM object
+     * 
+     * @param key The SSL_KEY object containing the key
+     * @return Pointer to the BIGNUM object representing the private key
+     */
     static BIGNUM* get_priv_key_bn(const SSL_KEY* key);
+
+    /**
+     * @brief Get the public key as an EC_POINT object
+     * 
+     * @param key The SSL_KEY object containing the key
+     * @param key_group Optional EC_GROUP object representing the key group (can be NULL)
+     * @return Pointer to the EC_POINT object representing the public key
+     */
     static EC_POINT* get_pub_key_point(const SSL_KEY* key, EC_GROUP* key_group=NULL);
+
+    /**
+     * @brief Generate an SSL_KEY using a specified EC_GROUP
+     * 
+     * @param group The EC_GROUP to use for key generation
+     * @return Pointer to the generated SSL_KEY object
+     */
     static SSL_KEY* generate_ec_key(EC_GROUP *group);
+
+    /**
+     * @brief Generate an SSL_KEY with a specified NID (curve type)
+     * 
+     * @param nid The NID of the curve to use
+     * @return Pointer to the generated SSL_KEY object
+     */
     static SSL_KEY* generate_ec_key(int nid);
+
+    /**
+     * @brief Free an SSL_KEY object
+     */
     static void free_key(SSL_KEY* key);
+
+    /**
+     * @brief Write an SSL_KEY to a PEM file
+     * 
+     * @param key The SSL_KEY object to write
+     * @param file_path The path to the PEM file
+     * @return true on success, false on failure
+     */
+    static bool write_keypair_to_pem(const SSL_KEY* key, const std::string& file_path);
+
+    /**
+     * @brief Read an SSL_KEY from a PEM file
+     * 
+     * @param file_path The path to the PEM file
+     * @return Pointer to the read SSL_KEY object, or NULL on failure
+     */
+    static SSL_KEY* read_keypair_from_pem(const std::string& file_path);
 
 
     static inline uint8_t generate_iv(unsigned char *iv, unsigned int len) { if (!RAND_bytes(iv, static_cast<int>(len))) { return 0; } else { return 1; } }


### PR DESCRIPTION
- Adds the new `em_crypto_t::write_keypair_to_pem` and `em_crypto_t::read_keypair_from_pem` functions. 
- Implements the saving and reading of local bootstrapping PEM files for private key information.