### PR TITLE
Fix warning for controller

### DIFF
--- a/inc/dm_ssid_2_vid_map.h
+++ b/inc/dm_ssid_2_vid_map.h
@@ -30,8 +30,8 @@ public:
     int init();
 
     em_ssid_2_vid_map_info_t *get_ssid_2_vid_map_info() { return &m_ssid_2_vid_map_info; }
-    dm_ssid_2_vid_map_t *get_first() { return (dm_ssid_2_vid_map_t *)hash_map_get_first(m_list); }
-    dm_ssid_2_vid_map_t *get_next(dm_ssid_2_vid_map_t *ssid_2_vid) { return (dm_ssid_2_vid_map_t *)hash_map_get_next(m_list, ssid_2_vid); }
+    dm_ssid_2_vid_map_t *get_first() { return static_cast<dm_ssid_2_vid_map_t *>(hash_map_get_first(m_list)); }
+    dm_ssid_2_vid_map_t *get_next(dm_ssid_2_vid_map_t *ssid_2_vid) { return static_cast<dm_ssid_2_vid_map_t *>(hash_map_get_next(m_list, ssid_2_vid)); }
     dm_orch_type_t update_list(const dm_ssid_2_vid_map_t& ssid_2_vid);
 
     void init_table();

--- a/src/dm/dm_network_ssid_list.cpp
+++ b/src/dm/dm_network_ssid_list.cpp
@@ -199,7 +199,7 @@ void dm_network_ssid_list_t::delete_list()
 
 bool dm_network_ssid_list_t::operator == (const db_easy_mesh_t& obj)
 {
-	dm_network_ssid_t *pnet_ssid = (dm_network_ssid_t*)&obj;
+	dm_network_ssid_t *pnet_ssid = const_cast<dm_network_ssid_t*>(reinterpret_cast<const dm_network_ssid_t*>(&obj));
 	unsigned int i, j;
 	bool matched = false;
 

--- a/src/dm/dm_op_class.cpp
+++ b/src/dm/dm_op_class.cpp
@@ -201,7 +201,7 @@ int dm_op_class_t::parse_op_class_id_from_key(const char *key, em_op_class_id_t 
             remain = tmp;
         } else if (i == 1) {
             *tmp = 0;
-            id->type = (em_op_class_type_t)atoi(remain);
+            id->type = static_cast<em_op_class_type_t>(atoi(remain));
             tmp++;
             id->op_class = atoi(tmp);
         }

--- a/src/dm/dm_op_class_list.cpp
+++ b/src/dm/dm_op_class_list.cpp
@@ -48,9 +48,9 @@ int dm_op_class_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
     em_op_class_info_t *info;
     mac_addr_str_t mac_str;
 
-    dm_op_class_t::parse_op_class_id_from_key((char *)parent, &id);
+    dm_op_class_t::parse_op_class_id_from_key(static_cast<char *>(parent), &id);
 	
-    pop_class = (dm_op_class_t *)get_first_op_class();
+    pop_class = static_cast<dm_op_class_t *>(get_first_op_class());
     while (pop_class != NULL) {
         info = pop_class->get_op_class_info();
 		dm_easy_mesh_t::macbytes_to_string(info->id.ruid, mac_str);
@@ -101,7 +101,7 @@ void dm_op_class_list_t::get_config(cJSON *obj_arr, em_op_class_type_t type)
 		return;
 	}		
 
-	op_class = (dm_op_class_t *)get_first_pre_set_op_class_by_type(type);
+	op_class = static_cast<dm_op_class_t *>(get_first_pre_set_op_class_by_type(type));
 	while (op_class) {
        	obj = cJSON_CreateObject(); 
 
@@ -112,7 +112,7 @@ void dm_op_class_list_t::get_config(cJSON *obj_arr, em_op_class_type_t type)
        	}
 
 		cJSON_AddItemToArray(obj_arr, obj);
-		op_class = (dm_op_class_t *)get_next_pre_set_op_class_by_type(type, op_class);
+		op_class = static_cast<dm_op_class_t *>(get_next_pre_set_op_class_by_type(type, op_class));
 	}
 }
 
@@ -139,7 +139,6 @@ int dm_op_class_list_t::set_config(db_client_t& db_client, const cJSON *obj_arr,
 int dm_op_class_list_t::set_config(db_client_t& db_client, dm_op_class_t& op_class, void *parent_id)
 {
     dm_orch_type_t op;
-    char *tmp = (char *)parent_id;
 
     //printf("dm_op_class_list_t::%s:%d: id: %s\n", __func__, __LINE__, (char *)parent_id);
     update_db(db_client, (op = get_dm_orch_type(db_client, op_class)), op_class.get_op_class_info());
@@ -154,7 +153,7 @@ dm_orch_type_t dm_op_class_list_t::get_dm_orch_type(db_client_t& db_client, cons
     mac_addr_str_t  mac_str;
     em_short_string_t   key;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)op_class.m_op_class_info.id.ruid, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(op_class.m_op_class_info.id.ruid), mac_str);
 	//printf("%s:%d: MAC: %s\tType: %d\tClass: %d\n", __func__, __LINE__, mac_str,
 			//op_class.m_op_class_info.id.type, op_class.m_op_class_info.id.op_class);
     snprintf(key, sizeof(key), "%s@%d@%d", mac_str, op_class.m_op_class_info.id.type, op_class.m_op_class_info.id.op_class);
@@ -186,7 +185,7 @@ void dm_op_class_list_t::update_list(const dm_op_class_t& op_class, dm_orch_type
     mac_addr_str_t	mac_str;
     em_long_string_t	key;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)op_class.m_op_class_info.id.ruid, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(op_class.m_op_class_info.id.ruid), mac_str);
     snprintf(key, sizeof(key), "%s@%d@%d", mac_str, op_class.m_op_class_info.id.type, op_class.m_op_class_info.id.op_class);
 
     switch (op) {
@@ -218,7 +217,7 @@ void dm_op_class_list_t::delete_list()
     while (pop_class != NULL) {
         tmp = pop_class;
         pop_class = get_next_op_class(pop_class);
-    	dm_easy_mesh_t::macbytes_to_string((unsigned char *)tmp->m_op_class_info.id.ruid, mac_str);
+        dm_easy_mesh_t::macbytes_to_string(static_cast<unsigned char *>(tmp->m_op_class_info.id.ruid), mac_str);
     	snprintf(key, sizeof(key), "%s@%d@%d", mac_str, tmp->m_op_class_info.id.type, tmp->m_op_class_info.id.op_class);
   
         remove_op_class(key);
@@ -235,7 +234,7 @@ int dm_op_class_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, voi
     mac_addr_str_t mac_str;
     em_long_string_t channels_str = {0}, id;
     char tmp[8];
-    em_op_class_info_t *info = (em_op_class_info_t *)data;
+    em_op_class_info_t *info = static_cast<em_op_class_info_t *>(data);
     int ret = 0;
     unsigned int i;
 
@@ -280,7 +279,7 @@ bool dm_op_class_list_t::search_db(db_client_t& db_client, void *ctx, void *key)
         db_client.get_string(ctx, str, 1);
 		//printf("%s:%d: Comparing source: %s target: %s\n", __func__, __LINE__, str, (char *)key);
 
-        if (strncmp(str, (char *)key, strlen((char *)key)) == 0) {
+        if (strncmp(str, static_cast<char *>(key), strlen(static_cast<char *>(key))) == 0) {
             return true;
         }
     }

--- a/src/dm/dm_policy.cpp
+++ b/src/dm/dm_policy.cpp
@@ -49,7 +49,7 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
 	//printf("%s:%d: Key: %s\tType: %d\n", __func__, __LINE__, (char *)parent_id, type);
 
     memset(&m_policy, 0, sizeof(em_policy_t));
-	parse_dev_radio_mac_from_key((char *)parent_id, &id);
+	parse_dev_radio_mac_from_key(static_cast<char *>(parent_id), &id);
 	strncpy(m_policy.id.net_id, id.net_id, strlen(id.net_id));
 	memcpy(m_policy.id.dev_mac, id.dev_mac, sizeof(mac_address_t));
 	memcpy(m_policy.id.radio_mac, id.radio_mac, sizeof(mac_address_t));
@@ -67,7 +67,7 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
 		}
 	} else if (type == em_policy_id_type_steering_param) {
 		if ((tmp = cJSON_GetObjectItem(obj, "Steering Policy")) != NULL) {
-			m_policy.policy = (em_steering_policy_type_t)tmp->valuedouble;
+			m_policy.policy = static_cast<em_steering_policy_type_t>(tmp->valuedouble);
 		}	
 		if ((tmp = cJSON_GetObjectItem(obj, "Utilization Threshold")) != NULL) {
 			m_policy.util_threshold = tmp->valuedouble;
@@ -130,7 +130,7 @@ void dm_policy_t::encode(cJSON *obj, em_policy_id_type_t id)
 		}
 
 	} else if (id == em_policy_id_type_steering_param) {
-    	cJSON_AddNumberToObject(obj, "Steering Policy", (unsigned int)m_policy.policy);
+		cJSON_AddNumberToObject(obj, "Steering Policy", static_cast<unsigned int>(m_policy.policy));
     	cJSON_AddNumberToObject(obj, "Utilization Threshold", m_policy.util_threshold);
     	cJSON_AddNumberToObject(obj, "RCPI Threshold", m_policy.rcpi_threshold);
 	} else if (id == em_policy_id_type_ap_metrics_rep) {
@@ -209,7 +209,7 @@ int dm_policy_t::parse_dev_radio_mac_from_key(const char *key, em_policy_id_t *i
             *tmp = 0;
 			dm_easy_mesh_t::string_to_macbytes(remain, id->radio_mac);
             tmp++;
-			id->type = (em_policy_id_type_t)atoi(tmp);
+			id->type = static_cast<em_policy_id_type_t>(atoi(tmp));
 		}
         i++;
     }

--- a/src/dm/dm_policy_list.cpp
+++ b/src/dm/dm_policy_list.cpp
@@ -47,10 +47,10 @@ int dm_policy_list_t::get_config(cJSON *parent_obj, void *parent, bool summary)
 	mac_address_t dev_mac;
 	mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-	dm_easy_mesh_t::string_to_macbytes((char *)parent, dev_mac);
+	dm_easy_mesh_t::string_to_macbytes(static_cast<char *>(parent), dev_mac);
 
 	// first report the global policies for the device, for global the radio id will be NULL
-    policy = (dm_policy_t *)get_first_policy();
+    policy = static_cast<dm_policy_t *>(get_first_policy());
     while (policy != NULL) {
 		if (memcmp(policy->m_policy.id.dev_mac, dev_mac, sizeof(mac_address_t)) != 0) {
 	    	policy = get_next_policy(policy);
@@ -92,7 +92,7 @@ int dm_policy_list_t::get_config(cJSON *parent_obj, void *parent, bool summary)
 	radio_steer_arr_obj = cJSON_CreateArray();
 	cJSON_AddItemToObject(parent_obj, "Radio Steering Parameters", radio_steer_arr_obj);
 
-    policy = (dm_policy_t *)get_first_policy();
+    policy = static_cast<dm_policy_t *>(get_first_policy());
     while (policy != NULL) {
 		if (memcmp(policy->m_policy.id.dev_mac, dev_mac, sizeof(mac_address_t)) != 0) {
 	    	policy = get_next_policy(policy);
@@ -145,7 +145,6 @@ int dm_policy_list_t::set_config(db_client_t& db_client, const cJSON *obj_arr, v
 int dm_policy_list_t::set_config(db_client_t& db_client, dm_policy_t& policy, void *parent_id)
 {
     dm_orch_type_t op;
-    char *tmp = (char *)parent_id;
 
     update_db(db_client, (op = get_dm_orch_type(db_client, policy)), policy.get_policy());
     update_list(policy, op);
@@ -159,8 +158,8 @@ dm_orch_type_t dm_policy_list_t::get_dm_orch_type(db_client_t& db_client, const 
     mac_addr_str_t	dev_mac_str, radio_mac_str;
 	em_long_string_t key;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)policy.m_policy.id.dev_mac, dev_mac_str);
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)policy.m_policy.id.radio_mac, radio_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(policy.m_policy.id.dev_mac), dev_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(policy.m_policy.id.radio_mac), radio_mac_str);
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s@%d", policy.m_policy.id.net_id, dev_mac_str, radio_mac_str, policy.m_policy.id.type);
 
     ppolicy = get_policy(key);
@@ -186,8 +185,8 @@ void dm_policy_list_t::update_list(const dm_policy_t& policy, dm_orch_type_t op)
     mac_addr_str_t	dev_mac_str, radio_mac_str;
 	em_long_string_t key;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)policy.m_policy.id.dev_mac, dev_mac_str);
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)policy.m_policy.id.radio_mac, radio_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(policy.m_policy.id.dev_mac), dev_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(policy.m_policy.id.radio_mac), radio_mac_str);
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s@%d", policy.m_policy.id.net_id, dev_mac_str, radio_mac_str, policy.m_policy.id.type);
 
 	//printf("%s:%d: Operation: %d for key: %s\n", __func__, __LINE__, op, key);
@@ -240,7 +239,7 @@ int dm_policy_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, void 
 {
     mac_addr_str_t dev_mac_str, radio_mac_str;
 	em_long_string_t key;
-    em_policy_t *policy = (em_policy_t *)data;
+    em_policy_t *policy = static_cast<em_policy_t *>(data);
     int ret = 0, i = 0;
 	mac_addr_str_t	sta_mac_str;
 	char sta_mac_list_str[1024];
@@ -297,7 +296,7 @@ bool dm_policy_list_t::search_db(db_client_t& db_client, void *ctx, void *key)
         db_client.get_string(ctx, str, 1);
 		//printf("%s:%d: Comparing source: %s target: %s\n", __func__, __LINE__, str, (char *)key);
 
-        if (strncmp(str, (char *)key, strlen((char *)key)) == 0) {
+        if (strncmp(str, static_cast<char *>(key), strlen(static_cast<char *>(key))) == 0) {
             return true;
         }
     }
@@ -335,7 +334,7 @@ int dm_policy_list_t::sync_db(db_client_t& db_client, void *ctx)
 			dm_easy_mesh_t::string_to_macbytes(sta_mac_str[i], policy.sta_mac[i]);
 		}		
 
-		policy.policy = (em_steering_policy_type_t)db_client.get_number(ctx, 3);
+		policy.policy = static_cast<em_steering_policy_type_t>(db_client.get_number(ctx, 3));
 		policy.interval = db_client.get_number(ctx, 4);
 		policy.rcpi_threshold = db_client.get_number(ctx, 5);
 		policy.rcpi_hysteresis = db_client.get_number(ctx, 6);

--- a/src/dm/dm_radio.cpp
+++ b/src/dm/dm_radio.cpp
@@ -54,7 +54,7 @@ int dm_radio_t::decode(const cJSON *obj, void *parent_id)
         dm_easy_mesh_t::name_from_mac_address(&m_radio_info.intf.mac, m_radio_info.intf.name);
     }
 
-    dm_radio_t::parse_radio_id_from_key((char *)parent_id, &m_radio_info.id);
+    dm_radio_t::parse_radio_id_from_key(static_cast<char *>(parent_id), &m_radio_info.id);
     dm_easy_mesh_t::macbytes_to_string(m_radio_info.id.ruid, mac_str);
     dm_easy_mesh_t::macbytes_to_string(m_radio_info.id.dev_mac, dev_mac);
 

--- a/src/dm/dm_radio_cap.cpp
+++ b/src/dm/dm_radio_cap.cpp
@@ -44,7 +44,7 @@ int dm_radio_cap_t::decode(const cJSON *obj, void *parent_id)
 {
     cJSON *tmp;
     unsigned int i;
-    em_interface_t	*id = (em_interface_t *)parent_id;
+    em_interface_t	*id = static_cast<em_interface_t *>(parent_id);
     
     memset(&m_radio_cap_info, 0, sizeof(em_radio_cap_info_t));
 

--- a/src/dm/dm_radio_cap_list.cpp
+++ b/src/dm/dm_radio_cap_list.cpp
@@ -86,7 +86,7 @@ dm_orch_type_t dm_radio_cap_list_t::get_dm_orch_type(db_client_t& db_client, con
     dm_radio_cap_t *pradio_cap;
     mac_addr_str_t  mac_str;
 	
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)radio_cap.m_radio_cap_info.ruid.mac, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(radio_cap.m_radio_cap_info.ruid.mac), mac_str);
 
     pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_get(m_list, mac_str));
     if (pradio_cap != NULL) {
@@ -111,7 +111,7 @@ void dm_radio_cap_list_t::update_list(const dm_radio_cap_t& radio_cap, dm_orch_t
     dm_radio_cap_t *pradio_cap;
     mac_addr_str_t	mac_str;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)radio_cap.m_radio_cap_info.ruid.mac, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(radio_cap.m_radio_cap_info.ruid.mac), mac_str);
     
     switch (op) {
         case dm_orch_type_db_insert:
@@ -143,7 +143,7 @@ void dm_radio_cap_list_t::delete_list()
     while (pradio_cap != NULL) {
         tmp = pradio_cap;
         pradio_cap = static_cast<dm_radio_cap_t *>(hash_map_get_next(m_list, pradio_cap));
-        dm_easy_mesh_t::macbytes_to_string((unsigned char *)tmp->m_radio_cap_info.ruid.mac, mac_str);
+        dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(tmp->m_radio_cap_info.ruid.mac), mac_str);
    
         hash_map_remove(m_list, mac_str);
         delete(tmp);

--- a/src/dm/dm_radio_list.cpp
+++ b/src/dm/dm_radio_list.cpp
@@ -48,9 +48,9 @@ int dm_radio_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
 int dm_radio_list_t::get_config(cJSON *obj_arr, void *parent, em_get_radio_list_reason_t reason)
 {
     dm_radio_t *pradio;
-    cJSON *obj, *sec_obj;
+    cJSON *obj;
     mac_addr_str_t  mac_str;
-    char *dev_mac_str = (char *)parent;
+    char *dev_mac_str = static_cast<char *>(parent);
     mac_address_t	dev_mac;
 
     dm_easy_mesh_t::string_to_macbytes(dev_mac_str, dev_mac);
@@ -76,7 +76,7 @@ int dm_radio_list_t::set_config(db_client_t& db_client, dm_radio_t& radio, void 
 {
     dm_orch_type_t op;
     
-	dm_radio_t::parse_radio_id_from_key((char *)parent_id, &radio.m_radio_info.id);
+    dm_radio_t::parse_radio_id_from_key(static_cast<char *>(parent_id), &radio.m_radio_info.id);
     
     update_db(db_client, (op = get_dm_orch_type(db_client, radio)), radio.get_radio_info());
     update_list(radio, op);
@@ -110,11 +110,11 @@ dm_orch_type_t dm_radio_list_t::get_dm_orch_type(db_client_t& db_client, const d
     mac_addr_str_t radio_mac_str, dev_mac_str;
     em_long_string_t key;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)radio.m_radio_info.id.dev_mac, dev_mac_str);
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)radio.m_radio_info.id.ruid, radio_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(radio.m_radio_info.id.dev_mac), dev_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(radio.m_radio_info.id.ruid), radio_mac_str);
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", radio.m_radio_info.id.net_id, dev_mac_str, radio_mac_str);
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)radio.m_radio_info.intf.mac, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(radio.m_radio_info.intf.mac), mac_str);
     pradio = get_radio(mac_str);
     if (pradio != NULL) {
         if (entry_exists_in_table(db_client, key) == false) {
@@ -141,9 +141,8 @@ void dm_radio_list_t::update_list(const dm_radio_t& radio, dm_orch_type_t op)
 {
     dm_radio_t *pradio;
     mac_addr_str_t	mac_str = {0};
-	em_long_string_t	key;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)radio.m_radio_info.intf.mac, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(radio.m_radio_info.intf.mac), mac_str);
 
     switch (op) {
         case dm_orch_type_db_insert:
@@ -174,7 +173,7 @@ void dm_radio_list_t::delete_list()
     while (pradio != NULL) {
         tmp = pradio;
         pradio = get_next_radio(pradio);       
-		dm_easy_mesh_t::macbytes_to_string((unsigned char *)tmp->m_radio_info.intf.mac, mac_str);
+        dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(tmp->m_radio_info.intf.mac), mac_str);
         remove_radio(mac_str);    
     }
 }   
@@ -188,12 +187,12 @@ bool dm_radio_list_t::operator == (const db_easy_mesh_t& obj)
 int dm_radio_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, void *data)
 {
     mac_addr_str_t radio_mac_str, dev_mac_str;
-    em_radio_info_t *info = (em_radio_info_t *)data;
+    em_radio_info_t *info = static_cast<em_radio_info_t *>(data);
     int ret = 0;
 	em_long_string_t key;
 
-	dm_easy_mesh_t::macbytes_to_string((unsigned char *)info->id.dev_mac, dev_mac_str);
-	dm_easy_mesh_t::macbytes_to_string((unsigned char *)info->id.ruid, radio_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(info->id.dev_mac), dev_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(info->id.ruid), radio_mac_str);
 	snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", info->id.net_id, dev_mac_str, radio_mac_str);
 
     switch (op) {
@@ -237,7 +236,7 @@ bool dm_radio_list_t::search_db(db_client_t& db_client, void *ctx, void *key)
     while (db_client.next_result(ctx)) {
         db_client.get_string(ctx, str, 1);
 
-        if (strncmp(str, (char *)key, strlen((char *)key)) == 0) {
+        if (strncmp(str, static_cast<char *>(key), strlen(static_cast<char *>(key))) == 0) {
             return true;
         }
     }
@@ -264,7 +263,7 @@ int dm_radio_list_t::sync_db(db_client_t& db_client, void *ctx)
         info.enabled = db_client.get_number(ctx, 3);
         info.media_data.media_type = db_client.get_number(ctx, 4);
         info.media_data.band = db_client.get_number(ctx, 5);
-	info.band = (em_freq_band_t) db_client.get_number(ctx, 5);
+        info.band = static_cast<em_freq_band_t> (db_client.get_number(ctx, 5));
         info.media_data.center_freq_index_1 = db_client.get_number(ctx, 6);
         info.media_data.center_freq_index_2 = db_client.get_number(ctx, 7);
         info.number_of_bss = db_client.get_number(ctx, 8);

--- a/src/dm/dm_scan_result.cpp
+++ b/src/dm/dm_scan_result.cpp
@@ -86,7 +86,7 @@ int dm_scan_result_t::decode(const cJSON *obj, void *parent_id)
 		}
 
 		if ((tmp = cJSON_GetObjectItem(arr_item, "Bandwidth")) != NULL) {
-			m_scan_result.neighbor[m_scan_result.num_neighbors].bandwidth = (wifi_channelBandwidth_t)cJSON_GetNumberValue(tmp);
+			m_scan_result.neighbor[m_scan_result.num_neighbors].bandwidth = static_cast<wifi_channelBandwidth_t>(cJSON_GetNumberValue(tmp));
 		}
 
 		if ((tmp = cJSON_GetObjectItem(arr_item, "BSSColor")) != NULL) {
@@ -199,7 +199,7 @@ int dm_scan_result_t::parse_scan_result_id_from_key(const char *key, em_scan_res
 			remain = tmp;
 		} else if (i == 5) {
             *tmp = 0; 
-			id->scanner_type = (em_scanner_type_t)atoi(remain);
+			id->scanner_type = static_cast<em_scanner_type_t>(atoi(remain));
             tmp++;
 			if (bssid != NULL) {
             	dm_easy_mesh_t::string_to_macbytes(tmp, bssid);

--- a/src/dm/dm_scan_result_list.cpp
+++ b/src/dm/dm_scan_result_list.cpp
@@ -46,21 +46,21 @@ int dm_scan_result_list_t::get_config(cJSON *parent_obj, void *parent, bool summ
 	dm_scan_result_t *res;
 	bool all_scan_rsults_of_radio = false;
 
-	dm_scan_result_t::parse_scan_result_id_from_key((char *)parent, &id);
+	dm_scan_result_t::parse_scan_result_id_from_key(static_cast<char *>(parent), &id);
 	if ((id.op_class == 0) && (id.channel == 0) && (id.scanner_type == em_scanner_type_radio)) {
 		all_scan_rsults_of_radio = true;
 	}
 
 	scan_res_arr_obj = cJSON_AddArrayToObject(parent_obj, "ScanResults");
 
-	res = (dm_scan_result_t *)get_first_scan_result();
+	res = static_cast<dm_scan_result_t *>(get_first_scan_result());
 	while (res != NULL) {
 		if (all_scan_rsults_of_radio == true) {
 			if ((strncmp(res->m_scan_result.id.net_id, id.net_id, strlen(id.net_id)) != 0) ||
 					(memcmp(res->m_scan_result.id.dev_mac, id.dev_mac, sizeof(mac_address_t)) != 0) ||
 					(memcmp(res->m_scan_result.id.scanner_mac, id.scanner_mac, sizeof(mac_address_t)) != 0) ||
 					(res->m_scan_result.id.scanner_type != em_scanner_type_radio)) {
-				res = (dm_scan_result_t *)get_next_scan_result(res);
+				res = static_cast<dm_scan_result_t *>(get_next_scan_result(res));
 				continue;
 			}
 		}	
@@ -70,7 +70,7 @@ int dm_scan_result_list_t::get_config(cJSON *parent_obj, void *parent, bool summ
 		cJSON_AddItemToArray(scan_res_arr_obj, scan_res_obj);
 		
 
-		res = (dm_scan_result_t *)get_next_scan_result(res);
+		res = static_cast<dm_scan_result_t *>(get_next_scan_result(res));
 	}
 	
     return 0;
@@ -103,7 +103,6 @@ int dm_scan_result_list_t::set_config(db_client_t& db_client, const cJSON *obj_a
 int dm_scan_result_list_t::set_config(db_client_t& db_client, dm_scan_result_t& scan_result, void *parent_id)
 {
     dm_orch_type_t op;
-    char *tmp = (char *)parent_id;
 	unsigned int i;
 	db_update_scan_result_t res;
 
@@ -129,11 +128,11 @@ dm_orch_type_t dm_scan_result_list_t::get_dm_orch_type(db_client_t& db_client, c
 	em_long_string_t key;
 	em_neighbor_t *nbr, null_nbr = {0};
 
-	nbr = (index == scan_result_self_index) ? &null_nbr:(em_neighbor_t *)&scan_result.m_scan_result.neighbor[index];
+	nbr = (index == scan_result_self_index) ? &null_nbr:const_cast<em_neighbor_t *>(&scan_result.m_scan_result.neighbor[index]);
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result.m_scan_result.id.dev_mac, dev_mac_str);
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result.m_scan_result.id.scanner_mac, scanner_mac_str);
-	dm_easy_mesh_t::macbytes_to_string((unsigned char *)nbr->bssid, bssid_str);
+	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(scan_result.m_scan_result.id.dev_mac), dev_mac_str);
+	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(scan_result.m_scan_result.id.scanner_mac), scanner_mac_str);
+	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(nbr->bssid), bssid_str);
 
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s@%d@%d@%d@%s", 
 					scan_result.m_scan_result.id.net_id, dev_mac_str, scanner_mac_str, scan_result.m_scan_result.id.op_class, 
@@ -165,7 +164,7 @@ void dm_scan_result_list_t::update_list(const dm_scan_result_t& scan_result, uns
 	em_long_string_t key;
 	em_neighbor_t *nbr, null_nbr = {0};
 
-	nbr = (index == scan_result_self_index) ? &null_nbr:(em_neighbor_t *)&scan_result.m_scan_result.neighbor[index];
+	nbr = (index == scan_result_self_index) ? &null_nbr:const_cast<em_neighbor_t *>(&scan_result.m_scan_result.neighbor[index]);
 
     dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result.m_scan_result.id.dev_mac, dev_mac_str);
     dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result.m_scan_result.id.scanner_mac, scanner_mac_str);
@@ -209,9 +208,9 @@ void dm_scan_result_list_t::delete_list()
         scan_result = get_next_scan_result(scan_result);
 
 		for (i = 0; i < scan_result->m_scan_result.num_neighbors; i++) {
-    		dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result->m_scan_result.id.dev_mac, dev_mac_str);
-    		dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result->m_scan_result.id.scanner_mac, scanner_mac_str);
-    		dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result->m_scan_result.neighbor[i].bssid, bssid_str);
+			dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(scan_result->m_scan_result.id.dev_mac), dev_mac_str);
+			dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(scan_result->m_scan_result.id.scanner_mac), scanner_mac_str);
+			dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(scan_result->m_scan_result.neighbor[i].bssid), bssid_str);
 
     		snprintf(key, sizeof(em_long_string_t), "%s@%s@%s@%d@%d@%d@%s", 
 						scan_result->m_scan_result.id.net_id, dev_mac_str, scanner_mac_str, scan_result->m_scan_result.id.op_class, 
@@ -231,7 +230,7 @@ int dm_scan_result_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, 
 {
     mac_addr_str_t dev_mac_str, scanner_mac_str, bssid_str;
 	em_long_string_t key;
-	db_update_scan_result_t *res = (db_update_scan_result_t *)data;
+	db_update_scan_result_t *res = static_cast<db_update_scan_result_t *>(data);
     em_scan_result_t *scan_result = res->result;
 	unsigned int index = res->index;
     int ret = 0;
@@ -239,9 +238,9 @@ int dm_scan_result_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, 
 
 	nbr = (index == scan_result_self_index) ? &null_nbr:&scan_result->neighbor[index];
 
-   	dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result->id.dev_mac, dev_mac_str);
-   	dm_easy_mesh_t::macbytes_to_string((unsigned char *)scan_result->id.scanner_mac, scanner_mac_str);
-   	dm_easy_mesh_t::macbytes_to_string((unsigned char *)nbr->bssid, bssid_str);
+	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(scan_result->id.dev_mac), dev_mac_str);
+	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(scan_result->id.scanner_mac), scanner_mac_str);
+	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(nbr->bssid), bssid_str);
 
    	snprintf(key, sizeof(em_long_string_t), "%s@%s@%s@%d@%d@%d@%s", 
 					scan_result->id.net_id, dev_mac_str, scanner_mac_str, scan_result->id.op_class, 
@@ -281,7 +280,7 @@ bool dm_scan_result_list_t::search_db(db_client_t& db_client, void *ctx, void *k
         db_client.get_string(ctx, str, 1);
 		//printf("%s:%d: Comparing source: %s target: %s\n", __func__, __LINE__, str, (char *)key);
 
-        if (strncmp(str, (char *)key, strlen((char *)key)) == 0) {
+		if (strncmp(str, static_cast<char *>(key), strlen(static_cast<char *>(key))) == 0) {
             return true;
         }
     }
@@ -324,7 +323,7 @@ int dm_scan_result_list_t::sync_db(db_client_t& db_client, void *ctx)
 		strncpy(scan_result.neighbor[scan_result.num_neighbors].ssid, str, strlen(str) + 1);
 
 		scan_result.neighbor[scan_result.num_neighbors].signal_strength = db_client.get_number(ctx, 8);
-		scan_result.neighbor[scan_result.num_neighbors].bandwidth = (wifi_channelBandwidth_t)db_client.get_number(ctx, 9);
+		scan_result.neighbor[scan_result.num_neighbors].bandwidth = static_cast<wifi_channelBandwidth_t>(db_client.get_number(ctx, 9));
 		scan_result.neighbor[scan_result.num_neighbors].bss_color = db_client.get_number(ctx, 10);
 		scan_result.neighbor[scan_result.num_neighbors].channel_util = db_client.get_number(ctx, 11);
 		scan_result.neighbor[scan_result.num_neighbors].sta_count = db_client.get_number(ctx, 12);

--- a/src/dm/dm_ssid_2_vid_map.cpp
+++ b/src/dm/dm_ssid_2_vid_map.cpp
@@ -98,13 +98,13 @@ dm_orch_type_t dm_ssid_2_vid_map_t::update_list(const dm_ssid_2_vid_map_t& ssid_
     bool found = false;
     mac_addr_str_t	mac_str;
 
-    pssid_2_vid_map = (dm_ssid_2_vid_map_t *)hash_map_get_first(m_list);
+    pssid_2_vid_map = static_cast<dm_ssid_2_vid_map_t *>(hash_map_get_first(m_list));
     while (pssid_2_vid_map != NULL) {
 	if (strncmp(ssid_2_vid_map.m_ssid_2_vid_map_info.id, pssid_2_vid_map->m_ssid_2_vid_map_info.id, strlen(ssid_2_vid_map.m_ssid_2_vid_map_info.id)) == 0) {
 	    found = true;
 	    break;
 	}	
-	pssid_2_vid_map = (dm_ssid_2_vid_map_t *)hash_map_get_next(m_list, pssid_2_vid_map);
+	pssid_2_vid_map = static_cast<dm_ssid_2_vid_map_t *>(hash_map_get_next(m_list, pssid_2_vid_map));
     }
 
     if (found == true) {
@@ -126,7 +126,7 @@ dm_orch_type_t dm_ssid_2_vid_map_t::update_list(const dm_ssid_2_vid_map_t& ssid_
 
 bool dm_ssid_2_vid_map_t::operator == (const db_easy_mesh_t& obj)
 {
-    dm_ssid_2_vid_map_t *pssid_2_vid_map = (dm_ssid_2_vid_map_t *)&obj;
+    dm_ssid_2_vid_map_t *pssid_2_vid_map = const_cast<dm_ssid_2_vid_map_t *>(reinterpret_cast<const dm_ssid_2_vid_map_t *>(&obj));
     unsigned int i, j;
     bool matched = false;
 
@@ -151,7 +151,7 @@ bool dm_ssid_2_vid_map_t::operator == (const db_easy_mesh_t& obj)
 int dm_ssid_2_vid_map_t::update_db(db_client_t& db_client, dm_orch_type_t op, void *data)
 {
     mac_addr_str_t mac_str;
-    em_ssid_2_vid_map_info_t *info = (em_ssid_2_vid_map_info_t *)data;
+    em_ssid_2_vid_map_info_t *info = static_cast<em_ssid_2_vid_map_info_t *>(data);
     int ret = 0;
 
     //printf("%s:%d: Opeartion:%d\n", __func__, __LINE__, op);

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -42,11 +42,10 @@
 
 int dm_sta_t::decode(const cJSON *obj, void *parent_id)
 {
-    cJSON *tmp, *tmp_arr;
+    cJSON *tmp;
     mac_addr_str_t  mac_str;
-    unsigned int i;
 
-    mac_address_t *bssid = (mac_address_t *)parent_id;
+    mac_address_t *bssid = static_cast<mac_address_t *>(parent_id);
 
     memset(&m_sta_info, 0, sizeof(em_sta_info_t));
     memcpy(&m_sta_info.bssid,bssid,sizeof(mac_address_t));
@@ -361,7 +360,7 @@ void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
             return;
         }
 
-        tag_id = (tag_type_t)sta->m_sta_info.frame_body[offset];
+        tag_id = static_cast<tag_type_t>(sta->m_sta_info.frame_body[offset]);
         length = sta->m_sta_info.frame_body[offset + 1];
 
         if (offset + 2 + length > sta->m_sta_info.frame_body_len) {
@@ -369,7 +368,7 @@ void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
             return;
         }
 
-        ieee80211_tagvalue_t *tag = (ieee80211_tagvalue_t *) malloc(sizeof(ieee80211_tagvalue_t) + length);
+        ieee80211_tagvalue_t *tag = static_cast<ieee80211_tagvalue_t *> (malloc(sizeof(ieee80211_tagvalue_t) + length));
         if (!tag) {
             printf("%s:%d: Memory allocation failed\n", __func__, __LINE__);
             return;
@@ -458,7 +457,7 @@ void dm_sta_t::decode_beacon_report(dm_sta_t *sta)
     int current_pkt_len = 0;
 
     em_sta_info_t *sta_info = &sta->m_sta_info;
-    ie = (unsigned char *)sta->m_sta_info.beacon_report_elem;
+    ie = static_cast<unsigned char *>(sta->m_sta_info.beacon_report_elem);
 
     for (i = 0; i < sta_info->num_beacon_meas_report; i++) {
         current_pkt_len = ie[1];

--- a/src/dm/dm_sta_list.cpp
+++ b/src/dm/dm_sta_list.cpp
@@ -53,7 +53,7 @@ int dm_sta_list_t::get_config(cJSON *obj_arr, void *parent, em_get_sta_list_reas
     bssid_t	bssid;
     unsigned int i;
 
-    dm_easy_mesh_t::string_to_macbytes((char *)parent, bssid);
+    dm_easy_mesh_t::string_to_macbytes(static_cast<char *>(parent), bssid);
 
     sta = get_first_sta();
     while (sta != NULL) {
@@ -100,7 +100,7 @@ int dm_sta_list_t::set_config(db_client_t& db_client, const cJSON *obj_arr, void
 int dm_sta_list_t::set_config(db_client_t& db_client, dm_sta_t& sta, void *parent_id)
 {
     dm_orch_type_t op;
-    char *tmp = (char *)parent_id;
+    char *tmp = static_cast<char *>(parent_id);
 
     //printf("dm_op_class_list_t::%s:%d: id: %s\n", __func__, __LINE__, (char *)parent_id);
     update_db(db_client, (op = get_dm_orch_type(db_client, sta)), sta.get_sta_info());
@@ -115,9 +115,9 @@ dm_orch_type_t dm_sta_list_t::get_dm_orch_type(db_client_t& db_client, const dm_
     mac_addr_str_t  sta_mac_str, bssid_mac_str, radio_mac_str;
     em_long_string_t key;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)sta.m_sta_info.id, sta_mac_str);
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)sta.m_sta_info.bssid, bssid_mac_str);
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)sta.m_sta_info.radiomac, radio_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(sta.m_sta_info.id), sta_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(sta.m_sta_info.bssid), bssid_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(sta.m_sta_info.radiomac), radio_mac_str);
     snprintf(key, sizeof (em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_mac_str, radio_mac_str);
 
     psta = get_sta(key);
@@ -150,9 +150,9 @@ void dm_sta_list_t::update_list(const dm_sta_t& sta, dm_orch_type_t op)
     mac_addr_str_t	sta_mac_str, bssid_mac_str, radio_mac_str;
     em_long_string_t key;
 
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)sta.m_sta_info.id, sta_mac_str);
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)sta.m_sta_info.bssid, bssid_mac_str);
-    dm_easy_mesh_t::macbytes_to_string((unsigned char *)sta.m_sta_info.radiomac, radio_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(sta.m_sta_info.id), sta_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(sta.m_sta_info.bssid), bssid_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(sta.m_sta_info.radiomac), radio_mac_str);
     snprintf(key, sizeof (em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_mac_str, radio_mac_str);
 
     switch (op) {
@@ -186,8 +186,8 @@ void dm_sta_list_t::delete_list()
         tmp = psta;
         psta = get_next_sta(psta);       
     
-   	dm_easy_mesh_t::macbytes_to_string((unsigned char *)tmp->m_sta_info.id, sta_mac_str);
-    	dm_easy_mesh_t::macbytes_to_string((unsigned char *)tmp->m_sta_info.bssid, bssid_mac_str);
+   	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(tmp->m_sta_info.id), sta_mac_str);
+    	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(tmp->m_sta_info.bssid), bssid_mac_str);
     	snprintf(key, sizeof (em_long_string_t), "%s@%s", sta_mac_str, bssid_mac_str);
         remove_sta(key);    
     }
@@ -201,7 +201,7 @@ bool dm_sta_list_t::operator == (const db_easy_mesh_t& obj)
 int dm_sta_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, void *data)
 {
     mac_addr_str_t sta_mac_str, bssid_mac_str, radio_mac_str;
-    em_sta_info_t *info = (em_sta_info_t *)data;
+    em_sta_info_t *info = static_cast<em_sta_info_t *>(data);
     int ret = 0;
     char frame_body[EM_MAX_FRAME_BODY_LEN*2];
 
@@ -251,7 +251,7 @@ bool dm_sta_list_t::search_db(db_client_t& db_client, void *ctx, void *key)
     while (db_client.next_result(ctx)) {
         db_client.get_string(ctx, mac, 1);
 
-        if (strncmp(mac, (char *)key, strlen((char *)key)) == 0) {
+        if (strncmp(mac, static_cast<char *>(key), strlen(static_cast<char *>(key))) == 0) {
             return true;
         }
     }
@@ -307,7 +307,7 @@ bool dm_sta_list_t::compare_db(db_client_t& db_client, const dm_sta_t& sta)
         db_client.get_string(ctx, frame_body, 21);
         dm_easy_mesh_t::unhex(strlen(frame_body), frame_body, EM_MAX_FRAME_BODY_LEN, info.frame_body);
 
-        if (memcmp((const void*)&sta.m_sta_info, (const void*)&info, sizeof(em_sta_info_t)) == 0) {
+        if (memcmp(static_cast<const void*>(&sta.m_sta_info), static_cast<const void*>(&info), sizeof(em_sta_info_t)) == 0) {
             return true;
         }
     }

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1110,6 +1110,7 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_agent_sta_link_metrics)
         EM_STATE_2S(em_state_max)
         EM_STATE_2S(em_state_agent_beacon_report_pending)
+        EM_STATE_2S(em_state_agent_channel_select_configuration_pending)
     }
 
     return "em_state_unknown";

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -107,11 +107,11 @@ char *get_formatted_time_em(char *time)
     char tmp[128];
 
     gettimeofday(&tv_now, NULL);
-    tm_info = (struct tm *)localtime(&tv_now.tv_sec);
+    tm_info = const_cast<struct tm *>(localtime(&tv_now.tv_sec));
 
     strftime(tmp, 128, "%m/%d/%y - %T", tm_info);
 
-    snprintf(time, 128, "%s.%06lld", tmp, (long long)tv_now.tv_usec);
+    snprintf(time, 128, "%s.%06lld", tmp, static_cast<long long>(tv_now.tv_usec));
     return time;
 }
 
@@ -173,7 +173,7 @@ void util::print_hex_dump(unsigned int length, uint8_t *buffer, easymesh_dbg_typ
 {
     int i;
     uint8_t buff[512] = {};
-    const uint8_t * pc = (const uint8_t *)buffer;
+    const uint8_t * pc = const_cast<const uint8_t *>(buffer);
 
     auto [fp, module_filename] = get_module_log_fd_name(module, EM_LOG_LVL_DEBUG);
     if (fp == NULL) {


### PR DESCRIPTION
Reason for change: 1) Handled static and const cast warnings 
2) Handled few unused variable warnings
3) Handled remaining missing default case for switch statement.
Test Procedure: Checked and compared the warning before and after fix, observed around 255 warning is fixed. Also compared the run time logs for OneWifi, controller and agent with and without changes and did not observe any additional logs/error. Tested the changes by changing the SSID and radio channel through CLI observed its works fine. 
Risks: Medium
Priority: P1