### PR TITLE
Updates to unified wifi mesh to allow it to compile with AL_SAP enabled post-"dual socket" changes

### DIFF
--- a/inc/al_service_utils.h
+++ b/inc/al_service_utils.h
@@ -4,18 +4,28 @@
 #include <vector>
 #include <iostream> // for std::cout
 #include <iomanip>  // for std::hex
+#include <sys/un.h>
+#include <array>
 
 // PrintByteStream function used for debugging only
+/**!
+ * @brief Prints the contents of a byte stream.
+ *
+ * This function takes a vector of unsigned characters and prints each byte in the stream.
+ *
+ * @param[in] byteStream A vector containing the byte stream to be printed.
+ *
+ * @note Ensure that the byte stream is not empty before calling this function.
+ */
+void printByteStream(const std::vector<unsigned char>& byteStream);
 
-	/**!
-	 * @brief Prints the contents of a byte stream.
-	 *
-	 * This function takes a vector of unsigned characters and prints each byte in the stream.
-	 *
-	 * @param[in] byteStream A vector containing the byte stream to be printed.
-	 *
-	 * @note Ensure that the byte stream is not empty before calling this function.
-	 */
-	void printByteStream(const std::vector<unsigned char>& byteStream);
+struct sockaddr_un createUnixSocketAddress(const std::string &path);
 
+struct sockaddr_in createUDPServerAddress(int port);
+
+struct sockaddr_in createUDPClientAddress(const std::string &ip, int port);
+
+std::string macAddressToString(const std::array<uint8_t, 6> arr);
+
+bool areMacsEqual(const std::array<uint8_t, 6> &first, const std::array<uint8_t, 6> &second);
 #endif // AL_SERVICE_UTILS_H

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -47,7 +47,9 @@
 #endif
 
 #define RETRY_SLEEP_INTERVAL_IN_MS 1000
-#define SOCKET_PATH "/tmp/ieee1905_tunnel"
+
+#define DATA_SOCKET_PATH "/tmp/al_data_socket"
+#define CONTROL_SOCKET_PATH "/tmp/al_control_socket"
 
 em_agent_t g_agent;
 const char *global_netid = "OneWifiMesh";
@@ -1647,7 +1649,7 @@ em_agent_t::~em_agent_t()
 #ifdef AL_SAP
 AlServiceAccessPoint* em_agent_t::al_sap_register()
 {
-    AlServiceAccessPoint* sap = new AlServiceAccessPoint(SOCKET_PATH);
+    AlServiceAccessPoint* sap = new AlServiceAccessPoint(DATA_SOCKET_PATH, CONTROL_SOCKET_PATH);
 
     AlServiceRegistrationRequest registrationRequest(ServiceOperation::SOP_ENABLE, ServiceType::SAP_TUNNEL_CLIENT);
     sap->serviceAccessPointRegistrationRequest(registrationRequest);

--- a/src/al-sap/al_service_utils.cpp
+++ b/src/al-sap/al_service_utils.cpp
@@ -1,3 +1,10 @@
+#include <string.h>
+#include <sstream>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <algorithm>
 #include "al_service_utils.h"
 
 
@@ -9,4 +16,51 @@ void printByteStream(const std::vector<unsigned char>& byteStream) {
     }
     std::cout << std::endl;
     #endif
+}
+
+struct sockaddr_un createUnixSocketAddress(const std::string &path)
+{
+    struct sockaddr_un address = {0};
+    address.sun_family = AF_UNIX;
+    strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+    return address;
+}
+
+struct sockaddr_in createUDPServerAddress(int port)
+{
+    sockaddr_in address = {0};
+    address.sin_family = AF_INET;
+    address.sin_port = htons(port);
+    address.sin_addr.s_addr = INADDR_ANY;
+    return address;
+}
+
+struct sockaddr_in createUDPClientAddress(const std::string &ip, int port)
+{
+    sockaddr_in address = {0};
+    address.sin_family = AF_INET;
+    address.sin_port = htons(port);
+    address.sin_addr.s_addr = inet_addr(ip.c_str());
+    return address;
+}
+
+std::string macAddressToString(const std::array<uint8_t, 6> arr)
+{
+    std::ostringstream oss;
+    bool first = true;
+    for (const auto &byte : arr)
+    {
+        if (!first)
+        {
+            oss << ":";
+        }
+        oss << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(byte);
+        first = false;
+    }
+    return oss.str();
+}
+
+bool areMacsEqual(const std::array<uint8_t, 6> &first, const std::array<uint8_t, 6> &second)
+{
+    return std::equal(begin(first), end(first), begin(second));
 }

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -57,7 +57,8 @@ const char *global_netid = "OneWifiMesh";
 AlServiceAccessPoint* g_sap;
 MacAddress g_al_mac_sap;
 
-#define SOCKET_PATH "/tmp/ieee1905_tunnel"
+#define DATA_SOCKET_PATH "/tmp/al_data_socket"
+#define CONTROL_SOCKET_PATH "/tmp/al_control_socket"
 #endif
 
 void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
@@ -886,7 +887,7 @@ em_ctrl_t::~em_ctrl_t()
 #ifdef AL_SAP
 AlServiceAccessPoint* em_ctrl_t::al_sap_register()
 {
-    AlServiceAccessPoint* sap = new AlServiceAccessPoint(SOCKET_PATH);
+    AlServiceAccessPoint* sap = new AlServiceAccessPoint(DATA_SOCKET_PATH, CONTROL_SOCKET_PATH);
 
     AlServiceRegistrationRequest registrationRequest(ServiceOperation::SOP_ENABLE, ServiceType::SAP_TUNNEL_CLIENT);
     sap->serviceAccessPointRegistrationRequest(registrationRequest);

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -615,7 +615,7 @@ int em_t::set_bp_filter()
 int em_t::start_al_interface()
 {
 #ifdef AL_SAP
-    m_fd = g_sap->getSocketDescriptor();
+    m_fd = g_sap->getDataSocketDescriptor();
 #else
     int sock_fd;
     struct sockaddr_ll addr_ll;


### PR DESCRIPTION
One commit (the utils files) is pulling the latest utils from the alsap sources in rdkb-ieee1905.1-service-access (which will be redundant from this point) and the other commit changes the AL_SAP parts of EasyMesh components (agent/controller) to work with the new "dual socket" alsap library API