### PR TITLE
RDKBACCL-974 : Observing build issues in today's tip

### DIFF
--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -51,6 +51,7 @@ onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/em/prov/easyconnect/ec_manager.cpp \
      $(top_srcdir)/src/em/prov/easyconnect/ec_pa_configurator.cpp \
      $(top_srcdir)/src/em/prov/easyconnect/ec_util.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_1905_encrypt_layer.cpp \
      $(top_srcdir)/src/em/disc/em_discovery.cpp \
      $(top_srcdir)/src/em/channel/em_channel.cpp  \
      $(top_srcdir)/src/em/capability/em_capability.cpp \

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -90,5 +90,6 @@ libemcli_la_SOURCES = \
  $(top_srcdir)/src/em/crypto/em_crypto.cpp \
  $(top_srcdir)/src/utils/util.cpp \
  $(top_srcdir)/src/em/prov/easyconnect/ec_util.cpp \
+ $(top_srcdir)/src/em/prov/easyconnect/ec_crypto.cpp \
  $(top_srcdir)/src/util_crypto/aes_siv.c \
  $(top_srcdir)/OneWifi/source/utils/collection.c

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -53,6 +53,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/em/prov/easyconnect/ec_manager.cpp \
      $(top_srcdir)/src/em/prov/easyconnect/ec_pa_configurator.cpp \
      $(top_srcdir)/src/em/prov/easyconnect/ec_util.cpp \
+     $(top_srcdir)/src/em/prov/easyconnect/ec_1905_encrypt_layer.cpp \
      $(top_srcdir)/src/em/prov/em_provisioning.cpp \
      $(top_srcdir)/src/em/disc/em_discovery.cpp \
      $(top_srcdir)/src/em/channel/em_channel.cpp  \


### PR DESCRIPTION
Reason for change: Observed below errors,
undefined reference to `ec_1905_encrypt_layer_t::rekey_1905_layer_ptk()' undefined reference to `ec_1905_encrypt_layer_t::handle_eapol_frame(unsigned char*, unsigned short, unsigned char*)' 
Test Procedure: Able to compile uwm
Risks: Low