### PR TITLE
DPP EasyConnect: Implement required endianness conversions

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -229,7 +229,7 @@ typedef struct {
 } ec_credential_object_t;
 
 /**
- * @brief A DPP attribute as defined in EC 8.1. Can be sent/received over the network.
+ * @brief A DPP attribute as defined in EasyConnect 8.1. Can be sent/received over the network.
  * 
  * @paragraph DPP attributes' ID and length fields are required to be little 
  *            endian when transferred over the network. In general, data 
@@ -245,11 +245,11 @@ typedef struct {
  */
 typedef struct {
     /**
-     * @brief Identifies the type of the DPP attribute. Assumed to be little endian, as described in EC 8.1.
+     * @brief Identifies the type of the DPP attribute. Assumed to be little endian, as described in EasyConnect 8.1.
      */
     uint16_t attr_id;
     /**
-     * @brief Length of the following fields in the attribute. Assumed to be little endian, as described in EC 8.1.
+     * @brief Length of the following fields in the attribute. Assumed to be little endian, as described in EasyConnect 8.1.
      */
     uint16_t length;
     /**
@@ -288,7 +288,7 @@ typedef struct {
      */
     uint16_t length;
     /**
-     * @brief Points to the `ec_attribute_t` instance this `ec_attribute_t` instance was derived from.
+     * @brief Points to the `ec_net_attribute_t` instance this `ec_net_attribute_t` instance was derived from.
      */
     ec_net_attribute_t *original;
     /**
@@ -400,7 +400,7 @@ typedef struct {
  */
 #define ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
     do { \
-        if(x.has_value()) { \
+        if(!x.has_value()) { \
             fprintf(stderr, errMsg, ## __VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
@@ -448,7 +448,7 @@ typedef struct {
  * @param errMsg Format string for error message
  * @param ... Additional arguments for the format string
  */
-#define ASSERT_OPT_HAS_VALUE(x, ret, errMsg, ...) ASSERT_MSG_FALSE(x.has_value(), ret, errMsg, ## __VA_ARGS__)
+#define ASSERT_OPT_HAS_VALUE(x, ret, errMsg, ...) ASSERT_MSG_TRUE(x.has_value(), ret, errMsg, ## __VA_ARGS__)
 
 #ifndef SSL_KEY
 #if OPENSSL_VERSION_NUMBER < 0x30000000L

--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -228,11 +228,74 @@ typedef struct {
       } creds;
 } ec_credential_object_t;
 
+/**
+ * @brief A DPP attribute as defined in EC 8.1. Can be sent/received over the network.
+ * 
+ * @paragraph DPP attributes' ID and length fields are required to be little 
+ *            endian when transferred over the network. In general, data 
+ *            transmitted over the network is big endian ("network byte 
+ *            order"), so DPP attributes must be treated as a different case.
+ *            Users of this struct MUST maintain the invariant that the 
+ *            `attr_id` and `length` are little endian. If anything needs to be
+ *            done with these values on the host, use an `ec_attribute_t`
+ *            instead.
+ * 
+ * @warning When doing any network operations involving DPP attributes, use `ec_net_attribute_t`, not `ec_attribute_t`. 
+ * @warning When executing logic on the host related to `attr_id` and `length`, use `ec_attribute_t`, not `ec_net_attribute_t`. 
+ */
 typedef struct {
+    /**
+     * @brief Identifies the type of the DPP attribute. Assumed to be little endian, as described in EC 8.1.
+     */
     uint16_t attr_id;
+    /**
+     * @brief Length of the following fields in the attribute. Assumed to be little endian, as described in EC 8.1.
+     */
     uint16_t length;
+    /**
+     * @brief Attribute-specific information fields. Endianness varies according to the specific DPP attribute type.
+     */
     uint8_t data[0];
-}__attribute__((packed)) ec_attribute_t;
+}__attribute__((packed)) ec_net_attribute_t;
+
+/**
+ * @brief Represents a DPP attribute that has been converted to host byte ordering. Not intended to be sent over the network. 
+ * 
+ * @paragraph This struct is intended to be used in any operations on DPP
+ *            attributes that occur entirely on the host. For example, after an
+ *            `ec_net_attribute_t` is read from a frame received from
+ *            the network, it must be converted to an `ec_attribute_t` to
+ *            ensure that the `attr_id` and `length` use host byte ordering. 
+ * 
+ * @paragraph Note that this struct includes a pointer, 
+ *            `ec_net_attribute_t *original`. This MUST ALWAYS point to the
+ *            `ec_net_attribute_t` instance that was used to derive this
+ *            `ec_attribute_t` instance. `original` is used in pointer
+ *            arithmetic based on its position in a frame. 
+ * 
+ * @note `ec_net_attribute_t *original` points to the `ec_attribute_t` instance this was derived from.
+ * 
+ * @warning When doing any network operations involving DPP attributes, use `ec_net_attribute_t`, not `ec_attribute_t`. 
+ * @warning When executing logic on the host related to `attr_id` and `length`, use `ec_attribute_t`, not `ec_net_attribute_t`. 
+ */
+typedef struct {
+    /**
+     * @brief Identifies the type of the DPP attribute. Assumed to be stored with host byte ordering.
+     */
+    uint16_t attr_id;
+    /**
+     * @brief Length of the following fields in the attribute. Assumed to be stored with host byte ordering.
+     */
+    uint16_t length;
+    /**
+     * @brief Points to the `ec_attribute_t` instance this `ec_attribute_t` instance was derived from.
+     */
+    ec_net_attribute_t *original;
+    /**
+     * @brief Shorthand for `this.original->data`. Must always equate to `this.original->data`. 
+     */
+    uint8_t *data;
+} ec_attribute_t;
 
 typedef struct {
     uint8_t category;
@@ -324,6 +387,68 @@ typedef struct {
 #define ASSERT_NULL(x, ret, errMsg, ...) ASSERT_MSG_TRUE(x == 0, ret, errMsg, ## __VA_ARGS__)
 #define ASSERT_EQUALS(x, y, ret, errMsg, ...) ASSERT_MSG_TRUE(x == y, ret, errMsg, ## __VA_ARGS__)
 #define ASSERT_NOT_EQUALS(x, y, ret, errMsg, ...) ASSERT_MSG_FALSE(x == y, ret, errMsg, ## __VA_ARGS__)
+
+/**
+ * @brief Asserts that a std::optional has a value, and if it doesn't, frees up to 3 pointers and returns a value
+ * @param x The std::optional to check for a value
+ * @param ret The value to return if x is nullopt
+ * @param ptr1 First pointer to free (can be NULL)
+ * @param ptr2 Second pointer to free (can be NULL) 
+ * @param ptr3 Third pointer to free (can be NULL)
+ * @param errMsg Format string for error message
+ * @param ... Additional arguments for the format string
+ */
+#define ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+    do { \
+        if(x.has_value()) { \
+            fprintf(stderr, errMsg, ## __VA_ARGS__); \
+            void *_tmp1 = (ptr1); \
+            void *_tmp2 = (ptr2); \
+            void *_tmp3 = (ptr3); \
+            if (_tmp1) { \
+                free(_tmp1); \
+            } \
+            if (_tmp2) { \
+                free(_tmp2); \
+            } \
+            if (_tmp3) { \
+                free(_tmp3); \
+            } \
+            return ret; \
+        } \
+    } while (0)
+
+/**
+ * @brief Asserts that a std::optional has a value, and if it doesn't, frees up to 2 pointers and returns a value
+ * @param x The std::optional to check for a value
+ * @param ret The value to return if x is nullopt
+ * @param ptr1 First pointer to free (can be NULL)
+ * @param ptr2 Second pointer to free (can be NULL) 
+ * @param errMsg Format string for error message
+ * @param ... Additional arguments for the format string
+ */
+#define ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
+    ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+
+/**
+ * @brief Asserts that a std::optional has a value, and if it doesn't, frees a pointer and returns a value
+ * @param x The std::optional to check for a value
+ * @param ret The value to return if x is nullopt
+ * @param ptr1 First pointer to free (can be NULL)
+ * @param errMsg Format string for error message
+ * @param ... Additional arguments for the format string
+ */
+#define ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, errMsg, ...) \
+    ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+
+/**
+ * @brief Asserts that a std::optional has a value, and returns a value if it doesn't
+ * @param x The std::optional to check for a value
+ * @param ret The value to return if x is nullopt
+ * @param errMsg Format string for error message
+ * @param ... Additional arguments for the format string
+ */
+#define ASSERT_OPT_HAS_VALUE(x, ret, errMsg, ...) ASSERT_MSG_FALSE(x.has_value(), ret, errMsg, ## __VA_ARGS__)
 
 #ifndef SSL_KEY
 #if OPENSSL_VERSION_NUMBER < 0x30000000L

--- a/inc/ec_util.h
+++ b/inc/ec_util.h
@@ -93,9 +93,9 @@ public:
 	 * @param[in] len The length of the buffer.
 	 * @param[in] id The attribute ID.
      * 
-     * @return std::optional<ec_attribute_t> The attribute if found, NULL otherwise
+     * @return const std::optional<ec_attribute_t> The attribute if found, NULL otherwise
      */
-    static std::optional<ec_attribute_t> get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id);
+    static std::optional<const ec_attribute_t> get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id);
 
     
 	/**
@@ -531,7 +531,7 @@ public:
 	 *
 	 * @note Forwards to `unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key);`
 	 */
-	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key);
+	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(const ec_attribute_t& wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key);
 
     
 	/**
@@ -550,7 +550,7 @@ public:
 	 *
 	 * @note Ensure that the key is valid and the frame is correctly set up before calling this function.
 	 */
-	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key);
+	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(const ec_attribute_t& wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key);
 
     // Used for storing channels / op-classes searched when looking for a given SSID.
     struct scanned_channels_t {

--- a/inc/ec_util.h
+++ b/inc/ec_util.h
@@ -84,19 +84,18 @@ public:
 	 */
 	static void init_frame(ec_frame_t *frame);
 
-    
-	/**
-	 * @brief Get an attribute from the buffer.
-	 *
+    /**
+     * @brief Get a host-byte-ordered attribute from the buffer
+     * 
 	 * This function retrieves an attribute from the specified buffer using the given attribute ID.
 	 *
 	 * @param[in] buff The buffer to get the attribute from.
 	 * @param[in] len The length of the buffer.
 	 * @param[in] id The attribute ID.
-	 *
-	 * @return ec_attribute_t* The attribute if found, NULL otherwise.
-	 */
-	static ec_attribute_t *get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id);
+     * 
+     * @return std::optional<ec_attribute_t> The attribute if found, NULL otherwise
+     */
+    static std::optional<ec_attribute_t> get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id);
 
     
 	/**
@@ -109,8 +108,8 @@ public:
 	 *                  if it is not large enough to hold the new attribute.
 	 * @param[in,out] buff_len The current length of the buffer. This will be updated to reflect the
 	 *                         new length after the attribute is added.
-	 * @param[in] id The identifier for the attribute to be added.
-	 * @param[in] len The length of the attribute data.
+	 * @param[in] id The identifier for the attribute to be added, in host byte ordering.
+	 * @param[in] len The length of the attribute data, in host byte ordering.
 	 * @param[in] data A pointer to the attribute data to be added to the buffer.
 	 *
 	 * @return uint8_t* A pointer to the buffer offset by the length of the attribute.
@@ -129,8 +128,8 @@ public:
 	 *
 	 * @param[out] buff The buffer to which the attribute will be added.
 	 * @param[in,out] buff_len The length of the buffer. This will be updated to reflect the new size.
-	 * @param[in] id The attribute ID that identifies the type of attribute being added.
-	 * @param[in] len The length of the attribute data.
+	 * @param[in] id The attribute ID that identifies the type of attribute being added, in host byte ordering.
+	 * @param[in] len The length of the attribute data, in host byte ordering.
 	 * @param[in] data The attribute data to be added to the buffer.
 	 *
 	 * @return uint8_t* A pointer to the buffer offset by the length of the attribute.
@@ -149,8 +148,8 @@ public:
 	 *
 	 * @param[in,out] buff The buffer to add the attribute to.
 	 * @param[in,out] buff_len The length of the buffer, which will be updated after adding the attribute.
-	 * @param[in] id The attribute ID.
-	 * @param[in] str The attribute as a string.
+	 * @param[in] id The attribute ID, in host byte ordering.
+	 * @param[in] str The attribute as a string, in host byte ordering.
 	 *
 	 * @return uint8_t* Pointer to the buffer offset by the length of the attribute.
 	 *
@@ -168,7 +167,7 @@ public:
 	 *
 	 * @param[out] buff The buffer to add the attribute to.
 	 * @param[in,out] buff_len The current length of the buffer, which may be updated if reallocation occurs.
-	 * @param[in] id The attribute ID.
+	 * @param[in] id The attribute ID, in host byte ordering.
 	 * @param[in] val The uint8_t attribute value.
 	 *
 	 * @return uint8_t* The buffer offset by the length of the attribute.
@@ -190,8 +189,8 @@ public:
 	 * @param[out] buff The buffer to which the attribute will be added.
 	 * @param[in,out] buff_len A pointer to the size of the buffer. It will be
 	 * updated if the buffer is reallocated.
-	 * @param[in] id The attribute ID to be added.
-	 * @param[in] val The uint16_t attribute value to be added.
+	 * @param[in] id The attribute ID to be added, in host byte ordering.
+	 * @param[in] val The uint16_t attribute value to be added, in host byte ordering.
 	 *
 	 * @return uint8_t* A pointer to the buffer offset by the length of the
 	 * attribute.
@@ -449,7 +448,7 @@ public:
 	* @returns The total size of the EC attribute, including the data.
 	*/
 	static inline size_t get_ec_attr_size(uint16_t data_len) {
-        return offsetof(ec_attribute_t, data) + data_len;
+        return offsetof(ec_net_attribute_t, data) + data_len;
     };
 
     
@@ -519,20 +518,20 @@ public:
 	 * This function unwraps a wrapped attribute using the provided key and
 	 * optional additional authenticated data (AAD) from the frame.
 	 *
-	 * @param[in] wrapped_attrib The wrapped attribute to unwrap (retrieved using `get_attribute`).
+	 * @param[in] wrapped_attrib The wrapped attribute to unwrap (retrieved using `get_attrib`).
 	 * @param[in] frame The frame to use as AAD. Can be NULL if no AAD is needed.
 	 * @param[in] uses_aad Whether the wrapped attribute uses AAD.
 	 * @param[in] key The key to use for decryption.
 	 *
 	 * @return std::pair<uint8_t*, uint16_t> A heap allocated buffer of unwrapped attributes on success,
-	 *         which can then be fetched via `get_attribute`, along with the length of that buffer.
+	 *         which can then be fetched via `get_attrib`, along with the length of that buffer.
 	 *         The buffer is NULL and the size is 0 on failure.
 	 *
 	 * @warning The caller is responsible for freeing the memory returned by this function.
 	 *
-	 * @note Forwards to `unwrap_wrapped_attrib(ec_attribute_t *wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key);`
+	 * @note Forwards to `unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key);`
 	 */
-	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(ec_attribute_t* wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key);
+	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key);
 
     
 	/**
@@ -551,7 +550,7 @@ public:
 	 *
 	 * @note Ensure that the key is valid and the frame is correctly set up before calling this function.
 	 */
-	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(ec_attribute_t *wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key);
+	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key);
 
     // Used for storing channels / op-classes searched when looking for a given SSID.
     struct scanned_channels_t {

--- a/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
@@ -164,18 +164,18 @@ bool ec_ctrl_configurator_t::handle_proxied_config_result_frame(uint8_t *encap_f
 
     ec_frame_t *frame = reinterpret_cast<ec_frame_t *>(encap_frame);
     
-    ec_attribute_t *wrapped_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_wrapped_data);
-    ASSERT_NOT_NULL(wrapped_attr, false, "%s:%d: No wrapped data in Proxied DPP Configuration Result frame\n", __func__, __LINE__);
+    auto wrapped_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_wrapped_data);
+    ASSERT_OPT_HAS_VALUE(wrapped_attr, false, "%s:%d: No wrapped data in Proxied DPP Configuration Result frame\n", __func__, __LINE__);
 
     // Unwrap with k_e
-    auto [unwrapped_attrs, unwrapped_attrs_len] = ec_util::unwrap_wrapped_attrib(wrapped_attr, frame, true, e_ctx->ke);
+    auto [unwrapped_attrs, unwrapped_attrs_len] = ec_util::unwrap_wrapped_attrib(*wrapped_attr, frame, true, e_ctx->ke);
     if (unwrapped_attrs == nullptr || unwrapped_attrs_len == 0) {
         em_printfout("Failed to unwrap attributes.");
         return false;
     }
 
-    ec_attribute_t *e_nonce_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_enrollee_nonce);
-    ASSERT_NOT_NULL_FREE(e_nonce_attr, false, unwrapped_attrs, "%s:%d: DPP Configuration Result frame did not contain E-nonce\n", __func__, __LINE__);
+    auto e_nonce_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_enrollee_nonce);
+    ASSERT_OPT_HAS_VALUE_FREE(e_nonce_attr, false, unwrapped_attrs, "%s:%d: DPP Configuration Result frame did not contain E-nonce\n", __func__, __LINE__);
 
     if (conn_ctx->nonce_len != e_nonce_attr->length || memcmp(e_ctx->e_nonce, e_nonce_attr->data, e_nonce_attr->length) != 0) {
         em_printfout("E-nonce contained in DPP Configuration Result frame for '%s' does not match E-nonce in stored connection context.", enrollee_mac.c_str());
@@ -183,8 +183,8 @@ bool ec_ctrl_configurator_t::handle_proxied_config_result_frame(uint8_t *encap_f
         return false;
     }
 
-    ec_attribute_t *status_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_dpp_status);
-    ASSERT_NOT_NULL_FREE(status_attr, false, unwrapped_attrs, "%s:%d: DPP Configuration Result frame did not contain DPP Status\n", __func__, __LINE__);
+    auto status_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_dpp_status);
+    ASSERT_OPT_HAS_VALUE_FREE(status_attr, false, unwrapped_attrs, "%s:%d: DPP Configuration Result frame did not contain DPP Status\n", __func__, __LINE__);
 
     ec_status_code_t dpp_status = static_cast<ec_status_code_t>(status_attr->data[0]);
     if (dpp_status == DPP_STATUS_OK) {
@@ -221,18 +221,18 @@ bool ec_ctrl_configurator_t::handle_proxied_conn_status_result_frame(uint8_t *en
 
     ec_frame_t *frame = reinterpret_cast<ec_frame_t *>(encap_frame);
     
-    ec_attribute_t *wrapped_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_wrapped_data);
-    ASSERT_NOT_NULL(wrapped_attr, false, "%s:%d: No wrapped data in Proxied DPP Configuration Result frame\n", __func__, __LINE__);
+    auto wrapped_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_wrapped_data);
+    ASSERT_OPT_HAS_VALUE(wrapped_attr, false, "%s:%d: No wrapped data in Proxied DPP Configuration Result frame\n", __func__, __LINE__);
 
     // Unwrap with k_e
-    auto [unwrapped_attrs, unwrapped_attrs_len] = ec_util::unwrap_wrapped_attrib(wrapped_attr, frame, true, e_ctx->ke);
+    auto [unwrapped_attrs, unwrapped_attrs_len] = ec_util::unwrap_wrapped_attrib(*wrapped_attr, frame, true, e_ctx->ke);
     if (unwrapped_attrs == nullptr || unwrapped_attrs_len == 0) {
         em_printfout("Failed to unwrap attributes.");
         return false;
     }
 
-    ec_attribute_t *e_nonce_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_enrollee_nonce);
-    ASSERT_NOT_NULL_FREE(e_nonce_attr, false, unwrapped_attrs, "%s:%d: DPP Connection Status Result frame did not contain E-nonce\n", __func__, __LINE__);
+    auto e_nonce_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_enrollee_nonce);
+    ASSERT_OPT_HAS_VALUE_FREE(e_nonce_attr, false, unwrapped_attrs, "%s:%d: DPP Connection Status Result frame did not contain E-nonce\n", __func__, __LINE__);
 
     if (conn_ctx->nonce_len != e_nonce_attr->length || memcmp(e_ctx->e_nonce, e_nonce_attr->data, e_nonce_attr->length) != 0) {
         em_printfout("E-nonce contained in DPP Connection Status Result frame for '%s' does not match E-nonce in stored connection context.", enrollee_mac.c_str());
@@ -240,8 +240,8 @@ bool ec_ctrl_configurator_t::handle_proxied_conn_status_result_frame(uint8_t *en
         return false;
     }
 
-    ec_attribute_t *conn_status_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_conn_status);
-    ASSERT_NOT_NULL_FREE(conn_status_attr, false, unwrapped_attrs, "%s:%d: DPP Connection Status frame did not contain a Connection Status attribute\n", __func__, __LINE__);
+    auto conn_status_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_conn_status);
+    ASSERT_OPT_HAS_VALUE_FREE(conn_status_attr, false, unwrapped_attrs, "%s:%d: DPP Connection Status frame did not contain a Connection Status attribute\n", __func__, __LINE__);
 
     cJSON *conn_status_obj = cJSON_ParseWithLength(reinterpret_cast<const char *>(conn_status_attr->data), conn_status_attr->length);
 
@@ -269,17 +269,17 @@ bool ec_ctrl_configurator_t::handle_proxied_dpp_configuration_request(uint8_t *e
     ec_gas_initial_request_frame_t *initial_request_frame = reinterpret_cast<ec_gas_initial_request_frame_t *>(encap_frame);
 
     uint8_t session_dialog_token = initial_request_frame->base.dialog_token;
-    ec_attribute_t *wrapped_attrs = ec_util::get_attrib(initial_request_frame->query, initial_request_frame->query_len, ec_attrib_id_wrapped_data);
-    ASSERT_NOT_NULL(wrapped_attrs, false, "%s:%d: No wrapped data attribute found!\n", __func__, __LINE__);
+    auto wrapped_attrs = ec_util::get_attrib(initial_request_frame->query, initial_request_frame->query_len, ec_attrib_id_wrapped_data);
+    ASSERT_OPT_HAS_VALUE(wrapped_attrs, false, "%s:%d: No wrapped data attribute found!\n", __func__, __LINE__);
     
     ASSERT_NOT_NULL(e_ctx->ke, false, "%s:%d: Ephemeral context for Enrollee '" MACSTRFMT "' does not contain valid key 'ke'!\n", __func__, __LINE__, MAC2STR(src_mac));
-    auto [unwrapped_attrs, unwrapped_attrs_len] = ec_util::unwrap_wrapped_attrib(wrapped_attrs, reinterpret_cast<uint8_t*>(initial_request_frame), encap_frame_len, initial_request_frame->query, true, e_ctx->ke);
+    auto [unwrapped_attrs, unwrapped_attrs_len] = ec_util::unwrap_wrapped_attrib(*wrapped_attrs, reinterpret_cast<uint8_t*>(initial_request_frame), encap_frame_len, initial_request_frame->query, true, e_ctx->ke);
     if (unwrapped_attrs == nullptr || unwrapped_attrs_len == 0) {
         em_printfout("Failed to unwraped wrapped data, aborting!");
         return false;
     }
     auto e_nonce_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_enrollee_nonce);
-    ASSERT_NOT_NULL_FREE(e_nonce_attr, false, unwrapped_attrs, "%s:%d: No Enrollee nonce attribute found!\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE_FREE(e_nonce_attr, false, unwrapped_attrs, "%s:%d: No Enrollee nonce attribute found!\n", __func__, __LINE__);
     uint16_t e_nonce_len = e_nonce_attr->length;
     if (e_nonce_len != conn_ctx->nonce_len) {
         em_printfout("Enrollee nonce length (%d) does not match expected length (%d)!", e_nonce_len, conn_ctx->nonce_len);
@@ -295,7 +295,7 @@ bool ec_ctrl_configurator_t::handle_proxied_dpp_configuration_request(uint8_t *e
     memcpy(e_ctx->e_nonce, e_nonce_attr->data, e_nonce_len);
 
     auto dpp_config_request_obj_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_dpp_config_req_obj);
-    ASSERT_NOT_NULL_FREE(dpp_config_request_obj_attr, false, unwrapped_attrs, "%s:%d: No DPP Configuration Request Object found in DPP Configuration Request frame!\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE_FREE(dpp_config_request_obj_attr, false, unwrapped_attrs, "%s:%d: No DPP Configuration Request Object found in DPP Configuration Request frame!\n", __func__, __LINE__);
 
     // Copy the DPP Configuration Request Object string to an std::string to free the unwrapped attributes
     std::string dpp_config_request_obj_str(reinterpret_cast<char *>(dpp_config_request_obj_attr->data), dpp_config_request_obj_attr->length);
@@ -425,20 +425,20 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
 
     size_t attrs_len = len - EC_FRAME_BASE_SIZE;
 
-    ec_attribute_t* status_attrib = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_dpp_status);
-    ASSERT_NOT_NULL(status_attrib, false, "%s:%d: No DPP status attribute found\n", __func__, __LINE__);
+    auto status_attrib = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_dpp_status);
+    ASSERT_OPT_HAS_VALUE(status_attrib, false, "%s:%d: No DPP status attribute found\n", __func__, __LINE__);
     
     ec_status_code_t dpp_status = static_cast<ec_status_code_t>(status_attrib->data[0]);
 
-    ec_attribute_t *prim_wrapped_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_wrapped_data);
-    ASSERT_NOT_NULL(prim_wrapped_attr, false, "%s:%d: No wrapped data attribute found\n", __func__, __LINE__);
+    auto prim_wrapped_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_wrapped_data);
+    ASSERT_OPT_HAS_VALUE(prim_wrapped_attr, false, "%s:%d: No wrapped data attribute found\n", __func__, __LINE__);
 
     if (dpp_status != DPP_STATUS_OK) {
         em_printfout("DPP Status not OK");
 
         // Unwrap the wrapped data with the K1 key
 
-        auto [unwrapped_data, unwrapped_data_len] =  ec_util::unwrap_wrapped_attrib(prim_wrapped_attr, frame, true, e_ctx->k1);
+        auto [unwrapped_data, unwrapped_data_len] =  ec_util::unwrap_wrapped_attrib(*prim_wrapped_attr, frame, true, e_ctx->k1);
         if (unwrapped_data == NULL || unwrapped_data_len == 0) {
             em_printfout("Failed to unwrap wrapped data");
             // Abort the exchange
@@ -467,10 +467,10 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
 
     // Initiator Bootstrapping Key Hash is present, allow mutual auth.
     auto B_i_hash_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_init_bootstrap_key_hash);
-    e_ctx->is_mutual_auth = (B_i_hash_attr != NULL); // If the attribute is present, mutual authentication is possible
+    e_ctx->is_mutual_auth = B_i_hash_attr.has_value(); // If the attribute is present, mutual authentication is possible
 
     auto P_r_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_resp_proto_key);
-    ASSERT_NOT_NULL(P_r_attr, false, "%s:%d: No Responder Public Protocol Key attribute found\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE(P_r_attr, false, "%s:%d: No Responder Public Protocol Key attribute found\n", __func__, __LINE__);
 
     // Decode the Responder Public Protocol Key
     e_ctx->public_resp_proto_key = ec_crypto::decode_ec_point(*conn_ctx, P_r_attr->data);
@@ -491,7 +491,7 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
     util::print_hex_dump(conn_ctx->digest_len, e_ctx->k2);
 
     // Unwrap the wrapped data with the K2 key
-    auto [prim_unwrapped_data, prim_unwrapped_len] =  ec_util::unwrap_wrapped_attrib(prim_wrapped_attr, frame, true, e_ctx->k2);
+    auto [prim_unwrapped_data, prim_unwrapped_len] =  ec_util::unwrap_wrapped_attrib(*prim_wrapped_attr, frame, true, e_ctx->k2);
     if (prim_unwrapped_data == NULL || prim_unwrapped_len == 0) {
         em_printfout("Failed to unwrap wrapped data");
         // Abort the exchange
@@ -500,7 +500,7 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
 
     // Verify the recieved I-nonce is the same sent in the Authentication Request
     auto i_nonce_attr = ec_util::get_attrib(prim_unwrapped_data, prim_unwrapped_len, ec_attrib_id_init_nonce);
-    ASSERT_NOT_NULL_FREE(i_nonce_attr, false, prim_unwrapped_data, "%s:%d: No Initiator Nonce attribute found\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE_FREE(i_nonce_attr, false, prim_unwrapped_data, "%s:%d: No Initiator Nonce attribute found\n", __func__, __LINE__);
 
     if (e_ctx->i_nonce == nullptr) {
         em_printfout("Initiator Nonce is nullptr! Aborting.");
@@ -519,7 +519,7 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
     }
 
     auto r_nonce_attr = ec_util::get_attrib(prim_unwrapped_data, prim_unwrapped_len, ec_attrib_id_resp_nonce);
-    ASSERT_NOT_NULL_FREE(r_nonce_attr, false, prim_unwrapped_data, "%s:%d: No Responder Nonce attribute found\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE_FREE(r_nonce_attr, false, prim_unwrapped_data, "%s:%d: No Responder Nonce attribute found\n", __func__, __LINE__);
 
     // Set the Responder Nonce
     e_ctx->r_nonce = reinterpret_cast<uint8_t*>(calloc(r_nonce_attr->length, 1));
@@ -528,7 +528,7 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
 
     // Get Responder Capabilities
     auto resp_caps_attr = ec_util::get_attrib(prim_unwrapped_data, prim_unwrapped_len, ec_attrib_id_resp_caps);
-    ASSERT_NOT_NULL_FREE(resp_caps_attr, false, prim_unwrapped_data, "%s:%d: No Responder Capabilities attribute found\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE_FREE(resp_caps_attr, false, prim_unwrapped_data, "%s:%d: No Responder Capabilities attribute found\n", __func__, __LINE__);
     const ec_dpp_capabilities_t resp_caps = {
         .byte = resp_caps_attr->data[0]
     };
@@ -604,10 +604,10 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
     //  EasyConnect 8.2.3
 
     auto sec_wrapped_attr = ec_util::get_attrib(prim_unwrapped_data, prim_unwrapped_len, ec_attrib_id_wrapped_data);
-    ASSERT_NOT_NULL_FREE(sec_wrapped_attr, false, prim_unwrapped_data, "%s:%d: No secondary wrapped data attribute found\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE_FREE(sec_wrapped_attr, false, prim_unwrapped_data, "%s:%d: No secondary wrapped data attribute found\n", __func__, __LINE__);
 
     // Unwrap the secondary wrapped data with the KE key
-    auto [sec_unwrapped_data, sec_unwrapped_len] =  ec_util::unwrap_wrapped_attrib(sec_wrapped_attr, frame, false, e_ctx->ke);
+    auto [sec_unwrapped_data, sec_unwrapped_len] =  ec_util::unwrap_wrapped_attrib(*sec_wrapped_attr, frame, false, e_ctx->ke);
     ASSERT_NOT_NULL_FREE(sec_unwrapped_data, false, prim_unwrapped_data, "%s:%d: Failed to unwrap secondary wrapped data\n", __func__, __LINE__);
 
     // Free the primary unwrapped data since it is no longer needed (secondary unwrapped data is heap allocated)
@@ -615,7 +615,7 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
 
     // Get Responder Auth Tag
     auto resp_auth_tag_attr = ec_util::get_attrib(sec_unwrapped_data, sec_unwrapped_len, ec_attrib_id_resp_auth_tag);
-    ASSERT_NOT_NULL_FREE(resp_auth_tag_attr, false, sec_unwrapped_data, "%s:%d: No Responder Auth Tag attribute found\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE_FREE(resp_auth_tag_attr, false, sec_unwrapped_data, "%s:%d: No Responder Auth Tag attribute found\n", __func__, __LINE__);
     uint8_t resp_auth_tag[resp_auth_tag_attr->length] = {0};
     memcpy(resp_auth_tag, resp_auth_tag_attr->data, resp_auth_tag_attr->length);
     free(sec_unwrapped_data);

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -159,8 +159,8 @@ bool ec_enrollee_t::handle_auth_request(ec_frame_t *frame, size_t len, uint8_t s
     if (m_send_pres_announcement_thread.joinable()) m_send_pres_announcement_thread.join();
     size_t attrs_len = len - EC_FRAME_BASE_SIZE;
 
-    ec_attribute_t *B_r_hash_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_resp_bootstrap_key_hash);
-    ASSERT_NOT_NULL(B_r_hash_attr, false, "%s:%d No responder bootstrapping key hash attribute found\n", __func__, __LINE__);
+    auto B_r_hash_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_resp_bootstrap_key_hash);
+    ASSERT_OPT_HAS_VALUE(B_r_hash_attr, false, "%s:%d No responder bootstrapping key hash attribute found\n", __func__, __LINE__);
 
     uint8_t* responder_keyhash = ec_crypto::compute_key_hash(m_boot_data().responder_boot_key);
     ASSERT_NOT_NULL(responder_keyhash, false, "%s:%d failed to compute responder bootstrapping key hash\n", __func__, __LINE__);
@@ -174,8 +174,8 @@ bool ec_enrollee_t::handle_auth_request(ec_frame_t *frame, size_t len, uint8_t s
     
     if (m_boot_data().initiator_boot_key != NULL){
         // Initiator bootstrapping key is present on enrollee, mutual authentication is possible
-        ec_attribute_t *B_i_hash_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_init_bootstrap_key_hash);
-        ASSERT_NOT_NULL(B_i_hash_attr, false, "%s:%d No initiator bootstrapping key hash attribute found\n", __func__, __LINE__);
+        auto B_i_hash_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_init_bootstrap_key_hash);
+        ASSERT_OPT_HAS_VALUE(B_i_hash_attr, false, "%s:%d No initiator bootstrapping key hash attribute found\n", __func__, __LINE__);
         uint8_t* initiator_keyhash = ec_crypto::compute_key_hash(m_boot_data().initiator_boot_key);
         if (initiator_keyhash != NULL) {
             if (memcmp(B_i_hash_attr->data, initiator_keyhash, B_i_hash_attr->length) == 0) {
@@ -192,7 +192,7 @@ bool ec_enrollee_t::handle_auth_request(ec_frame_t *frame, size_t len, uint8_t s
         }     
     }
 
-   ec_attribute_t *channel_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_channel);
+   auto channel_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_channel);
     if (channel_attr && channel_attr->length == sizeof(uint16_t)) {
         /*
         the Responder determines whether it can use the requested channel for the
@@ -209,9 +209,9 @@ Authentication Request frame without replying to it.
         // Maybe just attempt to send it on the channel
     }
 
-    ec_attribute_t *pub_init_proto_key_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_init_proto_key);
+    auto pub_init_proto_key_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_init_proto_key);
 
-    ASSERT_NOT_NULL(pub_init_proto_key_attr, false, "%s:%d No public initiator protocol key attribute found\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE(pub_init_proto_key_attr, false, "%s:%d No public initiator protocol key attribute found\n", __func__, __LINE__);
     ASSERT_EQUALS(pub_init_proto_key_attr->length, BN_num_bytes(m_c_ctx.prime) * 2, false, "%s:%d Invalid public initiator protocol key length\n", __func__, __LINE__);
 
     if (m_eph_ctx().public_init_proto_key) {
@@ -237,26 +237,26 @@ Authentication Request frame without replying to it.
     printf("Key K_1:\n");
     util::print_hex_dump(static_cast<unsigned int> (m_c_ctx.digest_len), m_eph_ctx().k1);
 
-    ec_attribute_t *wrapped_data_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_wrapped_data);
-    ASSERT_NOT_NULL(wrapped_data_attr, false, "%s:%d No wrapped data attribute found\n", __func__, __LINE__);
+    auto wrapped_data_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_wrapped_data);
+    ASSERT_OPT_HAS_VALUE(wrapped_data_attr, false, "%s:%d No wrapped data attribute found\n", __func__, __LINE__);
 
     // Attempt to unwrap the wrapped data with generated k1 (from sent keys)
-    auto [wrapped_data, wrapped_len] = ec_util::unwrap_wrapped_attrib(wrapped_data_attr, frame, true, m_eph_ctx().k1); 
+    auto [wrapped_data, wrapped_len] = ec_util::unwrap_wrapped_attrib(*wrapped_data_attr, frame, true, m_eph_ctx().k1); 
     if (wrapped_data == NULL || wrapped_len == 0) {
         em_printfout("failed to unwrap wrapped data");
         // "Abondon the exchange"
         return false;
     }
 
-    ec_attribute_t *init_caps_attr = ec_util::get_attrib(wrapped_data, static_cast<uint16_t> (wrapped_len), ec_attrib_id_init_caps);
-    ASSERT_NOT_NULL_FREE(init_caps_attr, false, wrapped_data, "%s:%d No initiator capabilities attribute found\n", __func__, __LINE__);
+    auto init_caps_attr = ec_util::get_attrib(wrapped_data, static_cast<uint16_t> (wrapped_len), ec_attrib_id_init_caps);
+    ASSERT_OPT_HAS_VALUE_FREE(init_caps_attr, false, wrapped_data, "%s:%d No initiator capabilities attribute found\n", __func__, __LINE__);
 
     const ec_dpp_capabilities_t init_caps = {
         .byte = init_caps_attr->data[0]
     };
 
-    ec_attribute_t *i_nonce_attr = ec_util::get_attrib(wrapped_data, static_cast<uint16_t>(wrapped_len), ec_attrib_id_init_nonce);
-    ASSERT_NOT_NULL_FREE(init_caps_attr, false, wrapped_data, "%s:%d: No initiator nonce attribute found\n", __func__, __LINE__);
+    auto i_nonce_attr = ec_util::get_attrib(wrapped_data, static_cast<uint16_t>(wrapped_len), ec_attrib_id_init_nonce);
+    ASSERT_OPT_HAS_VALUE_FREE(init_caps_attr, false, wrapped_data, "%s:%d: No initiator nonce attribute found\n", __func__, __LINE__);
     memcpy(m_eph_ctx().i_nonce, i_nonce_attr->data, i_nonce_attr->length);
     em_printfout("i-nonce (Configurator is initiator)");
     util::print_hex_dump(i_nonce_attr->length, m_eph_ctx().i_nonce);
@@ -265,7 +265,7 @@ Authentication Request frame without replying to it.
     free(wrapped_data);
 
     uint8_t init_proto_version = 0; // Undefined
-    ec_attribute_t *proto_version_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_proto_version);
+    auto proto_version_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_proto_version);
     if (proto_version_attr && proto_version_attr->length == 1) {
         init_proto_version = proto_version_attr->data[0];
     }
@@ -333,8 +333,8 @@ bool ec_enrollee_t::handle_auth_confirm(ec_frame_t *frame, size_t len, uint8_t s
 {
     size_t attrs_len = len - EC_FRAME_BASE_SIZE;
 
-    ec_attribute_t *status_attrib = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_dpp_status);
-    ASSERT_NOT_NULL(status_attrib, false, "%s:%d: No DPP status attribute found\n", __func__, __LINE__);
+    auto status_attrib = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_dpp_status);
+    ASSERT_OPT_HAS_VALUE(status_attrib, false, "%s:%d: No DPP status attribute found\n", __func__, __LINE__);
 
     ec_status_code_t dpp_status = static_cast<ec_status_code_t>(status_attrib->data[0]);
 
@@ -343,14 +343,14 @@ bool ec_enrollee_t::handle_auth_confirm(ec_frame_t *frame, size_t len, uint8_t s
         return false;
     }
 
-    ec_attribute_t *wrapped_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_wrapped_data);
-    ASSERT_NOT_NULL(wrapped_attr, false, "%s:%d: No wrapped data attribute found\n", __func__, __LINE__);
+    auto wrapped_attr = ec_util::get_attrib(frame->attributes, attrs_len, ec_attrib_id_wrapped_data);
+    ASSERT_OPT_HAS_VALUE(wrapped_attr, false, "%s:%d: No wrapped data attribute found\n", __func__, __LINE__);
 
     uint8_t* key = (dpp_status == DPP_STATUS_OK) ? m_eph_ctx().ke : m_eph_ctx().k2;
     ASSERT_NOT_NULL(key, false, "%s:%d: k_e or k_2 is NULL!\n", __func__, __LINE__);
 
     // If DPP Status is OK, wrap the I-auth with the KE key, otherwise wrap the Responder Nonce with the K2 key
-    auto [unwrapped_data, unwrapped_data_len] = ec_util::unwrap_wrapped_attrib(wrapped_attr, frame, true, key);
+    auto [unwrapped_data, unwrapped_data_len] = ec_util::unwrap_wrapped_attrib(*wrapped_attr, frame, true, key);
     if (unwrapped_data == NULL || unwrapped_data_len == 0) {
         em_printfout("Failed to unwrap wrapped data, aborting exchange");
         // Aborts exchange
@@ -365,7 +365,7 @@ bool ec_enrollee_t::handle_auth_confirm(ec_frame_t *frame, size_t len, uint8_t s
     }
 
     auto i_auth_tag_attr = ec_util::get_attrib(unwrapped_data, unwrapped_data_len, ec_attrib_id_init_auth_tag);
-    ASSERT_NOT_NULL_FREE(i_auth_tag_attr, false, unwrapped_data, "%s:%d: No initiator authentication tag attribute found\n", __func__, __LINE__);
+    ASSERT_OPT_HAS_VALUE_FREE(i_auth_tag_attr, false, unwrapped_data, "%s:%d: No initiator authentication tag attribute found\n", __func__, __LINE__);
     
     uint8_t i_auth_tag[i_auth_tag_attr->length] = {0};
     memcpy(i_auth_tag, i_auth_tag_attr->data, i_auth_tag_attr->length);
@@ -472,8 +472,8 @@ bool ec_enrollee_t::handle_config_response(uint8_t *buff, unsigned int len, uint
     ec_gas_initial_response_frame_t *config_response_frame = reinterpret_cast<ec_gas_initial_response_frame_t*>(buff);
 
 
-    ec_attribute_t *status_attrib = ec_util::get_attrib(reinterpret_cast<uint8_t*>(config_response_frame->resp), static_cast<size_t>(config_response_frame->resp_len), ec_attrib_id_dpp_status);
-    ASSERT_NOT_NULL(status_attrib, false, "%s:%d: No DPP status attribute found\n", __func__, __LINE__);
+    auto status_attrib = ec_util::get_attrib(reinterpret_cast<uint8_t*>(config_response_frame->resp), static_cast<size_t>(config_response_frame->resp_len), ec_attrib_id_dpp_status);
+    ASSERT_OPT_HAS_VALUE(status_attrib, false, "%s:%d: No DPP status attribute found\n", __func__, __LINE__);
 
     ec_status_code_t config_response_status_code = static_cast<ec_status_code_t>(status_attrib->data[0]);
 
@@ -496,38 +496,38 @@ bool ec_enrollee_t::handle_config_response(uint8_t *buff, unsigned int len, uint
         return false;
     }
 
-    ec_attribute_t *wrapped_attrs = ec_util::get_attrib(config_response_frame->resp, static_cast<size_t>(config_response_frame->resp_len), ec_attrib_id_wrapped_data);
-    ASSERT_NOT_NULL(wrapped_attrs, false, "%s:%d: Failed to get wrapped data attribute!\n", __func__, __LINE__);
+    auto wrapped_attrs = ec_util::get_attrib(config_response_frame->resp, static_cast<size_t>(config_response_frame->resp_len), ec_attrib_id_wrapped_data);
+    ASSERT_OPT_HAS_VALUE(wrapped_attrs, false, "%s:%d: Failed to get wrapped data attribute!\n", __func__, __LINE__);
 
-    auto [unwrapped_attrs, unwrapped_attrs_len] = ec_util::unwrap_wrapped_attrib(wrapped_attrs, reinterpret_cast<uint8_t*>(config_response_frame), sizeof(*config_response_frame), config_response_frame->resp, true, m_eph_ctx().ke);
+    auto [unwrapped_attrs, unwrapped_attrs_len] = ec_util::unwrap_wrapped_attrib(*wrapped_attrs, reinterpret_cast<uint8_t*>(config_response_frame), sizeof(*config_response_frame), config_response_frame->resp, true, m_eph_ctx().ke);
     if (unwrapped_attrs == nullptr || unwrapped_attrs_len == 0) {
         em_printfout("Failed to unwrap wrapped attributes.");
         return false;
     }
-    ec_attribute_t* e_nonce_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_enrollee_nonce);
-    ASSERT_NOT_NULL_FREE(e_nonce_attr, false, unwrapped_attrs, "%s:%d: No e-nonce in attributes!\n", __func__, __LINE__);
+    auto e_nonce_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_enrollee_nonce);
+    ASSERT_OPT_HAS_VALUE_FREE(e_nonce_attr, false, unwrapped_attrs, "%s:%d: No e-nonce in attributes!\n", __func__, __LINE__);
 
-    ec_attribute_t* dpp_config_obj_1905 = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_dpp_config_obj);
-    ASSERT_NOT_NULL_FREE(dpp_config_obj_1905, false, unwrapped_attrs, "%s:%d: No IEEE1905 Configuration object attribute found\n", __func__, __LINE__);
+    auto dpp_config_obj_1905 = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_dpp_config_obj);
+    ASSERT_OPT_HAS_VALUE_FREE(dpp_config_obj_1905, false, unwrapped_attrs, "%s:%d: No IEEE1905 Configuration object attribute found\n", __func__, __LINE__);
 
-    ec_attribute_t* dpp_config_obj_bsta = ec_util::get_attrib(reinterpret_cast<uint8_t*>(dpp_config_obj_1905) + dpp_config_obj_1905->length, unwrapped_attrs_len, ec_attrib_id_dpp_config_obj);
-    ASSERT_NOT_NULL_FREE(dpp_config_obj_bsta, false, unwrapped_attrs, "%s:%d: No bSTA Configuration object attribute found\n", __func__, __LINE__);
+    auto dpp_config_obj_bsta = ec_util::get_attrib(reinterpret_cast<uint8_t*>(dpp_config_obj_1905->original) + dpp_config_obj_1905->length, unwrapped_attrs_len, ec_attrib_id_dpp_config_obj);
+    ASSERT_OPT_HAS_VALUE_FREE(dpp_config_obj_bsta, false, unwrapped_attrs, "%s:%d: No bSTA Configuration object attribute found\n", __func__, __LINE__);
 
     // This is optional, so can be nullptr.
-    ec_attribute_t* send_connection_status_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_send_conn_status);
+    auto send_connection_status_attr = ec_util::get_attrib(unwrapped_attrs, unwrapped_attrs_len, ec_attrib_id_send_conn_status);
 
     // Parse JSON objects
-    cJSON *ieee1905_configuration_object = cJSON_ParseWithLength(reinterpret_cast<const char *>(dpp_config_obj_1905), static_cast<size_t>(dpp_config_obj_1905->length));
-    ASSERT_NOT_NULL_FREE(ieee1905_configuration_object, false, wrapped_attrs, "%s:%d: Could not parse IEEE1905 Configuration object, invalid JSON?\n", __func__, __LINE__);
+    cJSON *ieee1905_configuration_object = cJSON_ParseWithLength(reinterpret_cast<const char *>(dpp_config_obj_1905->original), static_cast<size_t>(dpp_config_obj_1905->length));
+    ASSERT_NOT_NULL(ieee1905_configuration_object, false, "%s:%d: Could not parse IEEE1905 Configuration object, invalid JSON?\n", __func__, __LINE__);
 
-    cJSON *bsta_configuration_object = cJSON_ParseWithLength(reinterpret_cast<const char *>(dpp_config_obj_bsta), static_cast<size_t>(dpp_config_obj_bsta->length));
-    ASSERT_NOT_NULL_FREE(bsta_configuration_object, false, wrapped_attrs, "%s:%d: Could not parse bSTA Configuration object, invalid JSON?\n", __func__, __LINE__);
+    cJSON *bsta_configuration_object = cJSON_ParseWithLength(reinterpret_cast<const char *>(dpp_config_obj_bsta->original), static_cast<size_t>(dpp_config_obj_bsta->length));
+    ASSERT_NOT_NULL(bsta_configuration_object, false, "%s:%d: Could not parse bSTA Configuration object, invalid JSON?\n", __func__, __LINE__);
 
     cJSON *bsta_cred_obj = cJSON_GetObjectItem(bsta_configuration_object, "cred");
     cJSON *bsta_discovery_obj = cJSON_GetObjectItem(bsta_configuration_object, "discovery");
     if (bsta_cred_obj == nullptr || bsta_discovery_obj == nullptr) {
         em_printfout("Incomplete bSTA Configuration object received");
-        free(wrapped_attrs);
+        free(unwrapped_attrs);
         cJSON_Delete(bsta_configuration_object);
         cJSON_Delete(ieee1905_configuration_object);
         return false;
@@ -536,7 +536,7 @@ bool ec_enrollee_t::handle_config_response(uint8_t *buff, unsigned int len, uint
     cJSON *bsta_ssid = cJSON_GetObjectItem(bsta_discovery_obj, "SSID");
     if (bsta_ssid == nullptr) {
         em_printfout("Could not get \"SSID\" from bSTA Configuration object.");
-        free(wrapped_attrs);
+        free(unwrapped_attrs);
         cJSON_Delete(bsta_configuration_object);
         cJSON_Delete(ieee1905_configuration_object);
         return false;
@@ -544,7 +544,7 @@ bool ec_enrollee_t::handle_config_response(uint8_t *buff, unsigned int len, uint
     cJSON *bsta_pass = cJSON_GetObjectItem(bsta_cred_obj, "pass");
     if (bsta_pass == nullptr) {
         em_printfout("Could not get \"pass\" from bSTA Configuration object.");
-        free(wrapped_attrs);
+        free(unwrapped_attrs);
         cJSON_Delete(bsta_configuration_object);
         cJSON_Delete(ieee1905_configuration_object);
         return false;
@@ -562,13 +562,13 @@ bool ec_enrollee_t::handle_config_response(uint8_t *buff, unsigned int len, uint
 
 
     // Only necessary if Configurator includes "sendConnStatus" in Configuration response.
-    bool needs_connection_status = (send_connection_status_attr != nullptr);
+    bool needs_connection_status = (send_connection_status_attr.has_value());
 
     // Mandatory Configuration Result frame indicating configuration status.
     auto [config_result_frame, config_result_frame_len] = create_config_result(connection_status);
     if (config_result_frame == nullptr || config_result_frame_len == 0) {
         em_printfout("Failed to create DPP Configuration Result frame");
-        free(wrapped_attrs);
+        free(unwrapped_attrs);
         cJSON_Delete(ieee1905_configuration_object);
         cJSON_Delete(bsta_configuration_object);
         return false;
@@ -584,7 +584,7 @@ bool ec_enrollee_t::handle_config_response(uint8_t *buff, unsigned int len, uint
     // No Conn Status frame needed.
     if (!needs_connection_status) {
         free(config_result_frame);
-        free(wrapped_attrs);
+        free(unwrapped_attrs);
         cJSON_Delete(bsta_configuration_object);
         cJSON_Delete(ieee1905_configuration_object);
         return ok;
@@ -594,16 +594,18 @@ bool ec_enrollee_t::handle_config_response(uint8_t *buff, unsigned int len, uint
     
     if (!conn_status_result_frame || conn_status_result_frame_len == 0) {
         em_printfout("Configurator required a Connection Status Result frame, but could not create one");
-        free(wrapped_attrs);
+        free(config_result_frame);
+        free(unwrapped_attrs);
         cJSON_Delete(ieee1905_configuration_object);
         cJSON_Delete(bsta_configuration_object);
         return false;
     }
     
-    if (!m_send_action_frame(sa, conn_status_result_frame, conn_status_result_frame_len, m_selected_freq, 0)) {
+    if (!m_send_action_frame(sa, conn_status_result_frame, conn_status_result_frame_len, 0, 0)) {
         em_printfout("Failed to send Connection Status Result frame to Configurator!");
+        free(config_result_frame);
+        free(unwrapped_attrs);
         free(conn_status_result_frame);
-        free(wrapped_attrs);
         cJSON_Delete(ieee1905_configuration_object);
         cJSON_Delete(bsta_configuration_object);
         return false;
@@ -611,8 +613,9 @@ bool ec_enrollee_t::handle_config_response(uint8_t *buff, unsigned int len, uint
     
     em_printfout("Sent a Connection Status Result frame to Configurator");
 
+    free(config_result_frame);
+    free(unwrapped_attrs);
     free(conn_status_result_frame);
-    free(wrapped_attrs);
     cJSON_Delete(bsta_configuration_object);
     cJSON_Delete(ieee1905_configuration_object);
     return true;    
@@ -961,12 +964,13 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_recfg_presence_announcement()
                           __LINE__);
 
     // Finite Cyclic Group attribute
+    // Must be little endian according to EC 8.1.1.12
     scoped_ec_group group(em_crypto_t::get_key_group(m_c_ctx.net_access_key));
     ASSERT_NOT_NULL_FREE2(group.get(), {}, frame, attribs,
                           "%s:%d: Failed to get elliptic curve group from network access key\n",
                           __func__, __LINE__);
     attribs = ec_util::add_attrib(attribs, &attribs_len, ec_attrib_id_finite_cyclic_group,
-                                  ec_crypto::get_tls_group_id_from_ec_group(group.get()));
+                                  SWAP_LITTLE_ENDIAN(ec_crypto::get_tls_group_id_from_ec_group(group.get())));
     ASSERT_NOT_NULL_FREE2(attribs, {}, frame, attribs,
                           "%s:%d: Failed to add finite cyclic group attribute\n", __func__,
                           __LINE__);

--- a/src/em/prov/easyconnect/ec_pa_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_pa_configurator.cpp
@@ -8,8 +8,8 @@ bool ec_pa_configurator_t::handle_presence_announcement(ec_frame_t *frame, size_
     em_printfout("Recieved a DPP Presence Announcement Frame from '" MACSTRFMT "'\n", MAC2STR(src_mac));
     size_t attrs_len = len - EC_FRAME_BASE_SIZE;
 
-    ec_attribute_t *B_r_hash_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_resp_bootstrap_key_hash);
-    ASSERT_NOT_NULL(B_r_hash_attr, false, "%s:%d No responder bootstrapping key hash attribute found\n", __func__, __LINE__);
+    auto B_r_hash_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_resp_bootstrap_key_hash);
+    ASSERT_OPT_HAS_VALUE(B_r_hash_attr, false, "%s:%d No responder bootstrapping key hash attribute found\n", __func__, __LINE__);
     std::string B_r_hash_str = em_crypto_t::hash_to_hex_string(B_r_hash_attr->data, B_r_hash_attr->length);
 
     // EasyMesh R6 5.3.4

--- a/src/em/prov/easyconnect/ec_util.cpp
+++ b/src/em/prov/easyconnect/ec_util.cpp
@@ -24,25 +24,35 @@ void ec_util::init_frame(ec_frame_t *frame)
     frame->crypto_suite = 0x01; // Section 3.3 (Currently only 0x01 is defined)
 }
 
-ec_attribute_t *ec_util::get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id)
+std::optional<ec_attribute_t> ec_util::get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id)
 {
     if (buff == NULL || len == 0) {
         fprintf(stderr, "Invalid input\n");
-        return NULL;
+        return std::nullopt;
     }
     size_t total_len = 0;
-    ec_attribute_t *attrib = reinterpret_cast<ec_attribute_t *>(buff);
+    ec_net_attribute_t *attrib = reinterpret_cast<ec_net_attribute_t *>(buff);
 
     while (total_len < len) {
-        if (attrib->attr_id == id) {
-            return attrib;
+        const uint16_t curr_id = SWAP_LITTLE_ENDIAN(attrib->attr_id);
+        const uint16_t curr_data_len = SWAP_LITTLE_ENDIAN(attrib->length);
+        const size_t attr_len = get_ec_attr_size(curr_data_len);
+        if (curr_id == id) {
+            // Create a copy of the found attrib, but with host byte ordering
+            ec_attribute_t host_attr = {
+                .attr_id = curr_id,
+                .length = curr_data_len,
+                .original = attrib,
+                .data = attrib->data
+            };
+            return host_attr;
         }
 
-        total_len += (get_ec_attr_size(attrib->length));
-        attrib = reinterpret_cast<ec_attribute_t *>(reinterpret_cast<uint8_t*>(attrib) + get_ec_attr_size(attrib->length));
+        total_len += attr_len;
+        attrib = reinterpret_cast<ec_net_attribute_t *>(reinterpret_cast<uint8_t*>(attrib) + attr_len);
     }
 
-    return NULL;
+    return std::nullopt;
 }
 
 
@@ -67,10 +77,10 @@ uint8_t* ec_util::add_attrib(uint8_t *buff, size_t* buff_len, ec_attrib_id_t id,
     uint8_t* tmp = base_ptr + *buff_len;
 
     memset(tmp, 0, get_ec_attr_size(len));
-    ec_attribute_t *attr = reinterpret_cast<ec_attribute_t *>(tmp);
-    // EC attribute id and length are in host byte order according to the spec (8.1)
-    attr->attr_id = id;
-    attr->length = len;
+    ec_net_attribute_t *attr = reinterpret_cast<ec_net_attribute_t *>(tmp);
+    // EC attribute id and length are little endian according to the spec (8.1)
+    attr->attr_id = SWAP_LITTLE_ENDIAN(id);
+    attr->length = SWAP_LITTLE_ENDIAN(len);
     memcpy(attr->data, data, len);
 
     *buff_len += get_ec_attr_size(len);
@@ -138,11 +148,11 @@ bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> creat
 
     // Encapsulate the attributes in a wrapped data attribute
     uint16_t wrapped_attrib_len = wrapped_len + AES_BLOCK_SIZE;
-    ec_attribute_t *wrapped_attrib = static_cast<ec_attribute_t *>(calloc(sizeof(ec_attribute_t) + wrapped_attrib_len, 1));
-    ASSERT_NOT_NULL_FREE(wrapped_attrib, NULL, wrapped_attrib, "Failed to allocate wrapped attribute");
-
-    wrapped_attrib->attr_id = ec_attrib_id_wrapped_data;
-    wrapped_attrib->length = wrapped_attrib_len;
+    ec_net_attribute_t *wrapped_attrib = static_cast<ec_net_attribute_t *>(calloc(sizeof(ec_net_attribute_t) + wrapped_attrib_len, 1));
+    ASSERT_NOT_NULL_FREE(wrapped_attrib, NULL, wrap_attribs, "Failed to allocate wrapped attribute");
+    // EC attribute id and length are little endian according to the spec (8.1)
+    wrapped_attrib->attr_id = SWAP_LITTLE_ENDIAN(ec_attrib_id_wrapped_data);
+    wrapped_attrib->length = SWAP_LITTLE_ENDIAN(wrapped_attrib_len);
     memset(wrapped_attrib->data, 0, wrapped_attrib_len);
 
     /**
@@ -184,12 +194,12 @@ uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attrib
     return add_wrapped_data_attr(reinterpret_cast<uint8_t*>(frame), sizeof(ec_frame_t), frame_attribs, non_wrapped_len, use_aad, key, create_wrap_attribs);
 }
 
-std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t* wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key)
+std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key)
 {
     return unwrap_wrapped_attrib(wrapped_attrib, reinterpret_cast<uint8_t*>(frame), sizeof(ec_frame_t), frame->attributes, uses_aad, key);
 }
 
-std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t *wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key)
+std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key)
 {
     siv_ctx ctx;
 
@@ -216,8 +226,9 @@ std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t *wra
     }
     */
 
-    uint8_t* wrapped_ciphertext = wrapped_attrib->data + AES_BLOCK_SIZE;
-    uint16_t wrapped_len = wrapped_attrib->length - AES_BLOCK_SIZE;
+    uint8_t* wrapped_ciphertext = wrapped_attrib.data + AES_BLOCK_SIZE;
+    // wrapped_len is host byte ordered as long as wrapped_attrib was gotten by `ec_util::get_attrib`
+    uint16_t wrapped_len = wrapped_attrib.length - AES_BLOCK_SIZE;
 
     uint8_t* unwrap_attribs = reinterpret_cast<uint8_t*>(calloc(wrapped_len, 1));
     int result = -1;
@@ -226,14 +237,14 @@ std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t *wra
             em_printfout("AAD input is NULL, AAD decryption failed!");
             return {nullptr, 0};
         }
-        size_t pre_wrapped_attribs_size = static_cast<size_t>(reinterpret_cast<uint8_t*>(wrapped_attrib) - frame_attribs);
+        size_t pre_wrapped_attribs_size = static_cast<size_t>(reinterpret_cast<uint8_t*>(wrapped_attrib.original) - frame_attribs);
         result = siv_decrypt(&ctx, wrapped_ciphertext, unwrap_attribs, wrapped_len,
-                             wrapped_attrib->data, 2,
+                             wrapped_attrib.data, 2,
                              frame, frame_len,
                              frame_attribs, pre_wrapped_attribs_size);
     } else {
         result = siv_decrypt(&ctx, wrapped_ciphertext, unwrap_attribs, wrapped_len,
-                             wrapped_attrib->data, 0);
+                             wrapped_attrib.data, 0);
     }
 
     if (result < 0) {
@@ -269,9 +280,7 @@ bool ec_util::parse_dpp_chirp_tlv(em_dpp_chirp_value_t* chirp_tlv, uint16_t chir
         return true;
     }
 
-    uint16_t h_len;
-    memcpy(&h_len, data_ptr, sizeof(uint16_t));
-    *hash_len = ntohs(h_len);
+    *hash_len = util::deref_net_uint16_to_host(data_ptr);
     data_ptr += sizeof(uint16_t);
     data_len -= static_cast<uint16_t>(sizeof(uint16_t));
     if (*hash_len == 0) {
@@ -328,8 +337,7 @@ std::pair<em_dpp_chirp_value_t*, uint16_t> ec_util::create_dpp_chirp_tlv(bool ma
         data_ptr += sizeof(mac_addr_t);
     }
     if (hash_validity) {
-        uint16_t net_hashlen = htons(hash_len);
-        memcpy(data_ptr, &net_hashlen, sizeof(uint16_t));
+        util::set_net_uint16_from_host(hash_len, data_ptr);
         data_ptr += sizeof(uint16_t); 
     }
     if (hash_len > 0 && hash_validity) {
@@ -371,9 +379,7 @@ bool ec_util::parse_encap_dpp_tlv(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_
     data_ptr++;
 
     // Get frame length - Fix for alignment issue
-    uint16_t frame_len;
-    memcpy(&frame_len, data_ptr, sizeof(uint16_t));
-    *encap_frame_len = ntohs(frame_len);
+    *encap_frame_len = util::deref_net_uint16_to_host(data_ptr);
     data_ptr += sizeof(uint16_t);
 
     if (data_len < *encap_frame_len) {
@@ -417,7 +423,7 @@ std::pair<em_encap_dpp_t*, uint16_t> ec_util::create_encap_dpp_tlv(bool dpp_fram
     *data_ptr = frame_type;
     data_ptr++;
 
-    *reinterpret_cast<uint16_t *>(data_ptr) = htons(static_cast<uint16_t>(encap_frame_len));
+    util::set_net_uint16_from_host(static_cast<uint16_t>(encap_frame_len), data_ptr);
     data_ptr += sizeof(uint16_t);
 
     memcpy(data_ptr, encap_frame, encap_frame_len);

--- a/src/em/prov/easyconnect/ec_util.cpp
+++ b/src/em/prov/easyconnect/ec_util.cpp
@@ -24,7 +24,7 @@ void ec_util::init_frame(ec_frame_t *frame)
     frame->crypto_suite = 0x01; // Section 3.3 (Currently only 0x01 is defined)
 }
 
-std::optional<ec_attribute_t> ec_util::get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id)
+std::optional<const ec_attribute_t> ec_util::get_attrib(uint8_t *buff, size_t len, ec_attrib_id_t id)
 {
     if (buff == NULL || len == 0) {
         fprintf(stderr, "Invalid input\n");
@@ -194,12 +194,12 @@ uint8_t* ec_util::add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attrib
     return add_wrapped_data_attr(reinterpret_cast<uint8_t*>(frame), sizeof(ec_frame_t), frame_attribs, non_wrapped_len, use_aad, key, create_wrap_attribs);
 }
 
-std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key)
+std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(const ec_attribute_t& wrapped_attrib, ec_frame_t *frame, bool uses_aad, uint8_t* key)
 {
     return unwrap_wrapped_attrib(wrapped_attrib, reinterpret_cast<uint8_t*>(frame), sizeof(ec_frame_t), frame->attributes, uses_aad, key);
 }
 
-std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(ec_attribute_t wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key)
+std::pair<uint8_t*, uint16_t> ec_util::unwrap_wrapped_attrib(const ec_attribute_t& wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key)
 {
     siv_ctx ctx;
 

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -148,6 +148,7 @@ int em_provisioning_t::send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, si
         return -1;
     }
 
+    em_printfout("Sent Proxied Encap DPP msg");
     // TODO: If needed, likely not
 	//set_state(em_state_ctrl_configured);
 

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -39,6 +39,7 @@
 
 
 #include "util.h"
+#include <netinet/in.h>
 
 extern "C" {
     extern char *__progname;
@@ -429,4 +430,22 @@ std::string util::akm_to_oui(std::string akm) {
     const auto it = akm_map.find(akm);
     if (it == akm_map.end()) return std::string();
     return it->second;
+}
+
+uint16_t util::deref_net_uint16_to_host(const void* const ptr) {
+    if (ptr == nullptr) {
+        return 0;
+    }
+    uint16_t net_val;
+    memcpy(&net_val, ptr, sizeof(uint16_t));
+    return ntohs(net_val);
+}
+
+bool util::set_net_uint16_from_host(const uint16_t host_val, void* const ptr) {
+    if (ptr == nullptr) {
+        return false;
+    }
+    uint16_t net_val = htons(host_val);
+    memcpy(ptr, &net_val, sizeof(uint16_t));
+    return true;
 }

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -2,20 +2,7 @@
 #include <string>
 #include <memory>
 
-// Include necessary headers from your project
-// Adjust paths as needed based on your project structure
-#include "util.h" 
-
 // Basic sanity test
 TEST(OneWifiEmTest, SanityCheck) {
     EXPECT_TRUE(true);
-}
-
-TEST(OneWifiEmTest, TestStringSplit) {
-    std::string test = "Valid.Data.String";
-    std::vector<std::string> result = util::split_by_delim(test, '.');
-    EXPECT_EQ(result.size(), 3);
-    EXPECT_EQ(result[0], "Valid");
-    EXPECT_EQ(result[1], "Data");
-    EXPECT_EQ(result[2], "String");
 }

--- a/tests/test_ec_attrib.cpp
+++ b/tests/test_ec_attrib.cpp
@@ -105,14 +105,14 @@ TEST_F(ECUtilAttributeTest, GetAttribute) {
     ASSERT_NE(buffer, nullptr);
 
     // Test retrieving existing attributes
-    ec_attribute_t* attr1 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_dpp_status);
-    ASSERT_NE(attr1, nullptr);
+    auto attr1 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_dpp_status);
+    ASSERT_NE(attr1, std::nullopt);
     EXPECT_EQ(attr1->attr_id, ec_attrib_id_dpp_status);
     EXPECT_EQ(attr1->length, sizeof(uint8_t));
     EXPECT_EQ(attr1->data[0], 0x42);
 
-    ec_attribute_t* attr2 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_init_bootstrap_key_hash);
-    ASSERT_NE(attr2, nullptr);
+    auto attr2 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_init_bootstrap_key_hash);
+    ASSERT_NE(attr2, std::nullopt);
     EXPECT_EQ(attr2->attr_id, ec_attrib_id_init_bootstrap_key_hash);
     EXPECT_EQ(attr2->length, sizeof(uint16_t));
 
@@ -120,15 +120,15 @@ TEST_F(ECUtilAttributeTest, GetAttribute) {
     memcpy(&data, attr2->data, sizeof(uint16_t));
     EXPECT_EQ(data, 0x1234);
 
-    ec_attribute_t* attr3 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_channel);
-    ASSERT_NE(attr3, nullptr);
+    auto attr3 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_channel);
+    ASSERT_NE(attr3, std::nullopt);
     EXPECT_EQ(attr3->attr_id, ec_attrib_id_channel);
     EXPECT_EQ(attr3->length, 11); // Length of "test_string"
     EXPECT_EQ(std::string(reinterpret_cast<char*>(attr3->data), attr3->length), "test_string");
 
     // Test retrieving non-existent attribute
-    ec_attribute_t* attr4 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_wrapped_data);
-    EXPECT_EQ(attr4, nullptr);
+    auto attr4 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_wrapped_data);
+    EXPECT_EQ(attr4, std::nullopt);
 }
 
 // Test adding attributes with different types
@@ -157,22 +157,22 @@ TEST_F(ECUtilAttributeTest, AddAttributeDifferentTypes) {
     ASSERT_NE(buffer, nullptr);
     
     // Verify all attributes were added correctly
-    ec_attribute_t* attr1 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_dpp_status);
-    ASSERT_NE(attr1, nullptr);
+    auto attr1 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_dpp_status);
+    ASSERT_NE(attr1, std::nullopt);
     EXPECT_EQ(attr1->data[0], u8_val);
     
-    ec_attribute_t* attr2 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_init_bootstrap_key_hash);
+    auto attr2 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_init_bootstrap_key_hash);
 
     uint16_t data = 0;
     memcpy(&data, attr2->data, sizeof(uint16_t));
     EXPECT_EQ(data, u16_val);
     
-    ec_attribute_t* attr3 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_channel);
-    ASSERT_NE(attr3, nullptr);
+    auto attr3 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_channel);
+    ASSERT_NE(attr3, std::nullopt);
     EXPECT_EQ(std::string(reinterpret_cast<char*>(attr3->data), attr3->length), str_val);
     
-    ec_attribute_t* attr4 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_proto_version);
-    ASSERT_NE(attr4, nullptr);
+    auto attr4 = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_proto_version);
+    ASSERT_NE(attr4, std::nullopt);
     EXPECT_EQ(attr4->length, sizeof(raw_data));
     EXPECT_EQ(memcmp(attr4->data, raw_data, sizeof(raw_data)), 0);
 }
@@ -180,10 +180,10 @@ TEST_F(ECUtilAttributeTest, AddAttributeDifferentTypes) {
 // Test attribute size calculation
 TEST_F(ECUtilAttributeTest, AttributeSizeCalculation) {
     // Test various attribute sizes
-    EXPECT_EQ(ec_util::get_ec_attr_size(0), offsetof(ec_attribute_t, data));
-    EXPECT_EQ(ec_util::get_ec_attr_size(1), offsetof(ec_attribute_t, data) + 1);
-    EXPECT_EQ(ec_util::get_ec_attr_size(10), offsetof(ec_attribute_t, data) + 10);
-    EXPECT_EQ(ec_util::get_ec_attr_size(100), offsetof(ec_attribute_t, data) + 100);
+    EXPECT_EQ(ec_util::get_ec_attr_size(0), offsetof(ec_net_attribute_t, data));
+    EXPECT_EQ(ec_util::get_ec_attr_size(1), offsetof(ec_net_attribute_t, data) + 1);
+    EXPECT_EQ(ec_util::get_ec_attr_size(10), offsetof(ec_net_attribute_t, data) + 10);
+    EXPECT_EQ(ec_util::get_ec_attr_size(100), offsetof(ec_net_attribute_t, data) + 100);
 }
 
 // Test adding and retrieving multiple attributes
@@ -214,8 +214,8 @@ TEST_F(ECUtilAttributeTest, MultipleAttributes) {
     
     // Verify all attributes
     for (int i = 0; i < NUM_ATTRIBUTES; i++) {
-        ec_attribute_t* attr = ec_util::get_attrib(buffer, buffer_len, ids[i]);
-        ASSERT_NE(attr, nullptr) << "Failed to retrieve attribute " << i;
+        auto attr = ec_util::get_attrib(buffer, buffer_len, ids[i]);
+        ASSERT_NE(attr, std::nullopt) << "Failed to retrieve attribute " << i;
         EXPECT_EQ(attr->attr_id, ids[i]);
         EXPECT_EQ(attr->length, sizeof(uint8_t));
         EXPECT_EQ(attr->data[0], values[i]);
@@ -225,8 +225,8 @@ TEST_F(ECUtilAttributeTest, MultipleAttributes) {
 // Test behavior with null buffer
 TEST_F(ECUtilAttributeTest, NullBuffer) {
     // Test get_attrib with null buffer
-    ec_attribute_t* attr = ec_util::get_attrib(nullptr, 10, ec_attrib_id_dpp_status);
-    EXPECT_EQ(attr, nullptr);
+    auto attr = ec_util::get_attrib(nullptr, 10, ec_attrib_id_dpp_status);
+    EXPECT_EQ(attr, std::nullopt);
     
     // Test add_attrib with valid data but null buffer
     size_t buffer_len = 0;
@@ -236,7 +236,7 @@ TEST_F(ECUtilAttributeTest, NullBuffer) {
     
     // Verify the attribute was added correctly
     attr = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_dpp_status);
-    ASSERT_NE(attr, nullptr);
+    ASSERT_NE(attr, std::nullopt);
     EXPECT_EQ(attr->data[0], test_val);
 }
 
@@ -255,18 +255,18 @@ TEST_F(ECUtilAttributeTest, CopyAttrsToFrame) {
     frame = new_frame;
     
     // Verify attributes were copied correctly
-    ec_attribute_t* attr1 = ec_util::get_attrib(frame->attributes, buffer_len, ec_attrib_id_dpp_status);
-    ASSERT_NE(attr1, nullptr);
+    auto attr1 = ec_util::get_attrib(frame->attributes, buffer_len, ec_attrib_id_dpp_status);
+    ASSERT_NE(attr1, std::nullopt);
     EXPECT_EQ(attr1->data[0], 0x42);
     
-    ec_attribute_t* attr2 = ec_util::get_attrib(frame->attributes, buffer_len, ec_attrib_id_init_bootstrap_key_hash);
-    ASSERT_NE(attr2, nullptr);
+    auto attr2 = ec_util::get_attrib(frame->attributes, buffer_len, ec_attrib_id_init_bootstrap_key_hash);
+    ASSERT_NE(attr2, std::nullopt);
     uint16_t data = 0;
     memcpy(&data, attr2->data, sizeof(uint16_t));
     EXPECT_EQ(data, 0x1234);
     
-    ec_attribute_t* attr3 = ec_util::get_attrib(frame->attributes, buffer_len, ec_attrib_id_channel);
-    ASSERT_NE(attr3, nullptr);
+    auto attr3 = ec_util::get_attrib(frame->attributes, buffer_len, ec_attrib_id_channel);
+    ASSERT_NE(attr3, std::nullopt);
     EXPECT_EQ(std::string(reinterpret_cast<char*>(attr3->data), attr3->length), "test_string");
 }
 
@@ -326,8 +326,8 @@ TEST_F(ECUtilAttributeTest, AddWrappedDataAttributeNoAAD) {
     buffer = new_buff;
 
     // Check that the wrapped data attribute was added
-    ec_attribute_t* wrapped_attr = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_wrapped_data);
-    ASSERT_NE(wrapped_attr, nullptr);
+    auto wrapped_attr = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_wrapped_data);
+    ASSERT_NE(wrapped_attr, std::nullopt);
     EXPECT_EQ(wrapped_attr->attr_id, ec_attrib_id_wrapped_data);
 }
 
@@ -367,8 +367,8 @@ TEST_F(ECUtilAttributeTest, AddWrappedDataAttributeAAD) {
     buffer = new_buff;
 
     // Check that the wrapped data attribute was added
-    ec_attribute_t* wrapped_attr = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_wrapped_data);
-    ASSERT_NE(wrapped_attr, nullptr);
+    auto wrapped_attr = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_wrapped_data);
+    ASSERT_NE(wrapped_attr, std::nullopt);
     EXPECT_EQ(wrapped_attr->attr_id, ec_attrib_id_wrapped_data);
 }
 
@@ -401,17 +401,17 @@ TEST_F(ECUtilAttributeTest, WrapUnwrapDataAttributeNoAAD) {
     buffer = new_buff;
 
     // Check that the wrapped data attribute was added
-    ec_attribute_t* wrapped_attr = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_wrapped_data);
-    ASSERT_NE(wrapped_attr, nullptr);
+    auto wrapped_attr = ec_util::get_attrib(buffer, buffer_len, ec_attrib_id_wrapped_data);
+    ASSERT_NE(wrapped_attr, std::nullopt);
     EXPECT_EQ(wrapped_attr->attr_id, ec_attrib_id_wrapped_data);
 
     // Unwrap the wrapped data attribute
 
-    auto [unwrapped_attribs, unwrapped_len] = ec_util::unwrap_wrapped_attrib(wrapped_attr, frame, false, mock_key);
+    auto [unwrapped_attribs, unwrapped_len] = ec_util::unwrap_wrapped_attrib(*wrapped_attr, frame, false, mock_key);
     ASSERT_NE(unwrapped_attribs, nullptr);
     ASSERT_NE(unwrapped_len, 0);
-    ec_attribute_t* unwrapped_attr = ec_util::get_attrib(unwrapped_attribs, unwrapped_len, ec_attrib_id_enrollee_nonce);
-    ASSERT_NE(unwrapped_attr, nullptr);
+    auto unwrapped_attr = ec_util::get_attrib(unwrapped_attribs, unwrapped_len, ec_attrib_id_enrollee_nonce);
+    ASSERT_NE(unwrapped_attr, std::nullopt);
     EXPECT_EQ(unwrapped_attr->attr_id, ec_attrib_id_enrollee_nonce);
     EXPECT_EQ(unwrapped_attr->length, sizeof(uint8_t));
     EXPECT_EQ(unwrapped_attr->data[0], 0x99);
@@ -456,17 +456,17 @@ TEST_F(ECUtilAttributeTest, WrapUnwrapDataAttributeAAD) {
     ASSERT_NE(frame, nullptr);
 
     // Check that the wrapped data attribute was added
-    ec_attribute_t* wrapped_attr = ec_util::get_attrib(frame->attributes, buffer_len, ec_attrib_id_wrapped_data);
-    ASSERT_NE(wrapped_attr, nullptr);
+    auto wrapped_attr = ec_util::get_attrib(frame->attributes, buffer_len, ec_attrib_id_wrapped_data);
+    ASSERT_NE(wrapped_attr, std::nullopt);
     EXPECT_EQ(wrapped_attr->attr_id, ec_attrib_id_wrapped_data);
 
     // Unwrap the wrapped data attribute
 
-    auto [unwrapped_attribs, unwrapped_len] = ec_util::unwrap_wrapped_attrib(wrapped_attr, frame, true, mock_key);
+    auto [unwrapped_attribs, unwrapped_len] = ec_util::unwrap_wrapped_attrib(*wrapped_attr, frame, true, mock_key);
     ASSERT_NE(unwrapped_attribs, nullptr);
     ASSERT_NE(unwrapped_len, 0);
-    ec_attribute_t* unwrapped_attr = ec_util::get_attrib(unwrapped_attribs, unwrapped_len, ec_attrib_id_enrollee_nonce);
-    ASSERT_NE(unwrapped_attr, nullptr);
+    auto unwrapped_attr = ec_util::get_attrib(unwrapped_attribs, unwrapped_len, ec_attrib_id_enrollee_nonce);
+    ASSERT_NE(unwrapped_attr, std::nullopt);
     EXPECT_EQ(unwrapped_attr->attr_id, ec_attrib_id_enrollee_nonce);
     EXPECT_EQ(unwrapped_attr->length, sizeof(uint8_t));
     EXPECT_EQ(unwrapped_attr->data[0], 0x99);
@@ -551,16 +551,16 @@ TEST_F(ECUtilAttributeTest, AttributeReallocation) {
     }
     
     // Verify total buffer size
-    size_t expected_size = NUM_ATTRS * (offsetof(ec_attribute_t, data) + LARGE_ATTR_SIZE);
+    size_t expected_size = NUM_ATTRS * (offsetof(ec_net_attribute_t, data) + LARGE_ATTR_SIZE);
     EXPECT_EQ(buffer_len, expected_size);
     
     // Verify we can still retrieve attributes
     for (int i = 0; i < NUM_ATTRS; i++) {
         ec_attrib_id_t id = all_ec_attribute_ids[i];
-        ec_attribute_t* attr = ec_util::get_attrib(buffer, buffer_len, id);
+        auto attr = ec_util::get_attrib(buffer, buffer_len, id);
         
         // We may have overwritten some attributes when cycling through IDs
-        if (attr != nullptr) {
+        if (attr.has_value()) {
             EXPECT_EQ(attr->attr_id, id);
             EXPECT_EQ(attr->length, LARGE_ATTR_SIZE);
             // Check a few values in the buffer

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <string>
+
+#include "util.h" 
+#include <netinet/in.h>
+
+TEST(EmUtilTest, TestStringSplit) {
+    std::string test = "Valid.Data.String";
+    std::vector<std::string> result = util::split_by_delim(test, '.');
+    EXPECT_EQ(result.size(), 3);
+    EXPECT_EQ(result[0], "Valid");
+    EXPECT_EQ(result[1], "Data");
+    EXPECT_EQ(result[2], "String");
+}
+
+class EmUtilByteOrderTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        // Print information for debugging
+        int n = 1;
+        bool is_little_endian = *reinterpret_cast<char *> (&n) == 1;
+        printf("Host is %s endian\n", is_little_endian ? "little" : "big");
+        printf("misaligned_t is %ld bytes long\n", sizeof(misaligned_t));
+    }
+
+    // The following struct deliberately misaligns the start of `data16`
+    typedef struct {
+        uint8_t _padding;
+        uint16_t data16;
+    } __attribute__((__packed__)) misaligned_t;
+
+    // CONSTANTS
+    const uint16_t host_val16 = static_cast<uint16_t>(0x4321u);
+    const uint16_t net_val16 = htons(host_val16);
+};
+
+
+TEST_F(EmUtilByteOrderTest, TestDerefNetUint16) {
+    const misaligned_t bad_const_struct = {
+        ._padding = 0x12u,
+        .data16 = htons(0x3456u),
+    };
+
+    // Null inputs should return 0.
+    EXPECT_EQ(util::deref_net_uint16_to_host(nullptr), 0);
+    // We should be able to recover host_val16 (host order) from net_val16 (net order) with this function.
+    EXPECT_EQ(util::deref_net_uint16_to_host(&net_val16), host_val16);
+    // GCC/G++ emits a warning that we may have an unaligned pointer value. Disable that as it's intended here. 
+    #pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+    // We should be able to recover the correct value from a misaligned struct.
+    EXPECT_EQ(util::deref_net_uint16_to_host(&(bad_const_struct.data16)), 0x3456);
+    #pragma GCC diagnostic pop
+}
+
+TEST_F(EmUtilByteOrderTest, TestSetNetUint16) {
+    uint16_t mut_val16 = 0;
+    misaligned_t bad_mut_struct = {
+            ._padding = 0,
+            .data16 = 0,
+        };
+    // Trying to set a value at a null address should return false
+    EXPECT_FALSE(util::set_net_uint16_from_host(host_val16, nullptr));
+
+    // mut_val16 should get set to net_val16 (with network byte order)
+    EXPECT_TRUE(util::set_net_uint16_from_host(host_val16, &mut_val16));
+    EXPECT_EQ(mut_val16, net_val16);
+
+    // GCC/G++ emits a warning that we may have an unaligned pointer value. Disable that as it's intended here. 
+    #pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+    // We should be able to set the correct value in a misaligned struct.
+    EXPECT_TRUE(util::set_net_uint16_from_host(host_val16, &(bad_mut_struct.data16)));
+    #pragma GCC diagnostic pop
+    EXPECT_EQ(bad_mut_struct.data16, net_val16);
+}


### PR DESCRIPTION
The EasyConnect and EasyMesh specs require network byte order in some places and little endian in other places. This PR adds a bunch of byte order conversions throughout the EasyConnect code to improve spec conformity. 

One area that required a significant refactor was DPP attributes: ID and length fields are expected to be little endian. I introduced a new type, `ec_host_attribute_t`, to describe a DPP attribute where these fields are in host byte order. This will (hopefully) eliminate ambiguity about the byte ordering of a given instance. 

This code depends on the presence of `__BYTE_ORDER` and `__LITTLE_ENDIAN` as predefined macros, and it requires being able to import `byteswap.h`. All of these conditions are satisfied by glibc. 