### PR TITLE
RDKBACCL-829 : For IEEE1905 builds,enable al sap in easymesh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ AC_FUNC_MALLOC
  
 AC_CONFIG_FILES(
     src/cli/Makefile
+    src/al-sap/Makefile
     src/ctrl/Makefile
     src/agent/Makefile
     src/Makefile

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -127,3 +127,4 @@ onewifi_em_agent_SOURCES =  \
 
 
 onewifi_em_agent_LDFLAGS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwifi_webconfig -lrbus
+onewifi_em_agent_LDADD = $(top_builddir)/src/al-sap/libalsap.la

--- a/src/al-sap/Makefile.am
+++ b/src/al-sap/Makefile.am
@@ -16,5 +16,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##########################################################################
-SUBDIRS = cli al-sap ctrl agent
+AM_CFLAGS = -D_ANSC_LINUX
+AM_CFLAGS += -D_ANSC_USER
+AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
  
+ACLOCAL_AMFLAGS = -I m4
+hardware_platform = i686-linux-gnu
+lib_LTLIBRARIES=libalsap.la
+ 
+libalsap_la_CPPFLAGS = \
+    -I$(top_srcdir)/inc 
+ 
+libalsap_la_CPPFLAGS += -g -fPIC
+ 
+libalsap_la_SOURCES = \
+ $(top_srcdir)/src/al-sap/al_service_access_point.cpp \
+ $(top_srcdir)/src/al-sap/al_service_exception.cpp \
+ $(top_srcdir)/src/al-sap/al_service_registration_response.cpp \
+ $(top_srcdir)/src/al-sap/al_service_data_unit.cpp \
+ $(top_srcdir)/src/al-sap/al_service_registration_request.cpp \
+ $(top_srcdir)/src/al-sap/al_service_utils.cpp

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -144,4 +144,5 @@ onewifi_em_ctrl_SOURCES =  \
  
  
 onewifi_em_ctrl_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lrbus -fsanitize=address -fsanitize=undefined -lmariadb
+onewifi_em_ctrl_LDADD = $(top_builddir)/src/al-sap/libalsap.la
 


### PR DESCRIPTION
Reason for change: Added required makefile and configure changes to support al-sap integartion in bpi
Test Procedure: Able to compile uwm
Risks: Low