### PR TITLE
Add subscription for association status

### DIFF
--- a/inc/ec_enrollee.h
+++ b/inc/ec_enrollee.h
@@ -175,6 +175,18 @@ public:
 	 */
 	bool add_presence_announcement_freq(unsigned int freq);
 
+	/**
+	 * @brief Handles an association status event.
+	 * 
+	 * If this event maps to our bSTA's association attempt, check the association status and send a Configuration Status Result frame
+	 * 
+	 * If this event does NOT map to our bSTAs association attempt, just throw it away
+	 * 
+	 * @param sta_data The STA data containing association status
+	 * @return true on success, otherwise false
+	 */
+	bool handle_assoc_status(const rdk_sta_data_t &sta_data);
+
 private:
 
     
@@ -420,6 +432,13 @@ private:
 	// Key -> sender's MAC + dialog_token (example: aabbcceeddff_42) as a string
 	// Value -> buffer for re-assembling GAS frame fragments
 	std::unordered_map<std::string, gas_fragment_buffer_t> m_gas_fragments;
+
+	/**
+	 * @brief Map of BSSIDs (as strings) that we are awaiting association status for
+	 * Key: BSSID (as string)
+	 * Value: The MAC of the node we're trying to associate to
+	 */
+	std::unordered_map<std::string, mac_addr_t> m_awaiting_assoc_status = {};
 };
 
 #endif // EC_ENROLLEE_H

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -215,6 +215,14 @@ public:
 	 */
 	bool handle_cce_ie(unsigned int freq);
 
+	/**
+	 * @brief Handle an association status event (for the Enrollee's bSTA association attempt)
+	 * 
+	 * @param sta_data The STA data which contains association status
+	 * @return true on success otherwise false
+	 */
+	bool handle_assoc_status(const rdk_sta_data_t &sta_data);
+
 
 private:
     bool m_is_controller;

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -185,6 +185,13 @@ class em_agent_t : public em_mgr_t {
 	 * @param event The event containing the `bss_info_t` which heard the CCE IE in a beacon or probe response
 	 */
 	void handle_recv_cce_ie(em_bus_event_t *event);
+
+	/**
+	 * @brief Handles the reception of association status of a STA
+	 * 
+	 * @param event The event containing the `rdk_sta_data_t` info which includes the association status along with other information
+	 */
+	void handle_recv_assoc_status(em_bus_event_t *event);
     
 	/**!
 	 * @brief Handles the BTM response action frame.
@@ -807,9 +814,19 @@ public:
 	 * @param event_name The name of the event
 	 * @param data The raw event data
 	 * @param userData User provided callback data
-	 * @return int 0 on success, otherwise -1
+	 * @return int 1 on success, otherwise -1
 	 */
 	static int cce_ie_cb(char *event_name, raw_data_t *data, void *userData);
+
+	/**
+	 * @brief Callback for association status event
+	 * 
+	 * @param event_name The name of the event
+	 * @param data The raw event data
+	 * @param userData Optional user-provided callback data
+	 * @return int 1 on success, otherwise -1
+	 */
+	static int association_status_cb(char *event_name, raw_data_t *data, void *userData);
     
 	/**!
 	 * @brief Retrieves the associated data for the given input.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2596,6 +2596,7 @@ typedef enum {
     em_bus_event_type_recv_gas_frame,
     em_bus_event_type_get_sta_client_type,
     em_bus_event_type_cce_ie,
+    em_bus_event_type_assoc_status,
 
     em_bus_event_type_max
 } em_bus_event_type_t;

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -164,3 +164,12 @@ bool ec_manager_t::handle_cce_ie(unsigned int freq)
     }
     return m_enrollee->add_presence_announcement_freq(freq);
 }
+
+bool ec_manager_t::handle_assoc_status(const rdk_sta_data_t &sta_data)
+{
+    if (!m_enrollee) {
+        // No Enrollee so we don't care about this spurious association status event
+        return true;
+    }
+    return m_enrollee->handle_assoc_status(sta_data);
+}


### PR DESCRIPTION
If the Enrollee's association to the mesh bSTA fails and the Configurator has requested a Configuration Result Status Frame, we can asynchronously send this frame based on the result of Configuration which is provided by the OneWifi subscription.

Also corrects a previous misunderstanding from the EasyConnect spec --

Upon receiving the final Configuration Response frame, the Enrollee shall immediately send a DPP Configuration Result frame prior to any association attempt.

Depends on https://github.com/rdkcentral/OneWifi/pull/287 for the subscribable path