### PR TITLE
Add subscription to CCE IEs from OneWifi EasyConnect app

### DIFF
--- a/inc/ec_enrollee.h
+++ b/inc/ec_enrollee.h
@@ -167,6 +167,14 @@ public:
 	ec_enrollee_t(const ec_enrollee_t&) = delete;
     ec_enrollee_t& operator=(const ec_enrollee_t&) = delete;
 
+	/**
+	 * @brief Adds a frequency to send Presence Announcement frames on
+	 * 
+	 * @param freq The new frequency to add 
+	 * @return true on success, false otherwise
+	 */
+	bool add_presence_announcement_freq(unsigned int freq);
+
 private:
 
     

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -206,6 +206,15 @@ public:
 	 */
 	inline bool is_enrollee_onboarding() { return m_is_e_onboarding; }
 
+	/**
+	 * @brief Handle a CCE information element being heard
+	 * (add the frequency the CCE IE was heard on to Enrollee's list of Presence Announcement frequencies)
+	 * 
+	 * @param freq The frequency that a CCE IE was heard on
+	 * @return true on success, otherwise false
+	 */
+	bool handle_cce_ie(unsigned int freq);
+
 
 private:
     bool m_is_controller;

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -178,6 +178,13 @@ class em_agent_t : public em_mgr_t {
 	 * @note Ensure that the evt parameter is properly initialized before calling this function.
 	 */
 	void handle_recv_wfa_action_frame(em_bus_event_t *evt);
+
+	/**
+	 * @brief Handles the reception of CCE Information Element events
+	 * 
+	 * @param event The event containing the `bss_info_t` which heard the CCE IE in a beacon or probe response
+	 */
+	void handle_recv_cce_ie(em_bus_event_t *event);
     
 	/**!
 	 * @brief Handles the BTM response action frame.
@@ -793,6 +800,16 @@ public:
 	 * @note Ensure that the data pointer is valid before accessing its contents.
 	 */
 	static int beacon_report_cb(char *event_name, raw_data_t *data, void *userData);
+
+	/**
+	 * @brief Callback for a DPP CCE (Configurator Connectivity Element) being heard from OneWifi
+	 * 
+	 * @param event_name The name of the event
+	 * @param data The raw event data
+	 * @param userData User provided callback data
+	 * @return int 0 on success, otherwise -1
+	 */
+	static int cce_ie_cb(char *event_name, raw_data_t *data, void *userData);
     
 	/**!
 	 * @brief Retrieves the associated data for the given input.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2591,6 +2591,7 @@ typedef enum {
     em_bus_event_type_recv_wfa_action_frame,
     em_bus_event_type_recv_gas_frame,
     em_bus_event_type_get_sta_client_type,
+    em_bus_event_type_cce_ie,
 
     em_bus_event_type_max
 } em_bus_event_type_t;

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -322,6 +322,37 @@ void em_agent_t::handle_btm_request_action_frame(em_bus_event_t *evt)
     }
 }
 
+void em_agent_t::handle_recv_cce_ie(em_bus_event_t *event)
+{
+    if (event == nullptr) {
+        em_printfout("NULL event!");
+        return;
+    }
+    const size_t expected_size = sizeof(wifi_bss_info_t);
+    if (event->data_len > expected_size) {
+        em_printfout("Expected event of size %d, got %d, not handling", expected_size, event->data_len);
+        return;
+    }
+    wifi_bss_info_t *bss_info = reinterpret_cast<wifi_bss_info_t *>(event->u.raw_buff);
+    bool freq_ok = (bss_info->freq > 0);
+
+    if (!freq_ok) {
+        em_printfout("Heard a CCE information element on invalid frequency (%d), not handling", bss_info->freq);
+        return;
+    }
+
+    em_t *al_node = get_al_node();
+    if (al_node == nullptr) {
+        em_printfout("AL node is nullptr!");
+        return;
+    }
+
+    if (!al_node->m_ec_manager->handle_cce_ie(bss_info->freq)) {
+        em_printfout("EC manager failed to handle new frequency from a CCE IE!");
+        return;
+    }
+}
+
 void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
 {
     if (!evt) {
@@ -668,6 +699,10 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
             handle_recv_gas_frame(evt);
             break;
 
+        case em_bus_event_type_cce_ie:
+            handle_recv_cce_ie(evt);
+            break;
+
         default:
             break;
     }    
@@ -852,7 +887,31 @@ void em_agent_t::input_listener()
         return;
     }
 
+    for (int i = 0; i < MAX_NUM_RADIOS; i++) {
+        // OneWifi bus path is 1-indexed, here
+        std::string cce_ind_path = "Device.WiFi.Radio." + std::to_string(i + 1) + ".CCEInd";
+        em_printfout("Attempting to subscribe to '%s'", cce_ind_path.c_str());
+        if (desc->bus_event_subs_fn(&m_bus_hdl, cce_ind_path.c_str(), reinterpret_cast<void *>(&em_agent_t::cce_ie_cb), nullptr, 0) != 0) {
+            // Failing to subscribe to this path is OK, as in the context of DPP,
+            // an Enrollee has a default channel list defined by the EasyConnect spec,
+            // as well as a list of channels defined in its' DPP URI. So, just log and move on.
+            em_printfout("Failed to subscribe to '%s', dynamic DPP channel list generation unavailable.", cce_ind_path.c_str());
+            continue;
+        }
+    }
+
     io(NULL);
+}
+
+int em_agent_t::cce_ie_cb(char *event_name, raw_data_t *data, void *userData)
+{
+    if (data == nullptr) {
+        em_printfout("NULL data from OneWifi callback!");
+        return -1;
+    }
+    g_agent.io_process(em_bus_event_type_cce_ie, reinterpret_cast<unsigned char *>(data->raw_data.bytes), data->raw_data_len);
+    return 1;
+
 }
 
 int em_agent_t::channel_scan_cb(char *event_name, raw_data_t *data, void *userData)

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -1292,3 +1292,10 @@ ec_gas_comeback_request_frame_t *ec_enrollee_t::create_comeback_request(uint8_t 
     if (frame == nullptr || len == 0) return nullptr;
     return reinterpret_cast<ec_gas_comeback_request_frame_t*>(frame);
 }
+
+bool ec_enrollee_t::add_presence_announcement_freq(unsigned int freq)
+{
+    m_pres_announcement_freqs.insert(static_cast<uint32_t>(freq));
+    em_printfout("Added %d to list of Presence Announcement frequencies", freq);
+    return true;
+}

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -154,3 +154,13 @@ bool ec_manager_t::upgrade_to_onboarded_proxy_agent()
     em_printfout("Upgraded enrollee agent to proxy agent");
     return true;
 }
+
+bool ec_manager_t::handle_cce_ie(unsigned int freq)
+{
+    if (!m_enrollee) {
+        em_printfout("New Presence Announcement frequency heard from a CCE IE, but no Enrollee");
+        // This is fine
+        return true;
+    }
+    return m_enrollee->add_presence_announcement_freq(freq);
+}


### PR DESCRIPTION
Forward heard frequencies to Enrollee

Patch to OneWifi which injects artificial beacons containing a CCE IE:
```
diff --git a/source/core/wifi_ctrl.c b/source/core/wifi_ctrl.c
index 8e0c136..19d7ddc 100644
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -282,6 +282,60 @@ bool is_sta_enabled(void)
         ctrl->eth_bh_status == false);
 }
 
+#if 1
+static void send_fake_scan_event(wifi_ctrl_t *ctrl, int radio_index) {
+    wifi_bss_info_t *bss_info = malloc(sizeof(wifi_bss_info_t));
+    if (!bss_info) {
+        printf("Failed to allocate wifi_bss_info_t!\n");
+        return;
+    }
+    memset(bss_info, 0, sizeof(wifi_bss_info_t));
+    char ssid[32] = { 0 };
+    snprintf(ssid, sizeof(ssid), "TestSSID_%d", radio_index);
+    memcpy(bss_info->bssid, (uint8_t[]){0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, sizeof(bssid_t));
+    strncpy(bss_info->ssid, ssid, sizeof(bss_info->ssid));
+    bss_info->rssi = -45;
+    bss_info->freq = 5180; // 5 GHz channel 36 (USA)
+
+    // Construct CCE IE
+    uint8_t cce_ie[] = { 
+            0xDD, 0x04,            // Vendor-Specific IE ID (0xDD), Length (4)
+            0x50, 0x6F, 0x9A, 0x1E // Wi-Fi Alliance OUI (50:6F:9A), CCE Type 0x1E
+    };
+
+
+    memcpy(bss_info->ie, cce_ie, sizeof(cce_ie));
+    bss_info->ie_len = sizeof(cce_ie);
+    scan_results_t scan_result;
+    memset(&scan_result, 0, sizeof(scan_results_t));
+    scan_result.num = 1;
+    scan_result.radio_index = radio_index;
+    memcpy(&scan_result.bss[0], bss_info, sizeof(*bss_info));
+
+    // Allocate event structure
+    wifi_event_t *fake_event = malloc(sizeof(wifi_event_t));
+    if (!fake_event) {
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: Failed to allocate wifi_event_t!\n", __func__, __LINE__);
+        free(bss_info);
+        return;
+    }
+    memset(fake_event, 0, sizeof(wifi_event_t));
+
+    fake_event->u.core_data.msg = malloc(sizeof(scan_results_t));
+    if (!fake_event->u.core_data.msg) {
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: Failed to allocate scan_results_t!\n", __func__, __LINE__);
+        free(fake_event);
+        free(bss_info);
+        return;
+    }
+    memcpy(fake_event->u.core_data.msg, &scan_result, sizeof(scan_result));
+    fake_event->u.core_data.len = sizeof(scan_result);
+    fake_event->event_type = wifi_event_type_hal_ind;
+    fake_event->sub_type = wifi_event_scan_results;
+    apps_mgr_event(&ctrl->apps_mgr, fake_event);
+}
+#endif
+
 void ctrl_queue_loop(wifi_ctrl_t *ctrl)
 {
     struct timespec time_to_wait;
@@ -341,6 +395,14 @@ void ctrl_queue_loop(wifi_ctrl_t *ctrl)
                         break;
                 }
 
+
+                #if 1
+                    // Publish fake scan event on each radio
+                    for (int i = 0; i < getNumberRadios(); i++) {
+                        send_fake_scan_event(ctrl, i);
+                    }
+                #endif
+
                 if (event->event_type != wifi_event_type_webconfig) {
                     // now forward the event to apps manager
                     apps_mgr_event(&ctrl->apps_mgr, event);
```



`/rdklogs/logs/wifiEc.txt`:
```
[OneWifi] 250418-18:04:47.911917<D>  handle_wifi_event_scan_results:75: Got scan results on radio 0
[OneWifi] 250418-18:04:47.912033<D>  handle_wifi_event_scan_results:98: BSS TestSSID_0 Beacon and/or Probe Response from BSSID 00:11:22:33:44:55 contains WFA CCE IE!
[OneWifi] 250418-18:04:47.912569<D>  handle_wifi_event_scan_results:110 parsed and published 1 frames containing CCE IE
```

Enrollee callback / adding heard frequency to presence announcement list:
```
handle_state_config_none:3718: autoconfig_search send successful
handle_state_config_none:3718: autoconfig_search send successful
handle_state_config_none:3718: autoconfig_search send successful
handle_state_config_none:3718: autoconfig_search send successful
handle_state_config_none:3718: autoconfig_search send successful
handle_state_config_none:3718: autoconfig_search send successful
[onewifi_em_agent] 04/18/25 - 18:03:27.829223 :ec_enrollee.cpp:1299: INFO: Added 5180 to list of Presence Announcement frequencies
handle_state_config_none:3718: autoconfig_search send successful
handle_state_config_none:3718: autoconfig_search send successful
handle_state_config_none:3718: autoconfig_search send successful
handle_state_config_none:3718: autoconfig_search send successful
```