### PR TITLE
RDKB-61018:Calculate and forward device angle and distance using Wi-F…

### DIFF
--- a/build/agent/makefile
+++ b/build/agent/makefile
@@ -110,6 +110,7 @@ AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_assoc_sta_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_csi_container.cpp \
     $(ONEWIFI_EM_SRC)/utils/util.cpp \
 
 AGENT_OBJECTS = $(AGENT_SOURCES:.cpp=.o)

--- a/build/cli/makefile
+++ b/build/cli/makefile
@@ -78,6 +78,7 @@ CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/cli/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
     $(ONEWIFI_EM_SRC)/em/em_net_node.cpp \
     $(ONEWIFI_EM_SRC)/utils/util.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_csi_container.cpp \
     $(ONEWIFI_EM_SRC)/em/prov/easyconnect/ec_util.cpp \
     $(ONEWIFI_EM_SRC)/em/prov/easyconnect/ec_crypto.cpp \
 

--- a/build/fynecli/makefile
+++ b/build/fynecli/makefile
@@ -70,6 +70,7 @@ CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/fynecli/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_policy.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_scan_result.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_sta.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_csi_container.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_radio_cap.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_cac_comp.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_ap_mld.cpp \

--- a/build/openwrt/agent/makefile
+++ b/build/openwrt/agent/makefile
@@ -123,6 +123,7 @@ AGENT_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_bsta_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_assoc_sta_mld.cpp \
     $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_csi_container.cpp \
     $(ONEWIFI_EM_SRC)/utils/util.cpp \
 
 AGENT_OBJECTS = $(AGENT_SOURCES:.cpp=.o)

--- a/build/openwrt/cli/makefile
+++ b/build/openwrt/cli/makefile
@@ -80,6 +80,7 @@ CLI_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/cli/*.cpp) \
     $(ONEWIFI_EM_SRC)/dm/dm_tid_to_link.cpp \
     $(ONEWIFI_EM_SRC)/em/em_net_node.cpp \
     $(ONEWIFI_EM_SRC)/utils/util.cpp \
+    $(ONEWIFI_EM_SRC)/dm/dm_csi_container.cpp \
     $(ONEWIFI_EM_SRC)/em/prov/easyconnect/ec_util.cpp \
 
 MAIN_SOURCE = $(ONEWIFI_EM_SRC)/cli/main.c

--- a/inc/dm_csi_container.h
+++ b/inc/dm_csi_container.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DM_CSI_CONTAINER_H
+#define DM_CSI_CONTAINER_H
+
+#include "em_base.h"
+
+class dm_csi_container_t {
+public:
+    em_csi_container_t    m_csi_container;
+
+public:
+    int init() { memset(&m_csi_container, 0, sizeof(em_csi_container_t)); return 0; }
+    em_csi_container_t *get_csi_container() { return &m_csi_container; }
+    int decode(const cJSON *obj, void *parent_id);
+    void encode(cJSON *obj);
+    void encode_data(cJSON *obj);
+	
+    bool operator == (const dm_csi_container_t& obj);
+    void operator = (const dm_csi_container_t& obj);
+
+    static int parse_csi_container_id_from_key(const char *key, em_csi_container_id_t *id);
+
+    dm_csi_container_t(em_csi_container_t *cont);
+    dm_csi_container_t(const dm_csi_container_t& cont);
+    dm_csi_container_t();
+    virtual ~dm_csi_container_t();
+};
+
+#endif

--- a/inc/dm_csi_container_list.h
+++ b/inc/dm_csi_container_list.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DM_CSI_CONTAINER_LIST_H
+#define DM_CSI_CONTAINER_LIST_H
+
+#include "em_base.h"
+#include "dm_csi_container.h"
+
+class dm_easy_mesh_t;
+class em_cmd_t;
+
+class dm_csi_container_list_t : public dm_csi_container_t {
+
+public:
+    int init();
+    int load_data();
+    dm_orch_type_t get_dm_orch_type(db_client_t& db_client, const dm_csi_container_t& cont);
+    void update_list(const dm_csi_container_t& cont, dm_orch_type_t op);   
+    void delete_list();
+    int analyze_config(const cJSON *obj_arr, void *parent_id, em_cmd_t *cmd[], em_cmd_params_t *param);
+    int get_config(cJSON *obj, void *parent_id);
+    int get_config(cJSON *obj, void *parent_id, bool summary = false);
+    int get_data(cJSON *obj, void *key);
+    virtual dm_csi_container_t *get_first_csi_container() = 0;
+    virtual dm_csi_container_t *get_next_csi_container(dm_csi_container_t *cont) = 0;
+    virtual dm_csi_container_t *get_csi_container(const char *key) = 0;
+    virtual void remove_csi_container(const char *key) = 0;
+    virtual void put_csi_container(const char *key, const dm_csi_container_t *cont) = 0;
+};
+
+#endif

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -32,6 +32,7 @@
 #include "dm_op_class.h"
 #include "dm_policy.h"
 #include "dm_scan_result.h"
+#include "dm_csi_container.h"
 #include "dm_radio_cap.h"
 #include "dm_cac_comp.h"
 #include "dm_ap_mld.h"
@@ -67,6 +68,8 @@ public:
     dm_op_class_t m_op_class[EM_MAX_OPCLASS];
 	unsigned int	m_num_policy;
 	dm_policy_t	m_policy[EM_MAX_POLICIES];
+    uint32_t           m_num_csi_containers;
+    dm_csi_container_t m_csi_containers[EM_MAX_CSI_CONTAINERS];
 	hash_map_t		*m_scan_result_map = NULL;
     hash_map_t  	*m_sta_map = NULL;
     hash_map_t      *m_sta_assoc_map = NULL;
@@ -2462,7 +2465,9 @@ public:
 	 * @note Ensure that the policy parameter is valid and supported by the system.
 	 */
 	void set_policy(dm_policy_t policy);
-    
+   
+        void set_csi_container(dm_csi_container_t cont);
+
 	/**!
 	 * @brief Retrieves the current em_t instance.
 	 *

--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -61,7 +61,9 @@ public:
 	 * @note Ensure that the event and command data are properly initialized before calling this function.
 	 */
 	int analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]);
-    
+
+        int analyze_csi(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
 	/**!
 	 * @brief Analyzes the auto-configuration renewal process.
 	 *

--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -31,6 +31,7 @@
 #include "dm_sta_list.h"
 #include "dm_policy_list.h"
 #include "dm_scan_result_list.h"
+#include "dm_csi_container_list.h"
 #include "dm_dpp.h"
 #include "db_client.h"
 #include "dm_easy_mesh_list.h"
@@ -45,7 +46,7 @@ class dm_easy_mesh_ctrl_t :
     public dm_ieee_1905_security_list_t, public dm_radio_list_t, public dm_radio_cap_list_t,
         
     public dm_op_class_list_t, public dm_bss_list_t, public dm_sta_list_t, public dm_policy_list_t,
-	public dm_scan_result_list_t {
+	public dm_scan_result_list_t, public dm_csi_container_list_t {
 
     db_client_t m_db_client;
     bool	m_initialized;
@@ -785,7 +786,9 @@ public:
 	 * @note Ensure that the JSON object is properly initialized before calling this function.
 	 */
 	int get_mld_config(cJSON *parent, char *key);
-    
+   
+        int get_csi_config(cJSON *parent, char *key);
+
     /**!
 	 * @brief Retrieves the wifi reset configuration from the given JSON object.
 	 *
@@ -851,7 +854,9 @@ public:
 	 * em_subdoc_info_t structure before calling this function.
 	 */
 	void get_config(em_long_string_t net_id, em_subdoc_info_t *subdoc);
-    
+
+        void get_csi_data(em_long_string_t net_id, mac_addr_str_t dev_mac_str, em_subdoc_info_t *subdoc);
+
 	/**!
 	* @brief Sets the configuration for the Easy Mesh.
 	*
@@ -1549,6 +1554,11 @@ public:
 	 */
 	void put_scan_result(const char *key, const dm_scan_result_t *scan_result, unsigned int index) { m_data_model_list.put_scan_result(key, scan_result, index); }
 
+        dm_csi_container_t *get_first_csi_container() { return m_data_model_list.get_first_csi_container(); }
+        dm_csi_container_t *get_next_csi_container(dm_csi_container_t *cont) { return m_data_model_list.get_next_csi_container(cont); }
+        dm_csi_container_t *get_csi_container(const char *key) { return m_data_model_list.get_csi_container(key); }
+        void remove_csi_container(const char *key) { m_data_model_list.remove_csi_container(key); }
+        void put_csi_container(const char *key, const dm_csi_container_t *cont) { m_data_model_list.put_csi_container(key, cont); }
 	
 	/**!
 	 * @brief Initializes the network topology.

--- a/inc/dm_easy_mesh_list.h
+++ b/inc/dm_easy_mesh_list.h
@@ -782,7 +782,12 @@ public:
 	 */
 	void put_scan_result(const char *key, const dm_scan_result_t *scan_result, unsigned int index);
 
-    
+        dm_csi_container_t *get_first_csi_container();
+        dm_csi_container_t *get_next_csi_container(dm_csi_container_t *cont);
+        dm_csi_container_t *get_csi_container(const char *key);
+        void remove_csi_container(const char *key);
+        void put_csi_container(const char *key, const dm_csi_container_t *cont);
+
 	/**!
 	 * @brief Constructor for the dm_easy_mesh_list_t class.
 	 *

--- a/inc/em.h
+++ b/inc/em.h
@@ -527,7 +527,7 @@ public:
 	 *
 	 * @note Ensure that the state provided is valid and within the expected range of states.
 	 */
-	void set_state(em_state_t state) {  m_sm.set_state(state); }
+	void set_state(em_state_t state);
 	
 	/**!
 	 * @brief Retrieves the service type.
@@ -1185,6 +1185,8 @@ public:
 	 */
 	static const char *state_2_str(em_state_t state);
 
+        em_state_t check_all_em_node_state(void);
+        void monitor_agent_state(void);
 
 	bool get_devteststatus(){return dev_test_enable;}
 	void set_devteststatus(bool enable ) { dev_test_enable = enable;} 

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -38,6 +38,11 @@
 class em_cmd_agent_t;
 class AlServiceAccessPoint;
 
+struct csi_sounding_set {
+    mac_address_t sounding_mac;
+    //need to add few more parameters
+};
+
 class em_agent_t : public em_mgr_t {
 
     em_orch_agent_t *m_orch;
@@ -538,7 +543,10 @@ public:
 	 * @note Ensure that the event structure is properly initialized before calling this function.
 	 */
 	void handle_sta_list(em_bus_event_t *evt);
-    
+
+        void handle_csi(em_bus_event_t *evt);
+        bool handle_csi_trigger(em_bus_event_t *evt);
+
 	/**!
 	 * @brief Handles the access point capability query event.
 	 *
@@ -847,7 +855,9 @@ public:
 	 * passing it to this function.
 	 */
 	static void onewifi_cb(char *event_name, raw_data_t *data, void *userData);
-    
+
+        static void csi_data_cb(char *event_name, raw_data_t *data, void *userData);
+
 	/**!
 	 * @brief Callback function for association statistics.
 	 *

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -428,6 +428,7 @@ public:
 	 */
 	int send_available_spectrum_inquiry_msg();
 
+        int send_csi_notification();
     
 	/**!
 	 * @brief Handles the channel scan request.
@@ -460,7 +461,9 @@ public:
 	 * @note Ensure the buffer is properly allocated and the length is correct.
 	 */
 	int handle_channel_scan_rprt(unsigned char *buff, unsigned int len);
-    
+   
+        int handle_csi_notification(unsigned char *buff, unsigned int len);
+
 	/**!
 	 * @brief Handles the result of a channel scan.
 	 *

--- a/inc/em_cmd_csi.h
+++ b/inc/em_cmd_csi.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_CSI_H
+#define EM_CMD_CSI_H
+
+#include "em_cmd.h"
+
+class em_cmd_csi_t : public em_cmd_t {
+
+public:
+    
+	/**!
+	 * @brief 
+	 *
+	 * This function is responsible for handling the csi. The comman is sent from
+	 * OneWifi to EasyMesh Agents for orhestrating the data all the way to Controller
+	 *
+	 * @param[in] param The command parameters required for execution.
+	 * @param[in,out] dm The easy mesh data structure that will be modified.
+	 *
+	 * @returns em_cmd_sta_list_t The result of the station list command execution.
+	 *
+	 * @note Ensure that the dm structure is properly initialized before calling this function.
+	 */
+	em_cmd_csi_t(em_cmd_params_t param, dm_easy_mesh_t& dm);
+};
+
+#endif

--- a/inc/em_cmd_ctrl.h
+++ b/inc/em_cmd_ctrl.h
@@ -59,6 +59,7 @@ public:
 	 */
 	int send_result(em_cmd_out_status_t status);
 
+        int send_result(unsigned char *result, unsigned int len);
     
 	/**!
 	 * @brief Constructor for em_cmd_ctrl_t class.

--- a/inc/em_cmd_get_csi_config.h
+++ b/inc/em_cmd_get_csi_config.h
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_GET_CSI_CONFIG_H
+#define EM_CMD_GET_CSI_CONFIG_H
+
+#include "em_cmd.h"
+
+class em_cmd_get_csi_config_t : public em_cmd_t {
+
+public:
+    
+	em_cmd_get_csi_config_t(em_cmd_params_t param, dm_easy_mesh_t& dm);
+};
+
+#endif

--- a/inc/em_cmd_get_csi_data.h
+++ b/inc/em_cmd_get_csi_data.h
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_GET_CSI_DATA_H
+#define EM_CMD_GET_CSI_DATA_H
+
+#include "em_cmd.h"
+
+class em_cmd_get_csi_data_t : public em_cmd_t {
+
+public:
+    
+	em_cmd_get_csi_data_t(em_cmd_params_t param, dm_easy_mesh_t& dm);
+};
+
+#endif

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -192,7 +192,9 @@ public:
 	 * @note Ensure that the event structure is properly initialized before calling this function.
 	 */
 	void handle_start_dpp(em_bus_event_t *evt);
-    
+
+        void handle_csi_event(em_bus_event_t *evt);
+
 	/**!
 	 * @brief Handles client steering based on the event provided.
 	 *
@@ -372,7 +374,9 @@ public:
 	 * @note Ensure that the event structure is properly initialized before calling this function.
 	 */
 	void handle_get_dm_data(em_bus_event_t *evt);
-    
+   
+        void handle_get_csi_data(em_bus_event_t *evt);
+
 	/**!
 	 * @brief Handles the DM commit event.
 	 *

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -210,7 +210,6 @@ public:
 	 */
 	em_t *get_al_node();
 
-    
 	/**
 	* @brief Get the physical AL node.
 	* In other words, the actual `em_t` node that is being used to perform EasyMesh operations.

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -457,6 +457,21 @@ void em_cmd_t::init()
             m_svc = em_service_type_ctrl;
             break;
 
+        case em_cmd_type_csi:
+            snprintf(m_name, sizeof(m_name), "%s", "csi");
+            m_svc = em_service_type_agent;
+            break;
+
+        case em_cmd_type_get_csi_config:
+            snprintf(m_name, sizeof(m_name), "%s", "get_csi_config");
+            m_svc = em_service_type_ctrl;
+            break;
+
+        case em_cmd_type_get_csi_data:
+            snprintf(m_name, sizeof(m_name), "%s", "get_csi_data");
+            m_svc = em_service_type_ctrl;
+            break;
+
         default:
             break;
 
@@ -500,7 +515,8 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_mld_config)
         BUS_EVENT_TYPE_2S(em_bus_event_type_mld_reconfig)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_reset)
-       
+        BUS_EVENT_TYPE_2S(em_bus_event_type_csi)
+
         default:
            break;
     }
@@ -770,6 +786,18 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
             type = em_cmd_type_get_reset;
             break;
 
+        case em_bus_event_type_csi:
+            type = em_cmd_type_csi;
+            break;
+
+        case em_bus_event_type_get_csi_config:
+            type = em_cmd_type_get_csi_config;
+            break;
+
+        case em_bus_event_type_get_csi_data:
+            type = em_cmd_type_get_csi_data;
+            break;
+
         default:
             break;
     }
@@ -820,6 +848,10 @@ em_bus_event_type_t em_cmd_t::cmd_2_bus_event_type(em_cmd_type_t ctype)
 
         case em_cmd_type_get_reset:
             type = em_bus_event_type_get_reset;
+            break;
+
+        case em_cmd_type_csi:
+            type = em_bus_event_type_csi;
             break;
 
         default:

--- a/src/cmd/em_cmd_csi.cpp
+++ b/src/cmd/em_cmd_csi.cpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <cjson/cJSON.h>
+#include "em_cmd_csi.h"
+
+em_cmd_csi_t::em_cmd_csi_t(em_cmd_params_t param, dm_easy_mesh_t &dm)
+{
+    em_cmd_ctx_t ctx;;
+
+    m_type = em_cmd_type_csi;
+    memcpy(&m_param, &param, sizeof(em_cmd_params_t));
+
+    memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+    m_num_orch_desc = 1;
+    m_orch_desc[0].op = dm_orch_type_ctrl_notify;
+    m_orch_desc[0].submit = true;
+    //m_orch_desc[1].op = dm_orch_type_csi_commit;
+    m_orch_op_idx = 0;
+    
+    strncpy(m_name, "csi", strlen("csi") + 1);
+    m_svc = em_service_type_agent;
+    init(dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+    ctx.type = m_orch_desc[0].op;    
+
+    m_data_model.set_cmd_ctx(&ctx);
+}

--- a/src/cmd/em_cmd_get_csi_config.cpp
+++ b/src/cmd/em_cmd_get_csi_config.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <cjson/cJSON.h>
+#include "em_cmd_get_csi_config.h"
+
+em_cmd_get_csi_config_t::em_cmd_get_csi_config_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
+{
+    em_cmd_ctx_t ctx;;
+
+    m_type = em_cmd_type_get_csi_config;
+    memcpy(&m_param, &param, sizeof(em_cmd_params_t));
+
+    memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+    m_num_orch_desc = 0;
+
+    strncpy(m_name, "get_csi_config", strlen("get_csi_config") + 1);
+    m_svc = em_service_type_ctrl;
+
+    init(dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+    m_data_model.set_cmd_ctx(&ctx);
+}

--- a/src/cmd/em_cmd_get_csi_data.cpp
+++ b/src/cmd/em_cmd_get_csi_data.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <cjson/cJSON.h>
+#include "em_cmd_get_csi_data.h"
+
+em_cmd_get_csi_data_t::em_cmd_get_csi_data_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
+{
+    em_cmd_ctx_t ctx;;
+
+    m_type = em_cmd_type_get_csi_data;
+    memcpy(&m_param, &param, sizeof(em_cmd_params_t));
+
+    memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+    m_num_orch_desc = 0;
+
+    strncpy(m_name, "get_csi_data", strlen("get_csi_data") + 1);
+    m_svc = em_service_type_ctrl;
+
+    init(dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+    m_data_model.set_cmd_ctx(&ctx);
+}

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -1478,6 +1478,37 @@ int dm_easy_mesh_ctrl_t::get_mld_config(cJSON *parent, char *key)
 	return 0;
 }
 
+int dm_easy_mesh_ctrl_t::get_csi_config(cJSON *parent, char *key)
+{
+    cJSON *ext_obj;
+
+    ext_obj = cJSON_AddArrayToObject(parent, "Extenders");
+    dm_csi_container_list_t::get_config(ext_obj, NULL, false);
+    return 0;
+}
+
+void dm_easy_mesh_ctrl_t::get_csi_data(em_long_string_t net_id, mac_addr_str_t dev_mac_str, em_subdoc_info_t *subdoc)
+{
+    cJSON *parent, *sounders;
+    em_long_string_t key;
+    char *tmp;
+    mac_addr_t null_mac = {0};
+    mac_addr_str_t  null_mac_str;
+
+    parent = cJSON_CreateObject();
+    sounders = cJSON_AddArrayToObject(parent, "Sounders");
+
+    dm_easy_mesh_t::macbytes_to_string(null_mac, null_mac_str);
+
+    snprintf(key, sizeof(em_long_string_t), "OneWifiMesh@%s@%s", dev_mac_str, null_mac_str);
+    dm_csi_container_list_t::get_data(sounders, (void *)key);
+
+    tmp = cJSON_Print(parent);
+    //printf("%s:%d: Subdoc: %s\n", __func__, __LINE__, tmp);
+    strncpy(subdoc->buff, tmp, strlen(tmp) + 1);
+    cJSON_free(parent);
+}
+
 void dm_easy_mesh_ctrl_t::get_config(em_long_string_t net_id, em_subdoc_info_t *subdoc)
 {
     cJSON *parent;
@@ -1526,6 +1557,8 @@ void dm_easy_mesh_ctrl_t::get_config(em_long_string_t net_id, em_subdoc_info_t *
         get_mld_config(parent, net_id);
     } else if (strncmp(subdoc->name, "WifiReset", strlen(subdoc->name)) == 0) {
         get_wifi_reset_config(parent, net_id);
+    } else if (strncmp(subdoc->name, "CSIConfig", strlen(subdoc->name)) == 0) {
+        get_csi_config(parent, net_id);
     }
 
     tmp = cJSON_Print(parent);
@@ -1595,6 +1628,7 @@ void dm_easy_mesh_ctrl_t::init_tables()
     dm_sta_list_t::init();
     dm_policy_list_t::init();
     dm_scan_result_list_t::init();
+    dm_csi_container_list_t::init();
 }
 
 int dm_easy_mesh_ctrl_t::load_net_ssid_table()
@@ -1634,6 +1668,8 @@ int dm_easy_mesh_ctrl_t::load_tables()
         printf("%s:%d: data base empty ... needs reset\n", __func__, __LINE__);
         return -1;
     }
+
+    dm_csi_container_list_t::load_data();
 
 	set_initialized();
 

--- a/src/ctrl/em_cmd_ctrl.cpp
+++ b/src/ctrl/em_cmd_ctrl.cpp
@@ -124,6 +124,24 @@ int em_cmd_ctrl_t::execute(char *result)
     return 0;
 }
 
+int em_cmd_ctrl_t::send_result(unsigned char *data, unsigned int len)
+{
+    ssize_t ret;
+    int sd;
+
+    if ((ret = SSL_write(m_ssl, data, len)) <= 0) {
+        printf("%s:%d: write error on socket, err:%d\n", __func__, __LINE__, errno);
+    }
+
+    //printf("%s:%d: Send success bytes sent:%d\n", __func__, __LINE__, ret);
+    sd = SSL_get_fd(m_ssl);
+    SSL_shutdown(m_ssl);
+    SSL_free(m_ssl);
+    close(sd);
+
+    return 0;
+}
+
 int em_cmd_ctrl_t::send_result(em_cmd_out_status_t status)
 {
     ssize_t ret;

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -57,6 +57,28 @@ AlServiceAccessPoint* g_sap;
 MacAddress g_al_mac_sap;
 #endif
 
+void em_ctrl_t::handle_csi_event(em_bus_event_t *evt)
+{
+    mac_addr_str_t  dev_mac_str, sounding_mac_str;
+    em_csi_container_t *cont;
+    em_long_string_t key;
+    dm_csi_container_t *pdm;
+    dm_easy_mesh_ctrl_t *dm;
+
+    cont = (em_csi_container_t *)&evt->params.u.csi_data_params;
+    
+    dm_easy_mesh_t::macbytes_to_string(cont->id.dev_mac, dev_mac_str);  
+    dm_easy_mesh_t::macbytes_to_string(cont->id.sounding_mac, sounding_mac_str);
+    printf("%s:%d: Device:%s Sounder:%s angle:%f distance:%f\n", __func__, __LINE__,
+        dev_mac_str, sounding_mac_str, cont->angle, cont->distance);
+	
+    snprintf(key, sizeof(em_long_string_t), "OneWifiMesh@%s@%s", dev_mac_str, sounding_mac_str);
+    pdm = new dm_csi_container_t(cont);
+
+    dm = (dm_easy_mesh_ctrl_t *)get_data_model("OneWifiMesh");
+    dm->put_csi_container(key, pdm);
+}
+
 void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
 {
     em_commit_info_t *info;
@@ -327,6 +349,24 @@ void em_ctrl_t::handle_get_dm_data(em_bus_event_t *evt)
     m_ctrl_cmd->send_result(em_cmd_out_status_success);
 }        
 
+void em_ctrl_t::handle_get_csi_data(em_bus_event_t *evt)
+{
+    unsigned int len;
+
+    em_cmd_params_t params = evt->params;
+
+    //em_cmd_t::dump_bus_event(evt);
+    if (params.u.args.num_args < 1) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_invalid_input);
+        return;
+    }
+
+    m_data_model.get_csi_data(params.u.args.args[1], params.u.args.args[2], &evt->u.subdoc);
+    evt->data_len = static_cast<unsigned int> (strlen(evt->u.subdoc.buff)) + 1;
+    m_ctrl_cmd->copy_bus_event(evt);
+    m_ctrl_cmd->send_result(em_cmd_out_status_success);       
+}
+
 void em_ctrl_t::handle_reset(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -440,7 +480,12 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
         case em_bus_event_type_scan_result:
         case em_bus_event_type_get_mld_config:
         case em_bus_event_type_get_reset:
+        case em_bus_event_type_get_csi_config:
             handle_get_dm_data(evt);
+            break;
+
+        case em_bus_event_type_get_csi_data:
+            handle_get_csi_data(evt);
             break;
 
         case em_bus_event_type_set_radio:
@@ -502,7 +547,11 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
         case em_bus_event_type_mld_reconfig:
 			handle_mld_reconfig(evt);
 			break;
-	
+
+        case em_bus_event_type_csi:
+            handle_csi_event(evt);
+            break;
+
         default:
             break;
     }
@@ -792,6 +841,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
         case em_msg_type_dpp_cce_ind:
         case em_msg_type_1905_rekey_req:
         case em_msg_type_1905_encap_eapol:
+        case em_msg_type_csi_notif:
 	        em = al_em;
 	        break;
 

--- a/src/dm/dm_csi_container.cpp
+++ b/src/dm/dm_csi_container.cpp
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include "dm_csi_container.h"
+#include "dm_easy_mesh.h"
+#include "dm_easy_mesh_ctrl.h"
+#include "util.h"
+
+int dm_csi_container_t::decode(const cJSON *obj, void *parent_id)
+{
+
+    return 0;
+}
+
+void dm_csi_container_t::encode_data(cJSON *obj)
+{
+	mac_addr_str_t mac_str;
+	cJSON *cov_arr, *cov_row, *cov_col;
+        cJSON *csi_obj, *csi_info;
+	unsigned int i, j;
+
+	dm_easy_mesh_t::macbytes_to_string(m_csi_container.id.sounding_mac, mac_str);
+	cJSON_AddStringToObject(obj, "MACAddress", mac_str);
+	csi_obj = cJSON_AddArrayToObject(obj, "CsiData");
+        csi_info = cJSON_CreateObject();
+        cJSON_AddNumberToObject(csi_info, "Angle", m_csi_container.angle);
+        cJSON_AddNumberToObject(csi_info, "Distance", m_csi_container.distance);
+        cJSON_AddItemToArray(csi_obj, csi_info);
+}
+
+void dm_csi_container_t::encode(cJSON *obj)
+{
+	mac_addr_str_t mac_str;
+
+	dm_easy_mesh_t::macbytes_to_string(m_csi_container.id.sounding_mac, mac_str);
+	cJSON_AddStringToObject(obj, "MACAddress", mac_str);
+}
+
+bool dm_csi_container_t::operator == (const dm_csi_container_t& obj)
+{
+
+}
+
+void dm_csi_container_t::operator = (const dm_csi_container_t& obj)
+{
+	memcpy(&m_csi_container, &obj.m_csi_container, sizeof(em_csi_container_t));
+}
+
+int dm_csi_container_t::parse_csi_container_id_from_key(const char *key, em_csi_container_id_t *id)
+{
+    em_long_string_t   str;
+    char *tmp, *remain;
+    unsigned int i = 0;
+
+    strncpy(str, key, strlen(key) + 1);
+    remain = str;
+    while ((tmp = strchr(remain, '@')) != NULL) {
+        if (i == 0) {
+            *tmp = 0;
+            strncpy(id->net_id, remain, strlen(remain) + 1);
+            tmp++;  
+            remain = tmp;
+        } else if (i == 1) {
+            *tmp = 0;
+            dm_easy_mesh_t::string_to_macbytes(remain, id->dev_mac);
+            tmp++;
+            dm_easy_mesh_t::string_to_macbytes(tmp, id->sounding_mac);
+        }  
+        i++;
+    }
+
+    return 0;
+}
+
+dm_csi_container_t::dm_csi_container_t(em_csi_container_t *cont)
+{
+    memcpy(&m_csi_container, cont, sizeof(em_csi_container_t));
+}
+
+dm_csi_container_t::dm_csi_container_t(const dm_csi_container_t& cont)
+{
+    memcpy(&m_csi_container, &cont.m_csi_container, sizeof(em_csi_container_t));
+}
+
+dm_csi_container_t::dm_csi_container_t()
+{
+
+}
+
+dm_csi_container_t::~dm_csi_container_t()
+{
+
+}

--- a/src/dm/dm_csi_container_list.cpp
+++ b/src/dm/dm_csi_container_list.cpp
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <linux/filter.h>
+#include <netinet/ether.h>
+#include <netpacket/packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include "em_cmd.h"
+#include "dm_csi_container_list.h"
+#include "dm_easy_mesh.h"
+#include "dm_easy_mesh_ctrl.h"
+
+int dm_csi_container_list_t::get_data(cJSON *parent, void *key)
+{
+	em_csi_container_id_t id;
+	dm_csi_container_t *cont = NULL;
+    cJSON *obj;
+	mac_addr_t null_mac = {0};
+	bool get_all = false;
+
+	dm_csi_container_t::parse_csi_container_id_from_key((char *)key, &id);
+	if (memcmp(id.sounding_mac, null_mac, sizeof(mac_address_t)) == 0) {
+		get_all = true;
+	}
+
+    cont = get_first_csi_container();
+    while (cont != NULL) {
+		if (memcmp(cont->m_csi_container.id.dev_mac, id.dev_mac, sizeof(mac_address_t)) == 0) {
+			if (get_all == true) {
+				obj = cJSON_CreateObject();
+				cont->encode_data(obj);
+				cJSON_AddItemToArray(parent, obj);
+			} else if (memcmp(cont->m_csi_container.id.sounding_mac, id.sounding_mac, sizeof(mac_address_t)) == 0) {
+				obj = cJSON_CreateObject();
+				cont->encode_data(obj);
+				cJSON_AddItemToArray(parent, obj);
+			}	
+		}	
+
+        cont = get_next_csi_container(cont);
+    }
+
+	return 0;
+}
+
+int dm_csi_container_list_t::get_config(cJSON *obj_arr, void *parent)
+{
+    return 0;
+}
+
+int dm_csi_container_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
+{
+	dm_csi_container_t *cont = NULL;
+    cJSON *obj;
+	mac_address_t	parent_mac = {0};
+
+	if (parent != NULL) {
+		dm_easy_mesh_t::string_to_macbytes((char *)parent, parent_mac);
+	}
+
+    cont = get_first_csi_container();
+    while (cont != NULL) {
+		if (memcmp(cont->m_csi_container.id.sounding_mac, cont->m_csi_container.id.dev_mac, sizeof(mac_address_t)) != 0) {
+        	cont = get_next_csi_container(cont);
+			continue;	
+		}	
+
+        obj = cJSON_CreateObject();
+        cont->encode(obj);
+
+        cJSON_AddItemToArray(obj_arr, obj);
+        cont = get_next_csi_container(cont);
+    }
+
+    return 0;
+}
+
+int dm_csi_container_list_t::analyze_config(const cJSON *obj_arr, void *parent_id, em_cmd_t *pcmd[], em_cmd_params_t *param)
+{
+    printf("%s:%d: Enter\n", __func__, __LINE__);
+
+    return 0;
+}
+
+dm_orch_type_t dm_csi_container_list_t::get_dm_orch_type(db_client_t& db_client, const dm_csi_container_t& csi_container)
+{
+    return dm_orch_type_db_insert;
+}
+
+void dm_csi_container_list_t::update_list(const dm_csi_container_t& csi_container, dm_orch_type_t op)
+{
+
+}
+
+void dm_csi_container_list_t::delete_list()
+{
+       
+}   
+
+int dm_csi_container_list_t::load_data()
+{
+    return 0;
+}
+
+int dm_csi_container_list_t::init()
+{
+	return 0;
+}

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -88,6 +88,11 @@ dm_easy_mesh_t& dm_easy_mesh_t::operator = (dm_easy_mesh_t const& obj)
         m_policy[i] = obj.m_policy[i];
     }
 
+    m_num_csi_containers = obj.m_num_csi_containers;
+    for (unsigned int i = 0; i < m_num_csi_containers; i++) {
+        m_csi_containers[i] = obj.m_csi_containers[i];
+    }
+
     sta = static_cast<dm_sta_t *> (hash_map_get_first(obj.m_sta_map));
     while (sta != NULL) {
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
@@ -2633,6 +2638,37 @@ void dm_easy_mesh_t::set_channels_list(dm_op_class_t op_class[], unsigned int nu
 			
 		memcpy(&poclass->m_op_class_info, &oclass->m_op_class_info, sizeof(em_op_class_info_t));
 	}
+}
+
+void dm_easy_mesh_t::set_csi_container(dm_csi_container_t cont)
+{
+    unsigned int i;
+    dm_csi_container_t *pcont;
+    bool found_match = false;
+
+    for (i = 0; i < m_num_csi_containers; i++) {
+        pcont = &m_csi_containers[i];
+        if (memcmp(cont.m_csi_container.id.sounding_mac,
+            pcont->m_csi_container.id.sounding_mac,
+            sizeof(mac_address_t)) == 0) {
+            found_match = true;
+            break;
+        }
+    }
+
+    if (found_match == false) {
+        if (m_num_csi_containers >= EM_MAX_CSI_CONTAINERS) {
+            mac_addr_str_t dev_mac_str;
+            dm_easy_mesh_t::macbytes_to_string((unsigned char *)cont.m_csi_container.id.dev_mac,
+                dev_mac_str);
+            printf("csi containers is full skip this:%s client info\r\n", dev_mac_str);
+            return;
+        }
+        pcont = &m_csi_containers[m_num_csi_containers];
+        m_num_csi_containers++;
+    }
+
+    memcpy(&pcont->m_csi_container, &cont.m_csi_container, sizeof(em_csi_container_t));
 }
 
 void dm_easy_mesh_t::print_op_class_list(dm_easy_mesh_t *dm)

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -1384,6 +1384,125 @@ int em_channel_t::send_available_spectrum_inquiry_msg()
 
 }
 
+int em_channel_t::send_csi_notification()
+{
+    unsigned short  msg_id = em_msg_type_csi_notif;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int len = 0, i;
+    unsigned short sz;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *pdm, *dm;
+    dm_csi_container_t *cont = NULL;
+    mac_addr_str_t  dev_mac_str, sounding_mac_str;
+
+    pdm = get_current_cmd()->get_data_model();
+    cont = &pdm->m_csi_containers[0];
+    dm_easy_mesh_t::macbytes_to_string(cont->m_csi_container.id.dev_mac, dev_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(cont->m_csi_container.id.sounding_mac, sounding_mac_str);
+    
+
+    printf("%s:%d: Device:%s Sounder:%s\n", __func__, __LINE__, dev_mac_str, sounding_mac_str);
+
+    dm = get_data_model();
+
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int> (sizeof(mac_address_t));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int> (sizeof(mac_address_t));
+
+    memcpy(tmp, reinterpret_cast<unsigned char *> (&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += static_cast<unsigned int> (sizeof(unsigned short));
+
+    cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
+
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_id);
+    cmdu->id = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    cmdu->relay_ind = 1;
+
+    tmp += sizeof(em_cmdu_t);
+    len += static_cast<unsigned int> (sizeof(em_cmdu_t));
+
+    // Device MAC Address type TLV
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_al_mac_address;
+    tlv->len = htons(sizeof(mac_address_t));
+    memcpy(tlv->value, cont->m_csi_container.id.dev_mac, sizeof(mac_address_t));
+
+    tmp += (sizeof (em_tlv_t) + sizeof(mac_address_t));
+    len += static_cast<unsigned int> (sizeof (em_tlv_t) + sizeof(mac_address_t));
+
+    // Sounding client MAC Address type TLV
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_rdk_sounding_sta_mac;
+    tlv->len = htons(sizeof(mac_address_t));
+    memcpy(tlv->value, cont->m_csi_container.id.sounding_mac, sizeof(mac_address_t));
+
+    tmp += (sizeof (em_tlv_t) + sizeof(mac_address_t));
+    len += static_cast<unsigned int> (sizeof (em_tlv_t) + sizeof(mac_address_t));
+
+    // fill the CSI angle and distance info
+
+    printf("csi angle:%f distance:%f\r\n", cont->m_csi_container.angle,
+        cont->m_csi_container.distance);
+
+    //CSI Angle tvl data
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_rdk_angle_csi_data;
+    sz = sizeof(double);
+    memcpy(tlv->value, (unsigned char *)&cont->m_csi_container.angle, sz);
+    tlv->len =  htons(sz);
+
+    tmp += (sizeof(em_tlv_t) + sz);
+    len += static_cast<unsigned int> (sizeof(em_tlv_t) + sz);
+
+    //CSI distance tvl data
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_rdk_distance_csi_data;
+    sz = sizeof(double);
+    memcpy(tlv->value, (unsigned char *)&cont->m_csi_container.distance, sz);
+    tlv->len =  htons(sz);
+
+    tmp += (sizeof(em_tlv_t) + sz);
+    len += static_cast<unsigned int> (sizeof(em_tlv_t) + sz);
+
+    // End of message
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += (sizeof (em_tlv_t));
+    len += static_cast<unsigned int> (sizeof (em_tlv_t));
+
+/*
+    if (em_msg_t(em_msg_type_csi_notif, em_profile_type_3, buff, len).validate(errors) == 0) {
+        printf("CSI notification msg validation failed\n");
+
+        return -1;
+    }
+*/
+
+    if (send_frame(buff, len)  < 0) {
+        printf("%s:%d: Topology notification send failed, error:%d\n", __func__, __LINE__, errno);
+        return -1;
+    }
+
+    //printf("%s:%d: CSI notification Send Successful\n", __func__, __LINE__);
+
+    return static_cast<int> (len);
+}
+
 int em_channel_t::handle_op_channel_report(unsigned char *buff, unsigned int len)
 {
     dm_easy_mesh_t *dm;
@@ -1896,6 +2015,54 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
 
 }
 
+int em_channel_t::handle_csi_notification(unsigned char *buff, unsigned int len)
+{
+    em_tlv_t    *tlv;
+    int tlv_len;
+    mac_addr_str_t dev_mac_str, sounding_mac_str;
+    em_event_t *evt;
+    em_csi_container_t *cont;
+
+    evt = (em_event_t *)malloc(sizeof(em_event_t));
+    evt->type = em_event_type_bus;
+    evt->u.bevt.data_len = 0;
+    evt->u.bevt.type = em_bus_event_type_csi;
+    cont = (em_csi_container_t *)&evt->u.bevt.params.u.csi_data_params;
+
+    memset(cont, 0, sizeof(em_csi_container_t));
+
+    tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
+
+    while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
+        if (tlv->type == em_tlv_type_rdk_sounding_sta_mac) {
+            memcpy(cont->id.sounding_mac, tlv->value, sizeof(mac_address_t));
+        } else if (tlv->type == em_tlv_type_rdk_angle_csi_data) {
+            memcpy(&cont->angle, tlv->value, htons(tlv->len));	
+        } else if (tlv->type == em_tlv_type_rdk_distance_csi_data) {
+            memcpy(&cont->distance, tlv->value, htons(tlv->len));	
+        } else if (tlv->type == em_tlv_type_al_mac_address) {
+            memcpy(cont->id.dev_mac, tlv->value, sizeof(mac_address_t));	
+        }
+
+        tlv_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+    }
+
+#if 1
+    dm_easy_mesh_t::macbytes_to_string(cont->id.dev_mac, dev_mac_str);	
+    dm_easy_mesh_t::macbytes_to_string(cont->id.sounding_mac, sounding_mac_str);	
+
+    printf("%s:%d: Device: %s Sounder: %s\n", __func__, __LINE__, 
+        dev_mac_str, sounding_mac_str);
+    printf("csi angle:%f distance:%f\r\n", cont->angle,
+        cont->distance);
+#endif
+    push_event(evt);
+    free(evt);
+    return 0;
+}
+
 int em_channel_t::handle_channel_scan_rprt(unsigned char *buff, unsigned int len)
 {
 	em_tlv_t    *tlv;
@@ -1998,7 +2165,11 @@ void em_channel_t::process_msg(unsigned char *data, unsigned int len)
            		handle_channel_scan_rprt(data, len);
 			}
             break;
-
+        case em_msg_type_csi_notif:
+            if (get_service_type() == em_service_type_ctrl) {
+                handle_csi_notification(data, len);
+            }
+            break;
         default:
             break;
     }
@@ -2010,6 +2181,11 @@ void em_channel_t::process_state()
 	dm_easy_mesh_t *dm;
 
     switch (get_state()) {
+        case em_state_agent_csi_notify:
+            send_csi_notification();
+            set_state(em_state_agent_unconfigured);
+            break;
+
 		case em_state_agent_channel_pref_query:
 			if ((get_service_type() == em_service_type_agent) && (get_state() < em_state_agent_channel_selection_pending)) {
 				send_channel_pref_report_msg();

--- a/src/fynecli/em_cmd_cli.cpp
+++ b/src/fynecli/em_cmd_cli.cpp
@@ -449,6 +449,18 @@ int em_cmd_cli_t::execute(char *result)
             snprintf(info->name, sizeof(info->name), "%s", param->u.args.fixed_args);
             break;
 
+        case em_cmd_type_get_csi_config:
+            bevt->type = em_bus_event_type_get_csi_config;
+            info = &bevt->u.subdoc;
+            strncpy(info->name, param->u.args.fixed_args, strlen(param->u.args.fixed_args) + 1);
+            break;
+
+        case em_cmd_type_get_csi_data:
+            bevt->type = em_bus_event_type_get_csi_data;
+            info = &bevt->u.subdoc;
+            strncpy(info->name, param->u.args.fixed_args, strlen(param->u.args.fixed_args) + 1);
+            break;
+
         default:
             break;
     }

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -139,6 +139,12 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
+        case em_cmd_type_csi:
+            if (em->get_state() == em_state_agent_unconfigured) {
+                return true;
+            }
+            break;
+
         default:
             if ((em->get_state() == em_state_agent_unconfigured) ||
                     (em->get_state() == em_state_agent_configured)) {
@@ -187,6 +193,10 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
     } else if (pcmd->m_type == em_cmd_type_ap_metrics_report) {
         if ((em->get_state() == em_state_agent_configured) ||
             ((em->get_state() == em_state_agent_ap_metrics_pending))) {
+            return true;
+        }
+    } else if (pcmd->m_type == em_cmd_type_csi) {
+        if (em->get_state() >= em_state_agent_unconfigured) {
             return true;
         }
     }
@@ -491,6 +501,13 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
             case em_cmd_type_ap_metrics_report:
                 if (memcmp(pcmd->m_param.u.ap_metrics_params.ruid,
                     em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+                break;
+
+            case em_cmd_type_csi:
+                if (em->is_al_interface_em() == true) {
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
                 }


### PR DESCRIPTION
…i CSI data.

Reason for change: Added support in the EasyMesh agent code to forward device angle
                   and distance data to the controller. The controller will then
                   maintain a database of all connected node data.

Test Procedure:1) Load the EasyMesh build onto the device. 2) Once the agent transitions from an unconfigured to a configured state,
   trigger the EmCsiSetMac namespace. This will instruct the OneWifi module
   to begin calculating the CSI-based angle and distance, and send the data back to the agent.
3) Upon receiving the data, the agent will forward it to the controller. 4) The controller will then maintain this data for all connected clients.

Priority: P1
Risks: Low

Signed-off-by: aniketnarsinhbhai_Patel@comcast.com