### PR TITLE
OpenWRT related changes in unified-wifi-mesh

### DIFF
--- a/build/openwrt/agent/makefile
+++ b/build/openwrt/agent/makefile
@@ -1,0 +1,151 @@
+##########################################################################
+ # Copyright 2023 Comcast Cable Communications Management, LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+ # SPDX-License-Identifier: Apache-2.0
+##########################################################################
+
+include ../makefile.inc
+
+#
+# program
+#
+PROGRAM = $(INSTALLDIR)/bin/onewifi_em_agent
+
+INCLUDEDIRS = \
+	-I$(ONEWIFI_EM_HOME)/inc \
+	-I$(ONEWIFI_EM_HOME)/src/utils \
+	-I$(ONEWIFI_HAL_INTF_HOME) \
+	-I$(ONEWIFI_HOME)/source/utils \
+	-I$(ONEWIFI_HOME)/include \
+    	-I$(ONEWIFI_BUS_LIB_HOME)/inc \
+    	-I$(ONEWIFI_HOME)/lib/log \
+    	-I$(ONEWIFI_HOME)/lib/ds \
+    	-I$(ONEWIFI_HOME)/source/platform/linux \
+    	-I$(ONEWIFI_HOME)/source/platform/common \
+    	-I$(ONEWIFI_HOME)/source/platform/linux/he_bus/inc \
+        -I$(ONEWIFI_EM_HOME)/src/util_crypto \
+        -I$(ONEWIFI_HOME)/source/ccsp
+
+ifeq ($(WITH_SAP), 1)
+INCLUDEDIRS += -I$(AL_SAP_HOME)/include
+endif
+
+ifneq ($(OS), Darwin)
+CFLAGS += -DPLATFORM_LINUX
+else
+CFLAGS += -DPLATFORM_OSX
+endif
+
+$(info The value of VARIABLE is $(ONEWIFI_HAL_INTF_HOME))
+
+CXXFLAGS += $(INCLUDEDIRS) -g -DEASY_MESH_NODE -DEM_APP -Wall -Wextra -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fpermissive #-Werror -O2
+
+ifeq ($(WITH_SAP), 1)
+CXXFLAGS += -DAL_SAP
+endif
+
+LDFLAGS += $(LIBDIRS) $(LIBS)
+
+LIBDIRS = \
+	-L$(INSTALLDIR)/lib \
+	-L$(ONEWIFI_HOME)/install/lib/ \
+	-L/usr/local/lib    \
+	-L/usr/local/ssl/lib/ \
+
+ifeq ($(WITH_SAP), 1)
+LIBDIRS += -L$(AL_SAP_HOME)/build/lib
+endif
+
+LIBS = -lgcc -lc -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwebconfig -lhebus
+
+ifeq ($(WITH_SAP), 1)
+LIBS += -lalsap
+endif
+
+ifneq ($(OS), Darwin)
+LIBDIRS += -L$(INSTALLDIR)/lib/platform/x86-64
+else
+LIBDIRS += -L$(INSTALLDIR)/lib/platform/darwin
+endif
+
+GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c \
+    $(ONEWIFI_EM_SRC)/util_crypto/aes_siv.c \
+    $(ONEWIFI_HOME)/lib/common/util.c \
+    $(ONEWIFI_HOME)/source/platform/linux/bus.c \
+
+AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/config/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/prov/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/prov/easyconnect/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/disc/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/channel/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/capability/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/metrics/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/steering/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/policy_cfg/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/crypto/*.cpp) \
+    	$(ONEWIFI_EM_SRC)/orch/em_orch.cpp \
+    	$(ONEWIFI_EM_SRC)/orch/em_orch_agent.cpp \
+	$(wildcard $(ONEWIFI_EM_SRC)/cmd/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/agent/*.cpp) \
+	$(ONEWIFI_EM_SRC)/dm/dm_device.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_ieee_1905_security.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_easy_mesh.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_radio.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_bss.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_dpp.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_network_ssid.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_network.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_op_class.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_policy.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_scan_result.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_sta.cpp \
+	$(ONEWIFI_EM_SRC)/dm/dm_radio_cap.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_assoc_sta_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
+    $(ONEWIFI_EM_SRC)/utils/util.cpp \
+
+AGENT_OBJECTS = $(AGENT_SOURCES:.cpp=.o)
+GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 
+ALLOBJECTS = $(AGENT_OBJECTS) $(GENERIC_OBJECTS)
+
+all: $(BUS_LIBRARY) $(PROGRAM)
+
+$(PROGRAM): $(ALLOBJECTS)
+	$(CXX) -o $@ $(ALLOBJECTS) $(LDFLAGS)
+
+$(GENERIC_OBJECTS): %.o: %.c
+	$(CC) $(CXXFLAGS) -o $@ -c $<
+
+$(AGENT_OBJECTS): %.o: %.cpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+# Clean target: "make -f Makefile.Linux clean" to remove unwanted objects and executables.
+#
+
+clean:
+	$(RM) $(ALLOBJECTS) $(PROGRAM)
+
+#
+# Run target: "make -f Makefile.Linux run" to execute the application
+#             You will need to add $(VARIABLE_NAME) for any command line parameters 
+#             that you defined earlier in this file.
+# 
+
+run:
+	./$(PROGRAM) 

--- a/build/openwrt/cli/makefile
+++ b/build/openwrt/cli/makefile
@@ -1,0 +1,118 @@
+##########################################################################
+ # Copyright 2023 Comcast Cable Communications Management, LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+ # SPDX-License-Identifier: Apache-2.0
+##########################################################################
+
+include ../makefile.inc
+
+#
+# program
+#
+
+PROGRAM = $(INSTALLDIR)/bin/onewifi_em_cli
+EM_CLI_LIBRARY = $(INSTALLDIR)/lib/libemcli.so
+
+INCLUDEDIRS = \
+	-I$(ONEWIFI_EM_HOME)/inc \
+	-I$(ONEWIFI_EM_HOME)/src/utils \
+	-I$(ONEWIFI_EM_HOME)/src/util/ \
+	-I$(ONEWIFI_HAL_INTF_HOME) \
+	-I$(ONEWIFI_HOME)/source/utils \
+	-I$(ONEWIFI_HOME)/include \
+	-I$(ONEWIFI_HOME)/source/platform/linux \
+	-I$(ONEWIFI_HOME)/source/platform/common \
+    -I$(ONEWIFI_HOME)/source/platform/linux/he_bus/inc \
+	-I$(ONEWIFI_HOME)/source/ccsp \
+    -I$(RBUS_HOME)/include \
+	-I$(WIFI_CJSON) \
+
+CXXFLAGS = $(INCLUDEDIRS) -g -std=c++17 -fPIC -fpermissive
+CFLAGS = $(INCLUDEDIRS) -g
+LDFLAGS = $(LIBDIRS) $(LIBS)
+LIBDIRS = \
+	-L$(INSTALLDIR)/lib \
+
+LIBS = -lemcli -lm -pthread -ldl -lcjson -lreadline -lssl -lcrypto
+
+GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c	\
+
+CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/cli/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/cmd/*.cpp) \
+    $(wildcard $(ONEWIFI_EM_SRC)/em/crypto/*.cpp) \
+    $(ONEWIFI_EM_SRC)/dm/dm_device.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_ieee_1905_security.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_easy_mesh.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_radio.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_bss.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_dpp.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_network_ssid.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_network.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_op_class.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_policy.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_scan_result.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_sta.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_radio_cap.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_assoc_sta_mld.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
+    $(ONEWIFI_EM_SRC)/em/em_net_node.cpp \
+    $(ONEWIFI_EM_SRC)/utils/util.cpp \
+
+MAIN_SOURCE = $(ONEWIFI_EM_SRC)/cli/main.c
+
+CLI_OBJECTS = $(CLI_SOURCES:.cpp=.o)
+GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 
+EMCLIOBJECTS = $(CLI_OBJECTS) $(GENERIC_OBJECTS)
+MAIN_OBJECT = $(MAIN_SOURCE:.c=.o) 
+
+all: $(EM_CLI_LIBRARY) $(PROGRAM)
+
+$(EM_CLI_LIBRARY): $(EMCLIOBJECTS)
+	$(CXX) -shared -o $@ $(EMCLIOBJECTS)
+
+$(GENERIC_OBJECTS): %.o: %.c
+	$(CC) $(CXXFLAGS) -o $@ -c $<
+
+$(CLI_OBJECTS): %.o: %.cpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+$(MAIN_OBJECT): %.o: %.c
+	$(CXX) $(CFLAGS) -o $@ -c $<
+
+$(PROGRAM):
+# use go 1.19 or above to build
+ifeq ($(CC), aarch64-linux-gnu-gcc-11)
+	CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -extldflags '-L$(INSTALLDIR)/lib -lcrypto -lssl -luuid'" -o $(PROGRAM) $(ONEWIFI_EM_SRC)/cli/*.go
+else
+	go build -ldflags="-extldflags '-L$(INSTALLDIR)/lib -lcrypto -lssl -luuid'" -o $(PROGRAM) $(ONEWIFI_EM_SRC)/cli/*.go
+endif
+# Clean target: "make -f Makefile.Linux clean" to remove unwanted objects and executables.
+#
+
+clean:
+	$(RM) $(MAIN_OBJECT) $(EMCLIOBJECTS) $(EM_CLI_LIBRARY) $(PROGRAM) $(PROGRAM)
+
+#
+# Run target: "make -f Makefile.Linux run" to execute the application
+#             You will need to add $(RUNARGS) for any command line parameters
+#             that you defined earlier in this file.
+# 
+
+run:
+	LD_LIBRARY_PATH=$(INSTALLDIR)/lib $(PROGRAM) $(RUNARGS)
+

--- a/build/openwrt/ctrl/makefile
+++ b/build/openwrt/ctrl/makefile
@@ -1,0 +1,175 @@
+##########################################################################
+ # Copyright 2023 Comcast Cable Communications Management, LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+ # SPDX-License-Identifier: Apache-2.0
+##########################################################################
+
+include ../makefile.inc
+
+#
+# program
+#
+
+
+PROGRAM = $(INSTALLDIR)/bin/onewifi_em_ctrl
+
+INCLUDEDIRS = \
+	-I$(ONEWIFI_EM_HOME)/inc \
+	-I$(ONEWIFI_HAL_INTF_HOME)/ \
+	-I$(ONEWIFI_HOME)/source/utils \
+	-I$(ONEWIFI_HOME)/include \
+   	-I$(RBUS_HOME)/include \
+   	-I$(ONEWIFI_EM_HOME)/src/util_crypto \
+	-I$(ONEWIFI_HOME)/lib/log \
+	-I$(ONEWIFI_HOME)/lib/ds \
+	-I$(ONEWIFI_HOME)/source/platform/linux \
+	-I$(ONEWIFI_HOME)/source/platform/common \
+	-I$(ONEWIFI_HOME)/source/platform/linux/he_bus/inc \
+	-I$(ONEWIFI_HOME)/source/ccsp \
+	-I$(STAGING_DIR)/ \
+
+ifeq ($(WITH_SAP), 1)
+INCLUDEDIRS += -I$(AL_SAP_HOME)/include
+endif
+
+ifneq ($(OS), Darwin)
+CFLAGS += -DPLATFORM_LINUX
+else
+CFLAGS += -DPLATFORM_OSX
+endif
+
+CXXFLAGS += $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined -fpermissive #-Werror -O2 -Weffc++
+
+ifeq ($(WITH_SAP), 1)
+CXXFLAGS += -DAL_SAP
+endif
+
+ifdef TESTING
+CXXFLAGS += -DTESTING
+endif
+
+LDFLAGS += $(LIBDIRS) $(LIBS)
+#LDFLAGS += $(LIBDIRS) $(LIBS) -fsanitize=address -fsanitize=undefined
+
+LIBDIRS = \
+	-L$(INSTALLDIR)/lib \
+	-L$(ONEWIFI_HOME)/install/lib/ \
+	-L/usr/local/lib    \
+	-L/usr/local/ssl/lib/ \
+
+ifeq ($(WITH_SAP), 1)
+LIBDIRS += -L$(AL_SAP_HOME)/build/lib
+endif
+
+ifneq ($(OS), Darwin)
+LIBDIRS += -L$(INSTALLDIR)/lib/platform/x86-64
+else
+LIBDIRS += -L$(INSTALLDIR)/lib/platform/darwin
+endif
+
+LIBS = -lm -pthread -ldl -luuid -lcjson -lssl -lcrypto -lmysqlcppconn -lhebus
+
+ifeq ($(WITH_SAP), 1)
+LIBS += -lalsap
+endif
+
+GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c \
+	$(ONEWIFI_EM_SRC)/util_crypto/aes_siv.c \
+	$(ONEWIFI_HOME)/lib/common/util.c \
+    $(ONEWIFI_HOME)/source/platform/linux/bus.c \
+
+
+CTRL_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/config/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/prov/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/prov/easyconnect/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/disc/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/channel/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/capability/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/metrics/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/steering/*.cpp) \
+    	$(wildcard $(ONEWIFI_EM_SRC)/em/policy_cfg/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/em/crypto/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/cmd/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/ctrl/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/db/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/dm/*.cpp) \
+	$(ONEWIFI_EM_SRC)/orch/em_orch.cpp \
+	$(ONEWIFI_EM_SRC)/orch/em_orch_ctrl.cpp \
+	$(ONEWIFI_EM_SRC)/utils/util.cpp \
+
+CTRL_OBJECTS = $(CTRL_SOURCES:.cpp=.o)
+GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 
+ALLOBJECTS = $(CTRL_OBJECTS) $(GENERIC_OBJECTS)
+
+all: $(PROGRAM)
+
+$(PROGRAM): $(ALLOBJECTS)
+	$(CXX) -o $@ $(ALLOBJECTS) $(LDFLAGS)
+
+$(GENERIC_OBJECTS): %.o: %.c
+	$(CC) $(CXXFLAGS) -o $@ -c $<
+
+$(CTRL_OBJECTS): %.o: %.cpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+# Clean everything
+clean:
+	$(RM) $(ALLOBJECTS) $(PROGRAM)
+	$(MAKE) clean_tests
+
+
+# Google Test integration
+TEST_DIR = $(ONEWIFI_EM_HOME)/tests
+TEST_EXEC = $(INSTALLDIR)/bin/onewifi_em_test
+TEST_SOURCES = $(wildcard $(TEST_DIR)/*.cpp)
+TEST_OBJECTS = $(TEST_SOURCES:.cpp=.o)
+TEST_CXXFLAGS = $(CXXFLAGS) -I/usr/include -I/usr/local/include -DTESTING
+
+# Test target
+test: check_test_files install_gtest $(TEST_OBJECTS)
+	@$(MAKE) $(ALLOBJECTS) TESTING=1
+	@echo "Building test executable with same link order as main build..."
+	$(CXX) -o $(TEST_EXEC) $(TEST_OBJECTS) $(ALLOBJECTS) $(LIBDIRS) $(LIBS) -lgtest -lgtest_main -pthread -fsanitize=address -fsanitize=undefined
+	@echo "Running tests..."
+	@$(TEST_EXEC)
+
+# Compile test source files
+$(TEST_DIR)/%.o: $(TEST_DIR)/%.cpp
+	@echo "Compiling test file $<..."
+	$(CXX) $(TEST_CXXFLAGS) -o $@ -c $<
+
+# Check if any test files exist
+check_test_files:
+	@if [ -z "$(TEST_SOURCES)" ]; then \
+		echo "Error: No test files found in $(TEST_DIR)/"; \
+		exit 1; \
+	fi
+
+# Install GTest if needed
+install_gtest:
+	@echo "Checking and installing Google Test if needed..."
+	@chmod +x $(ONEWIFI_EM_HOME)/build/install-gtest.sh
+	@$(ONEWIFI_EM_HOME)/build/install-gtest.sh
+
+# Run the program
+run:
+	./$(PROGRAM)
+
+# Clean test files only
+clean_tests:
+	$(RM) $(TEST_OBJECTS) $(TEST_EXEC)
+
+.PHONY: all test install_gtest check_test_files clean_tests compile_test_objects clean run

--- a/build/openwrt/makefile.inc
+++ b/build/openwrt/makefile.inc
@@ -1,0 +1,38 @@
+##########################################################################
+ # Copyright 2023 Comcast Cable Communications Management, LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+ # SPDX-License-Identifier: Apache-2.0
+##########################################################################
+
+OS = $(shell uname)
+PLATFORM = $(shell uname -a)
+
+WITH_SAP ?= 0
+
+BASE = $(shell pwd)
+
+ONEWIFI_EM_HOME = $(BASE)/../../../
+ONEWIFI_HOME = $(BASE)/../../../../OneWifi/
+ONEWIFI_HAL_INTF_HOME = $(BASE)/../../../../halinterface/include
+ONEWIFI_BUS_LIB_HOME = $(ONEWIFI_HOME)/lib/bus
+ONEWIFI_EM_SRC = $(ONEWIFI_EM_HOME)/src
+INSTALLDIR = $(ONEWIFI_EM_HOME)/install
+AL_SAP_HOME = $(BASE)/../../../rdkb-ieee1905.1-service-access
+OBJDIR = obj
+CXX = $(TARGET_CXX)
+CC = $(TARGET_CC)
+AR ?= $(TARGET_AR)
+RM = -rm -rf
+LDFLAGS = $(TARGET_LDFLAGS)

--- a/inc/dm_device.h
+++ b/inc/dm_device.h
@@ -20,6 +20,7 @@
 #define DM_DEVICE_H
 
 #include "em_base.h"
+#include <cstring>
 
 class dm_device_t {
 public:

--- a/inc/ec_crypto.h
+++ b/inc/ec_crypto.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <optional>
 #include <string>
+#include <cstring>
 #include <unordered_map>
 
 // forward decl

--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -25,9 +25,11 @@
 #include <openssl/dh.h>
 #include "em_base.h"
 #include <openssl/evp.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/param_build.h>
 #include <openssl/types.h>
 #include <openssl/core_names.h>
+#endif
 
 #include <optional>
 #include <vector>

--- a/inc/ieee80211.h
+++ b/inc/ieee80211.h
@@ -73,7 +73,7 @@ struct ieee80211_frame {
             uint8_t         i_addr2[IEEE80211_ADDR_LEN];
             uint8_t         i_addr3[IEEE80211_ADDR_LEN];
         };
-        u_int8_t    i_addr_all[3 * IEEE80211_ADDR_LEN];
+        uint8_t    i_addr_all[3 * IEEE80211_ADDR_LEN];
     };
     uint8_t         i_seq[2];
     /* possibly followed by addr4[IEEE80211_ADDR_LEN]; */

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1442,7 +1442,6 @@ AlServiceAccessPoint* em_agent_t::al_sap_register()
 
 int main(int argc, const char *argv[])
 {
-
     std::vector<std::string> args;
     // Skip the first argument which is the program name
     for (int i = 1; i < argc; i++) {

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -44,7 +44,9 @@
 #include <openssl/rand.h>
 #include <openssl/evp.h>
 #include <openssl/dh.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/provider.h>
+#endif
 #include <sys/types.h>
 #include <ifaddrs.h>
 #include "em.h"
@@ -93,10 +95,12 @@ em_crypto_t::em_crypto_t() {
             exit(1);
         }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
         if (OSSL_PROVIDER_load(NULL, "default") == NULL) {
             fprintf(stderr, "Failed to load default provider\n");
             exit(1);
         }
+#endif
     });
 }
 

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -281,6 +281,13 @@ em_t *em_mgr_t::get_phy_al_node()
 
 void *em_mgr_t::mgr_input_listen(void *arg)
 {
+    size_t stack_size2;
+    pthread_attr_t attr;
+
+    pthread_attr_init(&attr);
+    pthread_attr_getstacksize(&attr, &stack_size2);
+    pthread_attr_destroy(&attr);
+    printf("%s:%d Thread stack size = %ld bytes \n", __func__, __LINE__, stack_size2);
     em_mgr_t *mgr = static_cast<em_mgr_t *>(arg);
 
     mgr->input_listener();
@@ -289,11 +296,33 @@ void *em_mgr_t::mgr_input_listen(void *arg)
 
 int em_mgr_t::input_listen()
 {
-    if (pthread_create(&m_tid, NULL, em_mgr_t::mgr_input_listen, this) != 0) {
+    ssize_t stack_size = 0x800000; /* 8MB */
+    pthread_attr_t attr;
+    pthread_attr_t *attrp = NULL;
+    int ret = 0;
+    attrp = &attr;
+    pthread_attr_init(&attr);
+    // Setting explicitly stacksize as in few platforms(e.g. openwrt) if not called, the
+    // new thread will inherit the default stack size which is significantly less
+    // leading to stack overflow.
+    ret = pthread_attr_setstacksize(&attr, stack_size);
+    if (ret != 0) {
+        printf("%s:%d pthread_attr_setstacksize failed for size:%ld ret:%d\n",
+                __func__, __LINE__, stack_size, ret);
+    }
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+    if (pthread_create(&m_tid, attrp, em_mgr_t::mgr_input_listen, this) != 0) {
         printf("%s:%d: Failed to start em mgr thread\n", __func__, __LINE__);
+        if(attrp != NULL) {
+            pthread_attr_destroy(attrp);
+        }
         return -1;
     }
 
+    if(attrp != NULL) {
+        pthread_attr_destroy(attrp);
+    }
     return 0;
 }
 
@@ -376,6 +405,13 @@ void em_mgr_t::nodes_listener()
 
 void *em_mgr_t::mgr_nodes_listen(void *arg)
 {
+    size_t stack_size2;
+    pthread_attr_t attr;
+
+    pthread_attr_init(&attr);
+    pthread_attr_getstacksize(&attr, &stack_size2);
+    printf("%s:%d Thread stack size = %ld bytes \n", __func__, __LINE__, stack_size2);
+    pthread_attr_destroy(&attr);
     em_mgr_t *mgr = static_cast<em_mgr_t *>(arg);
 
     mgr->nodes_listener();
@@ -384,11 +420,32 @@ void *em_mgr_t::mgr_nodes_listen(void *arg)
 
 int em_mgr_t::nodes_listen()
 {
-    if (pthread_create(&m_tid, NULL, em_mgr_t::mgr_nodes_listen, this) != 0) {
+    ssize_t stack_size = 0x800000; /* 8MB */
+    pthread_attr_t attr;
+    pthread_attr_t *attrp = NULL;
+    int ret = 0;
+    attrp = &attr;
+    pthread_attr_init(&attr);
+    // Setting explicitly stacksize as in few platforms(e.g. openwrt) if not called, the
+    // new thread will inherit the default stack size which is significantly less
+    // leading to stack overflow.
+    ret = pthread_attr_setstacksize(&attr, stack_size);
+    if (ret != 0) {
+        printf("%s:%d pthread_attr_setstacksize failed for size:%ld ret:%d\n",
+                __func__, __LINE__, stack_size, ret);
+    }
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+    if (pthread_create(&m_tid, attrp, em_mgr_t::mgr_nodes_listen, this) != 0) {
         printf("%s:%d: Failed to start em mgr thread\n", __func__, __LINE__);
+        if(attrp != NULL) {
+            pthread_attr_destroy(attrp);
+        }
         return -1;
     }
-
+    if(attrp != NULL) {
+        pthread_attr_destroy(attrp);
+    }
     return 0;
 }
 

--- a/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
@@ -915,7 +915,6 @@ std::pair<uint8_t *, size_t> ec_ctrl_configurator_t::create_recfg_auth_confirm(s
     uint8_t trans_id = 0;
     ec_dpp_reconfig_flags_t reconfig_flags = {
         .connector_key = 1, // DONT REUSE
-        .reserved = 0
     };
 
 

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -33,7 +33,9 @@
 #include <sstream>
 
 #include <cstdlib>
+#ifdef __GLIBC__
 #include <execinfo.h>
+#endif
 
 
 #include "util.h"
@@ -43,6 +45,7 @@ extern "C" {
 }
 
 void util::print_stacktrace() {
+#ifdef __GLIBC__
     // Get the stack trace (Unix/Linux implementation)
     const int max_frames = 100;
     void* callstack[max_frames];
@@ -56,6 +59,7 @@ void util::print_stacktrace() {
     }
     
     free(symbols);
+#endif
 }
 
 char *util::get_date_time_rfc3399(char *buff, unsigned int len)


### PR DESCRIPTION
Reason for change: Address compilation and linking of unified-wifi-mesh in OpenWRT platform.
Test Procedure: Tested on BananaPi with agent, RPI as collocated agent.
Risks: Low