### PR TITLE
RDKB-61233: Easymesh - WiFi 7 Integration

### DIFF
--- a/inc/dm_assoc_sta_mld.h
+++ b/inc/dm_assoc_sta_mld.h
@@ -45,7 +45,7 @@ public:
 	 *
 	 * @returns A pointer to the `em_assoc_sta_mld_info_t` structure containing the AP MLD information.
 	 */
-	em_assoc_sta_mld_info_t *get_ap_mld_info() { return &m_assoc_sta_mld_info; }
+	em_assoc_sta_mld_info_t *get_assoc_sta_mld_info() { return &m_assoc_sta_mld_info; }
     
 	/**!
 	 * @brief Decodes a JSON object and associates it with a parent identifier.

--- a/inc/dm_bsta_mld.h
+++ b/inc/dm_bsta_mld.h
@@ -48,7 +48,7 @@ public:
 	 *
 	 * @note Ensure that the returned pointer is not null before accessing its members.
 	 */
-	em_bsta_mld_info_t *get_ap_mld_info() { return &m_bsta_mld_info; }
+	em_bsta_mld_info_t *get_bsta_mld_info() { return &m_bsta_mld_info; }
     
 	/**!
 	 * @brief Decodes a JSON object and associates it with a parent ID.

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -1611,7 +1611,18 @@ public:
 	 */
 	static unsigned int get_num_assoc_sta_mld(void *dm) { return (static_cast<dm_easy_mesh_t *>(dm))->get_num_assoc_sta_mld(); }
 
-    
+	em_ap_mld_info_t *get_ap_mld_frm_bssid(mac_address_t bss_id);
+	static em_ap_mld_info_t *get_ap_mld_frm_bssid(void *dm, mac_address_t bss_id) { return (static_cast<dm_easy_mesh_t *>(dm))->get_ap_mld_frm_bssid(bss_id); }
+
+	void update_ap_mld_info(em_ap_mld_info_t *ap_mld_info);
+	static void update_ap_mld_info(void *dm, em_ap_mld_info_t *ap_mld_info) { (static_cast<dm_easy_mesh_t *>(dm))->update_ap_mld_info(ap_mld_info); }
+
+	void update_bsta_mld_info(em_bsta_mld_info_t *bsta_mld_info);
+	static void update_bsta_mld_info(void *dm, em_bsta_mld_info_t *bsta_mld_info) { (static_cast<dm_easy_mesh_t *>(dm))->update_bsta_mld_info(bsta_mld_info); }
+
+	void update_assoc_sta_mld_info(em_assoc_sta_mld_info_t *assoc_sta_mld_info);
+	static void update_assoc_sta_mld_info(void *dm, em_assoc_sta_mld_info_t *assoc_sta_mld_info) { (static_cast<dm_easy_mesh_t *>(dm))->update_assoc_sta_mld_info(assoc_sta_mld_info); }
+
 	/**!
 	 * @brief Retrieves the Data Model DPP object.
 	 *

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2496,7 +2496,8 @@ typedef struct {
 typedef struct {
     unsigned char ap_mld_mac_addr_valid : 1;
     unsigned char reserved1 : 7;
-    em_ap_mld_ssids_t ssids[0];
+    unsigned char ssid_len;
+    ssid_t ssid;
     mac_addr_t ap_mld_mac_addr;
     unsigned char str : 1;
     unsigned char nstr : 1;

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -64,7 +64,7 @@ int dm_easy_mesh_agent_t::analyze_dev_init(em_bus_event_t *evt, em_cmd_t *pcmd[]
     int num = 0;
     dm_easy_mesh_agent_t  dm;
     em_cmd_t *tmp;
-    
+
 	dm.translate_onewifi_dml_data(reinterpret_cast<char *> (evt->u.raw_buff));
 #ifdef AL_SAP
     // When AL_SAP is enabled the agent and controller AL MAC should be changed
@@ -209,7 +209,8 @@ void dm_easy_mesh_agent_t::translate_onewifi_dml_data (char *str)
     webconfig_proto_easymesh_init(&ext, this, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
+            update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
     
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -271,7 +272,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, 
             get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
-            update_scan_results);
+            update_scan_results, update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
     if (webconfig_init(&config) != webconfig_error_none) {
@@ -345,7 +346,8 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
+            update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -758,7 +760,8 @@ int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcm
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
+            get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
+            update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -930,7 +933,8 @@ void dm_easy_mesh_agent_t::translate_and_decode_onewifi_subdoc(char *str, webcon
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
         get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-        get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
+        get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
+        update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -954,7 +958,8 @@ int dm_easy_mesh_agent_t::refresh_onewifi_subdoc(wifi_bus_desc_t *desc, bus_hand
     webconfig_proto_easymesh_init(&ext_data, this, m2_cfg, policy_config, get_num_radios, set_num_radios,
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
         get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
-        get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results);
+        get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
+        update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
 
     webconfig_t config;
     config.initializer = webconfig_initializer_onewifi;

--- a/src/dm/dm_ap_mld.cpp
+++ b/src/dm/dm_ap_mld.cpp
@@ -57,7 +57,13 @@ void dm_ap_mld_t::operator = (const dm_ap_mld_t& obj)
     this->m_ap_mld_info.emlsr = obj.m_ap_mld_info.emlsr;
     this->m_ap_mld_info.emlmr = obj.m_ap_mld_info.emlmr;
     this->m_ap_mld_info.num_affiliated_ap = obj.m_ap_mld_info.num_affiliated_ap;
-    memcpy(&this->m_ap_mld_info.affiliated_ap,&obj.m_ap_mld_info.affiliated_ap,sizeof(em_affiliated_ap_info_t));
+    for(unsigned int i = 0; i < this->m_ap_mld_info.num_affiliated_ap; i++) {
+        memcpy(&this->m_ap_mld_info.affiliated_ap[i].ruid, &obj.m_ap_mld_info.affiliated_ap[i].ruid, sizeof(mac_address_t));
+        this->m_ap_mld_info.affiliated_ap[i].mac_addr_valid = obj.m_ap_mld_info.affiliated_ap[i].mac_addr_valid;
+        memcpy(&this->m_ap_mld_info.affiliated_ap[i].mac_addr, &obj.m_ap_mld_info.affiliated_ap[i].mac_addr,sizeof(mac_address_t));
+        this->m_ap_mld_info.affiliated_ap[i].link_id_valid = obj.m_ap_mld_info.affiliated_ap[i].link_id_valid;
+        this->m_ap_mld_info.affiliated_ap[i].link_id = obj.m_ap_mld_info.affiliated_ap[i].link_id;
+    }
 }
 
 
@@ -93,7 +99,7 @@ dm_ap_mld_t::dm_ap_mld_t(const dm_ap_mld_t& ap_mld)
 
 dm_ap_mld_t::dm_ap_mld_t()
 {
-
+    memset(&m_ap_mld_info, 0, sizeof(em_ap_mld_info_t));
 }
 
 dm_ap_mld_t::~dm_ap_mld_t()

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -88,6 +88,11 @@ dm_easy_mesh_t& dm_easy_mesh_t::operator = (dm_easy_mesh_t const& obj)
         m_policy[i] = obj.m_policy[i];
     }
 
+    m_num_ap_mld = obj.m_num_ap_mld;
+    for (unsigned int i = 0; i < EM_MAX_AP_MLD; i++) {
+        m_ap_mld[i] = obj.m_ap_mld[i];
+    }
+
     sta = static_cast<dm_sta_t *> (hash_map_get_first(obj.m_sta_map));
     while (sta != NULL) {
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
@@ -184,6 +189,17 @@ int dm_easy_mesh_t::commit_config(dm_easy_mesh_t& dm, em_commit_target_t target)
 				}
 			}
 		}
+
+		em_printfout("Number of AP MLDs to commit : %d", dm.m_num_ap_mld);
+		for (i = 0; i < dm.m_num_ap_mld; i++) {
+			em_ap_mld_info_t *src_mld_info = dm.m_ap_mld[i].get_ap_mld_info();
+			if (src_mld_info->num_affiliated_ap > 0) {
+				update_ap_mld_info(src_mld_info);
+			} else {
+				em_printfout("Skipping MLD[%d] as no affiliated APs found", i);
+			}
+		}
+
 	}
     return false;
 }
@@ -2776,6 +2792,110 @@ void dm_easy_mesh_t::update_scan_results(em_scan_result_t *scan_result)
         res = create_new_scan_result(id);
         *res->get_scan_result() = *scan_result;
     }
+}
+
+em_ap_mld_info_t *dm_easy_mesh_t::get_ap_mld_frm_bssid(mac_address_t bss_id)
+{
+    unsigned int i, j;
+    em_ap_mld_info_t *ap_mld_info = NULL;
+
+    for (i = 0; i < m_num_ap_mld; i++) {
+        ap_mld_info = &m_ap_mld[i].m_ap_mld_info;
+        for (j = 0; j < ap_mld_info->num_affiliated_ap; ++j) {
+            if (memcmp(ap_mld_info->affiliated_ap[j].mac_addr, bss_id, sizeof(mac_address_t)) == 0) {
+                return ap_mld_info;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+void dm_easy_mesh_t::update_ap_mld_info(em_ap_mld_info_t *ap_mld_info)
+{
+
+    em_ap_mld_info_t *target_mld = NULL;
+
+    // Find existing MLD by MAC
+    em_printfout("m_num_ap_mld %d", m_num_ap_mld);
+    for (int i = 0; i < m_num_ap_mld; i++) {
+        if (memcmp(m_ap_mld[i].m_ap_mld_info.mac_addr, ap_mld_info->mac_addr, sizeof(mac_address_t)) == 0) {
+            target_mld = &m_ap_mld[i].m_ap_mld_info;
+            em_printfout("Found existing MLD at index %d", i);
+            break;
+        }
+    }
+
+    // If not found, create new entry
+    if (!target_mld) {
+        if (m_num_ap_mld >= EM_MAX_AP_MLD) {
+            em_printfout("Max MLD entries reached");
+            return;
+        }
+
+        target_mld = &m_ap_mld[m_num_ap_mld].m_ap_mld_info;
+        memset(target_mld, 0, sizeof(em_ap_mld_info_t));
+        em_printfout("Created new MLD at index %d", m_num_ap_mld);
+        m_num_ap_mld++;
+    }
+
+    // Update MLD fields
+    target_mld->mac_addr_valid = ap_mld_info->mac_addr_valid;
+    strncpy(target_mld->ssid, ap_mld_info->ssid, sizeof(ssid_t));
+    memcpy(target_mld->mac_addr, ap_mld_info->mac_addr, sizeof(mac_address_t));
+    target_mld->str = ap_mld_info->str;
+    target_mld->nstr = ap_mld_info->nstr;
+    target_mld->emlsr = ap_mld_info->emlsr;
+    target_mld->emlmr = ap_mld_info->emlmr;
+
+    // Loop through all affiliated APs
+    for (int j = 0; j < ap_mld_info->num_affiliated_ap; j++) {
+        em_affiliated_ap_info_t *input_ap = &ap_mld_info->affiliated_ap[j];
+        em_affiliated_ap_info_t *target_aff_ap = NULL;
+        bool aff_ap_found = false;
+
+        for (int k = 0; k < target_mld->num_affiliated_ap; k++) {
+            if (memcmp(target_mld->affiliated_ap[k].mac_addr, input_ap->mac_addr, sizeof(mac_address_t)) == 0) {
+                target_aff_ap = &target_mld->affiliated_ap[k];
+                aff_ap_found = true;
+                em_printfout("Found existing affiliated AP at index %d", k);
+                break;
+            }
+        }
+
+        if (!aff_ap_found) {
+            if (target_mld->num_affiliated_ap >= EM_MAX_AP_MLD) {
+                em_printfout("Max affiliated APs reached for MLD");
+                continue;
+            }
+
+            target_aff_ap = &target_mld->affiliated_ap[target_mld->num_affiliated_ap];
+            memset(target_aff_ap, 0, sizeof(em_affiliated_ap_info_t));
+            em_printfout("Added new affiliated AP at index %d",target_mld->num_affiliated_ap);
+            target_mld->num_affiliated_ap++;
+        }
+
+        // Update affiliated AP fields
+        target_aff_ap->mac_addr_valid = input_ap->mac_addr_valid;
+        target_aff_ap->link_id_valid = input_ap->link_id_valid;
+        target_aff_ap->ruid = input_ap->ruid;
+        memcpy(target_aff_ap->mac_addr, input_ap->mac_addr, sizeof(mac_address_t));
+        target_aff_ap->link_id = input_ap->link_id;
+    }
+
+    em_printfout("Updated MLD with %d affiliated APs", target_mld->num_affiliated_ap);
+}
+
+void dm_easy_mesh_t::update_bsta_mld_info(em_bsta_mld_info_t *bsta_mld_info)
+{
+    // TODO: Implement BMLD info update logic
+    em_printfout("Enter");
+}
+
+void dm_easy_mesh_t::update_assoc_sta_mld_info(em_assoc_sta_mld_info_t *assoc_sta_mld_info)
+{
+    // TODO: Implement ASSOC MLD info update logic
+    em_printfout("Enter");
 }
 
 void dm_easy_mesh_t::reset_db_cfg_type(db_cfg_type_t type) 


### PR DESCRIPTION
RDKB-61233: Easymesh - WiFi 7 Integration

Reason for change: Add support for WiFi 7 SLO/MLO in Easymesh.
Test Procedure: Ensure basic easymesh configuration and client connectivity works for wifi7 clients.
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>