### PR TITLE
RDKBACCL-697 : UWM integration in BPI platform

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,19 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+SUBDIRS = src

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,62 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+#                                              -*- Autoconf -*-
+# Process this file with autoconf to produce configure script.
+#
+ 
+AC_PREREQ([2.65])
+AC_INIT([unified-wifi-mesh], [1.0], [BUG-REPORT-ADDRESS])
+AM_INIT_AUTOMAKE([subdir-objects foreign ])
+LT_INIT
+ 
+AC_PREFIX_DEFAULT(`pwd`)
+AC_ENABLE_SHARED
+AC_DISABLE_STATIC
+ 
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIR([m4])
+ 
+# Checks for programs.
+AC_PROG_CC
+AC_PROG_CXX
+AC_PROG_INSTALL
+AM_PROG_CC_C_O
+AM_PROG_LIBTOOL(libtool)
+ 
+# Checks for header files.
+AC_CHECK_HEADERS([stdlib.h string.h unistd.h])
+ 
+# Checks for typedefs, structures, and compiler characteristics.
+AC_HEADER_STDBOOL
+AC_C_INLINE
+ 
+# Checks for library functions.
+AC_FUNC_MALLOC
+ 
+AC_CONFIG_FILES(
+    src/cli/Makefile
+    src/ctrl/Makefile
+    src/agent/Makefile
+    src/Makefile
+    Makefile
+)
+ 
+ 
+AC_OUTPUT
+ 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,0 +1,20 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+SUBDIRS = cli ctrl agent
+ 

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -1,0 +1,128 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+AM_CFLAGS = -D_ANSC_LINUX
+AM_CFLAGS += -D_ANSC_USER
+AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
+
+ACLOCAL_AMFLAGS = -I m4
+hardware_platform = i686-linux-gnu
+bin_PROGRAMS = onewifi_em_agent
+
+onewifi_em_agent_CPPFLAGS = \
+    -I$(top_srcdir)/inc \
+    -I$(top_srcdir)/src/utils \
+    -I$(top_srcdir)/src/util \
+    -I$(top_srcdir)/src/util_crypto \
+    -I$(top_srcdir)/OneWifi/lib/log \
+    -I$(top_srcdir)/OneWifi/source/platform/common \
+    -I$(top_srcdir)/OneWifi/source/platform/rdkb \
+    -I$(top_srcdir)/OneWifi/source/ccsp \
+    -I$(top_srcdir)/OneWifi/lib/ds
+
+onewifi_em_agent_SOURCES =  \
+     $(top_srcdir)/src/em/em.cpp \
+     $(top_srcdir)/src/em/em_mgr.cpp \
+     $(top_srcdir)/src/em/em_msg.cpp \
+     $(top_srcdir)/src/em/em_onewifi.cpp \
+     $(top_srcdir)/src/em/em_sm.cpp \
+     $(top_srcdir)/src/em/em_net_node.cpp \
+     $(top_srcdir)/src/em/config/em_configuration.cpp \
+     $(top_srcdir)/src/em/prov/em_provisioning.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_configurator.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_crypto.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_ctrl_configurator.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_enrollee.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_manager.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_pa_configurator.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_util.cpp \
+     $(top_srcdir)/src/em/disc/em_discovery.cpp \
+     $(top_srcdir)/src/em/channel/em_channel.cpp  \
+     $(top_srcdir)/src/em/capability/em_capability.cpp \
+     $(top_srcdir)/src/em/metrics/em_metrics.cpp \
+     $(top_srcdir)/src/em/steering/em_steering.cpp \
+     $(top_srcdir)/src/em/policy_cfg/em_policy_cfg.cpp \
+     $(top_srcdir)/src/em/crypto/em_crypto.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_ap_cap.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_cfg_renew.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_channel_pref_query.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_client_cap.cpp \
+     $(top_srcdir)/src/cmd/em_cmd.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_dev_init.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_dev_test.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_em_config.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_exec.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_channel.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_device.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_network.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_radio.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_ssid.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_onewifi_cb.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_op_channel_report.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_remove_device.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_reset.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_scan_channel.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_channel.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_policy.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_radio.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_ssid.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_assoc.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_disassoc.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_link_metrics.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_list.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_start_dpp.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_steer.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_topo_sync.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_scan_result.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_btm_report.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_beacon_report.cpp \
+     $(top_srcdir)/src/agent/dm_easy_mesh_agent.cpp \
+     $(top_srcdir)/src/agent/em_agent.cpp \
+     $(top_srcdir)/src/agent/em_cmd_agent.cpp \
+     $(top_srcdir)/src/agent/em_simulator.cpp \
+     $(top_srcdir)/src/dm/dm_ap_mld.cpp \
+     $(top_srcdir)/src/dm/dm_cac_comp.cpp \
+     $(top_srcdir)/src/dm/dm_easy_mesh.cpp \
+     $(top_srcdir)/src/dm/dm_network.cpp \
+     $(top_srcdir)/src/dm/dm_op_class.cpp \
+     $(top_srcdir)/src/dm/dm_radio_cap.cpp \
+     $(top_srcdir)/src/dm/dm_bss.cpp \
+     $(top_srcdir)/src/dm/dm_device.cpp \
+     $(top_srcdir)/src/dm/dm_dpp.cpp \
+     $(top_srcdir)/src/dm/dm_ieee_1905_security.cpp \
+     $(top_srcdir)/src/dm/dm_network_ssid.cpp \
+     $(top_srcdir)/src/dm/dm_policy.cpp \
+     $(top_srcdir)/src/dm/dm_scan_result.cpp \
+     $(top_srcdir)/src/dm/dm_radio.cpp \
+     $(top_srcdir)/src/dm/dm_sta.cpp \
+     $(top_srcdir)/src/dm/dm_tid_to_link.cpp \
+     $(top_srcdir)/src/dm/dm_bsta_mld.cpp \
+     $(top_srcdir)/src/dm/dm_assoc_sta_mld.cpp \
+     $(top_srcdir)/src/orch/em_orch.cpp  \
+     $(top_srcdir)/src/orch/em_orch_agent.cpp \
+     $(top_srcdir)/OneWifi/source/platform/rdkb/bus.c \
+     $(top_srcdir)/OneWifi/source/platform/common/bus_common.c \
+     $(top_srcdir)/OneWifi/lib/common/util.c \
+     $(top_srcdir)/OneWifi/source/utils/collection.c \
+     $(top_srcdir)/src/utils/util.cpp \
+     $(top_srcdir)/src/util_crypto/aes_siv.c
+
+
+onewifi_em_agent_LDFLAGS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwifi_webconfig -lrbus

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -1,0 +1,3 @@
+
+build:
+	go build -o ./onewifi_em_cli *.go

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -1,0 +1,93 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+AM_CFLAGS = -D_ANSC_LINUX
+AM_CFLAGS += -D_ANSC_USER
+AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
+ 
+ACLOCAL_AMFLAGS = -I m4
+hardware_platform = i686-linux-gnu
+lib_LTLIBRARIES=libemcli.la
+ 
+libemcli_la_CPPFLAGS = \
+    -I$(top_srcdir)/inc \
+    -I$(top_srcdir)/src/utils \
+    -I$(top_srcdir)/src/util
+ 
+libemcli_la_CPPFLAGS += -g -fPIC
+ 
+libemcli_la_SOURCES = \
+ $(top_srcdir)/src/cli/em_cli.cpp \
+ $(top_srcdir)/src/cli/em_cmd_cli.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_ap_cap.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_cfg_renew.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_channel_pref_query.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_client_cap.cpp \
+ $(top_srcdir)/src/cmd/em_cmd.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_dev_init.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_dev_test.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_em_config.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_exec.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_get_channel.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_get_device.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_get_network.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_get_radio.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_get_ssid.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_onewifi_cb.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_op_channel_report.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_remove_device.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_reset.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_scan_channel.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_set_channel.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_set_policy.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_set_radio.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_set_ssid.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_sta_assoc.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_sta_disassoc.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_sta_link_metrics.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_sta_list.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_start_dpp.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_sta_steer.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_topo_sync.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_beacon_report.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
+ $(top_srcdir)/src/dm/dm_device.cpp \
+ $(top_srcdir)/src/dm/dm_ieee_1905_security.cpp \
+ $(top_srcdir)/src/dm/dm_easy_mesh.cpp  \
+ $(top_srcdir)/src/dm/dm_radio.cpp \
+ $(top_srcdir)/src/dm/dm_bss.cpp \
+ $(top_srcdir)/src/dm/dm_dpp.cpp \
+ $(top_srcdir)/src/dm/dm_network_ssid.cpp \
+ $(top_srcdir)/src/dm/dm_network.cpp \
+ $(top_srcdir)/src/dm/dm_op_class.cpp \
+ $(top_srcdir)/src/dm/dm_policy.cpp \
+ $(top_srcdir)/src/dm/dm_sta.cpp \
+ $(top_srcdir)/src/dm/dm_radio_cap.cpp \
+ $(top_srcdir)/src/dm/dm_cac_comp.cpp \
+ $(top_srcdir)/src/dm/dm_ap_mld.cpp \
+ $(top_srcdir)/src/dm/dm_bsta_mld.cpp \
+ $(top_srcdir)/src/dm/dm_assoc_sta_mld.cpp \
+ $(top_srcdir)/src/dm/dm_tid_to_link.cpp \
+ $(top_srcdir)/src/dm/dm_scan_result.cpp \
+ $(top_srcdir)/src/em/em_net_node.cpp \
+ $(top_srcdir)/src/em/crypto/em_crypto.cpp \
+ $(top_srcdir)/src/utils/util.cpp \
+ $(top_srcdir)/src/em/prov/easyconnect/ec_util.cpp \
+ $(top_srcdir)/src/util_crypto/aes_siv.c \
+ $(top_srcdir)/OneWifi/source/utils/collection.c

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -1,0 +1,146 @@
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+AM_CFLAGS = -D_ANSC_LINUX
+AM_CFLAGS += -D_ANSC_USER
+AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
+ 
+ACLOCAL_AMFLAGS = -I m4
+hardware_platform = i686-linux-gnu
+bin_PROGRAMS = onewifi_em_ctrl
+ 
+onewifi_em_ctrl_CPPFLAGS = \
+    -I$(top_srcdir)/inc \
+    -I$(top_srcdir)/src/utils \
+    -I$(top_srcdir)/src/util \
+    -I$(top_srcdir)/src/util_crypto \
+    -I$(top_srcdir)/OneWifi/include \
+    -I$(top_srcdir)/OneWifi/lib/log  \
+    -I$(top_srcdir)/OneWifi/lib/ds  \
+    -I$(top_srcdir)/OneWifi/source/utils \
+    -I$(top_srcdir)/OneWifi/source/platform/rdkb \
+    -I$(top_srcdir)/OneWifi/source/platform/common \
+    -DUNIT_TEST
+
+onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Werror -O2
+
+onewifi_em_ctrl_SOURCES =  \
+     $(top_srcdir)/src/em/em.cpp \
+     $(top_srcdir)/src/em/em_mgr.cpp \
+     $(top_srcdir)/src/em/em_msg.cpp \
+     $(top_srcdir)/src/em/em_onewifi.cpp \
+     $(top_srcdir)/src/em/em_sm.cpp \
+     $(top_srcdir)/src/em/em_net_node.cpp \
+     $(top_srcdir)/src/em/config/em_configuration.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_configurator.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_crypto.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_ctrl_configurator.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_enrollee.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_manager.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_pa_configurator.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_util.cpp \
+     $(top_srcdir)/src/em/prov/em_provisioning.cpp \
+     $(top_srcdir)/src/em/disc/em_discovery.cpp \
+     $(top_srcdir)/src/em/channel/em_channel.cpp  \
+     $(top_srcdir)/src/em/capability/em_capability.cpp \
+     $(top_srcdir)/src/em/metrics/em_metrics.cpp \
+     $(top_srcdir)/src/em/steering/em_steering.cpp \
+     $(top_srcdir)/src/em/policy_cfg/em_policy_cfg.cpp \
+     $(top_srcdir)/src/em/crypto/em_crypto.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_ap_cap.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_cfg_renew.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_channel_pref_query.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_client_cap.cpp \
+     $(top_srcdir)/src/cmd/em_cmd.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_dev_init.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_dev_test.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_em_config.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_exec.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_channel.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_device.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_network.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_radio.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_ssid.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_onewifi_cb.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_op_channel_report.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_remove_device.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_reset.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_scan_channel.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_channel.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_policy.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_radio.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_ssid.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_assoc.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_disassoc.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_link_metrics.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_list.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_start_dpp.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_sta_steer.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_topo_sync.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_beacon_report.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
+     $(top_srcdir)/src/ctrl/dm_easy_mesh_ctrl.cpp \
+     $(top_srcdir)/src/ctrl/em_cmd_ctrl.cpp \
+     $(top_srcdir)/src/ctrl/em_ctrl.cpp \
+     $(top_srcdir)/src/ctrl/em_network_topo.cpp \
+     $(top_srcdir)/src/db/db_client.cpp \
+     $(top_srcdir)/src/db/db_column.cpp \
+     $(top_srcdir)/src/db/db_easy_mesh.cpp \
+     $(top_srcdir)/src/dm/dm_ap_mld.cpp \
+     $(top_srcdir)/src/dm/dm_cac_comp.cpp \
+     $(top_srcdir)/src/dm/dm_easy_mesh.cpp \
+     $(top_srcdir)/src/dm/dm_network.cpp \
+     $(top_srcdir)/src/dm/dm_op_class.cpp \
+     $(top_srcdir)/src/dm/dm_radio_cap.cpp \
+     $(top_srcdir)/src/dm/dm_ssid_2_vid_map.cpp \
+     $(top_srcdir)/src/dm/dm_bss.cpp \
+     $(top_srcdir)/src/dm/dm_bss_list.cpp \
+     $(top_srcdir)/src/dm/dm_bsta_mld.cpp \
+     $(top_srcdir)/src/dm/dm_device.cpp \
+     $(top_srcdir)/src/dm/dm_device_list.cpp \
+     $(top_srcdir)/src/dm/dm_dpp.cpp \
+     $(top_srcdir)/src/dm/dm_easy_mesh_list.cpp \
+     $(top_srcdir)/src/dm/dm_ieee_1905_security.cpp \
+     $(top_srcdir)/src/dm/dm_ieee_1905_security_list.cpp \
+     $(top_srcdir)/src/dm/dm_network_list.cpp \
+     $(top_srcdir)/src/dm/dm_network_ssid.cpp \
+     $(top_srcdir)/src/dm/dm_network_ssid_list.cpp \
+     $(top_srcdir)/src/dm/dm_op_class_list.cpp \
+     $(top_srcdir)/src/dm/dm_policy.cpp \
+     $(top_srcdir)/src/dm/dm_policy_list.cpp \
+     $(top_srcdir)/src/dm/dm_radio_cap_list.cpp \
+     $(top_srcdir)/src/dm/dm_radio.cpp \
+     $(top_srcdir)/src/dm/dm_radio_list.cpp \
+     $(top_srcdir)/src/dm/dm_sta.cpp \
+     $(top_srcdir)/src/dm/dm_sta_list.cpp \
+     $(top_srcdir)/src/dm/dm_tid_to_link.cpp \
+     $(top_srcdir)/src/dm/dm_assoc_sta_mld.cpp \
+     $(top_srcdir)/src/dm/dm_scan_result.cpp \
+     $(top_srcdir)/src/dm/dm_scan_result_list.cpp \
+     $(top_srcdir)/src/orch/em_orch.cpp  \
+     $(top_srcdir)/src/orch/em_orch_ctrl.cpp \
+     $(top_srcdir)/src/util_crypto/aes_siv.c \
+     $(top_srcdir)/src/utils/util.cpp \
+     $(top_srcdir)/OneWifi/source/utils/collection.c \
+     $(top_srcdir)/OneWifi/lib/common/util.c \
+     $(top_srcdir)/OneWifi/source/platform/rdkb/bus.c \ 
+     $(top_srcdir)/OneWifi/source/platform/common/bus_common.c
+ 
+ 
+onewifi_em_ctrl_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lmysqlcppconn -lrbus -fsanitize=address -fsanitize=undefined
+


### PR DESCRIPTION
Reason for change:  Added required Makefile and configure file changes to compile uwm in bpi platform.
Test Procedure: Able to generate em ctrl and agent binaries and emcli library.
SRCREV tested with  3c443368ef032665e7177761ca10c5620dacf485
Risks: Low