### PR TITLE
Fixes Controller/Agent Build Failures when `WITH_SAP` is enabled.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ install/bin/
 .clang-format
 *.log
 DPPURI_sendable.json
+*.a

--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -54,7 +54,7 @@ LIBDIRS = \
 	-L$(INSTALLDIR)/lib \
     -L$(ONEWIFI_HOME)/install/lib/
 ifeq ($(WITH_SAP), 1)
-LIBDIRS += -L$(AL_SAP_HOME)/build/lib
+LIBDIRS += -L$(AL_SAP_HOME)/
 endif
 
 LIBS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwebconfig -lhebus

--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -56,7 +56,7 @@ LIBDIRS = \
 	-L$(INSTALLDIR)/lib \
 	-L$(ONEWIFI_HOME)/install/lib/
 ifeq ($(WITH_SAP), 1)
-LIBDIRS += -L$(AL_SAP_HOME)/build/lib
+LIBDIRS += -L$(AL_SAP_HOME)/
 endif
 
 LIBS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lmysqlcppconn -lhebus

--- a/inc/al_service_registration_enums.h
+++ b/inc/al_service_registration_enums.h
@@ -5,8 +5,8 @@
 
 //keeps operation state
 enum class ServiceOperation : uint8_t {
-    ENABLE = 0x01, 
-    DISABLE = 0x02
+    SOP_ENABLE = 0x01, 
+    SOP_DISABLE = 0x02
 };
 //keeps the service type requested to the IEEE1905 layer
 enum class ServiceType : uint8_t {

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -43,7 +43,7 @@
 
 #include <vector>
 #ifdef AL_SAP
-#include "al_service_access_point.hpp"
+#include "al_service_access_point.h"
 #endif
 
 #define RETRY_SLEEP_INTERVAL_IN_MS 1000
@@ -1435,7 +1435,7 @@ AlServiceAccessPoint* em_agent_t::al_sap_register()
 {
     AlServiceAccessPoint* sap = new AlServiceAccessPoint(SOCKET_PATH);
 
-    AlServiceRegistrationRequest registrationRequest(ServiceOperation::SO_ENABLE, ServiceType::SAP_TUNNEL_CLIENT);
+    AlServiceRegistrationRequest registrationRequest(ServiceOperation::SOP_ENABLE, ServiceType::SAP_TUNNEL_CLIENT);
     sap->serviceAccessPointRegistrationRequest(registrationRequest);
 
     AlServiceRegistrationResponse registrationResponse = sap->serviceAccessPointRegistrationResponse();

--- a/src/al-sap/al_service_access_point.cpp
+++ b/src/al-sap/al_service_access_point.cpp
@@ -83,7 +83,7 @@ void AlServiceAccessPoint::serviceAccessPointDataRequest(AlServiceDataUnit& mess
     size_t totalSize = payload.size();
 
     //first condition to check if the service has been correctly registered enable
-    if (registrationRequest.getServiceOperation() == ServiceOperation::ENABLE || registrationResponse.getResult() == RegistrationResult::SUCCESS) {
+    if (registrationRequest.getServiceOperation() == ServiceOperation::SOP_ENABLE || registrationResponse.getResult() == RegistrationResult::SUCCESS) {
          
         // If payload size is less than or equal to 1500, send directly without fragmentation
         if (totalSize <= fragmentSize) {
@@ -139,7 +139,7 @@ void AlServiceAccessPoint::serviceAccessPointDataRequest(AlServiceDataUnit& mess
     #endif
     std::cout << "Cannot send data: Registration unsuccessful." << std::endl;
     throw AlServiceException("Registration unsuccessful", PrimitiveError::RegistrationError);
-    } else if (registrationRequest.getServiceOperation() != ServiceOperation::ENABLE) {
+    } else if (registrationRequest.getServiceOperation() != ServiceOperation::SOP_ENABLE) {
         #ifdef DEBUG_MODE
         // If the service operation is not enabled
         std::cout << "Cannot send data: Service operation not enabled." << std::endl;

--- a/src/al-sap/al_service_registration_request.cpp
+++ b/src/al-sap/al_service_registration_request.cpp
@@ -9,7 +9,7 @@ AlServiceRegistrationRequest::AlServiceRegistrationRequest(ServiceOperation oper
 
 // Default constructor
 AlServiceRegistrationRequest::AlServiceRegistrationRequest()
-    : serviceOperation(ServiceOperation::ENABLE), serviceType(ServiceType::SAP_TUNNEL_CLIENT) {}
+    : serviceOperation(ServiceOperation::SOP_ENABLE), serviceType(ServiceType::SAP_TUNNEL_CLIENT) {}
 
 // Setter for service operation
 void AlServiceRegistrationRequest::setServiceOperation(ServiceOperation service) {

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -46,7 +46,7 @@
 #include "util.h"
 
 #ifdef AL_SAP
-#include "al_service_access_point.hpp"
+#include "al_service_access_point.h"
 #endif
 
 em_ctrl_t g_ctrl;
@@ -842,7 +842,7 @@ AlServiceAccessPoint* em_ctrl_t::al_sap_register()
 {
     AlServiceAccessPoint* sap = new AlServiceAccessPoint(SOCKET_PATH);
 
-    AlServiceRegistrationRequest registrationRequest(ServiceOperation::SO_ENABLE, ServiceType::SAP_TUNNEL_CLIENT);
+    AlServiceRegistrationRequest registrationRequest(ServiceOperation::SOP_ENABLE, ServiceType::SAP_TUNNEL_CLIENT);
     sap->serviceAccessPointRegistrationRequest(registrationRequest);
 
     AlServiceRegistrationResponse registrationResponse = sap->serviceAccessPointRegistrationResponse();

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -52,7 +52,7 @@
 #include "util.h"
 
 #ifdef AL_SAP
-#include "al_service_access_point.hpp"
+#include "al_service_access_point.h"
 
 extern AlServiceAccessPoint* g_sap;
 extern MacAddress g_al_mac_sap;

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -47,7 +47,7 @@
 #include "util.h"
 
 #ifdef AL_SAP
-#include "al_service_access_point.hpp"
+#include "al_service_access_point.h"
 
 extern char *global_netid;
 extern AlServiceAccessPoint* g_sap;


### PR DESCRIPTION
- Fixes include path in `AL SAP` files
- Fixes collision with macro defined in `wifi_hal_generic.h`
- Corrects the path for the `libsap.a` library when building the controller and agent.