### PR TITLE
6 GHz radio configurations not working in EasyMesh

### DIFF
--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -279,6 +279,9 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
 			} else if (strcmp(subdoc_name->valuestring, "Vap_2.4G") == 0) {
 				printf("%s:%d Found SubDocName:Vap 2.4G recv\n", __func__, __LINE__);
 				freq_band = em_freq_band_24;
+			} else if (strcmp(subdoc_name->valuestring, "Vap_6G") == 0) {
+				printf("%s:%d Found SubDocName:Vap 6G recv\n", __func__, __LINE__);
+				freq_band = em_freq_band_60;
 			}
 		}
 		for (j = 0; j < get_num_radios(); j++) {

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1129,13 +1129,13 @@ void em_agent_t::onewifi_cb(char *event_name, raw_data_t *data, void *userData)
         return;
     }
 
-    if ((strcmp(subdoc_name->valuestring, "private") == 0) || (strcmp(subdoc_name->valuestring, "Vap_5G") == 0) ||
-        (strcmp(subdoc_name->valuestring, "Vap_2.4G") == 0)) {
+    if ((strcmp(subdoc_name->valuestring, "private") == 0) || (strcmp(subdoc_name->valuestring, "Vap_6G") == 0) ||
+        (strcmp(subdoc_name->valuestring, "Vap_5G") == 0) || (strcmp(subdoc_name->valuestring, "Vap_2.4G") == 0)) {
         printf("%s:%d Found SubDocName: private\n", __func__, __LINE__);
         g_agent.io_process(em_bus_event_type_onewifi_private_cb, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
 
-    } else if ((strcmp(subdoc_name->valuestring, "radio") == 0) || (strcmp(subdoc_name->valuestring, "radio_5G") == 0) ||
-        (strcmp(subdoc_name->valuestring, "radio_2.4G") == 0)) {
+    } else if ((strcmp(subdoc_name->valuestring, "radio") == 0) || (strcmp(subdoc_name->valuestring, "radio_6G") == 0) ||
+        (strcmp(subdoc_name->valuestring, "radio_5G") == 0) || (strcmp(subdoc_name->valuestring, "radio_2.4G") == 0)) {
         printf("%s:%d Found SubDocName: radio\n", __func__, __LINE__);
         g_agent.io_process(em_bus_event_type_onewifi_radio_cb, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
 


### PR DESCRIPTION
Reason for change: Add 6GHz support for easymesh
Test Procedure: Ensure 6 GHz radio is configured as expected.
Risks: Medium
Priority: P1