### PR TITLE
Fix EasyConnect message addressing

### DIFF
--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -83,7 +83,7 @@ public:
 	 * @note This function is optional to implement because the controller+configurator does not
 	 * handle 802.11 frames, but the proxy agent + configurator does.
 	 */
-	virtual bool handle_auth_response(ec_frame_t *frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN]) {
+	virtual bool handle_auth_response(ec_frame_t *frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN], uint8_t src_al_mac[ETH_ALEN]) {
         return true; // Optional to implement
     }
 
@@ -172,7 +172,7 @@ public:
 	 * 
 	 * @note Only implemented by the Controller Configurator
 	 */
-	virtual bool handle_recfg_announcement(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN]) {
+	virtual bool handle_recfg_announcement(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) {
 		return true;
 	}
 
@@ -184,7 +184,7 @@ public:
 	 * @param sa The source address (Enrollee)
 	 * @return true on success, otherwise false
 	 */
-	virtual bool handle_recfg_auth_response(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN]) {
+	virtual bool handle_recfg_auth_response(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) {
 		return true; // Optional to implement
 	}
     
@@ -199,7 +199,9 @@ public:
 	 *
 	 * @return true if the chirp notification was processed successfully, false otherwise.
 	 */
-	virtual bool process_chirp_notification(em_dpp_chirp_value_t* chirp_tlv, uint16_t tlv_len) = 0;
+	virtual bool process_chirp_notification(em_dpp_chirp_value_t* chirp_tlv, uint16_t tlv_len, uint8_t src_al_mac[ETH_ALEN]) {
+		return true; // Optional to implement
+	}
 
     
 	/**
@@ -211,10 +213,11 @@ public:
 	 * @param[in] encap_tlv_len The length of the 1905 Encap DPP TLV.
 	 * @param[in] chirp_tlv The DPP Chirp Value TLV to parse and handle (NULL if not present).
 	 * @param[in] chirp_tlv_len The length of the DPP Chirp Value TLV (0 if not present).
+	 * @param[in] src_al_mac The source AL MAC address of this message
 	 *
 	 * @return bool True if the message was processed successfully, false otherwise.
 	 */
-	virtual bool  process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len) = 0;
+	virtual bool  process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len, uint8_t src_al_mac[ETH_ALEN]) = 0;
 
 	/**
 	 * @brief Handle a Direct Encapsulated DPP Message (DPP Message TLV)
@@ -254,7 +257,7 @@ public:
 	 *
 	 * @note This function is overridden by subclass.
 	 */
-	virtual bool handle_proxied_dpp_configuration_request(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) {
+	virtual bool handle_proxied_dpp_configuration_request(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) {
         return true;
     }
 
@@ -272,7 +275,7 @@ public:
 	 *
 	 * @return true if the frame is handled successfully, otherwise false.
 	 */
-	virtual bool handle_proxied_config_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) {
+	virtual bool handle_proxied_config_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) {
         return true;
     }
 
@@ -290,7 +293,7 @@ public:
 	 *
 	 * @return true if the frame was handled successfully, otherwise false.
 	 */
-	virtual bool handle_proxied_conn_status_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) {
+	virtual bool handle_proxied_conn_status_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) {
         return true;
     }
 

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -38,7 +38,7 @@ public:
 	 *
 	 * @return true if the processing is successful, false otherwise.
 	 */
-	bool process_chirp_notification(em_dpp_chirp_value_t* chirp_tlv, uint16_t tlv_len) override;
+	bool process_chirp_notification(em_dpp_chirp_value_t* chirp_tlv, uint16_t tlv_len, uint8_t src_al_mac[ETH_ALEN]) override;
 
 	/**
 	 * @brief Start the EC configurator onboarding process for an enrollee.
@@ -60,10 +60,11 @@ public:
 	 * @param[in] encap_tlv_len The length of the 1905 Encap DPP TLV.
 	 * @param[in] chirp_tlv The DPP Chirp Value TLV to parse and handle (NULL if not present).
 	 * @param[in] chirp_tlv_len The length of the DPP Chirp Value TLV (0 if not present).
+	 * @param[in] src_al_mac The source AL MAC address of this message
 	 *
 	 * @return bool True if successful, false otherwise.
 	 */
-	bool process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len) override;
+	bool process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len, uint8_t src_al_mac[ETH_ALEN]) override;
 
 	/**
 	 * @brief Handle a Direct Encapsulated DPP Message (DPP Message TLV)
@@ -92,7 +93,7 @@ public:
 	 * @note This function is optional to implement because the controller+configurator does not handle 802.11,
 	 *       but the proxy agent + configurator does.
 	 */
-	bool handle_auth_response(ec_frame_t *frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN]) override;
+	bool handle_auth_response(ec_frame_t *frame, size_t len, uint8_t src_mac[ETHER_ADDR_LEN], uint8_t src_al_mac[ETH_ALEN]) override;
 
     
 	/**
@@ -108,7 +109,7 @@ public:
 	 *
 	 * @note Overrides parent implementation.
 	 */
-	bool handle_proxied_dpp_configuration_request(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) override;
+	bool handle_proxied_dpp_configuration_request(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) override;
 
     
 	/**
@@ -124,7 +125,7 @@ public:
 	 *
 	 * @return true if the frame was handled successfully, otherwise false.
 	 */
-	bool handle_proxied_config_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) override;
+	bool handle_proxied_config_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) override;
 
     
 	/**
@@ -140,7 +141,7 @@ public:
 	 *
 	 * @return true if the frame was handled successfully, otherwise false.
 	 */
-	bool handle_proxied_conn_status_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN]) override;
+	bool handle_proxied_conn_status_result_frame(uint8_t *encap_frame, uint16_t encap_frame_len, uint8_t dest_mac[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) override;
 
 	/**
 	 * @brief Handles a Reconfiguration Announcement frame
@@ -156,7 +157,7 @@ public:
 	 * 
 	 * @note Only implemented by the Controller Configurator
 	 */
-	bool handle_recfg_announcement(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN]) override;
+	bool handle_recfg_announcement(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) override;
 
 	/**
 	 * @brief Handles a Reconfiguration Authentication Response frame
@@ -166,7 +167,7 @@ public:
 	 * @param sa The source address (Enrollee)
 	 * @return true on success, otherwise false
 	 */
-	bool handle_recfg_auth_response(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN]) override;
+	bool handle_recfg_auth_response(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) override;
 
 private:
     // Private member variables can be added here

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -183,7 +183,7 @@ public:
 	 *
 	 * @note If the operation fails, all CCE IEs are removed before the function exits.
 	 */
-	bool upgrade_to_onboarded_proxy_agent();
+	bool upgrade_to_onboarded_proxy_agent(uint8_t ctrl_al_mac[ETH_ALEN]);
 
     
 	/**
@@ -197,11 +197,11 @@ public:
 	*
 	* @return true if the chirp notification was processed successfully, false otherwise.
 	*/
-	inline bool process_chirp_notification(em_dpp_chirp_value_t* chirp_tlv, uint16_t tlv_len) {
+	inline bool process_chirp_notification(em_dpp_chirp_value_t* chirp_tlv, uint16_t tlv_len, uint8_t src_al_mac[ETH_ALEN]) {
         if (!m_configurator) {
             return false;
         }
-        return m_configurator->process_chirp_notification(chirp_tlv, tlv_len);
+        return m_configurator->process_chirp_notification(chirp_tlv, tlv_len, src_al_mac);
     }
 
     
@@ -214,16 +214,17 @@ public:
 	 * @param[in] encap_tlv_len The length of the 1905 Encap DPP TLV.
 	 * @param[in] chirp_tlv The DPP Chirp Value TLV to parse and handle (NULL if not present).
 	 * @param[in] chirp_tlv_len The length of the DPP Chirp Value TLV (0 if not present).
+	 * @param[in] src_al_mac The source AL MAC address of this message
 	 *
 	 * @return bool True if the message was processed successfully, false otherwise.
 	 *
 	 * @note Ensure that the configurator is initialized before calling this function.
 	 */
-	inline bool process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len) {
+	inline bool process_proxy_encap_dpp_msg(em_encap_dpp_t *encap_tlv, uint16_t encap_tlv_len, em_dpp_chirp_value_t *chirp_tlv, uint16_t chirp_tlv_len, uint8_t src_al_mac[ETH_ALEN]) {
         if (!m_configurator) {
             return false;
         }
-        return m_configurator->process_proxy_encap_dpp_msg(encap_tlv, encap_tlv_len, chirp_tlv, chirp_tlv_len);
+        return m_configurator->process_proxy_encap_dpp_msg(encap_tlv, encap_tlv_len, chirp_tlv, chirp_tlv_len, src_al_mac);
     }
 
 	/**

--- a/inc/ec_ops.h
+++ b/inc/ec_ops.h
@@ -31,9 +31,10 @@ struct cJSON;
  * 
  * @param chirp_tlv The chirp TLV to send
  * @param len The length of the chirp TLV
+ * @param dest_al_mac The destination AL MAC address (6 bytes)
  * @return bool true if successful, false otherwise
  */
-using send_chirp_func = std::function<bool(em_dpp_chirp_value_t*, size_t)>;
+using send_chirp_func = std::function<bool(em_dpp_chirp_value_t*, size_t, uint8_t*)>;
 
 /**
  * @brief Sends a proxied encapsulated DPP message
@@ -42,9 +43,10 @@ using send_chirp_func = std::function<bool(em_dpp_chirp_value_t*, size_t)>;
  * @param encap_dpp_len The length of the 1905 Encap DPP TLV
  * @param chirp_tlv The chirp value to include in the message. If NULL, the message will not include a chirp value
  * @param chirp_len The length of the chirp value
+ * @param dst_al_mac The destination AL MAC address (6 bytes)
  * @return bool true if successful, false otherwise
  */
-using send_encap_dpp_func = std::function<bool(em_encap_dpp_t*, size_t, em_dpp_chirp_value_t*, size_t)>;
+using send_encap_dpp_func = std::function<bool(em_encap_dpp_t*, size_t, em_dpp_chirp_value_t*, size_t, uint8_t*)>;
 
 
 /**

--- a/inc/em_msg.h
+++ b/inc/em_msg.h
@@ -116,6 +116,22 @@ public:
 	static unsigned char* add_tlv(unsigned char *buff, unsigned int *len, em_tlv_type_t tlv_type, unsigned char *value, unsigned int value_len);
 
     
+
+	/**
+	 * @brief Get a TLV from the message.
+	 * 
+	 * This function retrieves a TLV (Type-Length-Value) structure from the message buffer based on the specified type.
+	 * 
+	 * @param[in] tlvs_buff The buffer containing the TLV structures.
+	 * @param[in] buff_len The length of the buffer.
+	 * @param[in] type The type of the TLV to retrieve.
+	 * 
+	 * @return em_tlv_t* A pointer to the TLV structure if found, or NULL if not found.
+	 * 
+	 * @note Ensure that the buffer is properly initialized and contains valid TLV structures before calling this function.
+	 */
+	static em_tlv_t *get_tlv(em_tlv_t *tlvs_buff, unsigned int buff_len, em_tlv_type_t type);
+
 	/**
 	 * @brief Add an EOM TLV to the message.
 	 *

--- a/inc/em_provisioning.h
+++ b/inc/em_provisioning.h
@@ -435,6 +435,7 @@ protected:
 	 *
 	 * @param[in] chirp Pointer to the chirp data to be sent.
 	 * @param[in] chirp_len Length of the chirp data.
+	 * @param[in] dest_al_mac Pointer to the destination AL MAC address (6 bytes).
 	 *
 	 * @returns int Status code indicating success or failure of the operation.
 	 * @retval 0 on success.
@@ -442,7 +443,7 @@ protected:
 	 *
 	 * @note Ensure that the chirp data is properly initialized before calling this function.
 	 */
-	int send_chirp_notif_msg(em_dpp_chirp_value_t *chirp, size_t chirp_len);
+	int send_chirp_notif_msg(em_dpp_chirp_value_t *chirp, size_t chirp_len, uint8_t dest_al_mac[ETH_ALEN]);
     
 	/**!
 	 * @brief Sends a proxied encapsulated DPP message.
@@ -451,6 +452,7 @@ protected:
 	 * @param[in] encap_dpp_len Length of the encapsulated DPP TLV.
 	 * @param[in] chirp Pointer to the DPP chirp value structure.
 	 * @param[in] chirp_len Length of the chirp value.
+	 * @param[in] dst_al_mac Pointer to the destination AL MAC address (6 bytes).
 	 *
 	 * @returns int
 	 * @retval 0 on success
@@ -458,7 +460,7 @@ protected:
 	 *
 	 * @note Ensure that the encapsulated DPP TLV and chirp values are properly initialized before calling this function.
 	 */
-	int send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, size_t encap_dpp_len, em_dpp_chirp_value_t *chirp, size_t chirp_len);
+	int send_prox_encap_dpp_msg(em_encap_dpp_t* encap_dpp_tlv, size_t encap_dpp_len, em_dpp_chirp_value_t *chirp, size_t chirp_len, uint8_t dst_al_mac[ETH_ALEN]);
 
 	/**!
 	 * @brief Sends a direct encapsulated DPP message. 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -876,7 +876,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
     char path[100] = {0};
     snprintf(path, sizeof(path), "Device.WiFi.AccessPoint.%d.RawFrame.Mgmt.Action.Tx", test_idx+1);
     
-    em_printfout("Sending action frame: VAP Idx (%d), Dest (" MACSTRFMT "), Frequency (%d), Dwell Time (%d)", test_idx, MAC2STR(dest_mac), frequency, wait_time_ms);
+    em_printfout("Sending action frame: VAP Idx (%d), Dest (" MACSTRFMT "), Frequency (%d), Dwell Time (%d), Length (%d)", test_idx, MAC2STR(dest_mac), frequency, wait_time_ms, action_frame_len);
     // Send the action frame
     bus_error_t rc;
     if ((rc = desc->bus_set_fn(&m_bus_hdl, path,  &raw_act_frame)) != 0) {
@@ -1087,7 +1087,7 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *u
 {
     (void)userData;
     struct ieee80211_mgmt *mgmt_frame = (struct ieee80211_mgmt *)data->raw_data.bytes;
-    printf("%s:%d Received Frame data for event [%s] and data of len:\n%d\n", __func__, __LINE__, event_name, data->raw_data_len);
+    em_printfout("Received Frame data for event [%s] and data of len: %d",event_name, data->raw_data_len);
 
     //util::print_hex_dump(data->raw_data_len, (uint8_t*)data->raw_data.bytes);
 

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -3067,6 +3067,9 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
     if ((dm != NULL) && (hdr != NULL)) {
         memcpy(&network.m_net_info.ctrl_id.mac, &hdr->src, sizeof(mac_address_t));
         dm->set_network(network);
+        if (get_mgr()->get_al_node() != NULL) {
+            get_ec_mgr().upgrade_to_onboarded_proxy_agent(hdr->src);
+        }
     }
     return 0;
 }
@@ -3138,9 +3141,6 @@ int em_configuration_t::handle_encrypted_settings()
     }
     get_mgr()->io_process(em_bus_event_type_m2ctrl_configuration, reinterpret_cast<unsigned char *> (&radioconfig), sizeof(radioconfig));
     set_state(em_state_agent_owconfig_pending);
-    if (get_service_type() == em_service_type_agent) {
-        get_ec_mgr().upgrade_to_onboarded_proxy_agent();
-    }
     return ret;
 }
 

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -29,6 +29,7 @@
 #include "em_msg.h"
 //#include "util.h"
 #include "em_configuration.h"
+#include "util.h"
 
 bool em_msg_t::get_tlv(em_tlv_t *itlv)
 {
@@ -253,6 +254,26 @@ em_tlv_t *em_msg_t::get_tlv(em_tlv_type_t type)
     unsigned int len;
 
     tlv = reinterpret_cast<em_tlv_t *> (m_buff); len = m_len;
+    while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
+        if (tlv->type == type) {
+            return tlv; 
+        }
+        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + ntohs(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
+    }
+
+    return NULL;
+}
+
+em_tlv_t *em_msg_t::get_tlv(em_tlv_t* tlvs_buff, unsigned int buff_len, em_tlv_type_t type)
+{
+
+    EM_ASSERT_NOT_NULL(tlvs_buff, NULL, "Buffer is NULL");
+    EM_ASSERT_MSG_TRUE(buff_len > 0, NULL, "Buffer length is zero");
+
+    em_tlv_t    *tlv = tlvs_buff;
+    unsigned int len = buff_len;
+
     while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
         if (tlv->type == type) {
             return tlv; 


### PR DESCRIPTION
- Added source AL MAC parameter to all EC message handlers
- Store controller's AL MAC during agent onboarding so proxy agents know where to send specific EasyConnect messages
- Require destination AL MAC for all message