### PR TITLE
Fixes for DPP Configuration object creation

### DIFF
--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -701,14 +701,15 @@ cJSON *em_provisioning_t::create_configurator_bsta_response_obj(ec_connection_co
     for (unsigned int i = 0; i < dm->get_num_bss(); i++) {
         const dm_bss_t *bss = dm->get_bss(i);
         if (!bss) continue;
-        if (bss->m_bss_info.backhaul_use && strncmp(bss->m_bss_info.ssid, network_ssid_info->ssid, strlen(network_ssid_info->ssid)) == 0) {
-            if (!cJSON_AddStringToObject(discovery_object, "BSSID", reinterpret_cast<const char *>(bss->m_bss_info.id.bssid))) {
+        if (bss->m_bss_info.id.haul_type == em_haul_type_backhaul && strncmp(bss->m_bss_info.ssid, network_ssid_info->ssid, strlen(network_ssid_info->ssid)) == 0) {
+            em_printfout("Found backhaul mesh! '%s'", bss->m_bss_info.ssid);
+            if (!cJSON_AddStringToObject(discovery_object, "BSSID", util::mac_to_string(bss->m_bss_info.bssid.mac).c_str())) {
                 em_printfout("Failed to add \"BSSID\" to bSTA Configuration Object");
                 cJSON_Delete(bsta_configuration_object);
                 cJSON_Delete(discovery_object);
                 return nullptr;
             }
-            if (!cJSON_AddStringToObject(discovery_object, "RUID", reinterpret_cast<const char *>(bss->m_bss_info.id.ruid))) {
+            if (!cJSON_AddStringToObject(discovery_object, "RUID", util::mac_to_string(bss->m_bss_info.ruid.mac).c_str())) {
                 em_printfout("Failed to add \"RUID\" to bSTA Configuration Object");
                 cJSON_Delete(bsta_configuration_object);
                 cJSON_Delete(discovery_object);


### PR DESCRIPTION
Two things:

1. `em_bss_info_t`'s `backhaul_use` field doesn't seem to be set correctly in the OneWifi webconfig codec. We can instead check that it's haultype is `em_haul_type_backhaul`

2. The `bssid` and `ruid` members of `em_bss_info_t`'s `id` member are also not populated. Grab them instead of `.bssid.mac` and `.ruid.mac`



-------------------------

Configurator log: Configuration object now (note `"BSSID"` and `"RUID"` keys now in the `"discovery"` object):

```
[onewifi_em_ctrl] 04/24/2025 - 23:17:17.969142 :em_provisioning.cpp:705: INFO: Found backhaul mesh! 'mesh_backhaul'
[onewifi_em_ctrl] 04/24/2025 - 23:17:18.085769 :ec_ctrl_configurator.cpp:1155: INFO: bSTA Configuration object:
{
	"wi-fi_tech":	"map",
	"discovery":	{
		"SSID":	"mesh_backhaul",
		"BSSID":	"1c:bf:ce:f4:bf:58",
		"RUID":	"1c:bf:ce:f4:bf:58"
	},
	"cred":	{
		"akm":	"506F9A02+000FAC08+",
		"psk_hex":	"9df6b4479c7b94eaef678b2f2fdc6311f2e5ddb562b64fe5a63135b25ed69bab",
		"pass":	"test-backhaul",
		"signedConnector":	"eyJ0eXAiOiJkcHBDb24iLCJraWQiOiJlcUszZ1NqY1E4dGlTQi8yTjNaRndWVlVMNFFtOTh6TWRYY0hHYjQ3NTVvPSIsImFsZyI6IkVTMjU2In0.eyJncm91cHMiOlt7Im5ldFJvbGUiOiJtYXBCYWNraGF1bFN0YSIsImdyb3VwSUQiOiJtYXBOVyJ9XSwibmV0QWNjZXNzS2V5Ijp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4IjoiIiwieSI6IiJ9fQ.MEQCIDMmW9NKmbEOgGb1hagbW6P7FOfEPzWaCJR_6Y1Asl0gAiB7J7CB7AFqqTpemIP8wXOKif_2p_8A6Df5G5ZgCzqjVQ",
		"csign":	{
			"kty":	"EC",
			"crv":	"P-256",
			"kid":	"eqK3gSjcQ8tiSB/2N3ZFwVVUL4Qm98zMdXcHGb4755o=",
			"x":	"sBLVhpjMMdUhQnOjTnT3i7mEvHdk+neiDOoNE0a09No=",
			"y":	"0L97N0ZVtkG90nFDi3L/1gXTgiGd3uSYXSaL4R2wFz0="
		},
		"ppKey":	{
			"kty":	"EC",
			"crv":	"P-256",
			"x":	"cZNx7qOXNo3KSiYDuo4sxTxPvyxVDNjgdRTMenPv1cg=",
			"y":	"A+hsZjcbykZox5fH0pAPEfGgR8qh8ZeJCr5ZNRajcWs="
		}
	}
}
```

Also note: `"BSSID"` and `"RUID"` inside of the `"discovery"` object are additions to the Configuration object definition by the EasyMesh spec, not inherent to the base EasyConnect spec.