### PR TITLE
Fixed GAS frame addressing + Added C-signing key generation + fixed up Config AAD

### DIFF
--- a/inc/ec_util.h
+++ b/inc/ec_util.h
@@ -303,9 +303,47 @@ public:
 	 */
 	static ec_frame_t* copy_attrs_to_frame(ec_frame_t *frame, uint8_t *attrs, size_t attrs_len);
 
+	/**
+	 * @brief Copy (override) attributes to a frame.
+	 *
+	 * This function copies the specified attributes to the given frame. If the frame
+	 * needs to be reallocated to accommodate the new attributes, the reallocated
+	 * frame is returned.
+	 *
+	 * @param[in,out] frame The frame to which the attributes will be copied. This
+	 * frame may be reallocated if necessary.
+	 * @param[in] attrs The attributes to copy to the frame.
+	 * @param[in] attrs_len The length of the attributes array.
+	 *
+	 * @return ec_gas_initial_request_frame_t* A pointer to the frame with the copied attributes. If the
+	 * frame was reallocated, the new pointer is returned.
+	 *
+	 * @warning The frame must be freed by the caller after use to prevent memory leaks.
+	 */
+	static ec_gas_initial_request_frame_t* copy_attrs_to_frame(ec_gas_initial_request_frame_t *frame, uint8_t *attrs, size_t attrs_len);
+
+	/**
+	 * @brief Copy (override) attributes to a frame.
+	 *
+	 * This function copies the specified attributes to the given frame. If the frame
+	 * needs to be reallocated to accommodate the new attributes, the reallocated
+	 * frame is returned.
+	 *
+	 * @param[in,out] frame The frame to which the attributes will be copied. This
+	 * frame may be reallocated if necessary.
+	 * @param[in] attrs The attributes to copy to the frame.
+	 * @param[in] attrs_len The length of the attributes array.
+	 *
+	 * @return ec_gas_initial_response_frame_t* A pointer to the frame with the copied attributes. If the
+	 * frame was reallocated, the new pointer is returned.
+	 *
+	 * @warning The frame must be freed by the caller after use to prevent memory leaks.
+	 */
+	static ec_gas_initial_response_frame_t* copy_attrs_to_frame(ec_gas_initial_response_frame_t *frame, uint8_t *attrs, size_t attrs_len);
+
     
 	/**
-	 * @brief Copy (over-write) attributes to a frame.
+	 * @brief Copy attributes to a frame.
 	 *
 	 * This function copies the specified attributes to a given frame starting at a specified offset.
 	 *
@@ -489,6 +527,46 @@ public:
 	 */
 	static uint8_t* add_wrapped_data_attr(ec_frame_t *frame, uint8_t* frame_attribs, size_t* non_wrapped_len, 
         bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs);
+
+	/**
+	 * @brief Add a wrapped data attribute to a frame
+	 *
+	 * This function adds a wrapped data attribute to the specified frame attributes.
+	 *
+	 * @param[in] frame The frame to use as Additional Authenticated Data (AAD). Can be NULL if no AAD is needed.
+	 * @param[in,out] frame_attribs The attributes to add the wrapped data attribute to and to use as AAD.
+	 * @param[in,out] non_wrapped_len The length of the non-wrapped attributes (`frame_attribs`).
+	 * @param[in] use_aad Whether to use AAD in the encryption.
+	 * @param[in] key The key to use for encryption.
+	 * @param[in] create_wrap_attribs A function to create the attributes to wrap and their length. Memory is handled by the function (see note).
+	 *
+	 * @return uint8_t* The new frame attributes with the wrapped data attribute added.
+	 *
+	 * @note The `create_wrap_attribs` function will allocate heap-memory which is freed inside the `add_wrapped_data_attr` function.
+	 *       **The caller should not use statically allocated memory in `create_wrap_attribs` or free the memory returned by `create_wrap_attribs`.**
+	 */
+	static uint8_t* add_wrapped_data_attr(ec_gas_initial_request_frame_t *frame, uint8_t* frame_attribs, size_t* non_wrapped_len, 
+        bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs);
+
+	/**
+	 * @brief Add a wrapped data attribute to a frame
+	 *
+	 * This function adds a wrapped data attribute to the specified frame attributes.
+	 *
+	 * @param[in] frame The frame to use as Additional Authenticated Data (AAD). Can be NULL if no AAD is needed.
+	 * @param[in,out] frame_attribs The attributes to add the wrapped data attribute to and to use as AAD.
+	 * @param[in,out] non_wrapped_len The length of the non-wrapped attributes (`frame_attribs`).
+	 * @param[in] use_aad Whether to use AAD in the encryption.
+	 * @param[in] key The key to use for encryption.
+	 * @param[in] create_wrap_attribs A function to create the attributes to wrap and their length. Memory is handled by the function (see note).
+	 *
+	 * @return uint8_t* The new frame attributes with the wrapped data attribute added.
+	 *
+	 * @note The `create_wrap_attribs` function will allocate heap-memory which is freed inside the `add_wrapped_data_attr` function.
+	 *       **The caller should not use statically allocated memory in `create_wrap_attribs` or free the memory returned by `create_wrap_attribs`.**
+	 */
+	static uint8_t* add_wrapped_data_attr(ec_gas_initial_response_frame_t *frame, uint8_t* frame_attribs, size_t* non_wrapped_len, 
+		bool use_aad, uint8_t* key, std::function<std::pair<uint8_t*, uint16_t>()> create_wrap_attribs);
 
     
 	/**!

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -337,13 +337,10 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
         printf("%s:%d: no node found for MAC '%s'\n", __func__, __LINE__, dest_mac);
         return;
     }
-    em_t *al_node = get_al_node();
-    if (!al_node) {
-        printf("%s:%d: no AL node present\n", __func__, __LINE__);
-        return;
-    }
 
-    auto gas_frame_base = (ec_gas_frame_base_t *)evt->u.raw_buff + mgmt_hdr_len;
+    em_t* al_node = get_al_node();
+
+    auto gas_frame_base = (ec_gas_frame_base_t *)(evt->u.raw_buff + mgmt_hdr_len);
 
     bool is_wfa_ec_gas = false;
 
@@ -394,19 +391,35 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
 
     if (is_wfa_ec_gas) {
         printf("%s:%d: Received WFA EC GAS frame\n", __func__, __LINE__);
-        bool dest_al_same = (memcmp(dest_node->get_radio_interface_mac(),
-                                    get_al_node()->get_radio_interface_mac(), ETH_ALEN) != 0);
-
-        if (!dest_al_same && !(m_data_model.get_colocated())) {
-            // DPP GAS Frame not sent to same radio as AL node, let's ignore it.
-            // We don't ignore it if this co-located since the AL-node will be the same as the controller (eth0)
-            // so if we ignore it, no packets will ever get through
+        bool dest_al_same = false;
+        if (dest_node != NULL && al_node != NULL) {
+            em_printfout("Dest radio node MAC '" MACSTRFMT "', al_node radio MAC '" MACSTRFMT"'\n", MAC2STR(dest_node->get_radio_interface_mac()), MAC2STR(al_node->get_radio_interface_mac()));
+            dest_al_same = (memcmp(dest_node->get_radio_interface_mac(), al_node->get_radio_interface_mac(), ETH_ALEN) == 0);
+        }
+    
+        auto ctrl_al = m_data_model.get_controller_interface_mac();
+        auto agent_al = m_data_model.get_agent_al_interface_mac();
+        bool is_colocated = (memcmp(ctrl_al, agent_al, ETH_ALEN) == 0);
+    
+        em_printfout("Dest MAC '" MACSTRFMT "', dest_al_same=%d, is_colocated=%d", MAC2STR(dest_node->get_radio_interface_mac()), dest_al_same, is_colocated);
+                                
+        /*
+        If any of the following conditions are satisfied:
+            - The destination MAC is the same as the AL node (mac address)
+            - The colocated flag is set
+        Then the `ec_manager` of the AL node will handle the action frame
+        
+        We don't ignore it if this co-located since the AL-node will be the same as the controller (eth0) 
+        so if we ignore it, no packets will ever get through
+        */
+        if (dest_al_same || is_colocated) {
+            if (!al_node->get_ec_mgr().handle_recv_gas_pub_action_frame(
+                gas_frame_base, full_frame_length - mgmt_hdr_len, mgmt_frame->sa)) {
+                printf("%s:%d: EC manager failed to handle GAS frame!\n", __func__, __LINE__);
+            }
             return;
         }
-        if (!dest_node->m_ec_manager->handle_recv_gas_pub_action_frame(
-                gas_frame_base, full_frame_length - mgmt_hdr_len, mgmt_frame->sa)) {
-            printf("%s:%d: EC manager failed to handle GAS frame!\n", __func__, __LINE__);
-        }
+
     }
 }
 

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -111,7 +111,8 @@ int em_provisioning_t::send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, si
         return -1;
     }
 
-    uint8_t buff[MAX_EM_BUFF_SZ];
+    // Make sure there is enough room for the TLV, the 1905 layer will deal with fragmentation.
+    uint8_t buff[MAX_EM_BUFF_SZ+encap_dpp_len];
     unsigned int len = 0;
     uint8_t *tmp = buff;
 
@@ -143,12 +144,15 @@ int em_provisioning_t::send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, si
         em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
         em_printfout("Sending Proxied Encap DPP msg from '" MACSTRFMT "' to '" MACSTRFMT "'\n", MAC2STR(hdr->src), MAC2STR(hdr->dst));
     }
+
+    em_printfout("Sending Proxied Encap DPP msg of length %d", len);
     if (send_frame(buff, len)  < 0) {
-        em_printfout("Proxied Encap DPP msg failed, error:%d", errno);
+        em_printfout("Proxied Encap DPP msg failed");
+        perror("send_frame");
         return -1;
     }
 
-    em_printfout("Sent Proxied Encap DPP msg");
+    
     // TODO: If needed, likely not
 	//set_state(em_state_ctrl_configured);
 


### PR DESCRIPTION
- Updated configuration "wrap"/"unwrap" AAD parameter to be more in line with the spec.
- Added C-signing key generation
- Added overloads for `add_wrapped_attr` and `copy_attrs_to_frame` for GAS frames.

Currently we are at the spot where the Controller successfully creates a Configuration response, however due to MTU of the `eth0` port on the Pi being 1,000, the 2,069 byte packet can't be sent without being fragmented (which is handled by the Rust 1905 daemon once we have access to it). This will also impact the sending of the GAS frame on the proxy agent side, involving the use of fragmentation and comeback frames.

Here are the logs as of now for quick reference:

## Controller
```shell
[onewifi_em_ctrl] 04/12/25 - 17:34:40.759593 :ec_ctrl_configurator.cpp:737: INFO: Enter
[onewifi_em_ctrl] 04/12/25 - 17:34:40.760280 :ec_ctrl_configurator.cpp:755: INFO: i-nonce
  0000  06 08 68 77 40 3b c1 03 48 29 63 91 c3 d4 bd f5  ..hw@;..H)c.....
  0010  ce 44 dd 58 36 96 9a b2 02 8c 9f 7a ce 48 e0 1e  .D.X6......z.H..
  0020  26 5b 7e 1c 27 0d 7c 11 6f f2 52 e7 e6 3e 1e ea  &[~.'.|.o.R..>..
  0030  21 57 33 9f fc f0 07 c5 a3 f7 5a 14 7c d9 d6 7b  !W3.......Z.|..{
  0040  ca 0a 64 0a fb 46 75 6f 81 9b 5c 51 01 8b 15 c5  ..d..Fuo..\Q....
  0050  fc 48 99 c3 5f 88 71 02 fa c5 5a 3d 3f a9 6c 17  .H.._.q...Z=?.l.
  0060  90 3e 2e 08 15 c9 5f 70 1d 02 60 56 39 ff b2 fa  .>...._p..`V9...
  0070  be 7c 32 98 ce 38 80 48 22 69 17 e2 51 29 47 b5  .|2..8.H"i..Q)G.
Key K_1:
  0000  96 40 3b 2f 28 17 86 86 a4 18 05 14 ad 3e f9 0c  .@;/(........>..
  0010  a7 98 1a e9 0f cb 08 87 9f 62 f6 d1 80 3e a7 03  .........b...>..
[onewifi_em_ctrl] 04/12/25 - 17:34:40.771789 :em_provisioning.cpp:145: INFO: Sending Proxied Encap DPP msg from 'd8:3a:dd:74:f1:46' to 'd8:3a:dd:74:f1:46'

[onewifi_em_ctrl] 04/12/25 - 17:34:40.772032 :em_provisioning.cpp:148: INFO: Sending Proxied Encap DPP msg of length 357
Key K_2:
  0000  64 44 51 f2 c2 b7 af 00 67 94 7e 10 82 65 bb 9c  dDQ.....g.~..e..
  0010  41 d3 1e c7 88 b1 1a d5 28 af 91 9f 77 f6 e4 8d  A.......(...w...
[onewifi_em_ctrl] 04/12/25 - 17:34:51.158706 :em_provisioning.cpp:145: INFO: Sending Proxied Encap DPP msg from 'd8:3a:dd:74:f1:46' to 'd8:3a:dd:74:f1:46'

[onewifi_em_ctrl] 04/12/25 - 17:34:51.158948 :em_provisioning.cpp:148: INFO: Sending Proxied Encap DPP msg of length 143
can_onboard_additional_aps not implemented
[onewifi_em_ctrl] 04/12/25 - 17:34:51.307995 :ec_ctrl_configurator.cpp:1102: INFO: IEEE1905 Configuration object:
{
	"wi-fi_tech":	"dpp",
	"dfCounterThreshold":	42,
	"cred":	{
		"akm":	"506F9A02",
		"signedConnector":	"eyJ0eXAiOiJkcHBDb24iLCJraWQiOiJnN085S3pzVHltVjRxWU1Lcm5Pd2xIdUJCalBCY1o0UmZIcFJPNngycGdFPSIsImFsZyI6IkVTMjU2In0.eyJncm91cHMiOlt7Im5ldFJvbGUiOiJtYXBBZ2VudCIsImdyb3VwSUQiOiJtYXBOVyJ9XSwibmV0QWNjZXNzS2V5Ijp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiIiwieSI6IiJ9fQ.MEQCIHSqpqsop3-sAw-bwydsdQr3tEBhFEVhvxYcyaRomW39AiBdDXjtXOUD7nudKitO84uzO0z5RUZziOPPEZ2I46CFvg",
		"csign":	{
			"kty":	"EC",
			"crv":	"P-256",
			"kid":	"g7O9KzsTymV4qYMKrnOwlHuBBjPBcZ4RfHpRO6x2pgE=",
			"x":	"5195w+DPtgYjQr0lXFV6rrEFZQGB8OnZS6uCEdEWvC8=",
			"y":	"8BNVT8QsbztaZTI9dRsNMyO3NGHVLk/1Sc5EPFpdBIA="
		},
		"ppKey":	{
			"kty":	"EC",
			"crv":	"P-256",
			"x":	"emx5UxjvhEIkZU/DCvwGOVIT/3fxN6pKjsLKdMKNSX0=",
			"y":	"XCxUNrggfofdZ5jqLIeQP1b1vyB9Jz9UHIbFcMNwDD0="
		}
	}
}
[onewifi_em_ctrl] 04/12/25 - 17:34:51.308773 :ec_ctrl_configurator.cpp:1103: INFO: bSTA Configuration object:
{
	"wi-fi_tech":	"map",
	"discovery":	{
		"SSID":	"mesh_backhaul"
	},
	"cred":	{
		"akm":	"506F9A02+000FAC08+",
		"psk_hex":	"9df6b4479c7b94eaef678b2f2fdc6311f2e5ddb562b64fe5a63135b25ed69bab",
		"pass":	"test-backhaul",
		"signedConnector":	"eyJ0eXAiOiJkcHBDb24iLCJraWQiOiJnN085S3pzVHltVjRxWU1Lcm5Pd2xIdUJCalBCY1o0UmZIcFJPNngycGdFPSIsImFsZyI6IkVTMjU2In0.eyJncm91cHMiOlt7Im5ldFJvbGUiOiJtYXBCYWNraGF1bFN0YSIsImdyb3VwSUQiOiJtYXBOVyJ9XSwibmV0QWNjZXNzS2V5Ijp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiIiwieSI6IiJ9fQ.MEYCIQCRVr1PlOSSep3OexG33m-SXE6twaMYae-KhAL93GbPbwIhAPMdSSyyYpW2J-OZlVQ8RMLSXstAtu3vUnkwxaNVEF2c",
		"csign":	{
			"kty":	"EC",
			"crv":	"P-256",
			"kid":	"g7O9KzsTymV4qYMKrnOwlHuBBjPBcZ4RfHpRO6x2pgE=",
			"x":	"5195w+DPtgYjQr0lXFV6rrEFZQGB8OnZS6uCEdEWvC8=",
			"y":	"8BNVT8QsbztaZTI9dRsNMyO3NGHVLk/1Sc5EPFpdBIA="
		},
		"ppKey":	{
			"kty":	"EC",
			"crv":	"P-256",
			"x":	"emx5UxjvhEIkZU/DCvwGOVIT/3fxN6pKjsLKdMKNSX0=",
			"y":	"XCxUNrggfofdZ5jqLIeQP1b1vyB9Jz9UHIbFcMNwDD0="
		}
	}
}
[onewifi_em_ctrl] 04/12/25 - 17:34:51.309965 :em_provisioning.cpp:145: INFO: Sending Proxied Encap DPP msg from 'd8:3a:dd:74:f1:46' to 'd8:3a:dd:74:f1:46'

[onewifi_em_ctrl] 04/12/25 - 17:34:51.310019 :em_provisioning.cpp:148: INFO: Sending Proxied Encap DPP msg of length 2069
[onewifi_em_ctrl] 04/12/25 - 17:34:51.332517 :em_provisioning.cpp:151: INFO: Proxied Encap DPP msg failed, error: Unknown error -1 (-1)
send_frame: Message too long
```

## Proxy Agent

```shell
analyze_scan_request:632 Scan Req send successfull
mgmt_action_frame_cb:886 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
68
  0000  d0 00 00 00 ff ff ff ff ff ff 94 18 65 5c e7 ac  ............e\..
  0010  ff ff ff ff ff ff 40 7b 04 09 50 6f 9a 1a 01 0d  ......@{..Po....
  0020  02 10 20 00 7b 3a e5 1d 8c cc 24 7d a5 81 77 d6  .. .{:....$}..w.
  0030  c4 7e 81 27 cf 55 64 89 21 28 74 8c 7d 1e 67 18  .~.'.Ud.!(t.}.g.
  0040  5e 2a 1f 52                                      ^*.R
handle_recv_wfa_action_frame:446: Received WFA action frame: Full Length: 68, VS Action Data Length: 39
Dest Mac Str: ff:ff:ff:ff:ff:ff
Received WFA action frame with broadcast destination MAC address
[onewifi_em_agent] 04/12/25 - 17:34:40.741625 :em_agent.cpp:481: INFO: Dest MAC 'ff:ff:ff:ff:ff:ff', dest_al_same=0, is_bcast=1, is_colocated=1
[onewifi_em_agent] 04/12/25 - 17:34:40.742047 :ec_pa_configurator.cpp:8: INFO: Recieved a DPP Presence Announcement Frame from '94:18:65:5c:e7:ac'

[onewifi_em_agent] 04/12/25 - 17:34:40.742329 :ec_pa_configurator.cpp:24: INFO: No matching hash value found for '7b3ae51d8ccc247da58177d6c47e8127cf5564892128748c7d1e67185e2a1f52' in the DPP Presence Announcement frame
[onewifi_em_agent] 04/12/25 - 17:34:40.742738 :em_provisioning.cpp:197: INFO: Sending CHIRP NOTIFICATION
[onewifi_em_agent] 04/12/25 - 17:34:40.773592 :ec_pa_configurator.cpp:237: INFO: Chirp TLV Hash: 7b3ae51d8ccc247da58177d6c47e8127cf5564892128748c7d1e67185e2a1f52
update_scan_results:2639 creating new scan result
update_scan_results:2639 creating new scan result
update_scan_results:2639 creating new scan result
update_scan_results:2639 creating new scan result
update_scan_results:2639 creating new scan result
analyze_scan_result:702 scanner mac: d8:3a:dd:74:f1:48 - analyze_scan_result subdoc decode success
mgmt_action_frame_cb:886 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
68
  0000  d0 00 00 00 ff ff ff ff ff ff 94 18 65 5c e7 ac  ............e\..
  0010  ff ff ff ff ff ff 60 7b 04 09 50 6f 9a 1a 01 0d  ......`{..Po....
  0020  02 10 20 00 7b 3a e5 1d 8c cc 24 7d a5 81 77 d6  .. .{:....$}..w.
  0030  c4 7e 81 27 cf 55 64 89 21 28 74 8c 7d 1e 67 18  .~.'.Ud.!(t.}.g.
  0040  5e 2a 1f 52                                      ^*.R
handle_recv_wfa_action_frame:446: Received WFA action frame: Full Length: 68, VS Action Data Length: 39
Dest Mac Str: ff:ff:ff:ff:ff:ff
Received WFA action frame with broadcast destination MAC address
[onewifi_em_agent] 04/12/25 - 17:34:51.045391 :em_agent.cpp:481: INFO: Dest MAC 'ff:ff:ff:ff:ff:ff', dest_al_same=0, is_bcast=1, is_colocated=1
[onewifi_em_agent] 04/12/25 - 17:34:51.045674 :ec_pa_configurator.cpp:8: INFO: Recieved a DPP Presence Announcement Frame from '94:18:65:5c:e7:ac'

[onewifi_em_agent] 04/12/25 - 17:34:51.045938 :ec_pa_configurator.cpp:36: INFO: Found matching hash value for '7b3ae51d8ccc247da58177d6c47e8127cf5564892128748c7d1e67185e2a1f52' in the DPP Presence Announcement frame
[onewifi_em_agent] 04/12/25 - 17:34:51.046177 :em_agent.cpp:753: INFO: Sending action frame: VAP Idx (0), Dest (94:18:65:5c:e7:ac), Frequency (0), Dwell Time (0)
mgmt_action_frame_cb:886 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
486
  0000  d0 00 00 00 1c bf ce fc 21 76 94 18 65 5c e7 ac  ........!v..e\..
  0010  ff ff ff ff ff ff 70 7b 04 09 50 6f 9a 1a 01 01  ......p{..Po....
  0020  00 10 01 00 00 02 10 20 00 7d 53 bb 98 70 0d 82  ....... .}S..p..
  0030  c9 1e 18 fa 54 f7 ff 84 8e 03 63 70 9a 99 fa 57  ....T.....cp...W
  0040  d2 01 0d 05 da 57 a4 95 85 09 10 40 00 3e f3 a1  .....W.....@.>..
  0050  cb 5f 60 7c 26 9b 20 d7 c1 cd b8 b0 24 41 ca 27  ._`|&. .....$A.'
  0060  7d 1d c5 f4 87 02 2d b4 c2 39 b6 df ee 70 68 1f  }.....-..9...ph.
  0070  55 34 69 f8 23 e1 15 d6 39 16 95 1f de 11 7c c0  U4i.#...9.....|.
  0080  5d 90 84 de a8 9f e4 4d a9 af 5f ff 16 04 10 55  ]......M.._....U
  0090  01 98 50 7a 3e 40 fa ff 9f da 84 57 1b 26 57 9a  ..Pz>@.....W.&W.
  00a0  07 af 68 01 3d cd 8d a7 9d 8e eb 5d fc 8a 3a ae  ..h.=......]..:.
  00b0  71 a1 e6 03 e1 d7 fd bc da 2c 08 b3 2c 92 5d 4e  q........,..,.]N
  00c0  a2 60 6f a5 c2 8b b2 c5 3c 8a 7b db 4f 2c 29 0f  .`o.....<.{.O,).
  00d0  c1 c2 09 4c 74 41 39 f3 3b ee bd 06 a2 39 61 dd  ...LtA9.;....9a.
  00e0  cd 41 19 de 84 53 ba 53 ec 0f 32 d3 2d 44 a7 4e  .A...S.S..2.-D.N
  00f0  39 99 8b ec ba 61 1c 28 0c a6 0a 26 60 d6 25 5d  9....a.(...&`.%]
  0100  be 3b 4e 24 14 b9 3a d7 69 67 bb 96 d1 7d 2e 52  .;N$..:.ig...}.R
  0110  25 53 c9 c4 94 72 5d 99 a1 11 a1 9d aa 60 c0 1c  %S...r]......`..
  0120  a0 e0 59 c6 d5 70 74 66 63 d3 e8 fb 22 db 1f a9  ..Y..ptfc..."...
  0130  c4 a0 5f e8 ad 00 04 8f fe fd e9 b6 5e 81 c1 85  .._.........^...
  0140  3f 3e 87 ab ef e7 16 00 62 a4 f1 ae 66 01 22 45  ?>......b...f."E
  0150  91 ce ad 91 21 fe c8 07 65 d9 cc 63 1e 97 4d fa  ....!...e..c..M.
  0160  b7 e7 4b 07 ed 64 ad 11 4b bd 99 fc de 4b 05 d2  ..K..d..K....K..
  0170  f8 59 bc ea b8 f3 41 b8 04 7b d7 3e f1 fb 7a 9e  .Y....A..{.>..z.
  0180  4a 0d 82 a8 f3 d2 45 a8 55 54 28 5b 71 c0 30 9f  J.....E.UT([q.0.
  0190  07 11 d5 0b b8 49 6c 90 0e 3a b3 aa d5 96 d7 89  .....Il..:......
  01a0  bf e7 83 3c 5a 78 fb 86 f7 8f a1 01 66 31 bc dd  ...<Zx......f1..
  01b0  c3 e3 f1 92 62 36 6e 4f 41 44 77 4f 2c 0b 8c d4  ....b6nOADwO,...
  01c0  34 3f d4 78 b0 88 c2 f9 e1 7a 3d 49 af 2e 66 a1  4?.x.....z=I..f.
  01d0  78 8c 25 3e f3 6a 40 34 df cd 20 4e dc d9 a6 94  x.%>.j@4.. N....
  01e0  d2 f8 e2 47 04 0c                                ...G..
handle_recv_wfa_action_frame:446: Received WFA action frame: Full Length: 486, VS Action Data Length: 457
Dest Mac Str: 1c:bf:ce:fc:21:76
[onewifi_em_agent] 04/12/25 - 17:34:51.148975 :em_agent.cpp:473: INFO: Dest radio node MAC '1c:bf:ce:fc:21:76', al_node radio MAC 'd8:3a:dd:74:f1:46'

[onewifi_em_agent] 04/12/25 - 17:34:51.149145 :em_agent.cpp:481: INFO: Dest MAC '1c:bf:ce:fc:21:76', dest_al_same=0, is_bcast=0, is_colocated=1
[onewifi_em_agent] 04/12/25 - 17:34:51.149276 :ec_pa_configurator.cpp:46: INFO: Received a DPP Authentication Response frame from '94:18:65:5c:e7:ac'

[onewifi_em_agent] 04/12/25 - 17:34:51.149528 :em_provisioning.cpp:145: INFO: Sending Proxied Encap DPP msg from 'd8:3a:dd:74:f1:46' to 'd8:3a:dd:74:f1:46'

[onewifi_em_agent] 04/12/25 - 17:34:51.149676 :em_provisioning.cpp:148: INFO: Sending Proxied Encap DPP msg of length 500
[onewifi_em_agent] 04/12/25 - 17:34:51.160448 :em_agent.cpp:753: INFO: Sending action frame: VAP Idx (0), Dest (94:18:65:5c:e7:ac), Frequency (0), Dwell Time (0)
mgmt_action_frame_cb:886 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
544
  0000  d0 00 00 00 1c bf ce fc 21 76 94 18 65 5c e7 ac  ........!v..e\..
  0010  ff ff ff ff ff ff 80 7b 04 0a 01 6c 08 00 dd 05  .......{...l....
  0020  50 6f 9a 1a 01 f9 01 04 10 f5 01 e1 c6 b5 53 1d  Po............S.
  0030  fe c9 26 ad 9c 6c 46 51 3c 21 a4 6d 21 4e 31 52  ..&..lFQ<!.m!N1R
  0040  a3 38 6b 99 ec 97 69 31 03 c8 03 b4 fb 6c 36 1a  .8k...i1.....l6.
  0050  83 a4 13 51 d2 54 5b c3 c3 79 2c 1f 66 62 f8 c8  ...Q.T[..y,.fb..
  0060  fb ef b7 18 8e eb c4 3a aa 5d a4 9c 77 d0 05 73  .......:.]..w..s
  0070  21 04 18 77 00 d7 bb 45 6e cf 7f dd 6c f3 78 e8  !..w...En...l.x.
  0080  df e1 b0 fb 16 4b 5d e7 4c c3 a3 ed 21 7d 61 32  .....K].L...!}a2
  0090  3f af 4e 8e 98 a6 77 a6 9d 2d 8e 4e d5 d4 a8 c8  ?.N...w..-.N....
  00a0  8c 82 75 1c 20 13 7c d5 c0 00 5d 7f f5 4c 57 ed  ..u. .|...]..LW.
  00b0  f4 4f fe 15 ad 85 28 d3 dc 9e e1 84 6f 5f 9f f4  .O....(.....o_..
  00c0  72 e2 49 d6 d9 82 27 dd 8c ef b8 2a 29 d1 27 1b  r.I...'....*).'.
  00d0  07 41 e3 e2 16 ee 4f 95 94 3c 40 92 41 3e cb ce  .A....O..<@.A>..
  00e0  a0 41 77 5f c7 6c 1d 1f 8a 68 bc dc ef d8 b5 4a  .Aw_.l...h.....J
  00f0  76 9d 2b 5c 3b 78 3d c9 02 49 8d 92 d7 34 64 7a  v.+\;x=..I...4dz
  0100  2c 49 ca 45 b7 da 49 39 bc fd 20 2e 1c 91 89 38  ,I.E..I9.. ....8
  0110  3e 72 d8 39 8c 4b f5 f9 98 69 fb f4 6d 33 16 9e  >r.9.K...i..m3..
  0120  2b 09 62 4b d6 dc e3 c4 c4 3c 12 b6 4b a8 b6 d5  +.bK.....<..K...
  0130  12 63 85 28 8f 54 27 f8 b9 42 66 07 be 77 57 f9  .c.(.T'..Bf..wW.
  0140  ef f2 5c 87 91 ad 13 57 32 5a d7 0a 9b 1a 46 35  ..\....W2Z....F5
  0150  31 81 9a d7 6a 67 8d a8 2b 9f 70 64 5f 5c bb 9c  1...jg..+.pd_\..
  0160  fe 94 a9 ac bb 0b b6 15 24 f2 74 9e 45 72 ac f8  ........$.t.Er..
  0170  2e ee 89 92 e7 8f 20 30 67 05 84 e5 2c eb 9d 5a  ...... 0g...,..Z
  0180  65 75 bf d6 d3 d0 eb 51 d7 a3 34 4d 3a 6c cc 53  eu.....Q..4M:l.S
  0190  35 5b a2 60 c0 2c 75 e9 2a 40 8c 1c 53 cb 84 ae  5[.`.,u.*@..S...
  01a0  a4 57 f6 2b 44 46 b8 df 32 83 ef 79 9a 0c 1d 69  .W.+DF..2..y...i
  01b0  0c 0f 9e aa 83 26 3a b6 00 fe 77 0d 3b 34 1d d7  .....&:...w.;4..
  01c0  38 a1 86 12 23 34 e6 dd 38 bd 64 cd 09 a8 03 d3  8...#4..8.d.....
  01d0  cd 5f ee 12 19 42 2a 46 65 b8 3b cb 07 d5 dc 97  ._...B*Fe.;.....
  01e0  e7 28 66 34 83 88 c6 29 36 1b e0 4f 36 0a ca 5a  .(f4...)6..O6..Z
  01f0  c1 22 c7 6c 3d 94 70 56 8d 34 0a 9c 88 90 ef 7f  .".l=.pV.4......
  0200  22 6e 8c 00 f3 3f b2 eb 44 19 9d 7d 79 11 c0 90  "n...?..D..}y...
  0210  be 8d 9d 82 a7 b5 66 a9 11 9a 16 d1 93 9e 3e 44  ......f.......>D
mgmt_action_frame_cb:908: GAS frame rx'd
handle_recv_gas_frame:349: Received GAS Initial Request
handle_recv_gas_frame:393: Received WFA EC GAS frame
[onewifi_em_agent] 04/12/25 - 17:34:51.186475 :em_agent.cpp:396: INFO: Dest radio node MAC '1c:bf:ce:fc:21:76', al_node radio MAC 'd8:3a:dd:74:f1:46'

[onewifi_em_agent] 04/12/25 - 17:34:51.186675 :em_agent.cpp:404: INFO: Dest MAC '1c:bf:ce:fc:21:76', dest_al_same=0, is_colocated=1
[onewifi_em_agent] 04/12/25 - 17:34:51.186804 :ec_manager.cpp:95: INFO: Got a GAS frame with 0a action!
[onewifi_em_agent] 04/12/25 - 17:34:51.186919 :ec_pa_configurator.cpp:59: INFO: Rx'd a DPP Configuration Request from 94:18:65:5c:e7:ac
[onewifi_em_agent] 04/12/25 - 17:34:51.187147 :em_provisioning.cpp:145: INFO: Sending Proxied Encap DPP msg from 'd8:3a:dd:74:f1:46' to 'd8:3a:dd:74:f1:46'

[onewifi_em_agent] 04/12/25 - 17:34:51.187288 :em_provisioning.cpp:148: INFO: Sending Proxied Encap DPP msg of length 558
```

## Enrollee

```shell
[onewifi_em_agent] 04/12/25 - 18:34:46.980248 :ec_util.cpp:810: INFO: DPP URI JSON: {
	"URI":	{
		"V":	2,
		"M":	"94:18:65:5c:e7:ac",
		"C":	"81/12",
		"K":	"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETSVD4oxeOhUS4SAfKmgfbPMMMhd9fqu8gu+tQBcgEEBMKixZpNc7ofa2dQ0aS3SGXPWRrxargUk7Ki549B9Egg=="
	}
}
read_bootstrap_data_from_files:838: Successfully read DPP URI JSON from path '/nvram/DPPURI.json'
read_bootstrap_data_from_files:855: Successfully read PEM file from path '/nvram/DPPURI.pem'
try_start_dpp_onboarding:1415: DPP bootstrapping data generated successfully
Enrollee MAC: 94:18:65:5c:e7:ac
Successfully initialized persistent context with params:
	NID: 415
	Digest Length: 32
	Nonce Length: 128
	Prime (Length: 32):
  0000  ff ff ff ff 00 00 00 01 00 00 00 00 00 00 00 00  ................
  0010  00 00 00 00 ff ff ff ff ff ff ff ff ff ff ff ff  ................
try_start_dpp_onboarding:1420: DPP onboarding started successfully
send_result:133: write error on socket, err:88
[onewifi_em_agent] 04/12/25 - 18:34:46.993051 :ec_enrollee.cpp:641: INFO: Enter
[onewifi_em_agent] 04/12/25 - 18:34:47.000014 :em_agent.cpp:753: INFO: Sending action frame: VAP Idx (0), Dest (ff:ff:ff:ff:ff:ff), Frequency (2467), Dwell Time (2000)
[onewifi_em_agent] 04/12/25 - 18:34:49.003564 :em_agent.cpp:753: INFO: Sending action frame: VAP Idx (0), Dest (ff:ff:ff:ff:ff:ff), Frequency (5220), Dwell Time (2000)
[onewifi_em_agent] 04/12/25 - 18:34:51.010834 :em_agent.cpp:753: INFO: Sending action frame: VAP Idx (0), Dest (ff:ff:ff:ff:ff:ff), Frequency (2437), Dwell Time (2000)
mgmt_action_frame_cb:886 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
299
  0000  d0 00 3a 01 94 18 65 5c e7 ac 1c bf ce fc 21 76  ..:...e\......!v
  0010  ff ff ff ff ff ff 90 0a 04 09 50 6f 9a 1a 01 00  ..........Po....
  0020  02 10 20 00 7d 53 bb 98 70 0d 82 c9 1e 18 fa 54  .. .}S..p......T
  0030  f7 ff 84 8e 03 63 70 9a 99 fa 57 d2 01 0d 05 da  .....cp...W.....
  0040  57 a4 95 85 03 10 40 00 cd e5 e6 ec cd 32 ab 64  W.....@......2.d
  0050  38 06 31 1c 93 4c f0 ea 68 24 7a be f5 70 2d c5  8.1..L..h$z..p-.
  0060  3e b3 45 94 40 2b 6e d1 15 38 2b 39 d6 48 a4 65  >.E.@+n..8+9.H.e
  0070  fe 09 d5 00 77 12 49 c8 01 96 ac 6f cf 11 fe 45  ....w.I....o...E
  0080  35 82 49 d2 7b 16 a0 21 18 10 02 00 51 0c 04 10  5.I.{..!....Q...
  0090  99 00 96 e0 3a 13 59 9c 20 5f e5 2b 3c f5 66 82  ....:.Y. _.+<.f.
  00a0  97 a7 23 87 a6 90 97 00 f0 c5 b2 af cc fa 58 0d  ..#...........X.
  00b0  63 97 8f 3e c2 fa 8f d6 6f 73 c2 f6 50 6e 03 3f  c..>....os..Pn.?
  00c0  4b 55 8a 08 d6 e8 ae 63 d2 6b 04 cf 9c 84 e3 8d  KU.....c.k......
  00d0  75 db a1 cd 70 6c aa 96 2c 49 77 5a 31 57 89 37  u...pl..,IwZ1W.7
  00e0  15 cf e4 ee 2e 0e fe 5a 38 8c 0a 7a c2 5b 16 18  .......Z8..z.[..
  00f0  06 79 bf 87 ed 7a 09 2f c8 ce c5 3e 71 f9 69 f7  .y...z./...>q.i.
  0100  a5 ef 38 33 bc 86 8f db f5 67 a3 ab 9c ee 76 33  ..83.....g....v3
  0110  49 2b f3 c4 64 35 e2 b6 cf 70 08 61 b1 50 5f c6  I+..d5...p.a.P_.
  0120  dd 7e a6 19 75 c1 f9 06 17 cb f5                 .~..u......
handle_recv_wfa_action_frame:446: Received WFA action frame: Full Length: 299, VS Action Data Length: 270
Dest Mac Str: 94:18:65:5c:e7:ac
[onewifi_em_agent] 04/12/25 - 18:34:51.051662 :em_agent.cpp:473: INFO: Dest radio node MAC '94:18:65:5c:e7:ac', al_node radio MAC '94:18:65:5c:e7:ac'

[onewifi_em_agent] 04/12/25 - 18:34:51.051834 :em_agent.cpp:481: INFO: Dest MAC '94:18:65:5c:e7:ac', dest_al_same=1, is_bcast=0, is_colocated=0
[onewifi_em_agent] 04/12/25 - 18:34:51.051928 :ec_enrollee.cpp:156: INFO: Recieved a DPP Authentication Request from '1c:bf:ce:fc:21:76', stopping Presence Announcement

[onewifi_em_agent] 04/12/25 - 18:34:51.121001 :ec_enrollee.cpp:203: INFO: Channel attribute: 3153
[onewifi_em_agent] 04/12/25 - 18:34:51.121190 :ec_enrollee.cpp:207: INFO: op_class: 12 channel 81
Key K_1:
  0000  96 40 3b 2f 28 17 86 86 a4 18 05 14 ad 3e f9 0c  .@;/(........>..
  0010  a7 98 1a e9 0f cb 08 87 9f 62 f6 d1 80 3e a7 03  .........b...>..
[onewifi_em_agent] 04/12/25 - 18:34:51.124033 :ec_enrollee.cpp:261: INFO: i-nonce (Configurator is initiator)
  0000  06 08 68 77 40 3b c1 03 48 29 63 91 c3 d4 bd f5  ..hw@;..H)c.....
  0010  ce 44 dd 58 36 96 9a b2 02 8c 9f 7a ce 48 e0 1e  .D.X6......z.H..
  0020  26 5b 7e 1c 27 0d 7c 11 6f f2 52 e7 e6 3e 1e ea  &[~.'.|.o.R..>..
  0030  21 57 33 9f fc f0 07 c5 a3 f7 5a 14 7c d9 d6 7b  !W3.......Z.|..{
  0040  ca 0a 64 0a fb 46 75 6f 81 9b 5c 51 01 8b 15 c5  ..d..Fuo..\Q....
  0050  fc 48 99 c3 5f 88 71 02 fa c5 5a 3d 3f a9 6c 17  .H.._.q...Z=?.l.
  0060  90 3e 2e 08 15 c9 5f 70 1d 02 60 56 39 ff b2 fa  .>...._p..`V9...
  0070  be 7c 32 98 ce 38 80 48 22 69 17 e2 51 29 47 b5  .|2..8.H"i..Q)G.
Key K_2:
  0000  64 44 51 f2 c2 b7 af 00 67 94 7e 10 82 65 bb 9c  dDQ.....g.~..e..
  0010  41 d3 1e c7 88 b1 1a d5 28 af 91 9f 77 f6 e4 8d  A.......(...w...
[onewifi_em_agent] 04/12/25 - 18:34:51.134930 :em_agent.cpp:753: INFO: Sending action frame: VAP Idx (0), Dest (1c:bf:ce:fc:21:76), Frequency (2437), Dwell Time (0)
[onewifi_em_agent] 04/12/25 - 18:34:51.138824 :ec_enrollee.cpp:324: INFO: Successfully sent DPP Status OK response frame to '1c:bf:ce:fc:21:76'
mgmt_action_frame_cb:886 Received Frame data for event [Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Rx] and data of len:
129
  0000  d0 00 3a 01 94 18 65 5c e7 ac 1c bf ce fc 21 76  ..:...e\......!v
  0010  ff ff ff ff ff ff a0 0a 04 09 50 6f 9a 1a 01 02  ..........Po....
  0020  00 10 01 00 00 02 10 20 00 7d 53 bb 98 70 0d 82  ....... .}S..p..
  0030  c9 1e 18 fa 54 f7 ff 84 8e 03 63 70 9a 99 fa 57  ....T.....cp...W
  0040  d2 01 0d 05 da 57 a4 95 85 04 10 34 00 2a d5 24  .....W.....4.*.$
  0050  eb d1 ec 79 cc 53 72 03 c2 db a0 68 e1 70 44 8a  ...y.Sr....h.pD.
  0060  6f e9 f7 21 a2 a9 66 ef da 43 89 12 4e 0b 3c 01  o..!..f..C..N.<.
  0070  4d c4 1d 01 7d 50 6a bd 51 8f fe 39 fb 8e f2 0e  M...}Pj.Q..9....
  0080  5e                                               ^
handle_recv_wfa_action_frame:446: Received WFA action frame: Full Length: 129, VS Action Data Length: 100
Dest Mac Str: 94:18:65:5c:e7:ac
[onewifi_em_agent] 04/12/25 - 18:34:51.167419 :em_agent.cpp:473: INFO: Dest radio node MAC '94:18:65:5c:e7:ac', al_node radio MAC '94:18:65:5c:e7:ac'

[onewifi_em_agent] 04/12/25 - 18:34:51.167551 :em_agent.cpp:481: INFO: Dest MAC '94:18:65:5c:e7:ac', dest_al_same=1, is_bcast=0, is_colocated=0
[onewifi_em_agent] 04/12/25 - 18:34:51.168248 :ec_enrollee.cpp:1044: INFO: E-nonce:
  0000  01 db 16 6e e3 15 d6 33 18 80 ef 2b 64 f2 16 bb  ...n...3...+d...
  0010  99 59 55 77 08 ed f8 c8 36 34 7d 76 d8 b1 a4 29  .YUw....64}v...)
  0020  be 71 e4 1c 27 e7 c8 1b 3b f3 fb 4d 9d 11 a5 57  .q..'...;..M...W
  0030  90 4b bc 5b cd 5a 2d 09 5f 06 ed af b9 ec 07 53  .K.[.Z-._......S
  0040  54 dd d1 85 30 0e e3 43 45 df 5f e2 37 9f e2 9b  T...0..CE._.7...
  0050  a5 95 62 9a c9 1b 6f 71 41 bb 4d d7 dc 89 e7 eb  ..b...oqA.M.....
  0060  a1 c5 9a 05 37 ff 6b 7d ce c0 95 87 9b d8 39 20  ....7.k}......9
  0070  d6 f2 c7 cd a6 6e 44 50 3c cc d7 b6 73 62 22 f7  .....nDP<...sb".
[onewifi_em_agent] 04/12/25 - 18:34:51.169353 :ec_enrollee.cpp:1085: INFO: Enrollee bSTA Configuration Request object:
{
	"netRole":	"mapAgent",
	"wi-fi_tech":	"map",
	"name":	"unified-agent",
	"bSTAList":	[{
			"netRole":	"mapBackhaulSta",
			"akm":	"000FAC02",
			"bSTA_Maximum_Links":	1,
			"RadioList":	[{
					"RUID":	"000000000000",
					"RadioChannelList":	""
				}, {
					"RUID":	"000000000000",
					"RadioChannelList":	""
				}],
			"channelList":	""
		}]
}
[onewifi_em_agent] 04/12/25 - 18:34:51.170674 :em_agent.cpp:753: INFO: Sending action frame: VAP Idx (0), Dest (1c:bf:ce:fc:21:76), Frequency (2437), Dwell Time (0)
[onewifi_em_agent] 04/12/25 - 18:34:51.173941 :ec_enrollee.cpp:463: INFO: Sent DPP Configuration Request 802.11 frame to Proxy Agent!
```


