### PR TITLE
Fixed the controller warning with werror flags, keeping werror disabled till further update.

### DIFF
--- a/src/cmd/em_cmd_exec.cpp
+++ b/src/cmd/em_cmd_exec.cpp
@@ -137,7 +137,8 @@ int em_cmd_exec_t::send_cmd(em_service_type_t to_svc, unsigned char *in, unsigne
     setsockopt(dsock, SOL_SOCKET, SO_RCVBUF, &sz, sizeof(sz)); // Receive buffer 1K
     memset(&addr, 0, sizeof(struct sockaddr_un));
     addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path));    
+    //strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path));
+    snprintf(addr.sun_path, sizeof(addr.sun_path), "%.*s", static_cast<int>(sizeof(addr.sun_path) - 1), sock_path);
     //snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", sock_path);
     if ((ret = connect(dsock, reinterpret_cast<const struct sockaddr *> (&addr), sizeof(struct sockaddr_un))) != 0) {
         snprintf(out, out_len, "%s:%d: connect error on socket, err:%d\n", __func__, __LINE__, errno);

--- a/src/cmd/em_cmd_exec.cpp
+++ b/src/cmd/em_cmd_exec.cpp
@@ -137,9 +137,7 @@ int em_cmd_exec_t::send_cmd(em_service_type_t to_svc, unsigned char *in, unsigne
     setsockopt(dsock, SOL_SOCKET, SO_RCVBUF, &sz, sizeof(sz)); // Receive buffer 1K
     memset(&addr, 0, sizeof(struct sockaddr_un));
     addr.sun_family = AF_UNIX;
-    //strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path));
     snprintf(addr.sun_path, sizeof(addr.sun_path), "%.*s", static_cast<int>(sizeof(addr.sun_path) - 1), sock_path);
-    //snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", sock_path);
     if ((ret = connect(dsock, reinterpret_cast<const struct sockaddr *> (&addr), sizeof(struct sockaddr_un))) != 0) {
         snprintf(out, out_len, "%s:%d: connect error on socket, err:%d\n", __func__, __LINE__, errno);
         return -1;

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -98,7 +98,7 @@ int dm_easy_mesh_ctrl_t::analyze_config_renew(em_bus_event_t *evt, em_cmd_t *pcm
     printf("%s:%d: Radio: %s\n", __func__, __LINE__, radio_str);
 
     evt->params.u.args.num_args = 1;
-    strncpy(evt->params.u.args.args[0], radio_str, strlen(radio_str) + 1);
+    strncpy(evt->params.u.args.args[0], radio_str, sizeof(em_long_string_t));
     pcmd[num] = new em_cmd_cfg_renew_t(em_service_type_ctrl, evt->params, dm);
 
     tmp = pcmd[num];
@@ -141,9 +141,9 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
         //sta_mac_str, (params->assoc.assoc_event == 1)?"associated with":"disassociated from", bss_mac_str, dev_mac_str);
 
     evt->params.u.args.num_args = 4;
-    strncpy(evt->params.u.args.args[0], dev_mac_str, strlen(dev_mac_str) + 1);
-    strncpy(evt->params.u.args.args[1], bss_mac_str, strlen(bss_mac_str) + 1);
-    strncpy(evt->params.u.args.args[2], sta_mac_str, strlen(sta_mac_str) + 1);
+    strncpy(evt->params.u.args.args[0], dev_mac_str, sizeof(em_long_string_t));
+    strncpy(evt->params.u.args.args[1], bss_mac_str, sizeof(em_long_string_t));
+    strncpy(evt->params.u.args.args[2], sta_mac_str, sizeof(em_long_string_t));
     len = (params->assoc.assoc_event == 1)?strlen("Assoc") + 1:strlen("Disassoc") + 1;
     strncpy(evt->params.u.args.args[3], (params->assoc.assoc_event == 1)?"Assoc":"Disassoc", len);
     pdm = get_data_model(global_netid, params->dev);
@@ -226,8 +226,8 @@ int dm_easy_mesh_ctrl_t::analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *pcmd[])
     printf("%s:%d: Radio: %s AL MAC: %s\n", __func__, __LINE__, radio_str, al_str);
 
     evt->params.u.args.num_args = 2;
-    strncpy(evt->params.u.args.args[0], radio_str, strlen(radio_str) + 1);
-    strncpy(evt->params.u.args.args[1], al_str, strlen(al_str) + 1);
+    strncpy(evt->params.u.args.args[0], radio_str, sizeof(em_long_string_t));
+    strncpy(evt->params.u.args.args[1], al_str, sizeof(em_long_string_t));
     pcmd[num] = new em_cmd_em_config_t(evt->params, dm);
     tmp = pcmd[num];
     num++;

--- a/src/ctrl/em_cmd_ctrl.cpp
+++ b/src/ctrl/em_cmd_ctrl.cpp
@@ -62,7 +62,7 @@ int em_cmd_ctrl_t::execute(char *result)
 
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", get_path());
+    snprintf(addr.sun_path, sizeof(addr.sun_path), "%.*s", static_cast<int>(sizeof(addr.sun_path) - 1), get_path());
 
     if ((ret = bind(lsock, reinterpret_cast<const struct sockaddr *> (&addr), sizeof(struct sockaddr_un))) == -1) {
         printf("%s:%d: bind error on socket: %d, err:%d\n", __func__, __LINE__, lsock, errno);

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -305,8 +305,6 @@ void em_ctrl_t::handle_get_dev_test(em_bus_event_t *evt)
 
 void em_ctrl_t::handle_set_dev_test(em_bus_event_t *evt)
 {
-    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
-    int num, ret;
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
@@ -863,7 +861,7 @@ void em_ctrl_t::start_complete()
 	//Initialze cli devtest
 	for (i = 0; i < em_dev_test_type_max; i++) {
 		dev_test.dev_test_info.num_iteration[i] = 50;
-		dev_test.dev_test_info.test_type[i] = (em_dev_test_type) i;
+		dev_test.dev_test_info.test_type[i] = static_cast<em_dev_test_type>(i);;
 		dev_test.dev_test_info.enabled[i] = 0;
 		dev_test.dev_test_info.num_of_iteration_completed[i] = 0;
 		dev_test.dev_test_info.test_inprogress[i] = 0;

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -550,7 +550,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
     bssid_t	bssid;
     dm_bss_t *bss;
     em_profile_type_t profile;
-    em_long_string_t key;
+    em_2xlong_string_t key;
     unsigned int i;
     bool found;
     mac_addr_str_t mac_str1, mac_str2, dev_mac_str, radio_mac_str;

--- a/src/ctrl/em_dev_test_ctrl.cpp
+++ b/src/ctrl/em_dev_test_ctrl.cpp
@@ -29,11 +29,10 @@
 
 void em_dev_test_t::encode(em_subdoc_info_t *subdoc, hash_map_t *m_em_map, bool update, bool testinprogress)
 {
-	cJSON *parent, *em_jlist, *em_j, *em_j_info, *em_state, *em_data, *dev_test, *dev_test_param;
+	cJSON *parent, *em_jlist, *em_data, *dev_test, *dev_test_param;
 	char *tmp;
 	em_t *em = NULL;
 	int i = 0;
-	mac_addr_str_t mac_str;
 	em_small_string_t enable;
 	em_short_string_t haul_type_str;
 
@@ -169,7 +168,7 @@ void em_dev_test_t:: decode(em_subdoc_info_t *subdoc, hash_map_t *m_em_map, cons
 		return;
 	}
 
-	arr_size = static_cast<unsigned int> (cJSON_GetArraySize(dev_test_obj));
+	arr_size = cJSON_GetArraySize(dev_test_obj);
 	if (arr_size != em_dev_test_type_max) {
 		printf("%s:%d: Invalid configuration:\n", __func__, __LINE__);
 		cJSON_Delete(parent_obj);
@@ -184,25 +183,25 @@ void em_dev_test_t:: decode(em_subdoc_info_t *subdoc, hash_map_t *m_em_map, cons
 		   snprintf(str_type, sizeof(str_type), "%s", cJSON_GetStringValue(tmp));
 		}
 		if (strncmp(str_type, "ssid_change", sizeof(str_type)) == 0) {
-		   index = (int) em_dev_test_type_ssid;
+		   index = static_cast<int>(em_dev_test_type_ssid);
 		} else {
-		   index = (int) em_dev_test_type_channel;
+		   index = static_cast<int>(em_dev_test_type_channel);
 		}
 		if ((tmp = cJSON_GetObjectItem(obj, "No_of_iteration")) != NULL) {
-			dev_test_info.num_iteration[index] = static_cast<unsigned int> (tmp->valuedouble);
+			dev_test_info.num_iteration[index] = static_cast<int> (tmp->valuedouble);
 		}
 
 		if ((tmp = cJSON_GetObjectItem(obj, "Current_iteration_inprogress")) != NULL) {
-			dev_test_info.test_inprogress[index] = static_cast<unsigned int> (tmp->valuedouble);
+			dev_test_info.test_inprogress[index] = static_cast<int> (tmp->valuedouble);
 		}
 		if ((tmp = cJSON_GetObjectItem(obj, "Num_of_iteration_completed")) != NULL) {
-			dev_test_info.num_of_iteration_completed[index] = static_cast<unsigned int> (tmp->valuedouble);
+			dev_test_info.num_of_iteration_completed[index] = static_cast<int> (tmp->valuedouble);
 		}
 		if ((tmp = cJSON_GetObjectItem(obj, "Haul_type:[Fronthault:0,Backhaul:1,IOT:2,Configurator:3,Hotspot:4]")) != NULL) {
 			dev_test_info.haul_type = static_cast<em_haul_type_t> (tmp->valuedouble);
 		}
 		if ((tmp = cJSON_GetObjectItem(obj, "Test_enabled")) != NULL) {
-			dev_test_info.enabled[index] = static_cast<unsigned int> (tmp->valuedouble);
+			dev_test_info.enabled[index] = static_cast<int> (tmp->valuedouble);
 			if (dev_test_info.enabled[index] == 0) {
 				dev_test_info.test_status[index] = em_dev_test_status_idle;
 				dev_test_info.test_inprogress[index] = 0;

--- a/src/db/db_client.cpp
+++ b/src/db/db_client.cpp
@@ -106,7 +106,7 @@ char *db_client_t::get_string(void *ctx, char *str, unsigned int col)
 
 int db_client_t::get_number(void *ctx, unsigned int col)
 {
-    int n;
+    int n = 0;
 
     assert(ctx != NULL);
 

--- a/src/dm/dm_bss.cpp
+++ b/src/dm/dm_bss.cpp
@@ -271,7 +271,7 @@ void dm_bss_t::encode(cJSON *obj, bool summary)
 void dm_bss_t::operator = (const dm_bss_t& obj)
 {
 	if (this == &obj) { return; }
-	strncpy(this->m_bss_info.id.net_id, obj.m_bss_info.id.net_id, strlen(obj.m_bss_info.id.net_id));
+	strncpy(this->m_bss_info.id.net_id, obj.m_bss_info.id.net_id, sizeof(em_long_string_t));
 	memcpy(this->m_bss_info.id.dev_mac, obj.m_bss_info.id.dev_mac, sizeof(mac_address_t));
 	memcpy(this->m_bss_info.id.ruid, obj.m_bss_info.id.ruid, sizeof(mac_address_t));
 	memcpy(this->m_bss_info.id.bssid, obj.m_bss_info.id.bssid, sizeof(mac_address_t));

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -842,7 +842,7 @@ int dm_easy_mesh_t::decode_config_set_radio(em_subdoc_info_t *subdoc, const char
         return EM_PARSE_ERR_NET_ID;
     }
 
-    strncpy(m_network.m_net_info.id, net_id, strlen(net_id) + 1);
+    strncpy(m_network.m_net_info.id, net_id, sizeof(em_long_string_t)-1);
 
     if ((dev_arr_obj = cJSON_GetObjectItem(net_obj, "DeviceList")) == NULL) {
         printf("%s:%d: Failed to parse: %s\n", __func__, __LINE__, subdoc->buff);
@@ -941,7 +941,7 @@ int dm_easy_mesh_t::decode_config_set_policy(em_subdoc_info_t *subdoc, const cha
         return EM_PARSE_ERR_NET_ID;
 	}
 
-	strncpy(m_network.m_net_info.id, net_id, strlen(net_id) + 1);
+	strncpy(m_network.m_net_info.id, net_id, sizeof(em_long_string_t)-1);
 
     if ((dev_arr_obj = cJSON_GetObjectItem(net_obj, "DeviceList")) == NULL) {
         printf("%s:%d: Failed to parse: %s\n", __func__, __LINE__, subdoc->buff);

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -842,7 +842,7 @@ int dm_easy_mesh_t::decode_config_set_radio(em_subdoc_info_t *subdoc, const char
         return EM_PARSE_ERR_NET_ID;
     }
 
-    strncpy(m_network.m_net_info.id, net_id, sizeof(em_long_string_t)-1);
+    snprintf(m_network.m_net_info.id, sizeof(em_long_string_t), "%s", net_id);
 
     if ((dev_arr_obj = cJSON_GetObjectItem(net_obj, "DeviceList")) == NULL) {
         printf("%s:%d: Failed to parse: %s\n", __func__, __LINE__, subdoc->buff);
@@ -941,7 +941,7 @@ int dm_easy_mesh_t::decode_config_set_policy(em_subdoc_info_t *subdoc, const cha
         return EM_PARSE_ERR_NET_ID;
 	}
 
-	strncpy(m_network.m_net_info.id, net_id, sizeof(em_long_string_t)-1);
+    snprintf(m_network.m_net_info.id, sizeof(em_long_string_t), "%s", net_id);
 
     if ((dev_arr_obj = cJSON_GetObjectItem(net_obj, "DeviceList")) == NULL) {
         printf("%s:%d: Failed to parse: %s\n", __func__, __LINE__, subdoc->buff);

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1546,10 +1546,10 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::get_data_model(const char *net_id, const un
 {
     dm_easy_mesh_t *dm = NULL;
     mac_addr_str_t mac_str;
-    em_short_string_t	key;
+    em_2xlong_string_t	key;
 
     dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (al_mac), mac_str);
-    snprintf(key, sizeof(em_short_string_t), "%s@%s", net_id, mac_str);
+    snprintf(key, sizeof(key), "%s@%s", net_id, mac_str);
     //printf("%s:%d: Retrieve data model at key: %s\n", __func__, __LINE__, key);
     dm = static_cast<dm_easy_mesh_t *> (hash_map_get(m_list, key));
 

--- a/src/dm/dm_network.cpp
+++ b/src/dm/dm_network.cpp
@@ -176,7 +176,7 @@ void dm_network_t::operator = (const dm_network_t& obj)
     if (this == &obj) { return; }
     memcpy(&this->m_net_info.id,&obj.m_net_info.id,sizeof(em_long_string_t));
     this->m_net_info.num_of_devices = obj.m_net_info.num_of_devices;
-    strncpy(this->m_net_info.timestamp, obj.m_net_info.timestamp, strlen(obj.m_net_info.timestamp) + 1);
+    strncpy(this->m_net_info.timestamp, obj.m_net_info.timestamp, sizeof(em_long_string_t));
     memcpy(&this->m_net_info.ctrl_id.mac ,&obj.m_net_info.ctrl_id.mac,sizeof(mac_address_t));
     memcpy(&this->m_net_info.ctrl_id.name,&obj.m_net_info.ctrl_id.name,sizeof(em_interface_name_t));
     this->m_net_info.num_mscs_disallowed_sta = obj.m_net_info.num_mscs_disallowed_sta;
@@ -198,7 +198,7 @@ int dm_network_t::init()
 	util::get_date_time_rfc3399(date_time, EM_DATE_TIME_BUFF_SZ);
 
 	memset(&m_net_info, 0, sizeof(em_network_info_t)); 
-	strncpy(m_net_info.timestamp, date_time, strlen(date_time) + 1);
+	strncpy(m_net_info.timestamp, date_time, sizeof(em_long_string_t));
 	return 0;
 }
 

--- a/src/dm/dm_network_list.cpp
+++ b/src/dm/dm_network_list.cpp
@@ -214,7 +214,7 @@ int dm_network_list_t::sync_db(db_client_t& db_client, void *ctx)
 
 	memset(&info, 0, sizeof(em_network_info_t));
 	util::get_date_time_rfc3399(date_time, EM_DATE_TIME_BUFF_SZ);
-	strncpy(info.timestamp, date_time, strlen(date_time) + 1);
+	strncpy(info.timestamp, date_time, sizeof(em_long_string_t));
 
     // there is only one row in network
     while (db_client.next_result(ctx)) {

--- a/src/dm/dm_network_ssid_list.cpp
+++ b/src/dm/dm_network_ssid_list.cpp
@@ -330,7 +330,7 @@ int dm_network_ssid_list_t::update_db(db_client_t& db_client, dm_orch_type_t op,
 	memset(hauls, 0, sizeof(em_long_string_t));
     for (i = 0; i < info->num_hauls; i++) {
         dm_network_ssid_t::haul_type_to_string(info->haul_type[i], haul_str);
-		snprintf(hauls + strlen(hauls), sizeof(hauls) - strlen(hauls) - 1, "%s,", haul_str);
+        snprintf(hauls + strlen(hauls), sizeof(hauls) - strlen(hauls) - 1, "%s,", haul_str);
     }
     hauls[strlen(hauls) - 1] = 0;
     //printf("%s:%d: Haul Types: %s\n", __func__, __LINE__, bands);

--- a/src/dm/dm_network_ssid_list.cpp
+++ b/src/dm/dm_network_ssid_list.cpp
@@ -330,8 +330,7 @@ int dm_network_ssid_list_t::update_db(db_client_t& db_client, dm_orch_type_t op,
 	memset(hauls, 0, sizeof(em_long_string_t));
     for (i = 0; i < info->num_hauls; i++) {
         dm_network_ssid_t::haul_type_to_string(info->haul_type[i], haul_str);
-        strncat(hauls, haul_str, strlen(haul_str));
-        strcat(hauls, ",");
+		snprintf(hauls + strlen(hauls), sizeof(hauls) - strlen(hauls) - 1, "%s,", haul_str);
     }
     hauls[strlen(hauls) - 1] = 0;
     //printf("%s:%d: Haul Types: %s\n", __func__, __LINE__, bands);

--- a/src/dm/dm_policy.cpp
+++ b/src/dm/dm_policy.cpp
@@ -79,7 +79,7 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
 			m_policy.interval = static_cast<short unsigned int>(tmp->valuedouble);
     	}
     	if ((tmp = cJSON_GetObjectItem(obj, "Managed Client Marker")) != NULL) {
-			strncpy(m_policy.managed_sta_marker, cJSON_GetStringValue(tmp), sizeof(em_long_string_t)-1);
+            snprintf(m_policy.managed_sta_marker, sizeof(em_long_string_t), "%s", cJSON_GetStringValue(tmp));
     	}
 	} else if (type == em_policy_id_type_radio_metrics_rep) {
     	if ((tmp = cJSON_GetObjectItem(obj, "STA RCPI Threshold")) != NULL) {

--- a/src/dm/dm_policy.cpp
+++ b/src/dm/dm_policy.cpp
@@ -49,7 +49,7 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
 
     memset(&m_policy, 0, sizeof(em_policy_t));
 	parse_dev_radio_mac_from_key(static_cast<char *>(parent_id), &id);
-	strncpy(m_policy.id.net_id, id.net_id, strlen(id.net_id));
+	strncpy(m_policy.id.net_id, id.net_id, sizeof(em_long_string_t));
 	memcpy(m_policy.id.dev_mac, id.dev_mac, sizeof(mac_address_t));
 	memcpy(m_policy.id.radio_mac, id.radio_mac, sizeof(mac_address_t));
 	m_policy.id.type = type;	
@@ -79,7 +79,7 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
 			m_policy.interval = static_cast<short unsigned int>(tmp->valuedouble);
     	}
     	if ((tmp = cJSON_GetObjectItem(obj, "Managed Client Marker")) != NULL) {
-			strncpy(m_policy.managed_sta_marker, cJSON_GetStringValue(tmp), sizeof(em_long_string_t));
+			strncpy(m_policy.managed_sta_marker, cJSON_GetStringValue(tmp), sizeof(em_long_string_t)-1);
     	}
 	} else if (type == em_policy_id_type_radio_metrics_rep) {
     	if ((tmp = cJSON_GetObjectItem(obj, "STA RCPI Threshold")) != NULL) {
@@ -183,7 +183,7 @@ void dm_policy_t::operator = (const dm_policy_t& obj)
     this->m_policy.sta_traffic_stats = obj.m_policy.sta_traffic_stats;
     this->m_policy.sta_link_metric = obj.m_policy.sta_link_metric;
     this->m_policy.sta_status = obj.m_policy.sta_status;
-    strncpy(this->m_policy.managed_sta_marker, obj.m_policy.managed_sta_marker, strlen(obj.m_policy.managed_sta_marker) + 1);
+    strncpy(this->m_policy.managed_sta_marker, obj.m_policy.managed_sta_marker, sizeof(em_long_string_t));
 }
 
 int dm_policy_t::parse_dev_radio_mac_from_key(const char *key, em_policy_id_t *id)

--- a/src/dm/dm_policy_list.cpp
+++ b/src/dm/dm_policy_list.cpp
@@ -253,8 +253,7 @@ int dm_policy_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, void 
 	memset(sta_mac_list_str, 0, sizeof(sta_mac_list_str));
     for (i = 0; i < policy->num_sta; i++) {
 		dm_easy_mesh_t::macbytes_to_string(policy->sta_mac[i], sta_mac_str);
-        strncat(sta_mac_list_str, sta_mac_str, strlen(sta_mac_str));
-        strncat(sta_mac_list_str, ",", strlen(",")+1);
+        snprintf(sta_mac_list_str + strlen(sta_mac_list_str), sizeof(sta_mac_list_str) - strlen(sta_mac_list_str) - 1,"%s,", sta_mac_str);
     }
 
 	if (strlen(sta_mac_list_str) > 0)

--- a/src/dm/dm_radio.cpp
+++ b/src/dm/dm_radio.cpp
@@ -221,7 +221,7 @@ bool dm_radio_t::operator == (const dm_radio_t& obj) {
 void dm_radio_t::operator = (const dm_radio_t& obj)
 {
 	if (this == &obj) { return; }
-	strncpy(this->m_radio_info.id.net_id, obj.m_radio_info.id.net_id, strlen(obj.m_radio_info.id.net_id) + 1);
+	strncpy(this->m_radio_info.id.net_id, obj.m_radio_info.id.net_id, sizeof(em_long_string_t));
 	memcpy(this->m_radio_info.id.dev_mac, obj.m_radio_info.id.dev_mac, sizeof(mac_address_t));
 	memcpy(this->m_radio_info.id.ruid, obj.m_radio_info.id.ruid, sizeof(mac_address_t));
 	

--- a/src/dm/dm_scan_result_list.cpp
+++ b/src/dm/dm_scan_result_list.cpp
@@ -314,7 +314,7 @@ int dm_scan_result_list_t::sync_db(db_client_t& db_client, void *ctx)
 		scan_result.scan_status = static_cast<unsigned char>(db_client.get_number(ctx, 2));
 		
 		db_client.get_string(ctx, str, 3);
-		strncpy(scan_result.timestamp, str, strlen(str) + 1);
+		strncpy(scan_result.timestamp, str, sizeof(em_long_string_t));
 
 		scan_result.util = static_cast<unsigned char>(db_client.get_number(ctx, 4));
 		scan_result.noise = static_cast<unsigned char>(db_client.get_number(ctx, 5));
@@ -323,8 +323,7 @@ int dm_scan_result_list_t::sync_db(db_client_t& db_client, void *ctx)
 		dm_easy_mesh_t::string_to_macbytes(str, scan_result.neighbor[scan_result.num_neighbors].bssid);
 
         db_client.get_string(ctx, str, 7);
-		strncpy(scan_result.neighbor[scan_result.num_neighbors].ssid, str, strlen(str) + 1);
-
+		snprintf(scan_result.neighbor[scan_result.num_neighbors].ssid, sizeof(ssid_t), "%.*s", static_cast<int>(sizeof(ssid_t) - 1), str);
 		scan_result.neighbor[scan_result.num_neighbors].signal_strength = static_cast<signed char>(db_client.get_number(ctx, 8));
 		scan_result.neighbor[scan_result.num_neighbors].bandwidth = static_cast<wifi_channelBandwidth_t>(db_client.get_number(ctx, 9));
 		scan_result.neighbor[scan_result.num_neighbors].bss_color = static_cast<unsigned char>(db_client.get_number(ctx, 10));

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -151,7 +151,6 @@ void dm_sta_t::encode(cJSON *obj, em_get_sta_list_reason_t reason)
 {
     mac_addr_str_t  mac_str;
     cJSON *reason_obj, *request_obj;
-    em_long_string_t client_info;
 
     dm_sta_t::decode_sta_capability(this);
     dm_sta_t::decode_beacon_report(this);

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -1913,7 +1913,7 @@ int em_channel_t::handle_channel_scan_rprt(unsigned char *buff, unsigned int len
 		if (tlv->type == em_tlv_type_channel_scan_rslt) {
 			res = reinterpret_cast<em_channel_scan_result_t *> (tlv->value);
 			
-			strncpy(id.net_id, dm->m_network.m_net_info.id, strlen(dm->m_network.m_net_info.id) + 1);	
+			strncpy(id.net_id, dm->m_network.m_net_info.id, sizeof(em_long_string_t));	
 			memcpy(id.dev_mac, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t));
             memcpy(id.scanner_mac, res->ruid, sizeof(mac_address_t));
             id.op_class = res->op_class;

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -401,7 +401,7 @@ int em_configuration_t::create_operational_bss_tlv(unsigned char *buff)
         	}
         	radio->bss_num++;
         	memcpy(bss->bssid, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t));
-        	strncpy(bss->ssid, dm->m_bss[j].m_bss_info.ssid, strlen(dm->m_bss[j].m_bss_info.ssid) + 1);
+            strncpy(bss->ssid, dm->m_bss[j].m_bss_info.ssid, sizeof(ssid_t));
         	bss->ssid_len = static_cast<unsigned char> (strlen(dm->m_bss[j].m_bss_info.ssid) + 1);
         	all_bss_len += static_cast<unsigned int> (sizeof(em_ap_operational_bss_t) + bss->ssid_len);
         	bss = reinterpret_cast<em_ap_operational_bss_t *>(reinterpret_cast<unsigned char *> (bss) + sizeof(em_ap_operational_bss_t) + bss->ssid_len);
@@ -449,7 +449,7 @@ int em_configuration_t::create_operational_bss_tlv_topology(unsigned char *buff)
 				}
 				radio->bss_num++;
 				memcpy(bss->bssid, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t));
-				strncpy(bss->ssid, dm->m_bss[j].m_bss_info.ssid, strlen(dm->m_bss[j].m_bss_info.ssid) + 1);
+				strncpy(bss->ssid, dm->m_bss[j].m_bss_info.ssid, sizeof(ssid_t));
 				bss->ssid_len = static_cast<unsigned char> (strlen(dm->m_bss[j].m_bss_info.ssid) + 1);
 				all_bss_len += static_cast<unsigned int> (sizeof(em_ap_operational_bss_t) + bss->ssid_len);
 				bss = reinterpret_cast<em_ap_operational_bss_t *>(reinterpret_cast<unsigned char *> (bss) + sizeof(em_ap_operational_bss_t) + bss->ssid_len);
@@ -501,7 +501,7 @@ int em_configuration_t::create_bss_config_rprt_tlv(unsigned char *buff)
         	bss_rprt_len += sizeof(em_bss_rprt_t);
         	memcpy(bss_rprt->bssid, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(bssid_t));
         	bss_rprt->ssid_len = static_cast<unsigned char> (strlen(dm->m_bss[j].m_bss_info.ssid) + 1);
-        	strncpy(bss_rprt->ssid, dm->m_bss[j].m_bss_info.ssid, strlen(dm->m_bss[j].m_bss_info.ssid) + 1);
+            strncpy(bss_rprt->ssid, dm->m_bss[j].m_bss_info.ssid, sizeof(ssid_t));
 	
     	    bss_rprt_len += bss_rprt->ssid_len;
 
@@ -615,7 +615,9 @@ int em_configuration_t::create_ap_mld_config_tlv(unsigned char *buff)
             affiliated_ap_mld->affiliated_mac_addr_valid = affiliated_ap_info.mac_addr_valid;
             affiliated_ap_mld->link_id_valid = affiliated_ap_info.link_id_valid;
             memcpy(affiliated_ap_mld->ruid, affiliated_ap_info.ruid.mac, sizeof(mac_address_t));
-            memcpy(affiliated_ap_mld->affiliated_mac_addr, affiliated_ap_info.mac_addr, sizeof(mac_address_t));
+            mac_addr_t temp_mac;
+            memcpy(temp_mac, affiliated_ap_info.mac_addr, sizeof(mac_addr_t));
+            memcpy(affiliated_ap_mld->affiliated_mac_addr, temp_mac, sizeof(mac_addr_t));
             memcpy(&affiliated_ap_mld->link_id, &affiliated_ap_info.link_id, sizeof(unsigned char));
 
             affiliated_ap_mld = reinterpret_cast<em_affiliated_ap_mld_t *> (reinterpret_cast<unsigned char *> (affiliated_ap_mld) + sizeof(em_affiliated_ap_mld_t));
@@ -846,7 +848,7 @@ void em_configuration_t::handle_ap_vendor_operational_bss(unsigned char *value, 
 				dm->set_num_bss(dm->get_num_bss() + 1);
 			}
 			// fill up id first
-			strncpy(dm_bss->m_bss_info.id.net_id, dm->m_device.m_device_info.id.net_id, strlen(dm->m_device.m_device_info.id.net_id) + 1);
+			strncpy(dm_bss->m_bss_info.id.net_id, dm->m_device.m_device_info.id.net_id, sizeof(em_long_string_t));
 			memcpy(dm_bss->m_bss_info.id.dev_mac, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t));
 			memcpy(dm_bss->m_bss_info.id.ruid, radio->ruid, sizeof(mac_address_t));
 			memcpy(dm_bss->m_bss_info.id.bssid, bss->bssid, sizeof(mac_address_t));
@@ -1452,8 +1454,7 @@ int em_configuration_t::handle_ap_operational_bss(unsigned char *buff, unsigned 
 				dm_bss = &dm->m_bss[dm->m_num_bss];
 
 				// fill up id first
-				strncpy(dm_bss->m_bss_info.id.net_id, dm->m_device.m_device_info.id.net_id, 
-							strlen(dm->m_device.m_device_info.id.net_id) + 1);
+				strncpy(dm_bss->m_bss_info.id.net_id, dm->m_device.m_device_info.id.net_id, sizeof(em_long_string_t));
 				memcpy(dm_bss->m_bss_info.id.dev_mac, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t));
 				memcpy(dm_bss->m_bss_info.id.ruid, radio->ruid, sizeof(mac_address_t));
 				memcpy(dm_bss->m_bss_info.id.bssid, bss->bssid, sizeof(mac_address_t));
@@ -1464,7 +1465,7 @@ int em_configuration_t::handle_ap_operational_bss(unsigned char *buff, unsigned 
 			}
             strncpy(dm_bss->m_bss_info.ssid, bss->ssid, bss->ssid_len);
 			dm_bss->m_bss_info.enabled = true;
-			strncpy(dm_bss->m_bss_info.timestamp, time_date, strlen(time_date) + 1);
+			strncpy(dm_bss->m_bss_info.timestamp, time_date, sizeof(em_long_string_t));
 
 			updated_at_least_one_bss = true;
 			
@@ -1587,7 +1588,7 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
     bool found_op_bss = false;
     bool found_profile = false;
     bool found_bss_config_rprt = false;
-    em_profile_type_t profile;
+    em_profile_type_t profile = em_profile_type_reserved;
 	dm_easy_mesh_t *dm;
     
 	dm = get_data_model();
@@ -1732,7 +1733,9 @@ int em_configuration_t::handle_ap_mld_config_tlv(unsigned char *buff, unsigned i
             affiliated_ap_info->mac_addr_valid = affiliated_ap_mld->affiliated_mac_addr_valid;
             affiliated_ap_info->link_id_valid = affiliated_ap_mld->link_id_valid;
             memcpy(affiliated_ap_info->ruid.mac, affiliated_ap_mld->ruid, sizeof(mac_address_t));
-            memcpy(affiliated_ap_info->mac_addr, affiliated_ap_mld->affiliated_mac_addr, sizeof(mac_address_t));
+            mac_addr_t temp_mac;
+            memcpy(temp_mac, affiliated_ap_mld->affiliated_mac_addr, sizeof(mac_addr_t));
+            memcpy(affiliated_ap_info->mac_addr, temp_mac, sizeof(mac_address_t));
             memcpy(&affiliated_ap_info->link_id, &affiliated_ap_mld->link_id, sizeof(unsigned char));
 
             affiliated_ap_mld = reinterpret_cast<em_affiliated_ap_mld_t *> (reinterpret_cast<unsigned char *> (affiliated_ap_mld) + sizeof(em_affiliated_ap_mld_t));
@@ -3163,7 +3166,7 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 
 	dm_easy_mesh_t *dm = get_data_model();
 	unsigned int no_of_haultype = 0, radio_exists, i;
-	dm_radio_t * radio;
+	dm_radio_t * radio = NULL;
 	bool is_colocated = dm->get_colocated();
 
 	for (i = 0; i < dm->get_num_radios(); i++) {
@@ -3194,7 +3197,7 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 	attr->id = htons(attr_id_no_of_haul_type);
 	size = 1;
 	attr->len = htons(static_cast<short unsigned int> (size));
-	attr->val[0] = static_cast<unsigned char> (no_of_haultype);
+	memcpy(reinterpret_cast<char *> (attr->val), reinterpret_cast<unsigned char *> (&no_of_haultype), sizeof(no_of_haultype));
 
 	len += static_cast<short> (sizeof(data_elem_attr_t) + size);
 	tmp += (sizeof(data_elem_attr_t) + size);

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -401,7 +401,7 @@ int em_configuration_t::create_operational_bss_tlv(unsigned char *buff)
         	}
         	radio->bss_num++;
         	memcpy(bss->bssid, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t));
-            strncpy(bss->ssid, dm->m_bss[j].m_bss_info.ssid, sizeof(ssid_t));
+        	strncpy(bss->ssid, dm->m_bss[j].m_bss_info.ssid, sizeof(ssid_t));
         	bss->ssid_len = static_cast<unsigned char> (strlen(dm->m_bss[j].m_bss_info.ssid) + 1);
         	all_bss_len += static_cast<unsigned int> (sizeof(em_ap_operational_bss_t) + bss->ssid_len);
         	bss = reinterpret_cast<em_ap_operational_bss_t *>(reinterpret_cast<unsigned char *> (bss) + sizeof(em_ap_operational_bss_t) + bss->ssid_len);
@@ -615,9 +615,7 @@ int em_configuration_t::create_ap_mld_config_tlv(unsigned char *buff)
             affiliated_ap_mld->affiliated_mac_addr_valid = affiliated_ap_info.mac_addr_valid;
             affiliated_ap_mld->link_id_valid = affiliated_ap_info.link_id_valid;
             memcpy(affiliated_ap_mld->ruid, affiliated_ap_info.ruid.mac, sizeof(mac_address_t));
-            mac_addr_t temp_mac;
-            memcpy(temp_mac, affiliated_ap_info.mac_addr, sizeof(mac_addr_t));
-            memcpy(affiliated_ap_mld->affiliated_mac_addr, temp_mac, sizeof(mac_addr_t));
+            memcpy(affiliated_ap_mld->affiliated_mac_addr, affiliated_ap_info.mac_addr, sizeof(mac_address_t));
             memcpy(&affiliated_ap_mld->link_id, &affiliated_ap_info.link_id, sizeof(unsigned char));
 
             affiliated_ap_mld = reinterpret_cast<em_affiliated_ap_mld_t *> (reinterpret_cast<unsigned char *> (affiliated_ap_mld) + sizeof(em_affiliated_ap_mld_t));
@@ -1733,9 +1731,7 @@ int em_configuration_t::handle_ap_mld_config_tlv(unsigned char *buff, unsigned i
             affiliated_ap_info->mac_addr_valid = affiliated_ap_mld->affiliated_mac_addr_valid;
             affiliated_ap_info->link_id_valid = affiliated_ap_mld->link_id_valid;
             memcpy(affiliated_ap_info->ruid.mac, affiliated_ap_mld->ruid, sizeof(mac_address_t));
-            mac_addr_t temp_mac;
-            memcpy(temp_mac, affiliated_ap_mld->affiliated_mac_addr, sizeof(mac_addr_t));
-            memcpy(affiliated_ap_info->mac_addr, temp_mac, sizeof(mac_address_t));
+            memcpy(affiliated_ap_info->mac_addr, affiliated_ap_mld->affiliated_mac_addr, sizeof(mac_address_t));
             memcpy(&affiliated_ap_info->link_id, &affiliated_ap_mld->link_id, sizeof(unsigned char));
 
             affiliated_ap_mld = reinterpret_cast<em_affiliated_ap_mld_t *> (reinterpret_cast<unsigned char *> (affiliated_ap_mld) + sizeof(em_affiliated_ap_mld_t));
@@ -3196,7 +3192,7 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 	attr->id = htons(attr_id_no_of_haul_type);
 	size = 1;
 	attr->len = htons(static_cast<short unsigned int> (size));
-	memcpy(reinterpret_cast<char *> (attr->val), reinterpret_cast<unsigned char *> (&no_of_haultype), sizeof(no_of_haultype));
+	memcpy(reinterpret_cast<char *> (attr->val), reinterpret_cast<unsigned char *> (&no_of_haultype), size);
 
 	len += static_cast<short> (sizeof(data_elem_attr_t) + size);
 	tmp += (sizeof(data_elem_attr_t) + size);

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -329,7 +329,8 @@ unsigned int em_msg_t::validate(char *errors[])
         }
 
         if ((m_tlv_member[i].m_requirement == mandatory) &&((m_tlv_member[i].m_present == false)||((sizeof(em_tlv_t) + htons(tlv->len)) < static_cast<size_t> (m_tlv_member[i].m_tlv_length)))) {
-            snprintf(m_errors[m_num_errors], sizeof(m_errors[m_num_errors]), "%s", m_tlv_member[i].m_spec);
+            strncpy(m_errors[m_num_errors], m_tlv_member[i].m_spec, sizeof(m_errors[m_num_errors]) - 1);
+            m_errors[m_num_errors][sizeof(m_errors[m_num_errors]) - 1] = '\0';
             m_num_errors++;
             errors[m_num_errors - 1] = m_errors[m_num_errors - 1];
             validation = false;
@@ -343,7 +344,8 @@ unsigned int em_msg_t::validate(char *errors[])
         }
 
         if ((m_tlv_member[i].m_requirement == bad) && (m_tlv_member[i].m_present == true)) {
-            snprintf(m_errors[m_num_errors], sizeof(m_errors[m_num_errors]), "%s", m_tlv_member[i].m_spec);
+            strncpy(m_errors[m_num_errors], m_tlv_member[i].m_spec, sizeof(m_errors[m_num_errors]) - 1);
+            m_errors[m_num_errors][sizeof(m_errors[m_num_errors]) - 1] = '\0';
             m_num_errors++;
             errors[m_num_errors - 1] = m_errors[m_num_errors - 1];
             //printf("%s:%d; TLV type: 0x%04x Length: %d, presence validation error, profile: %d\n", __func__, __LINE__, 

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -329,8 +329,7 @@ unsigned int em_msg_t::validate(char *errors[])
         }
 
         if ((m_tlv_member[i].m_requirement == mandatory) &&((m_tlv_member[i].m_present == false)||((sizeof(em_tlv_t) + htons(tlv->len)) < static_cast<size_t> (m_tlv_member[i].m_tlv_length)))) {
-            strncpy(m_errors[m_num_errors], m_tlv_member[i].m_spec, sizeof(m_errors[m_num_errors]) - 1);
-            m_errors[m_num_errors][sizeof(m_errors[m_num_errors]) - 1] = '\0';
+            strncpy(m_errors[m_num_errors], m_tlv_member[i].m_spec, sizeof(m_errors[m_num_errors]));
             m_num_errors++;
             errors[m_num_errors - 1] = m_errors[m_num_errors - 1];
             validation = false;
@@ -344,8 +343,7 @@ unsigned int em_msg_t::validate(char *errors[])
         }
 
         if ((m_tlv_member[i].m_requirement == bad) && (m_tlv_member[i].m_present == true)) {
-            strncpy(m_errors[m_num_errors], m_tlv_member[i].m_spec, sizeof(m_errors[m_num_errors]) - 1);
-            m_errors[m_num_errors][sizeof(m_errors[m_num_errors]) - 1] = '\0';
+            strncpy(m_errors[m_num_errors], m_tlv_member[i].m_spec, sizeof(m_errors[m_num_errors]));
             m_num_errors++;
             errors[m_num_errors - 1] = m_errors[m_num_errors - 1];
             //printf("%s:%d; TLV type: 0x%04x Length: %d, presence validation error, profile: %d\n", __func__, __LINE__, 

--- a/src/em/em_net_node.cpp
+++ b/src/em/em_net_node.cpp
@@ -88,7 +88,7 @@ void em_net_node_t::set_node_array_value(em_network_node_t *node, char *fmt)
 {
 	em_long_string_t value;
 	char *tmp, *remain;
-	em_network_node_data_type_t arrType;
+	em_network_node_data_type_t arrType = em_network_node_data_type_invalid;
 
 	if (node->type == em_network_node_data_type_array_str) {
 		arrType = em_network_node_data_type_string;
@@ -113,7 +113,7 @@ void em_net_node_t::set_node_array_value(em_network_node_t *node, char *fmt)
 		return;
 	}
 		
-	strncpy(value, tmp, strlen(tmp) + 1);
+	strncpy(value, tmp, sizeof(em_long_string_t)-1);
 
 	tmp = value;
 	remain = value;
@@ -126,7 +126,7 @@ void em_net_node_t::set_node_array_value(em_network_node_t *node, char *fmt)
 		memset(node->child[node->num_children], 0, sizeof(em_network_node_t));
 		node->child[node->num_children]->type = arrType;
 		if (arrType == em_network_node_data_type_string) {
-			strncpy(node->child[node->num_children]->value_str, remain, strlen(remain) + 1);
+			strncpy(node->child[node->num_children]->value_str, remain, sizeof(em_long_string_t));
 		} else if (arrType == em_network_node_data_type_number) {
 			node->child[node->num_children]->value_int = static_cast<unsigned int> (atoi(remain));
 		}
@@ -144,7 +144,7 @@ void em_net_node_t::set_node_array_value(em_network_node_t *node, char *fmt)
 	memset(node->child[node->num_children], 0, sizeof(em_network_node_t));
 	node->child[node->num_children]->type = arrType;
 	if (arrType == em_network_node_data_type_string) {
-		strncpy(node->child[node->num_children]->value_str, remain, strlen(remain) + 1);
+		strncpy(node->child[node->num_children]->value_str, remain, sizeof(em_long_string_t));
 	} else if (arrType == em_network_node_data_type_number) {
 		node->child[node->num_children]->value_int = static_cast<unsigned int> (atoi(remain));
 	}
@@ -302,7 +302,8 @@ void em_net_node_t::get_network_tree_node_string(char *str, em_network_node_t *n
             } else {
                 snprintf(tmp_str, sizeof(em_2xlong_string_t), "%d, ", node->child[i]->value_int);
             }
-            strncat(value_str, tmp_str, strlen(tmp_str));	
+            size_t available_len = std::min(strlen(tmp_str), (sizeof(value_str) - strlen(value_str) - 1));
+            strncat(value_str, tmp_str, available_len);
         }
 
         value_str[strlen(value_str) - 2] = ']';
@@ -369,7 +370,7 @@ char *em_net_node_t::get_network_tree_string(em_network_node_t *node)
 cJSON *em_net_node_t::network_tree_node_to_json(em_network_node_t *node, cJSON *parent)
 {
     unsigned int i;
-    cJSON *obj;
+    cJSON *obj = NULL;
 
     switch (node->type) {
         case em_network_node_data_type_invalid:
@@ -572,7 +573,7 @@ em_network_node_t *em_net_node_t::clone_network_tree(em_network_node_t *node)
     cloned->display_info.orig_node_ctr = node->display_info.orig_node_ctr;
 
     cloned->type = node->type;
-    strncpy(cloned->value_str, node->value_str, strlen(node->value_str) + 1);
+    strncpy(cloned->value_str, node->value_str, sizeof(em_long_string_t));
     cloned->value_int = node->value_int;
 
 	for (i = 0; i < node->num_children; i++) {
@@ -628,7 +629,7 @@ em_network_node_t *em_net_node_t::clone_network_tree_for_display(em_network_node
     cloned->display_info.orig_node_ctr = node->display_info.orig_node_ctr;
 
     cloned->type = node->type;
-    strncpy(cloned->value_str, node->value_str, strlen(node->value_str) + 1);
+    strncpy(cloned->value_str, node->value_str, sizeof(em_long_string_t));
     cloned->value_int = node->value_int;
 
     should_consider = (node->display_info.node_ctr == index);

--- a/src/em/em_net_node.cpp
+++ b/src/em/em_net_node.cpp
@@ -113,7 +113,7 @@ void em_net_node_t::set_node_array_value(em_network_node_t *node, char *fmt)
 		return;
 	}
 		
-	strncpy(value, tmp, sizeof(em_long_string_t)-1);
+	snprintf(value, sizeof(em_long_string_t), "%s", tmp);
 
 	tmp = value;
 	remain = value;

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -1154,7 +1154,7 @@ short em_metrics_t::create_beacon_metrics_query_tlv(unsigned char *buff, mac_add
 
     for (j = 0; j < dm->get_num_bss(); j++) {
         if (memcmp(&dm->m_bss[j].m_bss_info.bssid, sta->m_sta_info.bssid, sizeof(bssid_t)) != 0) {
-            strncpy(ssid, dm->m_bss[j].m_bss_info.ssid, sizeof(ssid_t)-1);
+            snprintf(ssid, sizeof(ssid_t), "%s", dm->m_bss[j].m_bss_info.ssid);
             break;
         }
     }

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -104,8 +104,8 @@ int em_metrics_t::handle_assoc_sta_vendor_link_metrics_tlv(unsigned char *buff)
 {
     em_assoc_sta_vendor_link_metrics_t *sta_metrics;
     //em_assoc_vendor_link_metrics_t *metrics;
-    dm_sta_t *sta;
-    unsigned int i;
+    dm_sta_t *sta = NULL;
+    //unsigned int i;
     dm_easy_mesh_t  *dm;
 
     dm = get_data_model();
@@ -266,7 +266,7 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
     unsigned int tmp_len = 0;
     dm_sta_t *sta;
-    em_beacon_metrics_resp_t *response;
+    em_beacon_metrics_resp_t *response = NULL;
     dm_easy_mesh_t  *dm;
     unsigned int report_len = 0;
 
@@ -854,7 +854,6 @@ int em_metrics_t::send_ap_metrics_response()
     dm_sta_t *sta;
     short msg_id = em_msg_type_ap_metrics_rsp;
     int bss_index = 0;
-    mac_addr_str_t rad_str;
 
     memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
@@ -880,7 +879,7 @@ int em_metrics_t::send_ap_metrics_response()
 
     //AP Metrics Response 17.1.17
     //AP Metrics TLV (17.2.22)
-    for (bss_index = 0; bss_index < dm->m_num_bss; bss_index++) {
+    for (bss_index = 0; bss_index < static_cast<int>(dm->m_num_bss); bss_index++) {
         if (memcmp(dm->m_bss[bss_index].m_bss_info.ruid.mac,
             get_current_cmd()->get_param()->u.ap_metrics_params.ruid, sizeof(mac_addr_t)) != 0) {
             continue;
@@ -916,7 +915,7 @@ int em_metrics_t::send_ap_metrics_response()
         sta = reinterpret_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
         while(sta != NULL) {
             if (memcmp(sta->get_sta_info()->bssid, dm->m_bss[bss_index].m_bss_info.bssid.mac, sizeof(mac_address_t)) != 0) {
-                sta = (dm_sta_t *)hash_map_get_next(dm->m_sta_map, sta);
+                sta = static_cast<dm_sta_t *>(hash_map_get_next(dm->m_sta_map, sta));
                 continue;
             }
             //Associated STA Traffic Stats TLV (17.2.35)
@@ -1155,7 +1154,7 @@ short em_metrics_t::create_beacon_metrics_query_tlv(unsigned char *buff, mac_add
 
     for (j = 0; j < dm->get_num_bss(); j++) {
         if (memcmp(&dm->m_bss[j].m_bss_info.bssid, sta->m_sta_info.bssid, sizeof(bssid_t)) != 0) {
-            strncpy(ssid, dm->m_bss[j].m_bss_info.ssid, sizeof(ssid_t));
+            strncpy(ssid, dm->m_bss[j].m_bss_info.ssid, sizeof(ssid_t)-1);
             break;
         }
     }
@@ -1267,16 +1266,16 @@ short em_metrics_t::create_ap_metrics_tlv(unsigned char *buff, dm_bss_t &dm_bss)
         memcpy(ap_metrics->bssid, dm_bss.m_bss_info.bssid.mac, sizeof(mac_address_t));
         len += static_cast<size_t> (sizeof(mac_address_t));
 
-        ap_metrics->channel_util = dm_bss.m_bss_info.numberofsta;
+        ap_metrics->channel_util = static_cast<unsigned char>(dm_bss.m_bss_info.numberofsta);
         len += static_cast<size_t> (sizeof(unsigned char));
 
-        ap_metrics->num_sta = htons(dm_bss.m_bss_info.numberofsta);
+        ap_metrics->num_sta = htons(static_cast<uint16_t>(dm_bss.m_bss_info.numberofsta));
         len += static_cast<size_t> (sizeof(unsigned short));
 
         ap_metrics->est_service_params_BE_bit = 1;
         len += static_cast<size_t> (sizeof(unsigned char));
 
-        for(int i = 0; i < sizeof(ap_metrics->est_service_params_BE); i++) {
+        for(int i = 0; i < static_cast<int>(sizeof(ap_metrics->est_service_params_BE)); i++) {
             ap_metrics->est_service_params_BE[i] = 0;
             len += static_cast<size_t> (sizeof(unsigned char));
         }

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -44,7 +44,7 @@
 short em_policy_cfg_t::create_metrics_rep_policy_tlv(unsigned char *buff)
 {
 	short len = 0;
-	dm_easy_mesh_t *dm;
+	dm_easy_mesh_t *dm = NULL;
 	dm_policy_t *policy;
 	bool found_match = false;
 	unsigned char *tmp = buff;
@@ -405,7 +405,7 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
         } else if (tlv->type == em_tlv_type_qos_mgmt_policy){
         } else if (tlv->type == em_tlv_vendor_plolicy_cfg) {
             em_vendor_policy_t *vendor = reinterpret_cast<em_vendor_policy_t *> (tlv->value);
-            strncpy(policy.vendor_policy.managed_client_marker, vendor->managed_client_marker, strlen(vendor->managed_client_marker)+1);
+            strncpy(policy.vendor_policy.managed_client_marker, vendor->managed_client_marker, sizeof(em_string_t)-1);
             data_len += sizeof(em_vendor_policy_t);
         }
 

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -405,7 +405,7 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
         } else if (tlv->type == em_tlv_type_qos_mgmt_policy){
         } else if (tlv->type == em_tlv_vendor_plolicy_cfg) {
             em_vendor_policy_t *vendor = reinterpret_cast<em_vendor_policy_t *> (tlv->value);
-            strncpy(policy.vendor_policy.managed_client_marker, vendor->managed_client_marker, sizeof(em_string_t)-1);
+            snprintf(policy.vendor_policy.managed_client_marker, sizeof(em_string_t), "%s", vendor->managed_client_marker);
             data_len += sizeof(em_vendor_policy_t);
         }
 

--- a/src/em/prov/easyconnect/ec_crypto.cpp
+++ b/src/em/prov/easyconnect/ec_crypto.cpp
@@ -107,7 +107,7 @@ size_t ec_crypto::compute_hkdf_key(ec_connection_context_t& c_ctx, uint8_t *key_
 BIGNUM* ec_crypto::calculate_Lx(ec_connection_context_t& c_ctx, const BIGNUM* bR, const BIGNUM* pR, const EC_POINT* BI)
 {
     EC_POINT* L = NULL;
-    BIGNUM *sum, *order, *L_x = NULL;
+    BIGNUM *sum = NULL, *order, *L_x = NULL;
     int success = 0;
     
     // Get the order of the curve (q)

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -1084,7 +1084,7 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_config_request()
     if (gethostname(hostname, sizeof(hostname)) != 0) {
         em_printfout("`gethostname` failed, defaulting DPP Configuration Request object key \"name\" to \"Enrollee\"");
         static const char *default_name = "Enrollee";
-        strncpy(hostname, default_name, strlen(default_name));
+        strncpy(hostname, default_name, sizeof(hostname)-1);
     }
     cJSON *name = cJSON_CreateString(hostname);
     if (!dpp_config_request_obj || !netRole || !wifi_tech) {

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -1084,7 +1084,7 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_config_request()
     if (gethostname(hostname, sizeof(hostname)) != 0) {
         em_printfout("`gethostname` failed, defaulting DPP Configuration Request object key \"name\" to \"Enrollee\"");
         static const char *default_name = "Enrollee";
-        strncpy(hostname, default_name, sizeof(hostname)-1);
+        strncpy(hostname, default_name, sizeof(hostname));
     }
     cJSON *name = cJSON_CreateString(hostname);
     if (!dpp_config_request_obj || !netRole || !wifi_tech) {

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -511,7 +511,7 @@ int em_provisioning_t::handle_proxy_encap_dpp(uint8_t *buff, unsigned int len)
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
 
-    uint16_t encap_tlv_len, chirp_tlv_len = 0;
+    uint16_t encap_tlv_len = 0, chirp_tlv_len = 0;
     em_encap_dpp_t* encap_tlv = NULL;
     em_dpp_chirp_value_t* chirp_tlv = NULL;
 


### PR DESCRIPTION
Reason for change: 1) Fixed all the warnings observed with werror flag in controller makefiles.
2) Fixed runtime error for valid value for type 'em_profile_type_t', observed after enabling werror.
3) Keeping werror disable in makefile till further update.
Test Procedure: Compared the run time logs for OneWifi, controller and agent with and without changes and did not observe any additional logs/error.
Tested the changes by changing the SSID, Passphrase and radio channel through CLI observed its works fine.
Risks: Medium
Priority: P1