### PR TITLE
Collecting assoc sta stats as part of Ap metrics response per "Metrics reporting policy"!

### DIFF
--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -310,7 +310,22 @@ public:
 	 */
 	int analyze_beacon_report(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 
-    
+	/**!
+	 * @brief Analyzes the AP Metrics report.
+	 *
+	 * This function processes the AP Metrics report received in the event and command structures.
+	 *
+	 * @param[in] evt Pointer to the event structure containing the AP Metrics report.
+	 * @param[in] pcmd Array of pointers to command structures for processing.
+	 *
+	 * @returns int Status code indicating the success or failure of the analysis.
+	 * @retval 0 on success.
+	 * @retval Non-zero error code on failure.
+	 *
+	 * @note Ensure that the event and command structures are properly initialized before calling this function.
+	 */
+	int analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
 	/**!
 	 * @brief Refreshes the OneWiFi subdocument.
 	 *

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -261,6 +261,17 @@ class em_agent_t : public em_mgr_t {
 	 */
 	void handle_recv_gas_frame(em_bus_event_t *evt);
 
+	/**!
+	 * @brief Handles the AP Metrics report event.
+	 *
+	 * This function processes the AP Metrics report event received from the event bus.
+	 *
+	 * @param[in] evt Pointer to the event structure containing the AP Metrics report data.
+	 *
+	 * @note Ensure that the event structure is properly initialized before calling this function.
+	 */
+	void handle_ap_metrics_report(em_bus_event_t *evt);
+
 public:
 
     bus_handle_t m_bus_hdl;
@@ -827,6 +838,22 @@ public:
 	 * @return int 1 on success, otherwise -1
 	 */
 	static int association_status_cb(char *event_name, raw_data_t *data, void *userData);
+	/**!
+	 * @brief Callback function for handling AP Metrics reports.
+	 *
+	 * This function is triggered when an AP Metrics report event occurs.
+	 *
+	 * @param[in] event_name The name of the event that triggered the callback.
+	 * @param[in] data Pointer to the raw data associated with the AP Metrics report.
+	 * @param[in] userData User-defined data passed to the callback function.
+	 *
+	 * @returns int Status code indicating the success or failure of the callback execution.
+	 * @retval 0 Success.
+	 * @retval -1 Failure.
+	 *
+	 * @note Ensure that the data pointer is valid before accessing its contents.
+	 */
+	static int ap_metrics_report_cb(char *event_name, raw_data_t *data, void *userData);
     
 	/**!
 	 * @brief Retrieves the associated data for the given input.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -1952,6 +1952,8 @@ typedef enum {
     em_cmd_type_get_mld_config,
     em_cmd_type_mld_reconfig,
     em_cmd_type_beacon_report,
+    em_cmd_type_ap_metrics_report,
+
     em_cmd_type_max,
 } em_cmd_type_t;
 
@@ -2597,6 +2599,7 @@ typedef enum {
     em_bus_event_type_get_sta_client_type,
     em_bus_event_type_cce_ie,
     em_bus_event_type_assoc_status,
+    em_bus_event_type_ap_metrics_report,
 
     em_bus_event_type_max
 } em_bus_event_type_t;
@@ -2825,6 +2828,13 @@ typedef struct {
     em_disassoc_params_t	params[MAX_STA_TO_DISASSOC];
 } em_cmd_disassoc_params_t;
 
+typedef struct {
+    mac_address_t   ruid;
+    bool sta_link_metrics_include;
+    bool sta_traffic_stats_include;
+    bool wifi6_status_report_include;
+} __attribute__((__packed__)) em_cmd_ap_metrics_rprt_params_t;
+
 typedef enum {
     em_network_node_data_type_invalid,
     em_network_node_data_type_false,
@@ -2864,6 +2874,7 @@ typedef struct {
         em_cmd_btm_report_params_t  btm_report_params;
         em_cmd_disassoc_params_t	disassoc_params;
 		em_cmd_scan_params_t	scan_params;
+        em_cmd_ap_metrics_rprt_params_t ap_metrics_params;
     } u;
 	em_network_node_t *net_node;
 } em_cmd_params_t;

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -914,9 +914,10 @@ typedef struct {
 
 typedef struct {
     mac_address_t sta_mac;
+    bssid_t bssid;
     em_string_t sta_client_type;
-    unsigned char num_bssids;
-    em_assoc_vendor_link_metrics_t assoc_vendor_link_metrics[0];
+    //unsigned char num_bssids;
+    //em_assoc_vendor_link_metrics_t assoc_vendor_link_metrics[0];
 }__attribute__((__packed__)) em_assoc_sta_vendor_link_metrics_t;
 
 typedef struct {

--- a/inc/em_cmd_ap_metrics_report.h
+++ b/inc/em_cmd_ap_metrics_report.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_AP_METRICS_REPORT_H
+#define EM_CMD_AP_METRICS_REPORT_H
+
+#include "em_cmd.h"
+
+class em_cmd_ap_metrics_report_t : public em_cmd_t {
+
+public:
+    
+	/**!
+	 * @brief 
+	 *
+	 * This function handles the beacon report command.
+	 *
+	 * @param[in] param The command parameters for the beacon report.
+	 * @param[in,out] dm The easy mesh data structure to be updated.
+	 *
+	 * @returns em_cmd_beacon_report_t
+	 *
+	 * @note Ensure that the dm structure is properly initialized before calling this function.
+	 */
+	em_cmd_ap_metrics_report_t(em_cmd_params_t param, dm_easy_mesh_t& dm);
+};
+
+#endif

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -453,12 +453,13 @@ class em_metrics_t {
 	 * This function generates an AP metrics TLV and stores it in the provided buffer.
 	 *
 	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
+	 * @param[in] buff Reference to dm_bss_t object whose data gets packed for the message.
 	 *
 	 * @returns short The length of the created TLV.
 	 *
 	 * @note Ensure the buffer is large enough to hold the TLV.
 	 */
-	short create_ap_metrics_tlv(unsigned char *buff);
+	short create_ap_metrics_tlv(unsigned char *buff, dm_bss_t &dm_bss);
     
 	/**!
 	 * @brief Creates an AP extension metrics TLV.
@@ -466,6 +467,7 @@ class em_metrics_t {
 	 * This function initializes and creates a TLV (Type-Length-Value) for AP extension metrics.
 	 *
 	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
+	 * @param[in] buff Reference to dm_bss_t object whose data gets packed for the message.
 	 *
 	 * @returns A short integer indicating the success or failure of the operation.
 	 * @retval 0 on success.
@@ -473,7 +475,7 @@ class em_metrics_t {
 	 *
 	 * @note Ensure the buffer is allocated with sufficient space before calling this function.
 	 */
-	short create_ap_ext_metrics_tlv(unsigned char *buff);
+	short create_ap_ext_metrics_tlv(unsigned char *buff, dm_bss_t &dm_bss);
     
 	/**!
 	 * @brief Creates a radio metrics TLV.

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -741,7 +741,8 @@ int dm_easy_mesh_agent_t::analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_
     mac_addr_str_t macstr;
     cJSON *json, *emap_metrics_report, *param_obj;
     int radio_index = 0;
-
+    
+    printf("%s:%d: Enter\n", __func__, __LINE__);
     translate_and_decode_onewifi_subdoc((char *)evt->u.raw_buff, webconfig_subdoc_type_em_ap_metrics_report, "AP Metrics Report");
 
     json = cJSON_Parse((const char *)evt->u.raw_buff);
@@ -761,7 +762,7 @@ int dm_easy_mesh_agent_t::analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_
     evt_param = &evt->params;
     dm_easy_mesh_t::macbytes_to_string(get_radio_by_ref(radio_index).get_radio_interface_mac(), macstr);
     memcpy(evt_param->u.ap_metrics_params.ruid, get_radio_by_ref(radio_index).get_radio_interface_mac(), sizeof(mac_addr_t));
-    //printf("%s:%d: Radio Index: %d and mac: %s\n", radio_index, macstr);
+    //printf("%s:%d: Radio Index: %d and mac: %s\n", __func__, __LINE__, radio_index, macstr);
 
     if (strstr((const char *)evt->u.raw_buff, "Associated STA Traffic Stats") != NULL) {
         //printf("Associated STA Traffic Stats found in JSON.\n");

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1379,8 +1379,6 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             break;
 
         case  em_msg_type_client_cap_query:
-            printf("%s:%d: Received client cap query\n", __func__, __LINE__);
-
             if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
                 len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_bss_id(&bss_mac) == false) {
                 printf("%s:%d: Could not find BSS mac for em_msg_type_client_cap_query\n", __func__, __LINE__);
@@ -1397,7 +1395,6 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             break;
 
         case em_msg_type_client_cap_rprt:
-            printf("%s:%d: Sending client cap report\n", __func__, __LINE__);
             break;
 
         case em_msg_type_op_channel_rprt:

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -619,6 +619,7 @@ const char *em_cmd_t::get_cmd_type_str(em_cmd_type_t type)
         CMD_TYPE_2S(em_cmd_type_get_mld_config)
         CMD_TYPE_2S(em_cmd_type_mld_reconfig)
         CMD_TYPE_2S(em_cmd_type_beacon_report)
+        CMD_TYPE_2S(em_cmd_type_ap_metrics_report)
 
         default:
            break;
@@ -746,6 +747,10 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
 
         case em_bus_event_type_beacon_report:
             type = em_cmd_type_beacon_report;
+            break;
+
+        case em_bus_event_type_ap_metrics_report:
+            type = em_cmd_type_ap_metrics_report;
             break;
 
         default:

--- a/src/cmd/em_cmd_ap_metrics_report.cpp
+++ b/src/cmd/em_cmd_ap_metrics_report.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <linux/filter.h>
+#include <netinet/ether.h>
+#include <netpacket/packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <cjson/cJSON.h>
+#include "em_cmd_ap_metrics_report.h"
+
+em_cmd_ap_metrics_report_t::em_cmd_ap_metrics_report_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
+{
+    em_cmd_ctx_t ctx;
+
+    m_type = em_cmd_type_ap_metrics_report;
+    memcpy(&m_param, &param, sizeof(em_cmd_params_t));
+    
+    memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+    m_num_orch_desc = 1;
+    m_orch_desc[0].submit = true;
+
+    strncpy(m_name, "ap_metrics_report", strlen("ap_metrics_report") + 1);
+    m_svc = em_service_type_agent;
+    init(&dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+    ctx.type = m_orch_desc[0].op;
+    m_data_model.set_cmd_ctx(&ctx);
+}
+

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -157,9 +157,7 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
         dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (pdm->get_radio_info(i)->id.ruid), ruid_str);
         snprintf(key, sizeof (em_2xlong_string_t), "%s@%s@%s@%s@", pdm->get_radio_info(i)->id.net_id, dev_mac_str, ruid_str, bss_mac_str);    
 
-        //pbss = get_bss(key);
-        //temp solution untill muliple bssid entries fixed
-        pbss = pdm->get_bss(pdm->get_radio_info(i)->id.ruid, params->assoc.bssid);
+        pbss = get_bss(key);
         if (pbss == NULL) {
             found = false;
             continue;

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -157,7 +157,9 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
         dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (pdm->get_radio_info(i)->id.ruid), ruid_str);
         snprintf(key, sizeof (em_2xlong_string_t), "%s@%s@%s@%s@", pdm->get_radio_info(i)->id.net_id, dev_mac_str, ruid_str, bss_mac_str);    
 
-        pbss = get_bss(key);
+        //pbss = get_bss(key);
+        //temp solution untill muliple bssid entries fixed
+        pbss = pdm->get_bss(pdm->get_radio_info(i)->id.ruid, params->assoc.bssid);
         if (pbss == NULL) {
             found = false;
             continue;

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -643,7 +643,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
             }
             break;
 
-        /* case em_msg_type_topo_notif:
+        case em_msg_type_topo_notif:
         case em_msg_type_client_cap_rprt:
         case em_msg_type_ap_metrics_rsp:
            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
@@ -662,7 +662,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
                 dm_easy_mesh_t::macbytes_to_string(bssid, mac_str1);
     
                 snprintf(key, sizeof (em_2xlong_string_t), "%s@%s@%s@%s@", dm->get_radio_info(i)->id.net_id, dev_mac_str, radio_mac_str, mac_str1);
-                printf("%s:%d: Topo Notify: key to get bss[%s] from data model: %s\n", __func__, __LINE__, mac_str1, key);
+                printf("%s:%d: key to get bss[%s] from data model: %s\n", __func__, __LINE__, mac_str1, key);
                 if ((bss = m_data_model.get_bss(key)) == NULL) {
                     found = false;
                     continue;
@@ -681,7 +681,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
                 return NULL;
             }
 
-            break; */
+            break;
 
         case em_msg_type_autoconf_resp:
         case em_msg_type_topo_query:
@@ -759,55 +759,6 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
             // TODO: Add more types and might have to work on addressing more
 	        em = al_em;
 	        break;
-
-        case em_msg_type_topo_notif:
-        case em_msg_type_client_cap_rprt:
-        case em_msg_type_ap_metrics_rsp://Temp solution until the problem of bssid associating with multiple radios is fixed
-            if (em_msg_type_ap_metrics_rsp == htons(cmdu->type)) {
-                printf("%s:%d: Rcvd ap metrics\n", __func__, __LINE__);
-            }
-
-            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
-                    len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_bss_id(&bssid) == false) {
-                printf("%s:%d: Could not find bss id in msg:0x%04x\n", __func__, __LINE__, htons(cmdu->type));
-                return NULL;
-            }
-
-            if ((dm = get_data_model(const_cast<const char *> (global_netid), const_cast<const unsigned char *> (hdr->src))) == NULL) {
-                printf("%s:%d: Can not find data model\n", __func__, __LINE__);
-            }
-
-            //find the radio for this bss
-            for (i = 0; i < dm->get_num_radios(); i++) {
-                found = true;
-                dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (dm->get_radio_info(i)->id.dev_mac), dev_mac_str);
-                dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (dm->get_radio_info(i)->id.ruid), radio_mac_str);
-                dm_easy_mesh_t::macbytes_to_string(bssid, mac_str1);
-
-                snprintf(key, sizeof (em_2xlong_string_t), "%s@%s@%s@%s@", dm->get_radio_info(i)->id.net_id, dev_mac_str, radio_mac_str, mac_str1);
-                if (em_msg_type_ap_metrics_rsp == htons(cmdu->type)) {
-                    printf("%s:%d: AP resp: key to get bss[%s] from data model: %s\n", __func__, __LINE__, mac_str1, key);
-                }
-
-                //if ((bss = m_data_model.get_bss(key)) == NULL) {
-                if ((bss = dm->get_bss(dm->get_radio_info(i)->id.ruid, bssid)) == NULL) {
-                    found = false;
-                    continue;
-                }
-                break;
-            }
-
-            if (found == false) {
-                printf("%s:%d: Could not find bss:%s from data model\n", __func__, __LINE__, mac_str1);
-                return NULL;
-            }
-
-            dm_easy_mesh_t::macbytes_to_string(bss->m_bss_info.ruid.mac, mac_str1);
-            if ((em = static_cast<em_t *> (hash_map_get(m_em_map, mac_str1))) == NULL) {
-                printf("%s:%d: Could not find radio:%s\n", __func__, __LINE__, mac_str1);
-                return NULL;
-            }
-            break;
 
         default:
             printf("%s:%d: Frame: 0x%04x not handled in controller\n", __func__, __LINE__, htons(cmdu->type));

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2261,7 +2261,7 @@ em_sta_info_t *dm_easy_mesh_t::get_sta_info(mac_address_t sta_mac, bssid_t bssid
     dm_sta_t *sta = NULL;
     const char	*map_str;
     mac_addr_str_t radio_str, bss_str, sta_str;
-    em_long_string_t key;
+    em_long_string_t key = {0};
 
     if (target == em_target_sta_map_assoc) {
         map = m_sta_assoc_map;
@@ -2446,9 +2446,10 @@ void dm_easy_mesh_t::deinit()
         hash_map_remove(m_sta_dassoc_map, key);
     }
 	hash_map_destroy(m_sta_dassoc_map);
-	if (m_wifi_data != NULL)
-		free(m_wifi_data);
-
+	if (m_wifi_data != NULL) {
+        free(m_wifi_data);
+        m_wifi_data = nullptr;
+    }
 }
 
 void dm_easy_mesh_t::set_policy(dm_policy_t policy)

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -156,12 +156,10 @@ void dm_sta_t::encode(cJSON *obj, em_get_sta_list_reason_t reason)
     dm_sta_t::decode_sta_capability(this);
     dm_sta_t::decode_beacon_report(this);
     dm_easy_mesh_t::macbytes_to_string(m_sta_info.id, mac_str);
-    if (strlen(m_sta_info.sta_client_type) == 0) {
-        snprintf(client_info, sizeof(client_info), "%s", mac_str);
-    } else {
-        snprintf(client_info, sizeof(client_info), "%s (%s)", m_sta_info.sta_client_type, mac_str);
+    if (strlen(m_sta_info.sta_client_type) != 0) {
+        cJSON_AddStringToObject(obj, "ClientType", m_sta_info.sta_client_type);
     }
-    cJSON_AddStringToObject(obj, "MACAddress", client_info);
+    cJSON_AddStringToObject(obj, "MACAddress", mac_str);
     cJSON_AddBoolToObject(obj, "Associated", m_sta_info.associated);
 
     if (reason == em_get_sta_list_reason_none) {

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -282,17 +282,17 @@ int em_capability_t::send_client_cap_query()
     tmp += (sizeof (em_tlv_t));
     len += (sizeof (em_tlv_t));
     if (em_msg_t(em_msg_type_client_cap_query, em_profile_type_3, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        printf("Channel Selection Request msg failed validation in tnx end\n");
+        printf("Capability Query msg failed validation in tnx end\n");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: Channel Selection Request msg failed, error:%d\n", __func__, __LINE__, errno);
+        printf("%s:%d: Capability Query msg failed, error:%d\n", __func__, __LINE__, errno);
         return -1;
     }
 
     m_cap_query_tx_cnt++;
-    printf("%s:%d: Capability Query (%d) Send Successful\n", __func__, __LINE__, m_cap_query_tx_cnt);
+    printf("%s:%d: Capability Query (%d) Send Successful for sta:%s\n", __func__, __LINE__, m_cap_query_tx_cnt, evt_param->u.args.args[1]);
 
     return static_cast<int> (len);
 }
@@ -379,6 +379,7 @@ int em_capability_t::send_client_cap_report_msg(mac_address_t sta, bssid_t bss)
     unsigned short msg_id = em_msg_type_client_cap_rprt;
     dm_easy_mesh_t *dm = get_data_model();
     mac_address_t ctrl_mac = {0xe4, 0x5f, 0x01, 0x40, 0x70, 0x5b};
+    mac_addr_str_t mac_str;
 
     //memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t)); 
     memcpy(tmp, ctrl_mac, sizeof(mac_address_t));
@@ -444,9 +445,12 @@ int em_capability_t::send_client_cap_report_msg(mac_address_t sta, bssid_t bss)
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: CLient Capablity report send failed, error:%d\n", __func__, __LINE__, errno);
+        printf("%s:%d: Client Capablity report send failed, error:%d\n", __func__, __LINE__, errno);
         return -1;
     }
+
+    dm_easy_mesh_t::macbytes_to_string(sta, mac_str);
+    printf("%s:%d: Client Capablity report Send Successful for sta:%s\n", __func__, __LINE__, mac_str);
 
     return static_cast<int> (len);
 }

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -1753,7 +1753,7 @@ int em_configuration_t::handle_eht_operations_tlv(unsigned char *buff)
     unsigned char *tmp = buff;
 
     unsigned char num_radios;
-    unsigned char num_bss;
+    unsigned char num_bss = 0;
 
     em_eht_operations_t eht_ops;
 

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -223,6 +223,10 @@ void em_t::orch_execute(em_cmd_t *pcmd)
         case em_cmd_type_beacon_report:
             m_sm.set_state(em_state_agent_beacon_report_pending);
             break;
+
+        case em_cmd_type_ap_metrics_report:
+            m_sm.set_state(em_state_agent_ap_metrics_pending);
+            break;
     
         default:
             break;
@@ -405,6 +409,12 @@ void em_t::handle_agent_state()
 
         case em_cmd_type_beacon_report:
             if (m_sm.get_state() == em_state_agent_beacon_report_pending) {
+                em_metrics_t::process_agent_state();
+            }
+            break;
+
+        case em_cmd_type_ap_metrics_report:
+            if (m_sm.get_state() == em_state_agent_ap_metrics_pending) {
                 em_metrics_t::process_agent_state();
             }
             break;

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -586,7 +586,7 @@ void em_msg_t::ap_metrics_query()
 
 void em_msg_t::ap_metrics_rsp()
 {
-    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_metrics, mandatory, "17.2.22 of Wi-Fi Easy Mesh 5.0", 24);
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_metrics, mandatory, "17.2.22 of Wi-Fi Easy Mesh 5.0", 16);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_ext_metric, (m_profile > em_profile_type_1) ? mandatory:bad, "17.2.61 of Wi-Fi Easy Mesh 5.0", 33);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_radio_metric, (m_profile > em_profile_type_1) ? optional:bad, "17.2.60 of Wi-Fi Easy Mesh 5.0", 13);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_assoc_sta_traffic_sts, optional, "17.2.35 of Wi-Fi Easy Mesh 5.0", 37);

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -118,6 +118,9 @@ bool em_msg_t::get_bss_id(mac_address_t *mac)
         } else if (tlv->type == em_tlv_type_client_info) {
             memcpy(mac, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
             return true;
+        } else if (tlv->type == em_tlv_type_ap_metrics) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
         }
 
         len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
@@ -194,7 +197,10 @@ bool em_msg_t::get_radio_id(mac_address_t *mac)
 		} else if (tlv->type == em_tlv_type_channel_scan_rslt) {
 			memcpy(mac, tlv->value, sizeof(mac_address_t));
             return true;
-		}
+		} else if (tlv->type == em_tlv_type_radio_metric) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
+        }
 
         len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
         tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -343,8 +343,9 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
     em_policy_cfg_params_t policy;
     em_tlv_t    *tlv;
     unsigned int tlv_len;
-	size_t data_len = 0;
-	unsigned int i = 0;
+    size_t data_len = 0;
+    unsigned int i = 0;
+    mac_addr_str_t mac_str;
 
     memset(&policy, 0, sizeof(em_policy_cfg_t));
 
@@ -385,6 +386,9 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
             for(i = 0; i < metrics->radios_num; i++) {
                 em_metric_rprt_policy_radio_t *radio = &metrics->radios[i];
                 memcpy(&policy.metrics_policy.radios[i], radio, sizeof(em_metric_rprt_policy_radio_t));
+
+                dm_easy_mesh_t::macbytes_to_string(policy.metrics_policy.radios[i].ruid, mac_str);
+                printf("%s:%d Recvd policy for radio %s\n", __func__, __LINE__, mac_str);
             }
             data_len += (metrics->radios_num * sizeof(em_metric_rprt_policy_radio_t));
         } else if (tlv->type == em_tlv_type_dflt_8021q_settings) {

--- a/src/orch/em_orch.cpp
+++ b/src/orch/em_orch.cpp
@@ -308,7 +308,8 @@ bool em_orch_t::is_cmd_type_in_progress(em_bus_event_t *evt)
 
     snprintf(key, sizeof(em_short_string_t), "%d", type);
 
-    if (type == em_cmd_type_cfg_renew ) {
+    if ((type == em_cmd_type_cfg_renew ) ||
+        (type == em_cmd_type_ap_metrics_report)) {
         return is_cmd_type_renew_in_progress(evt);
     }
     if ((stats = static_cast<em_cmd_stats_t *>(hash_map_get(m_cmd_map, key))) != NULL) {

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -121,6 +121,12 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
+        case em_cmd_type_ap_metrics_report:
+            if (em->get_state() == em_state_agent_configured) {
+                return true;
+            }
+            break;
+
         default:
             if ((em->get_state() == em_state_agent_unconfigured) ||
                     (em->get_state() == em_state_agent_configured)) {
@@ -163,6 +169,11 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
 	} else if (pcmd->m_type == em_cmd_type_beacon_report) {
         if ((em->get_state() == em_state_agent_configured) ||
             ((em->get_state() == em_state_agent_beacon_report_pending))) {
+            return true;
+        }
+    } else if (pcmd->m_type == em_cmd_type_ap_metrics_report) {
+        if ((em->get_state() == em_state_agent_configured) ||
+            ((em->get_state() == em_state_agent_ap_metrics_pending))) {
             return true;
         }
     }
@@ -459,6 +470,14 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
 
                 sta = em->find_sta(mac1, mac2);
                 if (sta != NULL) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+                break;
+
+            case em_cmd_type_ap_metrics_report:
+                if (memcmp(pcmd->m_param.u.ap_metrics_params.ruid,
+                    em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
                 }


### PR DESCRIPTION
Collecting assoc sta stats as part of Ap metrics response!

Test procedure: Trigger sta link metrics and traffic stats policy using CLI while connecting/disconnecting clients to the AP. If connected and policy is set, stats collection can be seen updated over Client connections menu.