### PR TITLE
6 GHz radio configurations fails after DB reset

### DIFF
--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -1948,7 +1948,7 @@ void em_channel_t::process_msg(unsigned char *data, unsigned int len)
     cmdu = reinterpret_cast<em_cmdu_t *> (data + sizeof(em_raw_hdr_t));
     switch (htons(cmdu->type)) {
         case em_msg_type_channel_pref_query:
-	        if (get_service_type() == em_service_type_agent) {
+		if ((get_service_type() == em_service_type_agent) && (get_state() < em_state_agent_channel_selection_pending)) {
 		        handle_channel_pref_query(data, len);
 	        }
             break; 

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -3170,9 +3170,6 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 		radio = dm->get_radio(i);
 		if (memcmp(radio->m_radio_info.id.ruid, get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
 			radio_exists = true;
-			if (radio->m_radio_info.band == em_freq_band_60) {
-				auth_type = 0x0200;
-			}
 			break;
 		}
 	}
@@ -3184,6 +3181,10 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 		if (no_of_haultype >= em_haul_type_max) {
 			no_of_haultype = em_haul_type_max ;
 		}
+	}
+
+	if (get_band() == 2) {
+		auth_type = 0x0200;
 	}
 
 	printf("%s:%d No of haultype=%d radio no of bss=%d \n", __func__, __LINE__,no_of_haultype, radio->m_radio_info.number_of_bss);


### PR DESCRIPTION
Reason for change: Add 6GHz support for easymesh
Test Procedure: Ensure 6 GHz radio is configured as expected.
Risks: Medium
Priority: P1