### PR TITLE
RDKBACCL-821 : observing build issues with latest tip revision of uwm

### DIFF
--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -98,6 +98,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/ctrl/em_cmd_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_network_topo.cpp \
+     $(top_srcdir)/src/ctrl/em_dev_test_ctrl.cpp \
      $(top_srcdir)/src/db/db_client.cpp \
      $(top_srcdir)/src/db/db_column.cpp \
      $(top_srcdir)/src/db/db_easy_mesh.cpp \


### PR DESCRIPTION
Reason for change: Observing below errors,
 undefined reference to `em_dev_test_t::em_dev_test_t()'
Test Procedure: Able to compile uwm
Risks: Low