### PR TITLE
B_R_x comes from respondor pub boot key, not initiator

### DIFF
--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -1041,6 +1041,9 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_config_request()
         return {};
     }
 
+    em_printfout("E-nonce:");
+    util::print_hex_dump(m_c_ctx.nonce_len, m_eph_ctx().e_nonce);
+
     if (m_boot_data().version <= 1) {
         em_printfout("EasyMesh R >= 5 mandates DPP version >= 2, current version is %d, bailing.", m_boot_data().version);
         return {};
@@ -1077,6 +1080,9 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_config_request()
     cJSON *bsta_info = m_get_bsta_info(nullptr);
     ASSERT_NOT_NULL_FREE(bsta_info, {}, m_eph_ctx().e_nonce, "%s:%d: bSTA info is nullptr!\n", __func__, __LINE__);
     cJSON_AddItemToObject(dpp_config_request_obj, "bSTAList", bsta_info);
+
+    // For debugging
+    em_printfout("Enrollee bSTA Configuration Request object:\n%s", cjson_utils::stringify(dpp_config_request_obj).c_str());
 
     // XXX: Dialog token can be thought of as a session key between Enrollee and Configurator regarding configuration
     // From specs (EasyMesh, EasyConnect, 802.11), it seems this is just arbitrarily chosen (1 byte), but

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -372,12 +372,27 @@ bool ec_enrollee_t::handle_auth_confirm(ec_frame_t *frame, size_t len, uint8_t s
 
     free(unwrapped_data);
 
+    if (m_eph_ctx().public_init_proto_key == nullptr) {
+        em_printfout("eph ctx public init proto key null");
+        return false;
+    }
+
+    if (m_eph_ctx().public_resp_proto_key == nullptr) {
+        em_printfout("eph ctx resp proto key nullptr");
+        return false;
+    }
+
+    if (m_boot_data().resp_pub_boot_key == nullptr) {
+        em_printfout("Boot data resp pub boot key is nullptr!");
+        return false;
+    }
+
     // Generate I-auth’ = H(R-nonce | I-nonce | PR.x | PI.x | BR.x | [ BI.x | ] 1)
     // Get P_I.x, P_R.x, B_I.x, and B_R.x
     BIGNUM* P_I_x = ec_crypto::get_ec_x(m_c_ctx, m_eph_ctx().public_init_proto_key);
     BIGNUM* P_R_x = ec_crypto::get_ec_x(m_c_ctx, m_eph_ctx().public_resp_proto_key);
-    BIGNUM* B_I_x = ec_crypto::get_ec_x(m_c_ctx, m_boot_data().resp_pub_boot_key);
-    BIGNUM* B_R_x = ec_crypto::get_ec_x(m_c_ctx, m_boot_data().init_pub_boot_key);
+    BIGNUM* B_I_x = ec_crypto::get_ec_x(m_c_ctx, m_boot_data().init_pub_boot_key);
+    BIGNUM* B_R_x = ec_crypto::get_ec_x(m_c_ctx, m_boot_data().resp_pub_boot_key);
 
     if (P_I_x == NULL || P_R_x == NULL || B_R_x == NULL) {
         em_printfout("Failed to get x-coordinates of P_I, P_R, and B_R");


### PR DESCRIPTION
Also adds logging if any necessary keys are nullptr.

Enrollee log (new bug is some sort of `nullptr` being passed to `memcpy` inside of `copy_attrs_to_frame`, I think):

```
[onewifi_em_agent] 04/12/25 - 00:05:25.647481 :em_agent.cpp:740: INFO: Sending action frame: VAP Idx (0), Dest (1c:bf:ce:f4:bf:58), Frequency (2437), Dwell Time (0)
[onewifi_em_agent] 04/12/25 - 00:05:25.651449 :ec_enrollee.cpp:324: INFO: Successfully sent DPP Status OK response frame to '1c:bf:ce:f4:bf:58'
mgmt_action_frame_cb:873 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
129
  0000  d0 00 3a 01 1c bf ce f8 eb b7 1c bf ce f4 bf 58  ..:............X
  0010  ff ff ff ff ff ff 80 01 04 09 50 6f 9a 1a 01 02  ..........Po....
  0020  00 10 01 00 00 02 10 20 00 82 80 93 1f a5 e6 31  ....... .......1
  0030  41 35 37 19 b2 04 68 63 63 2c 0a f3 08 71 1e 78  A57...hcc,...q.x
  0040  76 58 df bd de 4d 6a 9c 70 04 10 34 00 75 11 e1  vX...Mj.p..4.u..
  0050  50 ca 6d 55 8e 41 d7 d8 d2 bc 22 11 4f 30 08 94  P.mU.A....".O0..
  0060  ab 3b a4 8c ab 0c a5 4f 64 c9 26 2f 82 aa 04 9d  .;.....Od.&/....
  0070  8f 25 c6 6d 8f 65 46 44 82 bd 07 f3 26 a4 59 32  .%.m.eFD....&.Y2
  0080  c2                                               .
handle_recv_wfa_action_frame:433: Received WFA action frame: Full Length: 129, VS Action Data Length: 100
Dest Mac Str: 1c:bf:ce:f8:eb:b7
[onewifi_em_agent] 04/12/25 - 00:05:25.677850 :em_agent.cpp:460: INFO: Dest radio node MAC '1c:bf:ce:f8:eb:b7', al_node radio MAC '1c:bf:ce:f8:eb:b7'

[onewifi_em_agent] 04/12/25 - 00:05:25.678319 :em_agent.cpp:468: INFO: Dest MAC '1c:bf:ce:f8:eb:b7', dest_al_same=1, is_bcast=0, is_colocated=0
Frame attributes cannot be NULL for AAD encryption/home/tpolomik/em/unified-wifi-mesh/build/agent/../..//src/em/prov/easyconnect/ec_util.cpp:443:11: runtime error: null pointer passed as argument 2, which is declared to never be null
[onewifi_em_agent] 04/12/25 - 00:05:25.683686 :em_agent.cpp:740: INFO: Sending action frame: VAP Idx (0), Dest (1c:bf:ce:f4:bf:58), Frequency (2437), Dwell Time (0)
[onewifi_em_agent] 04/12/25 - 00:05:25.687670 :ec_enrollee.cpp:463: INFO: Sent DPP Configuration Request 802.11 frame to Proxy Agent!
```

But we're sorta kinda to the Configuration step! (once runtime error is solved of course) 🎉 