### PR TITLE
Fix for double co-located message recieving

### DIFF
--- a/inc/ec_util.h
+++ b/inc/ec_util.h
@@ -553,32 +553,6 @@ public:
 	 */
 	static std::pair<uint8_t*, uint16_t> unwrap_wrapped_attrib(ec_attribute_t *wrapped_attrib, uint8_t *frame, size_t frame_len, uint8_t *frame_attribs, bool uses_aad, uint8_t *key);
 
-    
-	/**
-	 * @brief Convert a hash to a hex string
-	 *
-	 * This function takes a hash and its length, converting it into a
-	 * hexadecimal string representation.
-	 *
-	 * @param[in] hash The hash to convert
-	 * @param[in] hash_len The length of the hash
-	 * @return std::string The hex string representation of the hash
-	 */
-	static std::string hash_to_hex_string(const uint8_t *hash, size_t hash_len);
-
-    
-	/**
-	 * @brief Convert a hash to a hex string.
-	 *
-	 * This function takes a vector of bytes representing a hash and converts it
-	 * into a hexadecimal string representation.
-	 *
-	 * @param[in] hash Vector containing the hash to convert.
-	 *
-	 * @returns std::string The hex string representation of the hash.
-	 */
-	static std::string hash_to_hex_string(const std::vector<uint8_t>& hash);
-
     // Used for storing channels / op-classes searched when looking for a given SSID.
     struct scanned_channels_t {
         uint32_t chan;

--- a/inc/em.h
+++ b/inc/em.h
@@ -35,6 +35,9 @@
 
 #include "util.h"
 
+#include <set>
+#include <string>
+
 class em_mgr_t;
 
 class em_t : 
@@ -58,6 +61,23 @@ class em_t :
     pthread_t   m_tid;
     bool    m_exit;
     bool m_is_al_em;
+	
+	/**
+	 * @brief Set of hashed messages that have been sent in co-located systems
+	 * 
+	 * This set is used to track the messages that have been sent 
+	 * to avoid recieving the same message that was sent by another co-located 1905 object.
+	 * 
+	 * For example: {Controller} -> {Controller, Co-located Agent}, or 
+	 * 				{Co-located Agent} -> {Controller, Co-located Agent})
+	 * 
+	 * This occurs because both the Controller and the Co-located Agent have the same AL-mac, 
+	 * resulting in them both recieving the messages they sent each other when infact, it should be:
+	 * 
+	 * {Controller} -> {Co-located Agent} and
+	 * {Co-located Agent} -> {Controller}
+	 */
+	std::set<std::string> m_coloc_sent_hashed_msgs;
 
     
 	/**!

--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -180,6 +180,44 @@ public:
 	inline static uint8_t platform_SHA256(uint8_t num_elem, uint8_t **addr, size_t *len, uint8_t *digest){
         return platform_hash(EVP_sha256(), num_elem, addr, len, digest);
     }
+
+	/**
+	 * @brief Convenience wrapper to compute SHA-256 hash for a single input element.
+	 *
+	 * @param[in] secret Pointer to the input data element.
+	 * @param[in] secret_len Length of the input data element.
+	 * @param[out] digest Output buffer for computed hash.
+	 *
+	 * @return 1 on success, 0 on failure.
+	 */
+	inline static uint8_t platform_SHA256(uint8_t *secret, size_t secret_len, uint8_t *digest){
+		uint8_t *addr[1];
+		size_t length[1];
+		addr[0] = secret;
+    	length[0] = secret_len;
+        return platform_hash(EVP_sha256(), 1, addr, length, digest);
+    }
+
+	/**
+	 * @brief Convenience wrapper to compute SHA-256 hash for a single input element.
+	 *
+	 * @param[in] secret Pointer to the input data element.
+	 * @param[in] secret_len Length of the input data element.
+	 *
+	 * @return std::vector<uint8_t> A vector containing the computed SHA-256 hash.
+	 */
+	inline static std::vector<uint8_t> platform_SHA256(uint8_t *secret, size_t secret_len){
+		uint8_t *addr[1];
+		size_t length[1];
+		addr[0] = secret;
+    	length[0] = secret_len;
+
+		std::vector<uint8_t> digest(SHA256_MAC_LEN);
+		if (platform_hash(EVP_sha256(), 1, addr, length, digest.data()) == 0) {
+			return {};
+		}
+		return digest;
+    }
     
 
     
@@ -1021,6 +1059,30 @@ public:
 	 */
 	inline void set_r_mac(unsigned char *mac) { memcpy(m_crypto_info.r_mac, mac, sizeof(mac_address_t)); }
 
+	/**
+	 * @brief Convert a hash to a hex string
+	 *
+	 * This function takes a hash and its length, converting it into a
+	 * hexadecimal string representation.
+	 *
+	 * @param[in] hash The hash to convert
+	 * @param[in] hash_len The length of the hash
+	 * @return std::string The hex string representation of the hash
+	 */
+	static std::string hash_to_hex_string(const uint8_t *hash, size_t hash_len);
+
+    
+	/**
+	 * @brief Convert a hash to a hex string.
+	 *
+	 * This function takes a vector of bytes representing a hash and converts it
+	 * into a hexadecimal string representation.
+	 *
+	 * @param[in] hash Vector containing the hash to convert.
+	 *
+	 * @returns std::string The hex string representation of the hash.
+	 */
+	static std::string hash_to_hex_string(const std::vector<uint8_t>& hash);
     
 	/**!
 	 * @brief Constructor for the em_crypto_t class.

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -482,6 +482,7 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
             if (!al_node->get_ec_mgr().handle_recv_ec_action_frame(ec_frame, full_action_frame_len, mgmt_frame->sa)){
                 em_printfout("EC manager failed to handle action frame!");
             }
+            return;
         }
         em_printfout("Did not find an EM node for action frame!");
     }

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -1604,3 +1604,17 @@ static std::optional<std::vector<uint8_t>> em_crypto_t::sign_data_ecdsa(const st
     return result;
 }
 #endif
+
+std::string em_crypto_t::hash_to_hex_string(const uint8_t *hash, size_t hash_len) {
+    char output[hash_len * 2 + 1];
+    for (size_t i = 0; i < hash_len; i++) {
+        sprintf(output + (i * 2), "%02x", hash[i]);
+    }
+    output[hash_len * 2] = '\0'; // Null-terminate the string
+    return std::string(output);
+}
+
+std::string em_crypto_t::hash_to_hex_string(const std::vector<uint8_t>& hash)
+{
+    return hash_to_hex_string(hash.data(), hash.size());
+}

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -242,7 +242,28 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
     em_cmdu_t *cmdu;
     mac_addr_str_t mac_str;
 
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(data);
     cmdu = reinterpret_cast<em_cmdu_t *>(data + sizeof(em_raw_hdr_t));
+
+
+    if (memcmp(hdr->src, hdr->dst, sizeof(mac_address_t)) == 0 &&
+        memcmp(hdr->src, m_ruid.mac, sizeof(mac_address_t)) == 0 &&
+        memcmp(hdr->dst, m_ruid.mac, sizeof(mac_address_t)) == 0) {
+
+        // This is a message that was sent to the same address it was sent from, 
+        // check if I infact sent it to myself
+        auto hash = em_crypto_t::platform_SHA256(data, len);
+        auto hash_str = em_crypto_t::hash_to_hex_string(hash);
+
+        if (m_coloc_sent_hashed_msgs.find(hash_str) != m_coloc_sent_hashed_msgs.end()) {
+            // I sent this same message type, I am likely the sender receiving it back
+            // since both the controller and colocated agent have the same AL-mac
+            // so, I should not process it
+            free(data);
+            m_coloc_sent_hashed_msgs.erase(hash_str);
+            return;
+        }
+    }
 
     dm_easy_mesh_t::macbytes_to_string(get_radio_interface_mac(), mac_str);
     switch (htons(cmdu->type)) {
@@ -607,6 +628,18 @@ int em_t::send_cmd(em_cmd_type_t type, em_service_type_t svc, unsigned char *buf
 int em_t::send_frame(unsigned char *buff, unsigned int len, bool multicast)
 {
     int ret = 0;
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+
+    if (memcmp(hdr->src, hdr->dst, sizeof(mac_address_t)) == 0 &&
+        memcmp(hdr->src, m_ruid.mac, sizeof(mac_address_t)) == 0 &&
+        memcmp(hdr->dst, m_ruid.mac, sizeof(mac_address_t)) == 0) {
+        // I am sending this message to a node with the same MAC address,
+        // store the message for later comparison
+        auto hash = em_crypto_t::platform_SHA256(buff, len);
+        if (hash.size() == SHA256_MAC_LEN) {
+            m_coloc_sent_hashed_msgs.insert(em_crypto_t::hash_to_hex_string(hash));
+        }
+    }
 #ifdef AL_SAP
     AlServiceDataUnit sdu;
     sdu.setSourceAlMacAddress(g_al_mac_sap);
@@ -628,7 +661,7 @@ int em_t::send_frame(unsigned char *buff, unsigned int len, bool multicast)
     struct sockaddr_ll sadr_ll;
     int sock;
     mac_address_t   multi_addr = {0x01, 0x80, 0xc2, 0x00, 0x00, 0x13};
-    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+
 
     dm_easy_mesh_t::name_from_mac_address(reinterpret_cast<mac_address_t *>(get_al_interface_mac()), ifname);
 

--- a/src/em/prov/easyconnect/ec_pa_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_pa_configurator.cpp
@@ -10,7 +10,7 @@ bool ec_pa_configurator_t::handle_presence_announcement(ec_frame_t *frame, size_
 
     ec_attribute_t *B_r_hash_attr = ec_util::get_attrib(frame->attributes, static_cast<uint16_t> (attrs_len), ec_attrib_id_resp_bootstrap_key_hash);
     ASSERT_NOT_NULL(B_r_hash_attr, false, "%s:%d No responder bootstrapping key hash attribute found\n", __func__, __LINE__);
-    std::string B_r_hash_str = ec_util::hash_to_hex_string(B_r_hash_attr->data, B_r_hash_attr->length);
+    std::string B_r_hash_str = em_crypto_t::hash_to_hex_string(B_r_hash_attr->data, B_r_hash_attr->length);
 
     // EasyMesh R6 5.3.4
     // If a Proxy Agent receives a DPP Presence Announcement frame, the Proxy Agent shall check if the bootstrapping
@@ -233,7 +233,7 @@ bool ec_pa_configurator_t::process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv
                 em_printfout("Failed to parse DPP Chirp TLV");
                 break;
             }
-            std::string chirp_hash_str = ec_util::hash_to_hex_string(chirp_hash, chirp_hash_len);
+            std::string chirp_hash_str = em_crypto_t::hash_to_hex_string(chirp_hash, chirp_hash_len);
             em_printfout("Chirp TLV Hash: %s", chirp_hash_str.c_str());
 
             free(chirp_hash);

--- a/src/em/prov/easyconnect/ec_util.cpp
+++ b/src/em/prov/easyconnect/ec_util.cpp
@@ -444,20 +444,6 @@ uint8_t *ec_util::copy_attrs_to_frame(uint8_t *frame, size_t frame_base_size, ui
     return new_frame;
 }
 
-std::string ec_util::hash_to_hex_string(const uint8_t *hash, size_t hash_len) {
-    char output[hash_len * 2 + 1];
-    for (size_t i = 0; i < hash_len; i++) {
-        sprintf(output + (i * 2), "%02x", hash[i]);
-    }
-    output[hash_len * 2] = '\0'; // Null-terminate the string
-    return std::string(output);
-}
-
-std::string ec_util::hash_to_hex_string(const std::vector<uint8_t>& hash)
-{
-    return hash_to_hex_string(hash.data(), hash.size());
-}
-
 std::string ec_util::generate_channel_list(const std::string& ssid, std::unordered_map<std::string, std::vector<scanned_channels_t>> scanned_channels_map)
 {
     // channelList ABNF:

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -139,12 +139,12 @@ int em_provisioning_t::send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, si
         //return -1;
     }
 
+    em_printfout("Sending Proxied Encap DPP msg");
     if (send_frame(buff, len)  < 0) {
         em_printfout("Proxied Encap DPP msg failed, error:%d", errno);
         return -1;
     }
 
-    em_printfout("Sent Proxied Encap DPP msg");
     // TODO: If needed, likely not
 	//set_state(em_state_ctrl_configured);
 
@@ -168,11 +168,10 @@ int em_provisioning_t::send_chirp_notif_msg(em_dpp_chirp_value_t *chirp, size_t 
     // NOTE: `get_ctrl_al_interface_mac` is really only for co-located so `get_peer_mac` does not work.
 
     //TODO: Decide on addressing.
-    em_printfout("Sending CHIRP NOTIFICATION");
     mac_addr_str_t peer_mac_str = {0}, al_mac_str = {0};
     dm_easy_mesh_t::macbytes_to_string(get_peer_mac(), peer_mac_str);
     dm_easy_mesh_t::macbytes_to_string(get_al_interface_mac(), al_mac_str);
-    em_printfout("Peer MAC: %s, AL MAC: %s", peer_mac_str, al_mac_str);
+    
     tmp = em_msg_t::add_1905_header(tmp, &len, get_peer_mac(), get_al_interface_mac(), em_msg_type_chirp_notif);
 
     // One DPP Chirp value tlv 17.2.83
@@ -187,6 +186,7 @@ int em_provisioning_t::send_chirp_notif_msg(em_dpp_chirp_value_t *chirp, size_t 
         //return -1;
     }
 
+    em_printfout("Sending CHIRP NOTIFICATION");
     if (send_frame(buff, len)  < 0) {
         em_printfout("Channel Selection Request msg failed, error:%d", errno);
         return -1;
@@ -764,7 +764,7 @@ cJSON *em_provisioning_t::create_configurator_bsta_response_obj(ec_connection_co
             return nullptr;
         }
 
-        cJSON_AddStringToObject(credential_object, "psk_hex", ec_util::hash_to_hex_string(psk).c_str());
+        cJSON_AddStringToObject(credential_object, "psk_hex", em_crypto_t::hash_to_hex_string(psk).c_str());
     }
 
     if (!cJSON_AddStringToObject(credential_object, "pass", network_ssid_info->pass_phrase)) {


### PR DESCRIPTION
Both the Controller and the Proxy Agent receive the same message when one of them sends a 1905 message because they share the same AL MAC address. This fixes this by keeping track of the messages sent (as SHA256 hashes) when the source and destination are the same and if that same message is received on that device then clearly it received the same message it sent itself and should be ignored.