### PR TITLE
ec_enrollee: store i-nonce from Auth Req frame if Configurator is initiator

### DIFF
--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -255,6 +255,12 @@ Authentication Request frame without replying to it.
         .byte = init_caps_attr->data[0]
     };
 
+    ec_attribute_t *i_nonce_attr = ec_util::get_attrib(wrapped_data, static_cast<uint16_t>(wrapped_len), ec_attrib_id_init_nonce);
+    ASSERT_NOT_NULL_FREE(init_caps_attr, false, wrapped_data, "%s:%d: No initiator nonce attribute found\n", __func__, __LINE__);
+    memcpy(m_eph_ctx().i_nonce, i_nonce_attr->data, i_nonce_attr->length);
+    em_printfout("i-nonce (Configurator is initiator)");
+    util::print_hex_dump(i_nonce_attr->length, m_eph_ctx().i_nonce);
+
     // Fetched all of the wrapped data attributes (init caps), free the wrapped data
     free(wrapped_data);
 


### PR DESCRIPTION
Enrollee was not parsing / saving i_nonce attr from Auth Req. frame, and then adding an empty i_nonce attr to be sent in Auth Resp. frame.

Logs, pre (Configurator creating auth response):
```
[onewifi_em_ctrl] 04/10/25 - 22:28:55.043798 :ec_ctrl_configurator.cpp:512: INFO: Ephemeral context i-nonce:
  0000  92 0d 11 55 3e 38 65 26 4c 62 c7 c8 72 71 d2 ff  ...U>8e&Lb..rq..
  0010  2e e1 f0 25 31 06 c0 42 71 c5 2b b2 9d 41 40 9a  ...%1..Bq.+..A@.
  0020  30 4d d5 a8 db ea 6a 8e 21 1d c6 fd f7 fe 5f 46  0M....j.!....._F
  0030  f4 ab ce 64 9e d6 2a 52 e9 dd 83 25 86 91 11 4f  ...d..*R...%...O
  0040  ca 1c 8a ac a2 33 66 bc 2a 81 f8 93 2e 29 04 7a  .....3f.*....).z
  0050  cd 9e a1 87 2a 3f 25 51 b3 53 23 dd d3 6f 63 4b  ....*?%Q.S#..ocK
  0060  aa b0 74 24 d8 a5 27 62 d4 08 b9 9b ae ce 36 f6  ..t$..'b......6.
  0070  4f d2 8d 08 10 0e a9 9a 15 58 20 bd 15 24 64 af  O........X ..$d.
[onewifi_em_ctrl] 04/10/25 - 22:28:55.044557 :ec_ctrl_configurator.cpp:514: INFO: Received i-nonce:
  0000  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  0010  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  0020  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  0030  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  0040  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  0050  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  0060  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  0070  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
```
... and would then give up on onboarding.


Logs, post (Configurator creating auth response):
```
[onewifi_em_ctrl] 04/10/25 - 22:49:45.221590 :ec_ctrl_configurator.cpp:725: INFO: Enter
[onewifi_em_ctrl] 04/10/25 - 22:49:45.222337 :ec_ctrl_configurator.cpp:743: INFO: i-nonce
  0000  9d 7d 23 a9 78 6c f2 0d c9 fa 77 ba e6 80 3e 87  .}#.xl....w...>.
  0010  99 0b fa 51 03 9b 52 4f c5 d6 0c ee 3f 5e ce 4c  ...Q..RO....?^.L
  0020  12 0d 7a 36 a7 ba d2 49 95 34 2d d3 93 9a fc 4a  ..z6...I.4-....J
  0030  8f 71 2a 12 e7 a5 db 0f 4f 2a 1e 9c a2 60 77 8b  .q*.....O*...`w.
  0040  4b d9 21 a9 ce eb eb 9f e7 e8 7f 53 30 bd 6e ee  K.!........S0.n.
  0050  27 c5 9b 75 52 3a 36 f6 26 3a 25 8d 00 9c de 53  '..uR:6.&:%....S
  0060  d1 b0 cd 07 c0 91 72 32 61 04 76 9f e5 e1 ea 67  ......r2a.v....g
  0070  d1 f8 a0 5a 1a 2c 05 aa b1 ca c5 fe 19 51 b0 c3  ...Z.,.......Q..
Key K_1:
  0000  bf 16 b7 36 0d b9 99 bc 7a 74 a4 a3 28 6b d5 21  ...6....zt..(k.!
  0010  a0 be d0 23 f7 ab 9a f8 9e 0e a4 30 cf 43 0e 3c  ...#.......0.C.<
[onewifi_em_ctrl] 04/10/25 - 22:49:45.235212 :em_provisioning.cpp:142: INFO: Sending Proxied Encap DPP msg

Key K_2:
  0000  bb 4e 43 3d b8 c9 4a 2f 09 c0 3f 71 e2 0d 9c 7b  .NC=..J/..?q...{
  0010  fe 15 8a b9 b8 98 a7 31 17 61 84 3c c3 75 68 3c  .......1.a.<.uh<
```

Logs, post (Enrollee reading / saving i_nonce attr from auth req frame):
```
Key K_1:
  0000  bf 16 b7 36 0d b9 99 bc 7a 74 a4 a3 28 6b d5 21  ...6....zt..(k.!
  0010  a0 be d0 23 f7 ab 9a f8 9e 0e a4 30 cf 43 0e 3c  ...#.......0.C.<
[onewifi_em_agent] 04/10/25 - 22:50:26.467394 :ec_enrollee.cpp:261: INFO: i-nonce (Configurator is initiator)
  0000  9d 7d 23 a9 78 6c f2 0d c9 fa 77 ba e6 80 3e 87  .}#.xl....w...>.
  0010  99 0b fa 51 03 9b 52 4f c5 d6 0c ee 3f 5e ce 4c  ...Q..RO....?^.L
  0020  12 0d 7a 36 a7 ba d2 49 95 34 2d d3 93 9a fc 4a  ..z6...I.4-....J
  0030  8f 71 2a 12 e7 a5 db 0f 4f 2a 1e 9c a2 60 77 8b  .q*.....O*...`w.
  0040  4b d9 21 a9 ce eb eb 9f e7 e8 7f 53 30 bd 6e ee  K.!........S0.n.
  0050  27 c5 9b 75 52 3a 36 f6 26 3a 25 8d 00 9c de 53  '..uR:6.&:%....S
  0060  d1 b0 cd 07 c0 91 72 32 61 04 76 9f e5 e1 ea 67  ......r2a.v....g
  0070  d1 f8 a0 5a 1a 2c 05 aa b1 ca c5 fe 19 51 b0 c3  ...Z.,.......Q..
Key K_2:
  0000  bb 4e 43 3d b8 c9 4a 2f 09 c0 3f 71 e2 0d 9c 7b  .NC=..J/..?q...{
  0010  fe 15 8a b9 b8 98 a7 31 17 61 84 3c c3 75 68 3c  .......1.a.<.uh<
```


Also slips in bonus logging for quick visual nonce match checks

