### PR TITLE
RDKBACCL-969 : unable to configure vap's in onewifi while we change the ssid  in cli

### DIFF
--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1225,7 +1225,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
     em_raw_hdr_t *hdr;
     em_cmdu_t *cmdu;
     em_interface_t intf;
-    em_freq_band_t band;
+    em_freq_band_t band = em_freq_band_unknown;
     dm_easy_mesh_t *dm;
     em_t *em = NULL;
     mac_address_t ruid;


### PR DESCRIPTION
Reason for change: Observed below errors,
find_em_for_msg_type:1339: Found existing AL MAC:8e:0b:6b:8b:b6:70_al find_em_for_msg_type:1359: Could not find em with matching band809119746 and expected state find_em_for_msg_type:1339: Found existing AL MAC:8e:0b:6b:8b:b6:70_al find_em_for_msg_type:1359: Could not find em with matching band809119744 and expected state find_em_for_msg_type:1339: Found existing AL MAC:8e:0b:6b:8b:b6:70_al
Assigning default value to avoid junk value being used. 
Test Procedure: Mentioned issue is not observed when we change ssid in cli. All vap's are configured in onewifi as well.
Also, fronthaul vap's only configured when we start the em_agent. 
Risks: Low