### PR TITLE
Fixed the bug for fyncli with reset on bpi device

### DIFF
--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -25,7 +25,9 @@ include ../makefile.inc
 PROGRAM = $(INSTALLDIR)/bin/onewifi_em_ctrl
 EM_CERT_SRC = $(INSTALLDIR)/config/test_cert.crt
 EM_KEY_SRC  = $(INSTALLDIR)/config/test_cert.key
-CERT_TARGETS = $(NVRAM_DIR)/test_cert.crt $(NVRAM_DIR)/test_cert.key
+EM_RESET_JSON = $(INSTALLDIR)/bin/Reset.json
+CERT_TARGETS = $(NVRAM_DIR)/test_cert.crt $(NVRAM_DIR)/test_cert.key $(NVRAM_DIR)/Reset.json
+
 
 INCLUDEDIRS = \
 	-I$(ONEWIFI_EM_HOME)/inc \
@@ -128,6 +130,9 @@ $(NVRAM_DIR)/test_cert.crt: $(EM_CERT_SRC) | $(NVRAM_DIR)
 	$(CP) $< $@
 
 $(NVRAM_DIR)/test_cert.key: $(EM_KEY_SRC) | $(NVRAM_DIR)
+	$(CP) $< $@
+
+$(NVRAM_DIR)/Reset.json: $(EM_RESET_JSON) | $(NVRAM_DIR)
 	$(CP) $< $@
 
 # Clean everything

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -1420,7 +1420,7 @@ int dm_easy_mesh_ctrl_t::get_wifi_reset_config(cJSON *parent, char *key)
 
     subdoc = reinterpret_cast<em_subdoc_info_t*>(buff);
 
-    if (em_cmd_exec_t::load_params_file("Reset.json",  subdoc->buff) < 0) {
+    if (em_cmd_exec_t::load_params_file("/nvram/Reset.json",  subdoc->buff) < 0) {
         printf("%s:%d: Failed to load test file\n", __func__, __LINE__);
         return -1;
     }

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -1674,9 +1674,9 @@ void dm_easy_mesh_t::str_to_securitymode(unsigned short *mode, char *sec_mode_st
 
 const char* dm_easy_mesh_t::get_platform()
 {
-    std::ifstream cpuinfo("/proc/cpuinfo");
+    std::ifstream platformName("/sys/firmware/devicetree/base/model");
     std::string line;
-    while (std::getline(cpuinfo, line)) {
+    while (std::getline(platformName, line)) {
         if (line.find("Raspberry Pi") != std::string::npos) return "rpi";
         if (line.find("Banana Pi") != std::string::npos) return "bpi";
     }


### PR DESCRIPTION
modified the changes to detect the banana pi platform and reset.json file from /nvram