### PR TITLE
RDKBACCL-578: EasyMesh Agent integration in BPI Extender device

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,9 @@ AC_DISABLE_STATIC
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
  
+# Check for em agent
+AM_CONDITIONAL([EM_EXTENDER], [test x$EM_EXTENDER = xtrue])
+
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,5 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##########################################################################
+if EM_EXTENDER
+SUBDIRS = al-sap agent
+else
 SUBDIRS = cli al-sap ctrl agent
- 
+endif
+


### PR DESCRIPTION
Reason for change: Added EM_EXTENDER flag for bpi extender builds
Test procedure: Build should go through, and only agent and al-sap should get compiled in extender
Risks: None