### PR TITLE
Fixed crash issue with controller

### DIFF
--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -523,9 +523,10 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     dm_easy_mesh_t::macbytes_to_string(get_radio_interface_mac(), radio_mac_str);
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
 
-    hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
-
-    dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
+    if (hash_map_get(dm->m_sta_assoc_map, key) == NULL) {
+        hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
+        dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
+    }
 
     return 0;
 }


### PR DESCRIPTION
Reason for change: 1) Multiple client reports are causing the same STA info to be repeatedly updated. This is followed by a repeated DB update, after which the entry is removed from the Assoc map again repeatedly, leading to the crash.
Test Procedure: With this changes we observed controller is running without crash.
Risks: Medium
Priority: P1