### PR TITLE
RDKBACCL-322 : Observing build issues in latest tip of uwm

### DIFF
--- a/inc/db_client.h
+++ b/inc/db_client.h
@@ -19,7 +19,7 @@
 #ifndef DB_CLIENT_H
 #define DB_CLIENT_H
 
-#ifdef OPENWRT_BUILD
+#if defined(OPENWRT_BUILD) || defined(_PLATFORM_BANANAPI_R4_)
 // MariaDB C client header for cross compiled OpenWRT
 #include <mysql/mysql.h>
 #else

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -34,7 +34,6 @@ onewifi_em_ctrl_CPPFLAGS = \
     -I$(top_srcdir)/OneWifi/source/utils \
     -I$(top_srcdir)/OneWifi/source/platform/rdkb \
     -I$(top_srcdir)/OneWifi/source/platform/common \
-    -I$(STAGING_DIR)/usr/include
     -DUNIT_TEST
 
 onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Werror -O2


### PR DESCRIPTION
Reason for change: Observing below errors,
1.../../../git/inc/db_client.h:27:10: fatal error: mariadb/mysql.h: No such file or directory
|    27 | #include <mariadb/mysql.h>
|       |          ^~~~~~~~~~~~~~~~
2.| Makefile:3260: *** missing separator.  Stop.
| make[2]: *** [Makefile:370: all-recursive] Error 1
Test Procedure: Able to compile uwm
Risks: Low