### PR TITLE
Ethernet DPP

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -111,6 +111,7 @@ AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_assoc_sta_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
     $(ONEWIFI_EM_SRC)/utils/util.cpp \
+	$(ONEWIFI_EM_SRC)/utils/timer.cpp \
 
 AGENT_OBJECTS = $(AGENT_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 

--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -103,6 +103,7 @@ CTRL_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
 	$(ONEWIFI_EM_SRC)/orch/em_orch.cpp \
 	$(ONEWIFI_EM_SRC)/orch/em_orch_ctrl.cpp \
 	$(ONEWIFI_EM_SRC)/utils/util.cpp \
+	$(ONEWIFI_EM_SRC)/utils/timer.cpp \
 
 CTRL_OBJECTS = $(CTRL_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 

--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -846,6 +846,11 @@ typedef struct {
      * @brief The temporary context that is used during the authentication / configuration process and should be securely freed after the process is complete.
      */
     ec_ephemeral_context_t eph_ctx;
+
+    /**
+     * @brief Is this Enrollee onboarding via ethernet?
+     */
+    bool is_eth;
 } ec_connection_context_t;
 
 

--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -231,6 +231,20 @@ public:
 	virtual bool  process_direct_encap_dpp_msg(uint8_t* dpp_frame, uint16_t dpp_frame_len, uint8_t src_mac[ETH_ALEN]) = 0;
 
 	/**
+	 * @brief Handles a chirp found in an Autoconf Search (extended) message.
+	 * 
+	 * @param chirp The DPP chirp.
+	 * @param len The length of the chirp hash (can be 0).
+	 * @param src_mac Where it came from (Enrollee).
+	 * @return true on success, otherwise false.
+	 * 
+	 */
+	virtual bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN]) {
+		// impl'd by Controller Configurator only
+		return false;
+	} 
+
+	/**
 	 * @brief Process a 1905 EAPOL Encapsulated Message (1905 Encap EAPOL TLV)
 	 *
 	 * @param[in] eapol_frame The frame parsed from the 1905 Encap EAPOL TLV
@@ -448,6 +462,8 @@ protected:
 	get_fbss_info_func m_get_fbss_info;
 
     can_onboard_additional_aps_func m_can_onboard_additional_aps;
+
+	send_autoconf_search_resp_func m_send_autoconf_resp_fn;
 
 	ec_1905_encrypt_layer_t m_1905_encrypt_layer;
 

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -80,6 +80,17 @@ public:
 	 */
 	bool  process_direct_encap_dpp_msg(uint8_t* dpp_frame, uint16_t dpp_frame_len, uint8_t src_mac[ETH_ALEN]) override;
 
+	/**
+	 * @brief Handles a chirp found in an Autoconf Search (extended) message.
+	 * 
+	 * @param chirp The DPP chirp.
+	 * @param len The length of the chirp hash (can be 0).
+	 * @param src_mac Where it came from (Enrollee).
+	 * @return true on success, otherwise false.
+	 * 
+	 */
+	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN]) override;
+
     
 	/**
 	 * @brief Handles an authentication response 802.11 frame, performing the necessary actions.
@@ -283,6 +294,16 @@ private:
 	 */
 	std::pair<uint8_t*, size_t> create_config_response_frame(uint8_t dest_mac[ETH_ALEN], uint8_t pa_al_mac[ETH_ALEN], const uint8_t dialog_token, ec_status_code_t dpp_status, bool is_sta = false);
 
+	/**
+	 * @brief Handles a GAS frame embedded in a Direct Encap DPP Message
+	 * 
+	 * @param frame The GAS frame
+	 * @param len The length of the frame
+	 * @param src_mac The origin of the frame
+	 * @return true on success otherwise false
+	 */
+	bool process_direct_encap_dpp_gas_msg(uint8_t* frame, uint16_t len, uint8_t src_mac[ETH_ALEN]);
+
     /**
      * @brief Maps Enrollee MAC (as string) to onboarded status. True if onboarded (now a Proxy Agent), false if still onboarding / onboarding failed.
      * 
@@ -300,6 +321,7 @@ private:
 
 	// The Group Master Key (GMK) used to securing the 1905 layer
 	std::vector<uint8_t> m_gmk;
+
 };
 
 #endif // EC_CTRL_CONFIGURATOR_H

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -279,6 +279,30 @@ public:
         
     }
 
+	/**
+	 * @brief Handles a chirp found in an Autoconf Search (extended) message.
+	 * 
+	 * @param chirp The DPP chirp.
+	 * @param src_mac Where it came from (Enrollee).
+	 * @return true on success, otherwise false.
+	 * 
+	 */
+	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN]) {
+		if (m_configurator) {
+			return m_configurator->handle_autoconf_chirp(chirp, len, src_mac);
+		}
+		// Not valid for Enrollee
+		return false;
+	}
+
+	bool handle_autoconf_resp_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN]) {
+		if (m_enrollee) {
+			m_enrollee->handle_autoconf_response_chirp(chirp, len, src_mac);
+		}
+		// Not valid for Configurator
+		return false;
+	}
+
 
 		/**
 	 * @brief Process a 1905 EAPOL encapsulated message.

--- a/inc/ec_ops.h
+++ b/inc/ec_ops.h
@@ -25,6 +25,28 @@
 
 struct cJSON;
 
+/**
+ * @brief Sends an Autoconf Search message (extended)
+ * 
+ * @param Chirp The chirp to include in the autoconf search message
+ * @param len The length of the hash in the chirp (can be 0)
+ * 
+ * @note No dest mac as autoconf search is a multicast message
+ * @return True on success otherwise false
+ */
+using send_autoconf_search_func = std::function<bool(em_dpp_chirp_value_t *, size_t)>;
+
+/**p
+ * @brief Sends an Autoconf Search Response message (extended)
+ * 
+ * @param Chirp The Chirp to include in the autoconf search response message
+ * @param len The length of the hash in the chirp (can be 0)
+ * @param dest_mac The destination MAC address to send the response to
+ * 
+ * @return True on success otherwise false
+ * 
+ */
+using send_autoconf_search_resp_func = std::function<bool(em_dpp_chirp_value_t *, size_t, uint8_t[ETH_ALEN])>;
 
 /**
  * @brief Sends a chirp notification
@@ -157,4 +179,6 @@ struct ec_ops_t {
     get_fbss_info_func get_fbss_info = nullptr;
     can_onboard_additional_aps_func can_onboard_additional_aps = nullptr;
     send_1905_eapol_encap_func send_1905_eapol_encap = nullptr; 
+    send_autoconf_search_func send_autoconf_search = nullptr;
+    send_autoconf_search_resp_func send_autoconf_search_resp = nullptr;
 };

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -302,6 +302,10 @@ public:
     bus_handle_t m_bus_hdl;
     bool do_start_dpp_onboarding = false;
     bool do_regen_dpp_uri = false;
+	/**
+	 * @brief Are we onboarding via DPP over Ethernet?
+	 */
+	bool ethernet_onboarding = false;
 
 	/**!
 	 * @brief Listens for input events and processes them accordingly.

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -38,14 +38,14 @@ class em_configuration_t {
 	 * @param[out] buff Pointer to the buffer where the response message will be stored.
 	 * @param[in] band The frequency band for which the response message is being created.
 	 * @param[in] dst Pointer to the destination address for the response message.
+	 * @param[in] chirp Optional pointer to a DPP chirp value to include in the message.
+	 * @param[in] hash_len Length of the hash to be included in the chirp (can be 0 if no chirp is present).
 	 *
-	 * @returns int Status code indicating success or failure of the message creation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
+	 * @return int The length of the created response message, or -1 on failure.
 	 *
 	 * @note Ensure that the buffer is adequately sized to hold the response message.
 	 */
-	int create_autoconfig_resp_msg(unsigned char *buff, em_freq_band_t band, unsigned char *dst);
+	int create_autoconfig_resp_msg(unsigned char *buff, em_freq_band_t band, unsigned char *dst, em_dpp_chirp_value_t *chirp = nullptr, size_t hash_len = 0);
     
 	/**!
 	 * @brief Creates an auto-configuration search message.
@@ -53,14 +53,14 @@ class em_configuration_t {
 	 * This function is responsible for generating a search message used in the auto-configuration process.
 	 *
 	 * @param[out] buff Pointer to the buffer where the search message will be stored.
+	 * @param[in] chirp Optional pointer to a DPP chirp value to include in the message.
+	 * @param[in] hash_len Length of the hash to be included in the chirp (can be 0 if no chirp is present).
 	 *
-	 * @returns int
-	 * @retval 0 on success
-	 * @retval -1 on failure
+	 * @returns int Size of CMDU created on success, otherwise -1
 	 *
 	 * @note Ensure that the buffer is allocated with sufficient size before calling this function.
 	 */
-	int create_autoconfig_search_msg(unsigned char *buff);
+	int create_autoconfig_search_msg(unsigned char *buff, em_dpp_chirp_value_t *chirp = nullptr, size_t hash_len = 0);
     
 	/**!
 	 * @brief Creates an auto-configuration WSC M1 message.
@@ -1553,6 +1553,10 @@ private:
     unsigned int m_m2_encrypted_settings_len;
 
 public:
+
+	bool send_autoconf_search_ext_chirp(em_dpp_chirp_value_t *chirp, size_t hash_len);
+
+	bool send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN]);
     
 	/**!
 	 * @brief Processes a message with the given data and length.

--- a/inc/timer.h
+++ b/inc/timer.h
@@ -1,0 +1,44 @@
+
+#ifndef THREADED_TIMER_H
+#define THREADED_TIMER_H
+
+#include <iostream>
+#include <thread>
+#include <functional>
+#include <chrono>
+#include <atomic>
+#include <memory>
+
+class ThreadedTimer {
+public:
+    ThreadedTimer();
+    ~ThreadedTimer();
+
+    /**
+     * @brief Call `callback` after `delay` milliseconds
+     * 
+     * @param delay The delay for the callback
+     * @param callback The callback
+     */
+    void execute_after(std::chrono::milliseconds delay, std::function<void()> callback);
+
+    /**
+     * @brief Starts a timer which calls `callback` with periodicity `interval`
+     * 
+     * @param interval The periodicity at which to call the callback
+     * @param callback The callback.
+     */
+    void start_periodic(std::chrono::milliseconds interval, std::function<void()> callback);
+
+    /**
+     * @brief Cancel this timer.
+     * 
+     */
+    void stop();
+
+private:
+    std::unique_ptr<std::thread> timer_thread;
+    std::atomic<bool> running;
+};
+
+#endif // THREADED_TIMER_H

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1873,6 +1873,10 @@ int main(int argc, const char *argv[])
             g_agent.do_regen_dpp_uri = true;
             continue;
         }
+        if (arg == "--ethernet") {
+            g_agent.ethernet_onboarding = true;
+            continue;
+        }
         if (data_model_path.empty()) {
             data_model_path = arg;
             continue;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1739,7 +1739,8 @@ bool em_t::initialize_ec_manager(){
                                                 std::placeholders::_1, std::placeholders::_2, 
                                                 std::placeholders::_3);
     ops.can_onboard_additional_aps = std::bind(&em_mgr_t::can_onboard_additional_aps, m_mgr);
-
+    ops.send_autoconf_search       = std::bind(&em_t::send_autoconf_search_ext_chirp, this,
+                                               std::placeholders::_1, std::placeholders::_2);
 
     // Enrollee callbacks
     if (service_type == em_service_type_agent) {
@@ -1754,6 +1755,9 @@ bool em_t::initialize_ec_manager(){
                                                 std::placeholders::_1);
         ops.get_backhaul_sta_info = std::bind(&em_t::create_configurator_bsta_response_obj, 
                                                 this, std::placeholders::_1);
+        ops.send_autoconf_search_resp =
+            std::bind(&em_t::send_autoconf_search_resp_ext_chirp, this, std::placeholders::_1,
+                      std::placeholders::_2, std::placeholders::_3);
     }
 
     // Read in the persistent security context for the controller or agent

--- a/src/em/prov/easyconnect/ec_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_configurator.cpp
@@ -15,6 +15,7 @@ ec_configurator_t::ec_configurator_t(const std::string &al_mac_addr, ec_ops_t& o
     m_get_1905_info              = ops.get_1905_info;
     m_get_fbss_info              = ops.get_fbss_info;
     m_can_onboard_additional_aps = ops.can_onboard_additional_aps;
+    m_send_autoconf_resp_fn      = ops.send_autoconf_search_resp;
 
     if (!sec_ctx.C_signing_key || !sec_ctx.pp_key || !sec_ctx.net_access_key || !sec_ctx.connector) {
         em_printfout("Key(s) missing, cannot secure 1905 layer!");

--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -1,0 +1,38 @@
+#include "timer.h"
+
+ThreadedTimer::ThreadedTimer() : running(false) {}
+
+ThreadedTimer::~ThreadedTimer() {
+    stop();
+}
+
+void ThreadedTimer::execute_after(std::chrono::milliseconds delay, std::function<void()> callback) {
+    stop();
+    running = true;
+    timer_thread = std::make_unique<std::thread>([this, delay, callback]() {
+        std::this_thread::sleep_for(delay);
+        if (running.load()) {
+            callback();
+        }
+    });
+}
+
+void ThreadedTimer::start_periodic(std::chrono::milliseconds interval, std::function<void()> callback) {
+    stop();
+    running = true;
+    timer_thread = std::make_unique<std::thread>([this, interval, callback]() {
+        while (running.load()) {
+            std::this_thread::sleep_for(interval);
+            if (running.load()) {
+                callback();
+            }
+        }
+    });
+}
+
+void ThreadedTimer::stop() {
+    running = false;
+    if (timer_thread && timer_thread->joinable()) {
+        timer_thread->join();
+    }
+}

--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include "timer.h"
+
+using namespace std::chrono_literals;
+
+TEST(ThreadedTimerTest, FiresAfterDelay) {
+    ThreadedTimer timer;
+    std::atomic<bool> fired = false;
+
+    timer.execute_after(100ms, [&]() {
+        fired = true;
+    });
+
+    std::this_thread::sleep_for(150ms);
+    EXPECT_TRUE(fired.load());
+}
+
+TEST(ThreadedTimerTest, StopPreventsFiring) {
+    ThreadedTimer timer;
+    std::atomic<bool> fired = false;
+
+    timer.execute_after(200ms, [&]() {
+        fired = true;
+    });
+
+    std::this_thread::sleep_for(50ms);
+    timer.stop();
+
+    std::this_thread::sleep_for(200ms);
+    EXPECT_FALSE(fired.load());
+}
+
+TEST(ThreadedTimerTest, PeriodicRunsMultipleTimes) {
+    ThreadedTimer timer;
+    std::atomic<int> counter{0};
+
+    timer.start_periodic(50ms, [&]() {
+        counter++;
+    });
+
+    std::this_thread::sleep_for(220ms);
+    timer.stop();
+
+    EXPECT_GE(counter.load(), 3);
+}
+
+TEST(ThreadedTimerTest, StopIsIdempotent) {
+    ThreadedTimer timer;
+    timer.execute_after(50ms, []{});
+    timer.stop();
+    timer.stop();
+    // Checks that a double stop doesn't deadlock. If we get here, we've passed.
+    SUCCEED();
+}


### PR DESCRIPTION
Impl of EasyMesh 5.3.5 (minus this: `If an Enrollee Multi-AP Agent detects that the link status of a Multi-AP Logical Ethernet Interface transitions to LINK_UP
[3] and the 1905 Layer is not already configured, the Enrollee Multi-AP Agent shall search for the Multi-AP Controller by
sending 1905 AP-Autoconfiguration Search messages per section 6.1. `. Instead, pass `--ethernet` along with `--start-dpp-onboard` to the Agent process).