### PR TITLE
Fix channel change request being sent to multiple radios

### DIFF
--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -475,11 +475,16 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                 break;
             
             case em_cmd_type_set_channel:
-		if (em->is_al_interface_em() == false) {
-                        dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
-                        printf("%s:%d Set Channel : %s push to queue \n", __func__, __LINE__,mac_str);
-                        queue_push(pcmd->m_em_candidates, em);
-                        count++;
+				if (em->is_al_interface_em() == false) {
+					for(i = 0; i < pcmd->m_param.u.args.num_args; i++) {
+						if(atoi(pcmd->m_param.u.args.args[i]) == em->get_band()) {
+							dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+							printf("%s:%d Set Channel : %s push to queue \n", __func__, __LINE__,mac_str);
+							queue_push(pcmd->m_em_candidates, em);
+							count++;
+							break;
+						}
+					}
                 }
                 break;
             case em_cmd_type_scan_channel:


### PR DESCRIPTION
Fix channel change request being sent to multiple radios

Reason for change: Channel change request from controller is currently sent to all radio irrespective of the channel changed. Added code to identify the band for which channel changed and based on that implemented orchestration code. 
Test Procedure: Ensure channel change request is sent to applicable radio's alone. 
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>