### PR TITLE
ec_enrollee::~ec_enrollee: join pres announcement thread

### DIFF
--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -15,6 +15,7 @@ ec_enrollee_t::ec_enrollee_t(std::string mac_addr, send_act_frame_func send_acti
 ec_enrollee_t::~ec_enrollee_t()
 {
     ec_util::free_connection_ctx(m_c_ctx);
+    if (m_send_pres_announcement_thread.joinable()) m_send_pres_announcement_thread.join();
 }
 
 bool ec_enrollee_t::start_onboarding(bool do_reconfig, ec_data_t* boot_data)


### PR DESCRIPTION
If Enrollee begins DPP onboarding, it will send presence announcement frames in a separate thread. If the Enrollee does not receive an authentication request signaling the thread to join, and the Enrollee process is killed, the presence announcement frame continues, and the Configurator continues receiving these frames even though there's no longer an Enrollee to response to.

This fixes by joining in destructor.