### PR TITLE
RDKBACCL-578: EasyMesh Agent integration in BPI Extender device

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,10 @@ AC_PROG_CXX
 AC_PROG_INSTALL
 AM_PROG_CC_C_O
 AM_PROG_LIBTOOL(libtool)
- 
+
+# em extender check
+AM_CONDITIONAL([EM_EXTENDER], [test x$EM_EXTENDER = xtrue])
+
 # Checks for header files.
 AC_CHECK_HEADERS([stdlib.h string.h unistd.h])
  

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,5 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##########################################################################
+if EM_EXTENDER
+SUBDIRS = agent
+else
 SUBDIRS = cli ctrl agent
- 
+endif


### PR DESCRIPTION
Reason for change: Added EM_EXTENDER flag for bpi extender builds
Test procedure: Build should go through, and only agent should get compiled in extender
Risks: None