### PR TITLE
Implement DPP onboarding of DPP capable STA (client devices)

### DIFF
--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -85,6 +85,12 @@ using get_backhaul_sta_info_func = std::function<cJSON*(ec_connection_context_t 
 using get_1905_info_func = std::function<cJSON*(ec_connection_context_t *)>;
 
 /**
+ * @brief Creates a DPP Configuration Response object for the fronthaul BSS interface(s)
+ * @return cJSON * on success, nullptr otherwise
+ */
+using get_fbss_info_func = std::function<cJSON*(ec_connection_context_t *)>;
+
+/**
  * @brief Used to determine if an additional AP can be on-boarded or not.
  * @return True if additional APs can be on-boraded into the mesh, false otherwise.
  */
@@ -109,7 +115,7 @@ public:
 	 */
 	ec_configurator_t(std::string mac_addr, send_chirp_func send_chirp_notification, send_encap_dpp_func send_prox_encap_dpp_msg, 
                         send_act_frame_func send_action_frame, get_backhaul_sta_info_func backhaul_sta_info_func, get_1905_info_func ieee1905_info_func,
-                        can_onboard_additional_aps_func can_onboard_func);
+                        get_fbss_info_func fbss_info_func, can_onboard_additional_aps_func can_onboard_func);
     
 	/**!
 	 * @brief Destructor for ec_configurator_t class.
@@ -396,6 +402,8 @@ protected:
     get_backhaul_sta_info_func m_get_backhaul_sta_info;
 
     get_1905_info_func m_get_1905_info;
+
+	get_fbss_info_func m_get_fbss_info;
 
     can_onboard_additional_aps_func m_can_onboard_additional_aps;
 

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -10,6 +10,7 @@ struct cJSON;
 typedef enum {
     dpp_config_obj_bsta,
     dpp_config_obj_ieee1905,
+	dpp_config_obj_fbss,
 } dpp_config_obj_type_e;
 
 class ec_ctrl_configurator_t : public ec_configurator_t {
@@ -30,8 +31,8 @@ public:
 	 * @note This constructor initializes the base class ec_configurator_t with the provided parameters.
 	 */
 	ec_ctrl_configurator_t(std::string mac_addr, send_chirp_func send_chirp_notification, send_encap_dpp_func send_prox_encap_dpp_msg,
-        get_backhaul_sta_info_func backhaul_sta_info_func, get_1905_info_func ieee1905_info_func, can_onboard_additional_aps_func can_onboard_func) :
-        ec_configurator_t(mac_addr, send_chirp_notification, send_prox_encap_dpp_msg, {}, backhaul_sta_info_func, ieee1905_info_func, can_onboard_func)
+        get_backhaul_sta_info_func backhaul_sta_info_func, get_1905_info_func ieee1905_info_func, get_fbss_info_func get_fbss_info, can_onboard_additional_aps_func can_onboard_func) :
+        ec_configurator_t(mac_addr, send_chirp_notification, send_prox_encap_dpp_msg, {}, backhaul_sta_info_func, ieee1905_info_func, get_fbss_info, can_onboard_func)
         {};
         // No MAC address needed for controller configurator
 
@@ -235,6 +236,8 @@ private:
 	 * @param[in] dialog_token The session dialog token for the Enrollee.
 	 * @param[in] dpp_status The status of the DPP Configuration. Use DPP_STATUS_OK for
 	 *                       success or DPP_STATUS_CONFIGURATION_FAILURE for failure.
+	 * @param is_sta Optional parameter to indicate if the frame is for a station (default is false). If this is for a STA being onboarded,
+	 * we provide fronthaul BSS information and don't issue a DPP Connector (EasyMesh 5.3.11)
 	 *
 	 * @return std::pair<uint8_t*, size_t> A pair containing the frame and its length
 	 *                                      on success, or nullptr and 0 on failure.
@@ -242,7 +245,7 @@ private:
 	 * @note Ensure that the destination MAC address is valid and that the dialog token
 	 *       and DPP status are correctly set before calling this function.
 	 */
-	std::pair<uint8_t*, size_t> create_config_response_frame(uint8_t dest_mac[ETH_ALEN], const uint8_t dialog_token, ec_status_code_t dpp_status);
+	std::pair<uint8_t*, size_t> create_config_response_frame(uint8_t dest_mac[ETH_ALEN], const uint8_t dialog_token, ec_status_code_t dpp_status, bool is_sta = false);
 
     
 	/**

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -32,7 +32,7 @@ public:
 	 * If the EasyMesh code is correctly implemented this should not be an issue.
 	 */
 	ec_manager_t(std::string mac_addr, send_chirp_func send_chirp, send_encap_dpp_func send_encap_dpp, send_act_frame_func send_action_frame, 
-        get_backhaul_sta_info_func get_bsta_info, get_1905_info_func get_1905_info, can_onboard_additional_aps_func can_onboard, toggle_cce_func toggle_cce, 
+        get_backhaul_sta_info_func get_bsta_info, get_1905_info_func get_1905_info, get_fbss_info_func get_fbss_info, can_onboard_additional_aps_func can_onboard, toggle_cce_func toggle_cce, 
 		start_stop_clist_build_func start_stop_clist_build_fn, bsta_connect_func bsta_connect_fn, bool m_is_controller);
     
 	/**!
@@ -247,6 +247,7 @@ private:
     get_backhaul_sta_info_func m_get_bsta_info_fn;
     get_1905_info_func m_get_1905_info_fn;
     can_onboard_additional_aps_func m_can_onboard_fn;
+	get_fbss_info_func m_get_fbss_info_fn;
     std::string m_stored_mac_addr;
     
     std::unique_ptr<ec_configurator_t> m_configurator;

--- a/inc/ec_pa_configurator.h
+++ b/inc/ec_pa_configurator.h
@@ -33,6 +33,7 @@ public:
         send_act_frame_func send_action_frame,
         get_backhaul_sta_info_func get_sta_info_func,
         get_1905_info_func ieee1905_info_func,
+		get_fbss_info_func fbss_info_func,
         toggle_cce_func toggle_cce_fn
     ) : ec_configurator_t(
             mac_addr,
@@ -41,6 +42,7 @@ public:
             send_action_frame,
             get_sta_info_func,
             ieee1905_info_func,
+			fbss_info_func,
             {}
         ),
         m_toggle_cce(toggle_cce_fn) { }

--- a/inc/em_provisioning.h
+++ b/inc/em_provisioning.h
@@ -455,6 +455,15 @@ protected:
 	 * @note Ensure that the connection context is properly initialized before calling this function.
 	 */
 	cJSON *create_ieee1905_response_obj(ec_connection_context_t *conn_ctx);
+
+	/**
+	 * @brief Create a fBSS (fronthaul BSS) Configuration response object for DPP STA onboarding
+	 * 
+	 * @param conn_ctx The connection context used to create the response object.
+	 * @return cJSON* Configuration response object on success, nullptr otherwise
+	 */
+	cJSON *create_fbss_response_obj(ec_connection_context_t *conn_ctx);
+
 public:
     
 	/**!

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1345,6 +1345,9 @@ em_t::em_t(em_interface_t *ruid, em_freq_band_t band, dm_easy_mesh_t *dm, em_mgr
             service_type == em_service_type_ctrl
                 ? std::bind(&em_t::create_ieee1905_response_obj, this, std::placeholders::_1)
                 : static_cast<get_1905_info_func>(nullptr),
+            service_type == em_service_type_ctrl
+                ? std::bind(&em_t::create_fbss_response_obj, this, std::placeholders::_1)
+                : static_cast<get_fbss_info_func>(nullptr),
             std::bind(&em_mgr_t::can_onboard_additional_aps, mgr),
             std::bind(&em_t::toggle_cce, this, std::placeholders::_1),
             std::bind(&em_t::start_stop_build_ec_channel_list, this, std::placeholders::_1),

--- a/src/em/prov/easyconnect/ec_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_configurator.cpp
@@ -10,12 +10,14 @@ ec_configurator_t::ec_configurator_t(
     send_act_frame_func send_action_frame,
     get_backhaul_sta_info_func backhaul_sta_info_func,
     get_1905_info_func ieee1905_info_func,
+    get_fbss_info_func get_fbss_info_func,
     can_onboard_additional_aps_func can_onboard_func) : m_mac_addr(mac_addr),
     m_send_chirp_notification(send_chirp_notification),
     m_send_prox_encap_dpp_msg(send_prox_encap_dpp_msg),
     m_send_action_frame(send_action_frame),
     m_get_backhaul_sta_info(backhaul_sta_info_func),
     m_get_1905_info(ieee1905_info_func),
+    m_get_fbss_info(get_fbss_info_func),
     m_can_onboard_additional_aps(can_onboard_func)
 {
 }

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -13,6 +13,7 @@ ec_manager_t::ec_manager_t(
     send_act_frame_func send_action_frame,
     get_backhaul_sta_info_func get_bsta_info,
     get_1905_info_func get_1905_info,
+    get_fbss_info_func get_fbss_info,
     can_onboard_additional_aps_func can_onboard,
     toggle_cce_func toggle_cce, 
     start_stop_clist_build_func start_stop_clist_build_fn, 
@@ -24,6 +25,7 @@ ec_manager_t::ec_manager_t(
     m_stored_action_frame_fn(send_action_frame),
     m_get_bsta_info_fn(get_bsta_info),
     m_get_1905_info_fn(get_1905_info),
+    m_get_fbss_info_fn(get_fbss_info),
     m_can_onboard_fn(can_onboard),
     m_stored_mac_addr(mac_addr),
     m_configurator(nullptr),
@@ -33,7 +35,7 @@ ec_manager_t::ec_manager_t(
     printf("EC Manager created with MAC: %s\n", mac_addr.c_str());  
     if (m_is_controller) {
         m_configurator = std::unique_ptr<ec_ctrl_configurator_t>(
-            new ec_ctrl_configurator_t(mac_addr, send_chirp, send_encap_dpp, get_bsta_info, get_1905_info, can_onboard)
+            new ec_ctrl_configurator_t(mac_addr, send_chirp, send_encap_dpp, get_bsta_info, get_1905_info, get_fbss_info, can_onboard)
         );
     } else {
         m_enrollee = std::unique_ptr<ec_enrollee_t>(
@@ -158,7 +160,7 @@ bool ec_manager_t::upgrade_to_onboarded_proxy_agent()
     m_enrollee.reset();
     
     // Create a new proxy agent configurator
-    m_configurator = std::unique_ptr<ec_pa_configurator_t>(new ec_pa_configurator_t(enrollee_mac, m_stored_chirp_fn, m_stored_encap_dpp_fn, m_stored_action_frame_fn, m_get_bsta_info_fn, m_get_1905_info_fn, m_toggle_cce_fn));
+    m_configurator = std::unique_ptr<ec_pa_configurator_t>(new ec_pa_configurator_t(enrollee_mac, m_stored_chirp_fn, m_stored_encap_dpp_fn, m_stored_action_frame_fn, m_get_bsta_info_fn, m_get_1905_info_fn, m_get_fbss_info_fn, m_toggle_cce_fn));
     em_printfout("Upgraded enrollee agent to proxy agent");
     return true;
 }

--- a/src/em/prov/em_provisioning.cpp
+++ b/src/em/prov/em_provisioning.cpp
@@ -674,6 +674,133 @@ cJSON *em_provisioning_t::create_enrollee_bsta_list(ec_connection_context_t *con
     return b_sta_list_arr;
 }
 
+cJSON *em_provisioning_t::create_fbss_response_obj(ec_connection_context_t *conn_ctx)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    ASSERT_NOT_NULL(dm, nullptr, "%s:%d: Failed to get data model handle.\n", __func__, __LINE__);
+
+    cJSON *fbss_configuration_object = cJSON_CreateObject();
+    ASSERT_NOT_NULL(fbss_configuration_object, nullptr, "%s:%d: Could not create fBSS Configuration Object\n", __func__, __LINE__);
+
+    if (!cJSON_AddStringToObject(fbss_configuration_object, "wi-fi_tech", "map")) {
+        em_printfout("Failed to add \"wi-fi_tech\" to Configuration Object");
+        cJSON_Delete(fbss_configuration_object);
+    }
+
+    cJSON *discovery_object = cJSON_CreateObject();
+    if (discovery_object == nullptr) {
+        em_printfout("Failed to create Discovery Object for DPP Configuration Object");
+        cJSON_Delete(fbss_configuration_object);
+    }
+
+    const em_network_ssid_info_t* network_ssid_info = dm->get_network_ssid_info_by_haul_type(em_haul_type_fronthaul);
+    if (network_ssid_info == nullptr) {
+        em_printfout("No fronthaul BSS found, cannot create fBSS Configuration Object");
+        cJSON_Delete(fbss_configuration_object);
+        cJSON_Delete(discovery_object);
+        return nullptr;
+    }
+
+    if (!cJSON_AddStringToObject(discovery_object, "SSID", network_ssid_info->ssid)) {
+        em_printfout("Could not add \"SSID\" to fBSS Configuration Object");
+        cJSON_Delete(fbss_configuration_object);
+        cJSON_Delete(discovery_object);
+        return nullptr;
+    }
+
+    for (int i = 0; i < dm->get_num_bss(); i++) {
+        const dm_bss_t *bss = dm->get_bss(i);
+        if (!bss) continue;
+        if (bss->m_bss_info.id.haul_type == em_haul_type_fronthaul && strncmp(bss->m_bss_info.ssid, network_ssid_info->ssid, strlen(network_ssid_info->ssid)) == 0) {
+            em_printfout("Found fronthaul BSS! '%s'", bss->m_bss_info.ssid);
+            if (!cJSON_AddStringToObject(discovery_object, "BSSID", util::mac_to_string(bss->m_bss_info.bssid.mac, "").c_str())) {
+                em_printfout("Failed to add \"BSSID\" to fBSS Configuration Object");
+                cJSON_Delete(fbss_configuration_object);
+                cJSON_Delete(discovery_object);
+                return nullptr;
+            }
+            if (!cJSON_AddStringToObject(discovery_object, "RUID", util::mac_to_string(bss->m_bss_info.ruid.mac, "").c_str())) {
+                em_printfout("Failed to add \"RUID\" to fBSS Configuration Object");
+                cJSON_Delete(fbss_configuration_object);
+                cJSON_Delete(discovery_object);
+                return nullptr;
+            }
+        }
+    }
+
+    cJSON *credential_object = cJSON_CreateObject();
+    if (credential_object == nullptr) {
+        em_printfout("Failed to create credential object for DPP Configuration object.");
+        cJSON_Delete(discovery_object);
+        cJSON_Delete(fbss_configuration_object);
+        return nullptr;
+    }
+
+    std::string akm_suites = {};
+    bool needs_psk_hex = false;
+    for (unsigned int i = 0; i < network_ssid_info->num_akms; i++) {
+        if (!akm_suites.empty()) akm_suites += "+";
+        akm_suites += util::akm_to_oui(network_ssid_info->akm[i]);
+
+    }
+    // "psk_hex" is a conditional field,
+    // present only if PSK or AKM or SAE is a selected AKM
+    const auto check_needs_psk_hex = [](std::string akm) -> bool {
+        // psk || sae
+        return akm == util::akm_to_oui("psk")
+        || akm == util::akm_to_oui("sae");
+    };
+
+    std::vector<std::string> akms = util::split_by_delim(akm_suites, '+');
+    for (const auto& akm : akms) {
+        if (check_needs_psk_hex(akm)) needs_psk_hex = true;
+    }
+
+    if (!cJSON_AddStringToObject(credential_object, "akm", akm_suites.c_str())) {
+        em_printfout("Failed to add \"akm\" to bSTA DPP Configuration Object");
+        cJSON_Delete(discovery_object);
+        cJSON_Delete(fbss_configuration_object);
+        cJSON_Delete(credential_object);
+        return nullptr;
+    }
+
+    if (needs_psk_hex) {
+        std::vector<uint8_t> psk = ec_crypto::gen_psk(std::string(network_ssid_info->pass_phrase), std::string(network_ssid_info->ssid));
+        if (psk.empty()) {
+            em_printfout("Failed to generate PSK");
+            cJSON_Delete(discovery_object);
+            cJSON_Delete(fbss_configuration_object);
+            cJSON_Delete(credential_object);
+            return nullptr;
+        }
+
+        cJSON_AddStringToObject(credential_object, "psk_hex", em_crypto_t::hash_to_hex_string(psk).c_str());
+    }
+
+    if (!cJSON_AddStringToObject(credential_object, "pass", network_ssid_info->pass_phrase)) {
+        em_printfout("Failed to add \"pass\" to bSTA DPP Configuration Object");
+        cJSON_Delete(discovery_object);
+        cJSON_Delete(credential_object);
+        cJSON_Delete(fbss_configuration_object);
+        return nullptr;
+    }
+
+    if (!cJSON_AddItemToObject(fbss_configuration_object, "discovery", discovery_object)) {
+        em_printfout("Failed to add \"discovery\" to bSTA DPP Configuration Object");
+        cJSON_Delete(credential_object);
+        cJSON_Delete(discovery_object);
+        cJSON_Delete(fbss_configuration_object);
+    }
+
+    if (!cJSON_AddItemToObject(fbss_configuration_object, "cred", credential_object)) {
+        em_printfout("Failed to add \"cred\" to bSTA DPP Configuration Object");
+        cJSON_Delete(credential_object);
+        cJSON_Delete(fbss_configuration_object);
+    }
+
+    return fbss_configuration_object;
+}
+
 cJSON *em_provisioning_t::create_configurator_bsta_response_obj(ec_connection_context_t *conn_ctx)
 {
     dm_easy_mesh_t *dm = get_data_model();


### PR DESCRIPTION
**Implements EasyMesh 5.3.11 Onboarding DPP-capable client devices (STAs)**

1. New `get_fbss_info_func` callback for grabbing fronthaul BSS configuration info and marshalling into a DPP Configuration response object
2. `is_sta` for `create_config_response_frame` indicating what type of configuration objects we need to create. `is_sta` is set if `wi_fi-tech` is "infra" and `netRole` is "sta" in Configuration Request object