### PR TITLE
Switched to loopback check for AL_SAP co_located frames.

### DIFF
--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -667,23 +667,17 @@ int em_t::send_frame(unsigned char *buff, unsigned int len, bool multicast)
         }
     }
 #ifdef AL_SAP
-    auto ctrl_al = m_data_model->get_controller_interface_mac();
-    auto agent_al = m_data_model->get_agent_al_interface_mac();
-    bool is_colocated = (memcmp(ctrl_al, agent_al, ETH_ALEN) == 0);
 
     AlServiceDataUnit sdu;
     sdu.setSourceAlMacAddress(g_al_mac_sap);
-    if (m_service_type == em_service_type_ctrl) {
-        if (is_loopback_frame || is_colocated) {
-            sdu.setDestinationAlMacAddress(g_al_mac_sap);
-        } else {
+    if (is_loopback_frame) {
+        sdu.setDestinationAlMacAddress(g_al_mac_sap);
+    } else {
+        // Set the destination AL MAC address based on the service type
+        if (m_service_type == em_service_type_ctrl) {
             sdu.setDestinationAlMacAddress({0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
         }
-    }
-    if (m_service_type == em_service_type_agent) {
-        if (is_loopback_frame || is_colocated) {
-            sdu.setDestinationAlMacAddress(g_al_mac_sap);
-        } else {
+        if (m_service_type == em_service_type_agent) {
             sdu.setDestinationAlMacAddress({0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
         }
     }


### PR DESCRIPTION
This change works with the SAP Tunnel with:
```json
{
        "almac":        [0, 0, 0, 0, 0, 0],
        "ip":   "0.0.0.0"
}
```
In the `tunnel_cfg.json` routing table.
