### PR TITLE
create_ieee1905_response_obj: include "cred" object

### DIFF
--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -818,6 +818,8 @@ cJSON *em_provisioning_t::create_ieee1905_response_obj(ec_connection_context_t *
         return nullptr;
     }
 
+    cJSON_AddItemToObject(dpp_configuration_object, "cred", credential_object);
+
     return dpp_configuration_object;
 }
 


### PR DESCRIPTION
`"cred"` object was created and populated but not added to the config object prior to returning -- fixes that