### PR TITLE
WIP: Toggle CCE on DPP start and subscribe to CCE IEs from OneWifi

### DIFF
--- a/inc/ec_enrollee.h
+++ b/inc/ec_enrollee.h
@@ -129,7 +129,14 @@ public:
 	 */
 	bool handle_gas_initial_response(ec_gas_initial_response_frame_t *frame, size_t len, uint8_t src_mac[ETH_ALEN]);
 
-    
+	/**
+	 * @brief Add a new frequency to send Presence Announcement frames on
+	 * 
+	 * @param freq The frequency to add
+	 * @return true on success, otherwise falses
+	 */
+	bool add_presence_announcement_freq(unsigned int freq);
+
 	/**!
 	 * @brief Tears down the existing connection by freeing associated resources.
 	 *

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -58,7 +58,13 @@ public:
 	 */
 	bool handle_recv_ec_action_frame(ec_frame_t* frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN]);
 
-
+	/**
+	 * @brief Tell Enrollee that we heard a CCE IE on `freq` so it should add `freq` to it's Presence Announcement frequency list
+	 * 
+	 * @param freq The frequency that a CCE IE was heard on
+	 * @return true on success, otherwise false
+	 */
+	bool handle_cce_ind_frequency(unsigned int freq);
     
 	/**!
 	 * @brief Handles the reception of a GAS public action frame.

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -247,6 +247,8 @@ class em_agent_t : public em_mgr_t {
 	 */
 	void handle_recv_gas_frame(em_bus_event_t *evt);
 
+	void handle_recv_cce_ind(em_bus_event_t *event);
+
 public:
 
     bus_handle_t m_bus_hdl;
@@ -793,6 +795,16 @@ public:
 	 * @note Ensure that the data pointer is valid before accessing its contents.
 	 */
 	static int beacon_report_cb(char *event_name, raw_data_t *data, void *userData);
+
+	/**
+	 * @brief Callback for handling CCE indication information elements heard in a Beacon
+	 * 
+	 * @param event_name The name of the event.
+	 * @param data The raw data of the event
+	 * @param userData User-data passed to the callback
+	 * @return int 0 on success, otherwise -1
+	 */
+	static int cce_indication_ie_cb(char *event_name, raw_data_t *data, void *userData);
     
 	/**!
 	 * @brief Retrieves the associated data for the given input.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -610,6 +610,10 @@ typedef struct {
 }__attribute__((__packed__)) em_dpp_bootstrap_uri_t;
 
 typedef struct {
+    uint8_t advertise_cce; // 1->Enable, 0->Disable
+} __attribute__((__packed__)) em_cce_indication_t;
+
+typedef struct {
     unsigned char enrollee_mac_addr_present : 1;
     unsigned char reserved : 1;
     unsigned char dpp_frame_indicator : 1;
@@ -2591,6 +2595,7 @@ typedef enum {
     em_bus_event_type_recv_wfa_action_frame,
     em_bus_event_type_recv_gas_frame,
     em_bus_event_type_get_sta_client_type,
+    em_bus_event_type_recv_cce_ind_msg,
 
     em_bus_event_type_max
 } em_bus_event_type_t;

--- a/inc/em_provisioning.h
+++ b/inc/em_provisioning.h
@@ -34,6 +34,7 @@ class em_provisioning_t {
 	 * This function is responsible for creating a CCE indication message and storing it in the provided buffer.
 	 *
 	 * @param[out] buff Pointer to the buffer where the CCE indication message will be stored.
+	 * @param enable Enable/disable CCE indication
 	 *
 	 * @returns int Status code indicating success or failure of the message creation.
 	 * @retval 0 Success
@@ -41,23 +42,7 @@ class em_provisioning_t {
 	 *
 	 * @note Ensure the buffer is properly allocated before calling this function.
 	 */
-	int create_cce_ind_msg(uint8_t *buff);
-    
-	/**!
-	 * @brief Creates a CCE indication command.
-	 *
-	 * This function is responsible for creating a CCE (Common Channel Element) indication command and storing it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the CCE indication command will be stored.
-	 *
-	 * @returns int
-	 * @retval 0 on success
-	 * @retval -1 on failure
-	 *
-	 * @note Ensure that the buffer is properly allocated before calling this function.
-	 */
-	int create_cce_ind_cmd(uint8_t *buff);
-    
+	int create_cce_ind_msg(uint8_t *buff, bool enable);
     
 	/**!
 	 * @brief Creates a BSS configuration request message.

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -754,6 +754,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
 
         case em_msg_type_chirp_notif:
         case em_msg_type_proxied_encap_dpp:
+        case em_msg_type_dpp_cce_ind:
             // TODO: Add more types and might have to work on addressing more
 	        em = al_em;
 	        break;

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -1292,3 +1292,10 @@ ec_gas_comeback_request_frame_t *ec_enrollee_t::create_comeback_request(uint8_t 
     if (frame == nullptr || len == 0) return nullptr;
     return reinterpret_cast<ec_gas_comeback_request_frame_t*>(frame);
 }
+
+bool ec_enrollee_t::add_presence_announcement_freq(unsigned int freq)
+{
+    m_pres_announcement_freqs.insert(static_cast<uint32_t>(freq));
+    em_printfout("Added %d to list of Presesnce Announcement frequencies from CCE IE", freq);
+    return true;
+}

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -126,6 +126,16 @@ bool ec_manager_t::handle_recv_gas_pub_action_frame(ec_gas_frame_base_t *frame, 
     return did_succeed;
 }
 
+bool ec_manager_t::handle_cce_ind_frequency(unsigned int freq)
+{
+    if (!m_enrollee) {
+        em_printfout("New frequency from CCE IE, but no Enrollee");
+        // This is fine
+        return true;
+    }
+    return m_enrollee->add_presence_announcement_freq(freq);
+}
+
 bool ec_manager_t::upgrade_to_onboarded_proxy_agent()
 {
     if (m_is_controller) {

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -45,19 +45,14 @@
 #include "util.h"
 #include "ec_util.h"
 
-int em_provisioning_t::create_cce_ind_cmd(uint8_t *buff)
-{
-    return 0;
-}
-
-int em_provisioning_t::create_cce_ind_msg(uint8_t *buff)
+int em_provisioning_t::create_cce_ind_msg(uint8_t *buff, bool enable)
 {
     uint16_t  msg_id = em_msg_type_dpp_cce_ind;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
     uint8_t *tmp = buff;
-    uint16_t enable = 0;
+    uint8_t cce_enable = 0;
     uint16_t type = htons(ETH_P_1905);
 
     memcpy(tmp, reinterpret_cast<uint8_t *> (get_peer_mac()), sizeof(mac_address_t));
@@ -85,9 +80,8 @@ int em_provisioning_t::create_cce_ind_msg(uint8_t *buff)
     // One DPP CCE Indication tlv 17.2.82
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_dpp_cce_indication;
-    //enable = (get_state() == em_state_agent_prov) ? 1:0;
-	enable = (get_state() == em_state_agent_configured) ? 1:0;
-    memcpy(tlv->value, &enable, sizeof(uint16_t));
+    cce_enable = (enable ? 1 : 0); 
+    memcpy(tlv->value, &cce_enable, sizeof(uint8_t));
     tlv->len = htons(sizeof(uint16_t));
 
     tmp += (sizeof(em_tlv_t) + sizeof(uint16_t));
@@ -407,49 +401,34 @@ int em_provisioning_t::create_dpp_direct_encap_msg(uint8_t *buff, uint8_t *frame
 
 int em_provisioning_t::handle_cce_ind_msg(uint8_t *buff, unsigned int len)
 {
-    em_tlv_t    *tlv;
-    unsigned int tmp_len;
-    int ret = 0;
-    unsigned int rq_ctr = 0, rx_ctr = 0;
-    //uint8_t msg[MAX_EM_BUFF_SZ]; commented since not used
-    //unsigned int sz;  commented since sz not used
+    em_tlv_t *tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
 
-    // mandatory need 17.2.82
-    rq_ctr = 1;
+    bool enable = false;
+    bool valid_tlv = false;
 
-    em_printfout("Parsing cce ind message");
-
-    tlv = reinterpret_cast<em_tlv_t *> (buff); tmp_len = len;
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if ((tlv->type == em_tlv_type_dpp_cce_indication) && (htons(tlv->len) == sizeof(uint16_t))) {
-            em_printfout("validated cce ind tlv");
-            rx_ctr++;
+    while ((tlv->type != em_tlv_type_eom)) {
+        if (tlv->type == em_tlv_type_dpp_cce_indication) {
+            em_cce_indication_t *cce_ind_tlv = reinterpret_cast<em_cce_indication_t *>(tlv->value);
+            enable = static_cast<bool>(cce_ind_tlv->advertise_cce);
+            valid_tlv = true;
+            break;
         }
-
-        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<uint8_t *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<uint8_t *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
-    if (rx_ctr != rq_ctr) {
-        em_printfout("cce ind message parsing failed");
+    if (!valid_tlv) {
+        em_printfout("Received a DPP CCE Indication Message but did not contain DPP CCE Indication TLV!");
         return -1;
     }
 
-    // if this is a proxy agent (must be provisioned) , ask onewifi to beacon cce otherwise send presence announcement
-    if (get_state() > em_state_agent_configured) {
-        //sz = static_cast<unsigned int> (create_cce_ind_cmd(msg)); commented since sz not used
-        //ret = send_cmd(msg, sz); // Modify send_cmd
-        if (ret > 0) {
-            em_printfout("cmd send success");
-            //set_state(em_state_agent_auth_req_pending);
-        } else {
-            em_printfout("cmd send failed, error:%d", errno);
-        }
+    bool cce_toggled = m_ec_manager->pa_cfg_toggle_cce(enable);
+    if (!cce_toggled) {
+        em_printfout("Could not toggle CCE to %d", static_cast<int>(enable));
+        return -1;
     }
 
-    return ret;
-
+    em_printfout("Successfully %s CCE in Beacons and Probe Responses", (enable == true ? "enabled" : "disabled"));
+    return 0;
 }
 
 void em_provisioning_t::process_msg(uint8_t *data, unsigned int len)


### PR DESCRIPTION
1. Toggle CCE IE injection into beacons when DPP starts
2. Subscribe to OneWifi easyconnect app to build additional frequencies where CCE IE is heard for Enrollee Presence Announcement channel list
