### PR TITLE
b_I optional in Configurator handle_auth_response

### DIFF
--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -737,7 +737,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
     char path[100] = {0};
     snprintf(path, sizeof(path), "Device.WiFi.AccessPoint.%d.RawFrame.Mgmt.Action.Tx", test_idx+1);
     
-    em_printfout("Sending action frame: VAP Idx (%d), Dest ("MACSTRFMT"), Frequency (%d), Dwell Time (%d)", test_idx, MAC2STR(dest_mac), frequency, wait_time_ms);
+    em_printfout("Sending action frame: VAP Idx (%d), Dest (" MACSTRFMT "), Frequency (%d), Dwell Time (%d)", test_idx, MAC2STR(dest_mac), frequency, wait_time_ms);
     // Send the action frame
     bus_error_t rc;
     if ((rc = desc->bus_set_fn(&m_bus_hdl, path,  &raw_act_frame)) != 0) {

--- a/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
@@ -554,14 +554,15 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
         return false;
     }
 
-    // b_I
-    ASSERT_NOT_NULL(conn_ctx->boot_data.init_priv_boot_key, false, "%s:%d: failed to get initiator bootstrapping private key\n", __func__, __LINE__);
     // B_R
     ASSERT_NOT_NULL(conn_ctx->boot_data.resp_pub_boot_key, false, "%s:%d: failed to get responder bootstrapping public key\n", __func__, __LINE__);
     // P_R
     ASSERT_NOT_NULL(e_ctx->public_resp_proto_key, false, "%s:%d: Responder Public Protocol Key was not recieved/set\n", __func__, __LINE__);
 
     if (e_ctx->is_mutual_auth){
+        // b_I
+        ASSERT_NOT_NULL(conn_ctx->boot_data.init_priv_boot_key, false, "%s:%d: failed to get initiator bootstrapping private key\n", __func__, __LINE__);
+
         // Perform **Initiator** L.x calculation (L = bI * (BR + PR))
 
         EC_POINT* sum = EC_POINT_new(conn_ctx->group);

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -283,9 +283,9 @@ Authentication Request frame without replying to it.
             return false;
         }
         if (m_send_action_frame(src_mac, resp_frame, resp_len, m_selected_freq, 0)){
-            em_printfout("Successfully sent DPP Status Not Compatible response frame");
+            em_printfout("Successfully sent DPP Status Not Compatible response frame to '" MACSTRFMT "'", MAC2STR(src_mac));
         } else {
-            em_printfout("Failed to send DPP Status Not Compatible response frame");
+            em_printfout("Failed to send DPP Status Not Compatible response frame to " MACSTRFMT "'", MAC2STR(src_mac));
         }
         return false;
     }
@@ -303,9 +303,9 @@ Authentication Request frame without replying to it.
             return false;
         }
         if (m_send_action_frame(src_mac, resp_frame, resp_len, m_selected_freq, 0)){
-            em_printfout("Successfully sent DPP Status Response Pending response frame");
+            em_printfout("Successfully sent DPP Status Response Pending response frame to '" MACSTRFMT "'", MAC2STR(src_mac));
         } else {
-            em_printfout("Failed to send DPP Status Response Pending response frame");
+            em_printfout("Failed to send DPP Status Response Pending response frame to '" MACSTRFMT "'", MAC2STR(src_mac));
         }
         return true;
     }
@@ -321,9 +321,9 @@ Authentication Request frame without replying to it.
     }
     bool did_succeed = m_send_action_frame(src_mac, resp_frame, resp_len, m_selected_freq, 0);
     if (did_succeed){
-        em_printfout("Successfully sent DPP Status OK response frame");
+        em_printfout("Successfully sent DPP Status OK response frame to '" MACSTRFMT "'", MAC2STR(src_mac));
     } else {
-        em_printfout("Failed to send DPP Status OK response frame");
+        em_printfout("Failed to send DPP Status OK response frame to '" MACSTRFMT "'", MAC2STR(src_mac));
     }
 
     return did_succeed;

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -139,7 +139,10 @@ int em_provisioning_t::send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, si
         //return -1;
     }
 
-    em_printfout("Sending Proxied Encap DPP msg");
+    {
+        em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+        em_printfout("Sending Proxied Encap DPP msg from '" MACSTRFMT "' to '" MACSTRFMT "'\n", MAC2STR(hdr->src), MAC2STR(hdr->dst));
+    }
     if (send_frame(buff, len)  < 0) {
         em_printfout("Proxied Encap DPP msg failed, error:%d", errno);
         return -1;


### PR DESCRIPTION
Additional logging for frame src/dst