### PR TITLE
Fix/1905 addressing and dpp config obj parse

### DIFF
--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -655,18 +655,21 @@ int em_t::send_frame(unsigned char *buff, unsigned int len, bool multicast)
         }
     }
 #ifdef AL_SAP
+    auto ctrl_al = m_data_model->get_controller_interface_mac();
+    auto agent_al = m_data_model->get_agent_al_interface_mac();
+    bool is_colocated = (memcmp(ctrl_al, agent_al, ETH_ALEN) == 0);
 
     AlServiceDataUnit sdu;
     sdu.setSourceAlMacAddress(g_al_mac_sap);
     if (m_service_type == em_service_type_ctrl) {
-        if (is_loopback_frame) {
+        if (is_loopback_frame || is_colocated) {
             sdu.setDestinationAlMacAddress(g_al_mac_sap);
         } else {
             sdu.setDestinationAlMacAddress({0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
         }
     }
     if (m_service_type == em_service_type_agent) {
-        if (is_loopback_frame) {
+        if (is_loopback_frame || is_colocated) {
             sdu.setDestinationAlMacAddress(g_al_mac_sap);
         } else {
             sdu.setDestinationAlMacAddress({0x00, 0x00, 0x00, 0x00, 0x00, 0x00});

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -707,13 +707,13 @@ cJSON *em_provisioning_t::create_configurator_bsta_response_obj(ec_connection_co
         if (!bss) continue;
         if (bss->m_bss_info.id.haul_type == em_haul_type_backhaul && strncmp(bss->m_bss_info.ssid, network_ssid_info->ssid, strlen(network_ssid_info->ssid)) == 0) {
             em_printfout("Found backhaul mesh! '%s'", bss->m_bss_info.ssid);
-            if (!cJSON_AddStringToObject(discovery_object, "BSSID", util::mac_to_string(bss->m_bss_info.bssid.mac).c_str())) {
+            if (!cJSON_AddStringToObject(discovery_object, "BSSID", util::mac_to_string(bss->m_bss_info.bssid.mac, "").c_str())) {
                 em_printfout("Failed to add \"BSSID\" to bSTA Configuration Object");
                 cJSON_Delete(bsta_configuration_object);
                 cJSON_Delete(discovery_object);
                 return nullptr;
             }
-            if (!cJSON_AddStringToObject(discovery_object, "RUID", util::mac_to_string(bss->m_bss_info.ruid.mac).c_str())) {
+            if (!cJSON_AddStringToObject(discovery_object, "RUID", util::mac_to_string(bss->m_bss_info.ruid.mac, "").c_str())) {
                 em_printfout("Failed to add \"RUID\" to bSTA Configuration Object");
                 cJSON_Delete(bsta_configuration_object);
                 cJSON_Delete(discovery_object);


### PR DESCRIPTION
Some 1905 messages enter `send_frame` with the destination address set as the 1905.1 multi-cast address:
```
(gdb) p/x hdr->src
$5 = {0xd8, 0x3a, 0xdd, 0x85, 0x9f, 0x56}
(gdb) p/x hdr->dst 
$6 = {0x1, 0x80, 0xc2, 0x0, 0x0, 0x13}
```

We still need the `is_colocated` flag for colocated agent<->controller 1905 routing

Additionally fixes encoding of BSSID / RUID in bSTA Configuration object. Enrollee parsing expected 12 bytes, but since these fields were encoded including ":", parsing fails. Removes the ":" separator.