### PR TITLE
Fix segmentation fault in controller and agent

### DIFF
--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1540,7 +1540,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             break;
         default:
             printf("%s:%d: Frame: %d not handled in agent\n", __func__, __LINE__, htons(cmdu->type));
-            assert(0);
+            em = NULL;
             break;	
 	}
 

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -790,7 +790,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
 
         default:
             printf("%s:%d: Frame: 0x%04x not handled in controller\n", __func__, __LINE__, htons(cmdu->type));
-            assert(0);
+            em = NULL;
             break;
     }
 


### PR DESCRIPTION
Fix segmentation fault in controller and agent

Reason for change:  Replaced assert(0) with  assigning em = NULL pointer to fix segmentation fault issue observed for unhandled message types.
Test Procedure: Ensure no segmentation fault for unhandled message types
Risks: Medium
Priority: P1