### PR TITLE
Increase Buffer size to handle bigger m1 and m2 size

### DIFF
--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -1246,8 +1246,8 @@ class em_configuration_t {
 
 private:
     em_profile_type_t   m_peer_profile;
-    unsigned char m_m1_msg[MAX_EM_BUFF_SZ];
-    unsigned char m_m2_msg[MAX_EM_BUFF_SZ];
+    unsigned char m_m1_msg[MAX_EM_BUFF_SZ*EM_MAX_BANDS];
+    unsigned char m_m2_msg[MAX_EM_BUFF_SZ*EM_MAX_BANDS];
     size_t m_m1_length;
     size_t m_m2_length;
 

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2862,7 +2862,7 @@ int em_configuration_t::handle_wsc_m2(unsigned char *buff, unsigned int len)
     unsigned int tmp_len;
     unsigned short id;
 
-    printf("%s:%d: Parsing m1 message, len: %d\n", __func__, __LINE__, len);
+    printf("%s:%d: Parsing m2 message, len: %d\n", __func__, __LINE__, len);
 
     m_m2_length = len - 12;
     memcpy(m_m2_msg, buff, m_m2_length);
@@ -3484,7 +3484,7 @@ int em_configuration_t::handle_autoconfig_wsc_m1(unsigned char *buff, unsigned i
         return -1;
     }
 	set_state(em_state_ctrl_wsc_m2_sent);
-	printf("%s:%d: autoconfig wsc m2 send\n", __func__, __LINE__);
+	printf("%s:%d: autoconfig wsc m2 send, len:%d\n", __func__, __LINE__, sz);
     memcpy(raw.al, const_cast<unsigned char *> (get_peer_mac()), sizeof(mac_address_t));
     memcpy(raw.radio, get_radio_interface_mac(), sizeof(mac_address_t));
 
@@ -3637,10 +3637,12 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
         case em_msg_type_autoconf_wsc:
             if ((get_wsc_msg_type(tlvs, tlvs_len) == em_wsc_msg_type_m2) &&
                     (get_service_type() == em_service_type_agent) && (get_state() == em_state_agent_wsc_m2_pending)) {
-                handle_autoconfig_wsc_m2(data, len);              
+                        printf("%s:%d: received wsc_m2 len:%d\n", __func__, __LINE__, len);
+                        handle_autoconfig_wsc_m2(data, len);
             } else if ((get_wsc_msg_type(tlvs, tlvs_len) == em_wsc_msg_type_m1) &&
                     (get_service_type() == em_service_type_ctrl) && (get_state() == em_state_ctrl_wsc_m1_pending))  {
-                handle_autoconfig_wsc_m1(data, len);
+                        printf("%s:%d: received wsc_m1 len:%d\n", __func__, __LINE__, len);
+                        handle_autoconfig_wsc_m1(data, len);
             }
 
             break;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -546,7 +546,7 @@ void em_t::proto_run()
             proto_timeout();
             pthread_mutex_lock(&m_iq.lock);
         } else {
-            printf("%s:%d em exited with rc - %d",__func__,__LINE__,rc);
+            printf("%s:%d em exited with rc - %d\n",__func__,__LINE__,rc);
             pthread_mutex_unlock(&m_iq.lock);
             return;
         }

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -402,15 +402,15 @@ void em_mgr_t::nodes_listener()
                     }
                 }
 #else
-                unsigned char buff[MAX_EM_BUFF_SZ];
+                unsigned char buff[MAX_EM_BUFF_SZ*EM_MAX_BANDS];
                 pthread_mutex_lock(&m_mutex);
                 int ret = FD_ISSET(em->get_fd(), &m_rset);
                 pthread_mutex_unlock(&m_mutex);
                 if (ret)
                 {
                     // receive data from this interface
-                    memset(buff, 0, MAX_EM_BUFF_SZ);
-                    ssize_t len = read(em->get_fd(), buff, MAX_EM_BUFF_SZ);
+                    memset(buff, 0, MAX_EM_BUFF_SZ*EM_MAX_BANDS);
+                    ssize_t len = read(em->get_fd(), buff, MAX_EM_BUFF_SZ*EM_MAX_BANDS);
                     if (len) {
                         proto_process(buff, static_cast<unsigned int>(len), em);
                     }


### PR DESCRIPTION
With multiple VAP the size of m1 and m2 is crossing 1024 and the buffer allocated is not enough to address this scenario. This is causing the Address Sanitizer to fail and causing crash. Increase the size to accommodate this.