### PR TITLE
Fix/auth resp

### DIFF
--- a/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
@@ -607,7 +607,7 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
     ASSERT_NOT_NULL_FREE(sec_wrapped_attr, false, prim_unwrapped_data, "%s:%d: No secondary wrapped data attribute found\n", __func__, __LINE__);
 
     // Unwrap the secondary wrapped data with the KE key
-    auto [sec_unwrapped_data, sec_unwrapped_len] =  ec_util::unwrap_wrapped_attrib(sec_wrapped_attr, frame, true, e_ctx->ke);
+    auto [sec_unwrapped_data, sec_unwrapped_len] =  ec_util::unwrap_wrapped_attrib(sec_wrapped_attr, frame, false, e_ctx->ke);
     ASSERT_NOT_NULL_FREE(sec_unwrapped_data, false, prim_unwrapped_data, "%s:%d: Failed to unwrap secondary wrapped data\n", __func__, __LINE__);
 
     // Free the primary unwrapped data since it is no longer needed (secondary unwrapped data is heap allocated)

--- a/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
@@ -658,11 +658,6 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
 
     uint8_t* r_auth_prime = ec_crypto::compute_hash(*conn_ctx, r_auth_hb);
 
-    BN_free(P_I_x);
-    BN_free(P_R_x);
-    BN_free(B_R_x);
-    if (B_I_x) BN_free(B_I_x);
-
     ASSERT_NOT_NULL(r_auth_prime, false, "%s:%d: Failed to compute R-auth'\n", __func__, __LINE__);
 
     if (memcmp(r_auth_prime, resp_auth_tag, sizeof(resp_auth_tag) != 0)) {
@@ -699,6 +694,12 @@ bool ec_ctrl_configurator_t::handle_auth_response(ec_frame_t *frame, size_t len,
     ec_crypto::add_to_hash(i_auth_hb, B_R_x); //B_R
     if (e_ctx->is_mutual_auth) ec_crypto::add_to_hash(i_auth_hb, B_I_x); //B_I
     ec_crypto::add_to_hash(i_auth_hb, static_cast<uint8_t> (1)); // 1 octet
+
+
+    BN_free(P_I_x);
+    BN_free(P_R_x);
+    BN_free(B_R_x);
+    if (B_I_x) BN_free(B_I_x);
 
     uint8_t* i_auth = ec_crypto::compute_hash(*conn_ctx, i_auth_hb);
     ASSERT_NOT_NULL(i_auth, false, "%s:%d: Failed to compute I-auth\n", __func__, __LINE__);

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -831,7 +831,7 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_auth_response(ec_status_code_
         wrap_attribs = ec_util::add_attrib(wrap_attribs, &wrapped_len, ec_attrib_id_resp_caps, m_dpp_caps.byte);
 
         // R-auth is wrapped in an additional wrapped data attribute (k_e) inside the main wrapped data attribute (k_2)
-        wrap_attribs = ec_util::add_wrapped_data_attr(frame, wrap_attribs, &wrapped_len, true, m_eph_ctx().ke, [&](){
+        wrap_attribs = ec_util::add_wrapped_data_attr(frame, wrap_attribs, &wrapped_len, false, m_eph_ctx().ke, [&](){
             size_t int_wrapped_len = 0;
             uint8_t* int_wrapped_attrs = ec_util::add_attrib(NULL, &int_wrapped_len, ec_attrib_id_resp_auth_tag, m_c_ctx.digest_len, r_auth);
             return std::make_pair(int_wrapped_attrs, int_wrapped_len);


### PR DESCRIPTION
Last of the bugs (hopefully?) for Auth Req/Auth Resp

Enrollee log (now onto Auth Confirmation!):
```
[onewifi_em_agent] 04/11/25 - 23:14:04.576403 :em_agent.cpp:740: INFO: Sending action frame: VAP Idx (0), Dest (1c:bf:ce:f4:bf:58), Frequency (2437), Dwell Time (0)
[onewifi_em_agent] 04/11/25 - 23:14:04.580709 :ec_enrollee.cpp:324: INFO: Successfully sent DPP Status OK response frame to '1c:bf:ce:f4:bf:58'
mgmt_action_frame_cb:873 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
129
  0000  d0 00 3a 01 1c bf ce f8 eb b7 1c bf ce f4 bf 58  ..:............X
  0010  ff ff ff ff ff ff d0 02 04 09 50 6f 9a 1a 01 02  ..........Po....
  0020  00 10 01 00 00 02 10 20 00 82 80 93 1f a5 e6 31  ....... .......1
  0030  41 35 37 19 b2 04 68 63 63 2c 0a f3 08 71 1e 78  A57...hcc,...q.x
  0040  76 58 df bd de 4d 6a 9c 70 04 10 34 00 8e 86 d8  vX...Mj.p..4....
  0050  84 c9 bf 87 bf c5 44 b0 13 cc 02 44 29 c2 d9 70  ......D....D)..p
  0060  be 8c 3f 69 d4 bd 29 a7 e3 62 15 ee e9 d0 ca 27  ..?i..)..b.....'
  0070  ce 68 7c bc 64 6e 66 d8 38 65 5c 0b d3 60 7d b7  .h|.dnf.8e\..`}.
  0080  14                                               .
handle_recv_wfa_action_frame:433: Received WFA action frame: Full Length: 129, VS Action Data Length: 100
Dest Mac Str: 1c:bf:ce:f8:eb:b7
[onewifi_em_agent] 04/11/25 - 23:14:04.607878 :em_agent.cpp:460: INFO: Dest radio node MAC '1c:bf:ce:f8:eb:b7', al_node radio MAC '1c:bf:ce:f8:eb:b7'

[onewifi_em_agent] 04/11/25 - 23:14:04.608000 :em_agent.cpp:468: INFO: Dest MAC '1c:bf:ce:f8:eb:b7', dest_al_same=1, is_bcast=0, is_colocated=0
[onewifi_em_agent] 04/11/25 - 23:14:04.608490 :ec_enrollee.cpp:383: INFO: Failed to get x-coordinates of P_I, P_R, and B_R
[onewifi_em_agent] 04/11/25 - 23:14:04.609082 :em_agent.cpp:483: INFO: EC manager failed to handle action frame!

```
