### PR TITLE
Fix warning for controller

### DIFF
--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -52,39 +52,39 @@ dm_easy_mesh_t dm_easy_mesh_t::operator = (dm_easy_mesh_t const& obj)
     em_long_string_t key;
     mac_addr_str_t radio_mac_str, bss_mac_str, sta_mac_str;
 
-    memcpy(&m_device, &obj.m_device, sizeof(dm_device_t));
-    memcpy(&m_network, &obj.m_network, sizeof(dm_network_t));
-    memcpy(&m_ieee_1905_security, &obj.m_ieee_1905_security, sizeof(dm_ieee_1905_security_t));
+    m_device = obj.m_device;
+    m_network = obj.m_network;
+    m_ieee_1905_security = obj.m_ieee_1905_security;
 
 	if (m_num_radios >= EM_MAX_BANDS) {
 		m_num_radios = 0;
 	}
     this->m_num_radios = obj.m_num_radios;
     for (unsigned int i = 0; i < obj.m_num_radios; i++) {
-        memcpy(&m_radio[i], &obj.m_radio[i], sizeof(dm_radio_t));
+        m_radio[i] = obj.m_radio[i];
     }
 
     this->m_num_bss = obj.m_num_bss;
     for (unsigned int i = 0; i < EM_MAX_BSSS; i++) {
-        memcpy(&m_bss[i], &obj.m_bss[i], sizeof(dm_bss_t));
+        m_bss[i] = obj.m_bss[i];
     }
-    memcpy(&m_dpp, &obj.m_dpp, sizeof(dm_dpp_t));
+    m_dpp = obj.m_dpp;
 
     m_num_opclass = obj.m_num_opclass;
     for (unsigned int i = 0; i < EM_MAX_OPCLASS; i++) {
-        memcpy(&m_op_class[i], &obj.m_op_class[i], sizeof(dm_op_class_t));
+        m_op_class[i] = obj.m_op_class[i];
     }
 
     this->m_num_net_ssids = obj.m_num_net_ssids;
     for (unsigned int i = 0; i < EM_MAX_NET_SSIDS; i++) {
-        memcpy(&m_network_ssid[i], &obj.m_network_ssid[i], sizeof(dm_network_ssid_t));
+        m_network_ssid[i] = obj.m_network_ssid[i];
     }
 
-    memcpy(&m_db_cfg_param, &obj.m_db_cfg_param, sizeof(em_db_cfg_param_t));
+    m_db_cfg_param = obj.m_db_cfg_param;
 
     m_num_policy = obj.m_num_policy;
     for (unsigned int i = 0; i < EM_MAX_POLICIES; i++) {
-        memcpy(&m_policy[i], &obj.m_policy[i], sizeof(dm_policy_t));
+        m_policy[i] = obj.m_policy[i];
     }
 
     sta = static_cast<dm_sta_t *> (hash_map_get_first(obj.m_sta_map));
@@ -1521,10 +1521,10 @@ int dm_easy_mesh_t::decode_client_cap_config(em_subdoc_info_t *subdoc, const cha
         if (id != NULL)
 	msg_id = static_cast<short unsigned int> (id->valuedouble);
         if (cltmac != NULL) {
-            snprintf(const_cast<char *> (clientmac), sizeof(clientmac), "%s", cJSON_GetStringValue(cltmac));
+            snprintf(const_cast<char *> (clientmac), sizeof(mac_addr_str_t), "%s", cJSON_GetStringValue(cltmac));
         }
         if (rmac != NULL) {
-	        snprintf(const_cast<char *> (radiomac), sizeof(radiomac), "%s", cJSON_GetStringValue(rmac));
+	        snprintf(const_cast<char *> (radiomac), sizeof(mac_addr_str_t), "%s", cJSON_GetStringValue(rmac));
         }
 	//printf("%s:%d: msg id %d rmac=%s\n", __func__, __LINE__,msg_id,radiomac);
 
@@ -1807,7 +1807,7 @@ int dm_easy_mesh_t::name_from_mac_address(const mac_address_t *mac, char *ifname
         addr = tmp->ifa_addr;
         ll_addr = reinterpret_cast<struct sockaddr_ll*> (tmp->ifa_addr);
         if ((addr != NULL) && (addr->sa_family == AF_PACKET) && (memcmp(ll_addr->sll_addr, mac, sizeof(mac_address_t)) == 0)) {
-            snprintf(ifname, sizeof(ifname), "%s", tmp->ifa_name);
+            snprintf(ifname, IFNAMSIZ, "%s", tmp->ifa_name);
             found = true;
             break;
         }
@@ -2044,7 +2044,8 @@ void dm_easy_mesh_t::create_autoconfig_renew_json_cmd(char* src_mac_addr, char* 
     cJSON_AddItemToObject(renew, "DeviceList", device_list);
     cJSON_AddItemToObject(root, "wfa-dataelements:Renew", renew);
     char* tmp = cJSON_Print(root);
-    snprintf(autoconfig_renew_json, sizeof(autoconfig_renew_json), "%s", tmp);
+    size_t tmp_length = strlen(tmp) + 1;
+    snprintf(autoconfig_renew_json, tmp_length, "%s", tmp);
     cJSON_Delete(root);
 }
 
@@ -2065,7 +2066,8 @@ void dm_easy_mesh_t::create_ap_cap_query_json_cmd(char* src_mac_addr, char* agen
     cJSON_AddItemToObject(query_info, "DeviceList", device_list);
     cJSON_AddItemToObject(root, "wfa-dataelements:Radiocap", query_info);
     char* tmp = cJSON_Print(root);
-    snprintf(ap_query_json, sizeof(ap_query_json), "%s", tmp);
+    size_t tmp_length = strlen(tmp) + 1;
+    snprintf(ap_query_json, tmp_length, "%s", tmp);
     cJSON_Delete(root);
 }
 
@@ -2087,7 +2089,8 @@ void dm_easy_mesh_t::create_client_cap_query_json_cmd(char* src_mac_addr, char* 
     cJSON_AddItemToObject(query_info, "DeviceList", device_list);
     cJSON_AddItemToObject(root, "wfa-dataelements:Clientcap", query_info);
     char* tmp = cJSON_Print(root);
-    snprintf(ap_query_json, sizeof(ap_query_json), "%s", tmp);
+    size_t tmp_length = strlen(tmp) + 1;
+    snprintf(ap_query_json, tmp_length, "%s", tmp);
     cJSON_Delete(root);
 }
 

--- a/src/dm/dm_op_class_list.cpp
+++ b/src/dm/dm_op_class_list.cpp
@@ -119,7 +119,7 @@ void dm_op_class_list_t::get_config(cJSON *obj_arr, em_op_class_type_t type)
 int dm_op_class_list_t::set_config(db_client_t& db_client, const cJSON *obj_arr, void *parent_id)
 {
     cJSON *obj;
-    unsigned int i, size;
+    int i, size;
     dm_op_class_t op_class;
     dm_orch_type_t op;
 

--- a/src/dm/dm_policy_list.cpp
+++ b/src/dm/dm_policy_list.cpp
@@ -128,7 +128,7 @@ int dm_policy_list_t::set_config(db_client_t& db_client, const cJSON *obj_arr, v
     cJSON *obj;
     dm_policy_t policy;
     dm_orch_type_t op;
-	unsigned int i, size;
+	int i, size;
 
     size = cJSON_GetArraySize(obj_arr);
 

--- a/src/dm/dm_radio_cap_list.cpp
+++ b/src/dm/dm_radio_cap_list.cpp
@@ -44,7 +44,7 @@ int dm_radio_cap_list_t::get_config(cJSON *obj_parent, void *parent, bool summar
     dm_radio_cap_t *pradio_cap;
     cJSON *obj;
 	
-    pradio_cap = (dm_radio_cap_t *)hash_map_get_first(m_list);
+    pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_get_first(m_list));
     while (pradio_cap != NULL) {
        	obj = cJSON_CreateObject(); 
 
@@ -54,7 +54,7 @@ int dm_radio_cap_list_t::get_config(cJSON *obj_parent, void *parent, bool summar
 	//cJSON_AddStringToObject(obj, "EHTCapabilities", pradio_cap->m_radio_cap_info.eht_cap);
 	//cJSON_AddNumberToObject(obj, "NumberOfOpClass", pradio_cap->m_radio_cap_info.num_op_classes);
 	//cJSON_AddObjectToObject(obj, obj_parent);
-	pradio_cap = (dm_radio_cap_t *)hash_map_get_next(m_list, pradio_cap);
+	pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_get_next(m_list, pradio_cap));
     }
     
 	
@@ -88,7 +88,7 @@ dm_orch_type_t dm_radio_cap_list_t::get_dm_orch_type(db_client_t& db_client, con
 	
     dm_easy_mesh_t::macbytes_to_string((unsigned char *)radio_cap.m_radio_cap_info.ruid.mac, mac_str);
 
-    pradio_cap = (dm_radio_cap_t *)hash_map_get(m_list, mac_str);
+    pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_get(m_list, mac_str));
     if (pradio_cap != NULL) {
         if (*pradio_cap == radio_cap) {
             printf("%s:%d: Device: %s in list\n", __func__, __LINE__,
@@ -119,13 +119,16 @@ void dm_radio_cap_list_t::update_list(const dm_radio_cap_t& radio_cap, dm_orch_t
             break;
 
         case dm_orch_type_db_update:
-            pradio_cap = (dm_radio_cap_t *)hash_map_get(m_list, mac_str);
+            pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_get(m_list, mac_str));
             memcpy(&pradio_cap->m_radio_cap_info, &radio_cap.m_radio_cap_info, sizeof(em_radio_cap_info_t));
             break;
 
         case dm_orch_type_db_delete:
-            pradio_cap = (dm_radio_cap_t *)hash_map_remove(m_list, mac_str);
+            pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_remove(m_list, mac_str));
             delete(pradio_cap);
+            break;
+
+        default:
             break;
     }
 
@@ -136,10 +139,10 @@ void dm_radio_cap_list_t::delete_list()
     dm_radio_cap_t *pradio_cap, *tmp;
     mac_addr_str_t  mac_str = {0};
    
-    pradio_cap = (dm_radio_cap_t *)hash_map_get_first(m_list);
+    pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_get_first(m_list));
     while (pradio_cap != NULL) {
         tmp = pradio_cap;
-        pradio_cap = (dm_radio_cap_t *)hash_map_get_next(m_list, pradio_cap);
+        pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_get_next(m_list, pradio_cap));
         dm_easy_mesh_t::macbytes_to_string((unsigned char *)tmp->m_radio_cap_info.ruid.mac, mac_str);
    
         hash_map_remove(m_list, mac_str);
@@ -155,9 +158,8 @@ bool dm_radio_cap_list_t::operator == (const db_easy_mesh_t& obj)
 int dm_radio_cap_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, void *data)
 {
     mac_addr_str_t mac_str;
-    em_radio_cap_info_t *info = (em_radio_cap_info_t *)data;
+    em_radio_cap_info_t *info = static_cast<em_radio_cap_info_t *>(data);
     int ret = 0;
-    unsigned int i;
 
     printf("%s:%d: Opeartion:%d\n", __func__, __LINE__, op);
 

--- a/src/dm/dm_radio_list.cpp
+++ b/src/dm/dm_radio_list.cpp
@@ -158,6 +158,9 @@ void dm_radio_list_t::update_list(const dm_radio_t& radio, dm_orch_type_t op)
         case dm_orch_type_db_delete:
             remove_radio(mac_str);
             break;
+
+        default:
+            break;
     }
 
 }

--- a/src/dm/dm_scan_result_list.cpp
+++ b/src/dm/dm_scan_result_list.cpp
@@ -190,6 +190,9 @@ void dm_scan_result_list_t::update_list(const dm_scan_result_t& scan_result, uns
         case dm_orch_type_db_delete:
             remove_scan_result(key);
             break;
+
+		default:
+		    break;
     }
 }
 


### PR DESCRIPTION
Reason for change: 1) Added missing default case for switch statement
2) Handled some static cast warnings
3) Handled no trivial copy-assignment with memcpy
4) Handled some warning related to snprintf arguments for buffer length.
Test Procedure: Checked and compared the warning before and after fix, observed around 229 warning is fixed. 
Also compared the run time logs for OneWifi, controller and agent with and without changes and did not observed any additional logs/error.
Tested with changing the SSID and radio channel through CLI observed its works fine.
Risks: Medium
Priority: P1