### PR TITLE
Fix/config request sending

### DIFF
--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -343,7 +343,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
         return;
     }
 
-    auto gas_frame_base = (ec_gas_frame_base_t *)evt->u.raw_buff + mgmt_hdr_len;
+    auto gas_frame_base = (ec_gas_frame_base_t *)(evt->u.raw_buff + mgmt_hdr_len);
 
     bool is_wfa_ec_gas = false;
 

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -1099,7 +1099,7 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_config_request()
     uint8_t *attribs = nullptr;
     size_t attribs_len = 0;
     // Wrap e-nonce and config req obj(s) with k_e
-    attribs = ec_util::add_wrapped_data_attr(reinterpret_cast<uint8_t *> (initial_req_frame), sizeof(ec_gas_initial_request_frame_t), attribs, &attribs_len, true, m_eph_ctx().ke, [&](){
+    attribs = ec_util::add_wrapped_data_attr(reinterpret_cast<uint8_t *> (initial_req_frame), sizeof(ec_gas_initial_request_frame_t), attribs, &attribs_len, false, m_eph_ctx().ke, [&](){
         size_t wrapped_len = 0;
         uint8_t* wrapped_attribs = ec_util::add_attrib(nullptr, &wrapped_len, ec_attrib_id_enrollee_nonce, m_c_ctx.nonce_len, m_eph_ctx().e_nonce);
         wrapped_attribs = ec_util::add_attrib(wrapped_attribs, &wrapped_len, ec_attrib_id_dpp_config_req_obj, cjson_utils::stringify(dpp_config_request_obj));
@@ -1136,7 +1136,7 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_config_result(ec_status_code_
     uint8_t *attribs = nullptr;
     size_t attribs_len = 0;
 
-    attribs = ec_util::add_wrapped_data_attr(frame, attribs, &attribs_len, true, m_eph_ctx().ke, [&]() {
+    attribs = ec_util::add_wrapped_data_attr(frame, attribs, &attribs_len, false, m_eph_ctx().ke, [&]() {
         size_t wrapped_len = 0;
         uint8_t *wrapped_attrs = ec_util::add_attrib(nullptr, &wrapped_len, ec_attrib_id_dpp_status, static_cast<uint8_t>(dpp_status));
         wrapped_attrs = ec_util::add_attrib(wrapped_attrs, &wrapped_len, ec_attrib_id_enrollee_nonce, m_c_ctx.nonce_len, m_eph_ctx().e_nonce);
@@ -1163,7 +1163,7 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_connection_status_result(ec_s
     uint8_t *attribs   = nullptr;
     size_t attribs_len = 0;
 
-    attribs = ec_util::add_wrapped_data_attr(frame, attribs, &attribs_len, true, m_eph_ctx().ke, [&]() {
+    attribs = ec_util::add_wrapped_data_attr(frame, attribs, &attribs_len, false, m_eph_ctx().ke, [&]() {
         size_t wrapped_len = 0;
         uint8_t *wrapped_attrs = ec_util::add_attrib(nullptr, &wrapped_len, ec_attrib_id_enrollee_nonce, m_c_ctx.nonce_len, m_eph_ctx().e_nonce);
         wrapped_attrs = ec_util::add_attrib(wrapped_attrs, &wrapped_len, ec_attrib_id_conn_status, cjson_utils::stringify(connection_status_object));


### PR DESCRIPTION
GAS frame type now parsed at the correct offset and forwarded to `ec_manager` to handle.

In Draft state as `m_configurator` is somehow `nullptr` inside of `ec_manager_t::handle_recv_gas_pub_action_frame`

Will be leaving in draft until resolved. 

Log showing correct GAS action type rx'd/parsed, followed immediately by SIGSEGV (PA/Configurator):

```
mgmt_action_frame_cb:895: GAS frame rx'd
handle_recv_gas_frame:352: Received GAS Initial Request
handle_recv_gas_frame:396: Received WFA EC GAS frame
/home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/build/agent/../..//src/agent/em_agent.cpp:406:71: runtime error: member call on null pointer of type 'struct ec_manager_t'
[onewifi_em_agent] 04/12/25 - 03:18:29.044500 :ec_manager.cpp:95: INFO: Got a GAS frame with 0a action!
/home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/build/agent/../..//src/em/prov/easyconnect/ec_manager.cpp:99:27: runtime error: member access within null pointer of type 'struct ec_manager_t'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==5675==ERROR: AddressSanitizer: SEGV on unknown address 0x0000000000e8 (pc 0x00556713bacc bp 0x007fc3b51fa0 sp 0x007fc3b51fa0 T0)
==5675==The signal is caused by a READ memory access.
==5675==Hint: address points to the zero page.
    #0 0x556713bacc in std::__uniq_ptr_impl<ec_configurator_t, std::default_delete<ec_configurator_t> >::_M_ptr() const /usr/include/c++/12/bits/unique_ptr.h:191
    #1 0x5567136b78 in std::unique_ptr<ec_configurator_t, std::default_delete<ec_configurator_t> >::get() const /usr/include/c++/12/bits/unique_ptr.h:462
    #2 0x5567136adc in std::unique_ptr<ec_configurator_t, std::default_delete<ec_configurator_t> >::operator->() const /usr/include/c++/12/bits/unique_ptr.h:455
    #3 0x55672d6988 in ec_manager_t::handle_recv_gas_pub_action_frame(ec_gas_frame_base_t*, unsigned long, unsigned char*) /home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/build/agent/../..//src/em/prov/easyconnect/ec_manager.cpp:99
    #4 0x5567476750 in em_agent_t::handle_recv_gas_frame(em_bus_event_t*) /home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/build/agent/../..//src/agent/em_agent.cpp:406
    #5 0x556747d220 in em_agent_t::handle_bus_event(em_bus_event_t*) /home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/build/agent/../..//src/agent/em_agent.cpp:648
    #6 0x556747d5d8 in em_agent_t::handle_event(em_event_t*) /home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/build/agent/../..//src/agent/em_agent.cpp:664
    #7 0x5567164f00 in em_mgr_t::start() /home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/build/agent/../..//src/em/em_mgr.cpp:507
    #8 0x556748b990 in main /home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/build/agent/../..//src/agent/em_agent.cpp:1501
    #9 0x7fb12e773c in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #10 0x7fb12e7814 in __libc_start_main_impl ../csu/libc-start.c:360
    #11 0x5567104dec in _start (/home/tpolomik/rdk-easymesh-dev/unified-wifi-mesh/install/bin/onewifi_em_agent+0xa14dec)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /usr/include/c++/12/bits/unique_ptr.h:191 in std::__uniq_ptr_impl<ec_configurator_t, std::default_delete<ec_configurator_t> >::_M_ptr() const
==5675==ABORTING
```



