### PR TITLE
RDKBACCL-706 : Observing uwm build errors in latest code sync

### DIFF
--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -44,6 +44,7 @@
 #include "dm_easy_mesh.h"
 #include "em_orch_ctrl.h"
 #include "util.h"
+#include "wifi_util.h"
 
 #ifdef AL_SAP
 #include "al_service_access_point.h"


### PR DESCRIPTION
Reason for change:  Errors are mentioned as below, ../../../git/inc/em_base.h:2243:35: error: 'WIFI_AP_MAX_VENDOR_IE_LEN' was not declared in this scope; did you mean 'WIFI_AP_MAX_WPSPIN_LEN'?
|  2243 |     unsigned char vendor_elements[WIFI_AP_MAX_VENDOR_IE_LEN];
|       |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~
|       |                                   WIFI_AP_MAX_WPSPIN_LEN

../../../git/src/ctrl/../../src/ctrl/em_ctrl.cpp:883:6: error: variable or field 'wifi_util_print' declared void
  883 | void wifi_util_print(wifi_log_level_t level, wifi_dbg_type_t module, char *format, ...)

./../../git/src/ctrl/../../src/ctrl/em_ctrl.cpp:883:22: error: 'wifi_log_level_t' was not declared in this scope; did you mean 'wifi_csi_dev_t'?
  883 | void wifi_util_print(wifi_log_level_t level, wifi_dbg_type_t module, char *format, ...)
      |                      ^~~~~~~~~~~~~~~~
      |                      wifi_csi_dev_t
../../../git/src/ctrl/../../src/ctrl/em_ctrl.cpp:883:46: error: 'wifi_dbg_type_t' was not declared in this scope; did you mean 'wifi_ru_type_t'?
  883 | void wifi_util_print(wifi_log_level_t level, wifi_dbg_type_t module, char *format, ...)
      |                                              ^~~~~~~~~~~~~~~
      |                                              wifi_ru_type_t

Test Procedure: Able to compile uwm without build errors
Risks: Low