### PR TITLE
Implements BSS Configuration Response, Result, and Agent List

### DIFF
--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -393,6 +393,11 @@ public:
 		return m_1905_encrypt_layer.rekey_1905_layer_gtk();
 	}
 
+	/**
+	 * @brief Retrieves the current security context.
+	 */
+	inline ec_persistent_sec_ctx_t* get_sec_ctx() { return &m_sec_ctx; };
+
     // Disable copy construction and assignment
     // Requires use of references or pointers when working with instances of this class
     
@@ -405,6 +410,23 @@ public:
 	 */
 	ec_configurator_t(const ec_configurator_t&) = delete;
     ec_configurator_t& operator=(const ec_configurator_t&) = delete;
+
+	/**
+	 * @brief Get the conn ctx object for a given peer AL MAC address.
+	 * 
+	 * @note Needed to retrieve the enrollee NAK for BSS Configuration Response.
+	 * 
+	 * @param peer_al_mac The AL MAC address of the peer for which the connection context is requested.
+	 * @return ec_connection_context_t* A pointer to the connection context associated with the given AL MAC address. NULL if not found. 
+	 */
+	inline ec_connection_context_t* get_al_conn_ctx(uint8_t peer_al_mac[ETH_ALEN]) {
+        for (auto& conn : m_connections) {
+			if (memcmp(conn.second.peer_al_mac, peer_al_mac, ETH_ALEN) == 0) {
+				return &conn.second;
+			}
+		}
+		return NULL;
+    }
 
 protected:
 	std::string m_al_mac_addr;

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -8,9 +8,12 @@
 struct cJSON;
 
 typedef enum {
+	dpp_config_obj_none = 0,
     dpp_config_obj_bsta,
     dpp_config_obj_ieee1905,
-	dpp_config_obj_fbss,
+	dpp_config_obj_fbss_sta,
+	dpp_config_obj_fbss_ap,
+	dpp_config_obj_backhaul_bss
 } dpp_config_obj_type_e;
 
 class ec_ctrl_configurator_t : public ec_configurator_t {
@@ -169,6 +172,22 @@ public:
 	 */
 	bool handle_recfg_auth_response(ec_frame_t *frame, size_t len, uint8_t sa[ETH_ALEN], uint8_t src_al_mac[ETH_ALEN]) override;
 
+
+	/**
+	 * @brief Finalizes a base DPP Configuration object.
+	 *
+	 * A base configuration object has all mandatory base fields filled out, including keys
+	 * "wi-fi_tech", "discovery", and "cred".
+	 *
+	 * @param[in,out] base The base JSON object to be finalized.
+	 * @param[in] config_obj_type The type of DPP Configuration object to fill out.
+	 * @param[in] sec_ctx The security context containing the Configurator's keys.
+	 * @param[in] enrollee_net_access_key The netAccessKey of the Enrollee, used as the netAccessKey in the new DPP Connector
+	 *
+	 * @return cJSON* DPP Configuration object on success, nullptr otherwise.
+	 */
+	static cJSON *finalize_dpp_config_obj(cJSON *base, dpp_config_obj_type_e config_obj_type, ec_persistent_sec_ctx_t* sec_ctx, SSL_KEY* enrollee_net_access_key);
+
 private:
     // Private member variables can be added here
 
@@ -263,20 +282,6 @@ private:
 	 *       and DPP status are correctly set before calling this function.
 	 */
 	std::pair<uint8_t*, size_t> create_config_response_frame(uint8_t dest_mac[ETH_ALEN], uint8_t pa_al_mac[ETH_ALEN], const uint8_t dialog_token, ec_status_code_t dpp_status, bool is_sta = false);
-
-	/**
-	 * @brief Finalizes a base DPP Configuration object.
-	 *
-	 * A base configuration object has all mandatory base fields filled out, including keys
-	 * "wi-fi_tech", "discovery", and "cred".
-	 *
-	 * @param[in,out] base The base JSON object to be finalized.
-	 * @param[in] conn_ctx The EC connection context.
-	 * @param[in] config_obj_type The type of DPP Configuration object to fill out.
-	 *
-	 * @return cJSON* DPP Configuration object on success, nullptr otherwise.
-	 */
-	cJSON *finalize_config_obj(cJSON *base, ec_connection_context_t& conn_ctx, dpp_config_obj_type_e config_obj_type);
 
     /**
      * @brief Maps Enrollee MAC (as string) to onboarded status. True if onboarded (now a Proxy Agent), false if still onboarding / onboarding failed.

--- a/inc/ec_enrollee.h
+++ b/inc/ec_enrollee.h
@@ -200,7 +200,7 @@ public:
 	/**
 	 * @brief Retrieves the current security context.
 	 */
-	inline ec_persistent_sec_ctx_t get_sec_ctx() { return m_sec_ctx; };
+	inline ec_persistent_sec_ctx_t* get_sec_ctx() { return &m_sec_ctx; };
 
 	/**!
 	 * @brief Retrieves the AL MAC address.

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -173,7 +173,37 @@ public:
 		return m_configurator->rekey_1905_layer_gtk();
 	}
 
-    
+	/**
+	 * @brief Get the security context of the node
+	 * 
+	 * @return ec_persistent_sec_ctx_t* Pointer to the security context, or NULL if not available.
+	 */
+	inline ec_persistent_sec_ctx_t* get_sec_ctx() {
+		if (m_enrollee) {
+			return m_enrollee->get_sec_ctx();
+		}
+		if (m_configurator) {
+			return m_configurator->get_sec_ctx();
+		}
+		return nullptr;
+	}
+
+	/**
+	 * @brief Get a connection context of the peer for a given peer AL MAC address.
+	 * 
+	 * @note Only necsessary for the configurator to access the cached enrollee NAK for the BSS Configuration Response.
+	 * 
+	 * @param peer_al_mac The AL MAC address of the peer device to get the connection context for.
+	 * @return ec_connection_context_t* Pointer to the connection context for the specified peer AL MAC address, or NULL if not found.
+	 */
+	inline ec_connection_context_t* get_al_conn_ctx(uint8_t peer_al_mac[ETH_ALEN]) {
+
+		if (m_configurator) {
+			return m_configurator->get_al_conn_ctx(peer_al_mac);
+		}
+		return NULL;
+    }
+
 	/**
 	 * @brief Upgrade an enrollee to an onboarded proxy agent.
 	 *

--- a/inc/ec_ops.h
+++ b/inc/ec_ops.h
@@ -110,23 +110,23 @@ using bsta_connect_func = std::function<bool(const std::string&, const std::stri
 
 /**
  * @brief Creates a DPP Configuration Response object for the backhaul STA interface.
- * @param conn_ctx Optional connection context (not needed for Enrollee, needed for Configurator) -- pass nullptr if not needed.
  * @param pa_al_mac The AL MAC address of the Proxy Agent that is being used to onboard the Enrollee.
  * @return cJSON * on success, nullptr otherwise
  */
-using get_backhaul_sta_info_func = std::function<cJSON*(ec_connection_context_t *, uint8_t*)>;
+using get_backhaul_sta_info_func = std::function<cJSON*(uint8_t*)>;
 
 /**
  * @brief Creates a DPP Configuration Response object for the 1905.1 interface.
  * @return cJSON * on success, nullptr otherwise.
  */
-using get_1905_info_func = std::function<cJSON*(ec_connection_context_t *)>;
+using get_1905_info_func = std::function<cJSON*()>;
 
 /**
  * @brief Creates a DPP Configuration Response object for the fronthaul BSS interface(s)
+ * @param pa_al_mac The AL MAC address of the Proxy Agent that is being used to onboard the Enrollee.
  * @return cJSON * on success, nullptr otherwise
  */
-using get_fbss_info_func = std::function<cJSON*(ec_connection_context_t *)>;
+using get_fbss_info_func = std::function<cJSON*(uint8_t*)>;
 
 /**
  * @brief Used to determine if an additional AP can be on-boarded or not.

--- a/inc/em.h
+++ b/inc/em.h
@@ -997,8 +997,65 @@ public:
 	 *
 	 * @note Ensure that the buffer is properly allocated before calling this function.
 	 */
-	short create_ap_radio_basic_cap(unsigned char *buff);   
+	short create_ap_radio_basic_cap(unsigned char *buff);
     //Msg-End
+
+	//START: DPP Callbacks for BSS information
+	// Originally done by @tuckerpo
+
+	/**!
+	 * @brief Creates a configurator BSTA response object.
+	 *
+	 * This function generates a cJSON object representing the BSTA response
+	 * based on the provided connection context.
+	 *
+	 * @param[in] pa_al_mac The AL MAC address of the Proxy Agent that is being used to onboard the Enrollee.
+	 *
+	 * @returns A pointer to the created cJSON object representing the BSTA response.
+	 *
+	 * @note Ensure that the connection context is properly initialized before calling this function.
+	 */
+	cJSON *create_configurator_bsta_response_obj(uint8_t pa_al_mac[ETH_ALEN]);
+    
+	/**!
+	 * @brief Creates an IEEE 1905 response object.
+	 *
+	 * This function generates a cJSON object that represents an IEEE 1905 response.
+	 *
+	 * @param[in] conn_ctx Pointer to the connection context used for creating the response.
+	 *
+	 * @returns A pointer to the created cJSON object representing the IEEE 1905 response.
+	 *
+	 * @note Ensure that the connection context is properly initialized before calling this function.
+	 */
+	cJSON *create_ieee1905_response_obj();
+
+	/**
+	 * @brief Create a fBSS (fronthaul BSS) Configuration response object for DPP STA onboarding
+	 * 
+	 * @param[in] pa_al_mac The AL MAC address of the Proxy Agent that is being used to onboard the Enrollee.
+	 * 
+	 * @return cJSON* Configuration response object on success, nullptr otherwise
+	 */
+	cJSON *create_fbss_response_obj(uint8_t pa_al_mac[ETH_ALEN]);
+
+	/**!
+	 * @brief Creates a list of enrollee BSTA.
+	 *
+	 * This function generates a cJSON object representing the list of enrollee BSTA
+	 * based on the provided connection context.
+	 *
+	 * @param[in] pa_al_mac UNUSED
+	 *
+	 * @returns A pointer to a cJSON object representing the enrollee BSTA list.
+	 *
+	 * @note Ensure that the connection context is properly initialized before calling this function.
+	 */
+	cJSON *create_enrollee_bsta_list(uint8_t pa_al_mac[ETH_ALEN]);
+    
+	cJSON *create_bss_dpp_response_obj(const em_bss_info_t *bss_info, bool is_sta_response, bool tear_down_bss);
+
+	// END: DPP Callbacks for BSS information
 
     
 	/**!

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -757,7 +757,23 @@ public:
 	 * @note Ensure that no data models are in use before calling this function.
 	 */
 	void delete_all_data_models() { }
-    
+	
+	/**!
+	 * @brief Retrieves the first data model in the data model list.
+	 *
+	 * @returns NULL since the agent does not manage multiple data models.
+	 */
+	dm_easy_mesh_t *get_first_dm() override { return nullptr; } 
+
+	/**!
+	 * @brief Retrieves the next data model in the data model list.
+	 *
+	 * @param[in] dm Pointer to the current data model.
+	 *
+	 * @returns NULL since the agent does not manage multiple data models.
+	 */
+	dm_easy_mesh_t *get_next_dm(dm_easy_mesh_t *dm) override { return nullptr; }
+
 	/**!
 	 * @brief Updates the tables with the provided EasyMesh data.
 	 *

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -613,10 +613,14 @@ typedef struct {
 } __attribute__((__packed__)) em_qos_mgmt_des_t;
 
 typedef struct {
-    unsigned char num_agents;
     mac_address_t agent_mac;
     unsigned char multi_ap_profile;
     unsigned char security;
+} __attribute__((__packed__)) em_agent_list_agent_t;
+
+typedef struct {
+    unsigned char num_agents;
+    unsigned char agents[0]; // em_agent_list_agent_t array
 } __attribute__((__packed__)) em_agent_list_t;
 
 typedef struct {

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -312,8 +312,7 @@ public:
 	 *
 	 * @note Ensure that the buffer is allocated with sufficient size before calling this function.
 	 */
-	short create_eht_operations_tlv(unsigned char *buff);
-
+	virtual short create_eht_operations_tlv(unsigned char *buff) = 0;
     
 	/**!
 	 * @brief Sends a channel scan request message.

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -96,6 +96,72 @@ class em_configuration_t {
 	int create_autoconfig_wsc_m2_msg(unsigned char *buff, em_haul_type_t haul_type[], unsigned int num_hauls);
     
 	/**!
+	 * @brief Creates a BSS configuration request message.
+	 *
+	 * This function initializes a buffer with the necessary data to form a BSS configuration request message.
+	 *
+	 * @param[out] buff Pointer to the buffer where the request message will be stored.
+	 * @param[in] dest_al_mac  The destination AL MAC address for the message.
+	 *
+	 * @returns int Status code indicating success or failure of the operation.
+	 * @retval the size of the request message on success. 
+	 * @retval -1 on failure.
+	 *
+	 * @note Ensure the buffer is allocated with sufficient size before calling this function.
+	 */
+	int create_bss_config_req_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN]);
+    
+	/**!
+	 * @brief Creates a BSS configuration response message.
+	 *
+	 * This function is responsible for creating a BSS configuration response message
+	 * and storing it in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the response message will be stored.
+	 * @param[in] dest_al_mac  The destination AL MAC address for the message.
+	 *
+	 * @returns int Status code indicating success or failure of the operation.
+	 * @retval the size of the response message on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note Ensure the buffer is allocated with sufficient size before calling this function.
+	 */
+	int create_bss_config_rsp_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN]);
+    
+	/**!
+	 * @brief Creates a BSS configuration response message.
+	 *
+	 * This function initializes a buffer with the BSS configuration response message.
+	 *
+	 * @param[out] buff Pointer to the buffer where the response message will be stored.
+	 * @param[in] dest_al_mac  The destination AL MAC address for the message.
+	 *
+	 * @returns int Status code indicating success or failure.
+	 * @retval the size of the response message on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note Ensure the buffer is allocated with sufficient size before calling this function.
+	 */
+	int create_bss_config_res_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN]);
+
+
+	/**!
+	 * @brief Creates an agent list message.
+	 *
+	 * This function generates an Agent List message according to EasyMesh R6 17.1.48
+	 *
+	 * @param[out] buff Pointer to the buffer where the agent list message will be stored.
+	 * @param[in] dest_al_mac The destination AL MAC address for the message.
+	 *
+	 * @returns int Status code indicating success or failure of the operation.
+	 * @retval the size of the agent list message on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note Ensure that the buffer is allocated with sufficient size before calling this function.
+	 */
+	int create_agent_list_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN]);
+
+	/**!
 	 * @brief Creates an operational BSS TLV.
 	 *
 	 * This function is responsible for creating an operational BSS TLV and storing it in the provided buffer.
@@ -243,9 +309,127 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the buffer is large enough to hold the TLV data.
 	 */
-	unsigned short create_eht_operations_tlv(unsigned char *buff);
+	virtual short create_eht_operations_tlv(unsigned char *buff) = 0;
 
-    
+	/**!
+	 * @brief Creates an AP capability TLV.
+	 *
+	 * This function is responsible for creating an Access Point (AP) capability
+	 * Type-Length-Value (TLV) structure and storing it in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
+	 *
+	 * @returns The length of the TLV on success, or -1 on failure
+	 *
+	 * @note Implemented by derived class
+	 */
+	virtual short create_ap_cap_tlv(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates a basic capability for the AP radio.
+	 *
+	 * This function initializes the basic capabilities of the AP radio and stores
+	 * the result in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the basic capability data will be stored.
+	 *
+	 * @return The length of the TLV on success, or -1 on failure.
+	 *
+	 * @note Implemented by derived class
+	 */
+	virtual short create_ap_radio_basic_cap(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates a profile 2 TLV.
+	 *
+	 * This function is responsible for creating a profile 2 TLV (Type-Length-Value) structure
+	 * and storing it in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
+	 *
+	 * @return The length of the TLV on success, or -1 on failure
+	 *
+	 * @note: Implemented by derived class
+	 */
+	virtual short create_prof_2_tlv(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates a HT TLV (Type-Length-Value) structure.
+	 *
+	 * This function initializes a HT TLV structure in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the HT TLV will be created.
+	 *
+	 * @return The size of the TLV created on success, or -1 on failure.
+	 *
+	 * @note Implemented by derived class
+	 */
+	virtual short create_ht_tlv(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates a VHT TLV (Very High Throughput Tag Length Value) structure.
+	 *
+	 * This function initializes a VHT TLV structure in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the VHT TLV will be created.
+	 *
+	 * @return The size of the TLV created on success, or -1 on failure.
+	 *
+	 * @note Implemented by derived class
+	 */
+	virtual short create_vht_tlv(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates a WiFi 6 TLV (Type-Length-Value) structure.
+	 *
+	 * This function is responsible for creating a WiFi 6 TLV structure and storing it in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
+	 * @return Length of TLV created on success otherwise -1
+	 *
+	 * @note This is a pure virtual function and must be implemented by derived classes.
+	 */
+	virtual short create_wifi6_tlv(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates a WiFi 7 TLV (Type-Length-Value) structure.
+	 *
+	 * This function is responsible for creating a TLV structure specific to WiFi 7.
+	 *
+	 * @param[out] buff A pointer to the buffer where the TLV will be created.
+	 * @return Length of TLV created on success otherwise -1
+	 *
+	 * @note Implemented by derived class
+	 */
+	virtual short create_wifi7_tlv(unsigned char *buff) = 0;
+
+	/**
+	 * @brief Create an AP Radio Advanced Capabilities TLV (EM 17.2.52)
+	 * 
+	 * @param buff The buffer to write the TLV to.
+	 * @return short The length of the TLV on success, -1 on failure
+	 * 
+	 * @note Implemented by derived class
+	 */
+	virtual short create_ap_radio_advanced_cap_tlv(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates a list of enrollee BSTA.
+	 *
+	 * This function generates a cJSON object representing the list of enrollee BSTA
+	 * based on the provided connection context.
+	 *
+	 * @param[in] pa_al_mac UNUSED
+	 *
+	 * @returns A pointer to a cJSON object representing the enrollee BSTA list.
+	 *
+	 * @note Ensure that the connection context is properly initialized before calling this function.
+	 */
+	virtual cJSON *create_enrollee_bsta_list(uint8_t pa_al_mac[ETH_ALEN]) = 0;
+
+
+	virtual cJSON *create_bss_dpp_response_obj(const em_bss_info_t *bss_info, bool is_sta_response, bool tear_down_bss) = 0;
+	
 	/**!
 	 * @brief Sends a topology response message.
 	 *
@@ -358,7 +542,75 @@ class em_configuration_t {
 	 */
 	int send_1905_ack_message(mac_addr_t sta_mac);
     
-    
+	
+
+	/**!
+	 * @brief Handles a BSS Configuration Request message and sends a Response to the source
+	 * 
+	 * EasyMesh 5.3.8 / EasyMesh 17.1.58
+	 * 
+	 * @param[in] buff Pointer to the buffer containing the BSS Configuration Request message.
+	 * @param[in] len Length of the message in bytes.
+	 * @param[in] src_al_mac Source AL MAC address of the sender.
+	 * 
+	 * @returns int
+	 * @retval 0 on success
+	 * @retval -1 on failure
+	 * @note Ensure that the buffer is properly allocated and contains a valid BSS Configuration Request message.
+	 */
+ 	int handle_bss_config_req_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]);
+
+
+	/**!
+	 * @brief Handles a BSS Configuration Response message and sends a Result to the source
+	 * 
+	 * EasyMesh 5.3.8 / EasyMesh 17.1.58
+	 * 
+	 * @param[in] buff Pointer to the buffer containing the BSS Configuration Response message.
+	 * @param[in] len Length of the message in bytes.
+	 * @param[in] src_al_mac Source AL MAC address of the sender.
+	 * 
+	 * @returns int
+	 * @retval 0 on success
+	 * @retval -1 on failure
+	 * @note Ensure that the buffer is properly allocated and contains a valid BSS Configuration Response message.
+	 */	
+	int handle_bss_config_rsp_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]);
+
+
+	/**!
+	 * @brief Handles a BSS Configuration Result message and sends an Agent List to the source
+	 * 
+	 * EasyMesh 5.3.8 / EasyMesh 17.1.58
+	 * 
+	 * @param[in] buff Pointer to the buffer containing the BSS Configuration Result message.
+	 * @param[in] len Length of the message in bytes.
+	 * @param[in] src_al_mac Source AL MAC address of the sender.
+	 * 
+	 * @returns int
+	 * @retval 0 on success
+	 * @retval -1 on failure
+	 * @note Ensure that the buffer is properly allocated and contains a valid BSS Configuration Result message.
+	 */
+	int handle_bss_config_res_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]);
+
+	/**!
+	 * @brief Handles the Agent List message and processes it.
+	 *
+	 * EasyMesh 5.3.8 / EasyMesh 17.1.58
+	 *
+	 * @param[in] buff Pointer to the buffer containing the Agent List message.
+	 * @param[in] len Length of the message in bytes.
+	 * @param[in] src_al_mac Source AL MAC address of the sender.
+	 *
+	 * @returns int
+	 * @retval 0 on success
+	 * @retval -1 on failure
+	 *
+	 * @note Ensure that the buffer is properly allocated and contains a valid Agent List message.
+	 */
+	int handle_agent_list_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]);
+	
 	/**!
 	 * @brief Handles the auto-configuration response.
 	 *
@@ -602,7 +854,24 @@ class em_configuration_t {
 	 * @note Ensure that the buffer is properly allocated and the length is correctly specified.
 	 */
 	int handle_ack_msg(unsigned char *buff, unsigned int len);
-    
+   
+	
+	/**!
+	 * @brief Handles the BSS Configuration Response TLV.
+	 *
+	 * This function processes the BSS Configuration Response TLV including tearing down, and setting up 
+	 * fronthaul and backhaul BSSs according to EasyMesh 5.3.8
+	 *
+	 * @param[in] tlv Pointer to the BSS Configuration Response TLV structure.
+	 *
+	 * @returns int Status code indicating success or failure.
+	 * @retval 0 on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note Ensure the TLV is properly initialized before calling this function.
+	 */
+	int handle_bss_config_rsp_tlv(em_tlv_t* tlv);
+
 	/**!
 	 * @brief Handles the AP MLD configuration TLV.
 	 *
@@ -752,6 +1021,51 @@ class em_configuration_t {
 	 * calling this function.
 	 */
 	int create_vendor_operational_bss_tlv(unsigned char *buff);
+
+	/**
+	 * @brief Creates a Backhaul STA Radio Capabilities TLV (17.2.65)
+	 * 
+	 * @param buff The buffer to write the TLV to.
+	 * @return int The length of the TLV created, or -1 on failure.
+	 */
+	int create_bsta_radio_cap_tlv(uint8_t *buff);
+
+	/**
+	 * @brief Creates an AKM Suite Capabilities TLV (17.2.78)
+	 * 
+	 * @param buff The buffer to write the TLV to.
+	 * @return int The length of the TLV created, or -1 on failure.
+	 */
+	int create_akm_suite_cap_tlv(uint8_t *buff);
+
+	/**
+	 * @brief Creates a BSS Configuration Response TLV (17.2.85)
+	 * 
+	 * @param buff The buffer to write the TLV to.
+	 * @param bss_info Pointer to the `em_bss_info_t` struct containing the information about the BSS to create on the agent.
+	 * @param dest_al_mac The destination AL MAC address (6 bytes).
+	 * @return int The length of the TLV created, or -1 on failure.
+	 */
+	int create_bss_conf_resp_tlv(uint8_t *buff, em_bss_info_t *bss_info, uint8_t dest_al_mac[ETH_ALEN]);
+
+	/**
+	 * @brief Creates a BSS Configuration Request TLV (17.2.84)
+	 * 
+	 * @param buff The buffer to write the TLV to.
+	 * @return int The length of the TLV created, or -1 on failure.
+	 */
+	int create_bss_conf_req_tlv(uint8_t *buff);
+
+	/**
+	 * @brief Creates an Agent List TLV (17.2.77) containing basic infomation about all agents in the network
+	 * 
+	 * @param buff The buffer to write the TLV to.
+	 * @return int The length of the TLV created, or -1 on failure.
+	 * 
+	 * @note Make sure that the buffer is large enough to hold the TLV data.
+	 */
+	int create_agent_list_tlv(uint8_t *buff);
+
  
     // state handlers 
     
@@ -1056,24 +1370,6 @@ class em_configuration_t {
 	 * @note This is a pure virtual function and must be implemented by derived classes.
 	 */
 	virtual em_cmd_t *get_current_cmd() = 0;
-    
-	/**!
-	 * @brief Creates a basic capability for the AP radio.
-	 *
-	 * This function is responsible for setting up the basic capabilities
-	 * of the access point (AP) radio using the provided buffer.
-	 *
-	 * @param[out] buff A pointer to the buffer where the basic capabilities
-	 * will be stored. The buffer should be allocated by the caller.
-	 *
-	 * @returns A short integer indicating the success or failure of the operation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure that the buffer is properly allocated before calling this function.
-	 * @note This function is a pure virtual function that must be implemented by the derived class.
-	 */
-	virtual short create_ap_radio_basic_cap(unsigned char *buff) = 0;
     
 	/**!
 	 * @brief Checks if the interface is an AL interface.

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -460,7 +460,22 @@ public:
 	 */
 	void update_network_topology() { m_data_model.update_network_topology(); }
 
-    
+	/**!
+	 * @brief Retrieves the first data model in the agent list.
+	 *
+	 * @returns A pointer to the first `dm_easy_mesh_t` data model, or nullptr if no dms are available.
+	 */
+	dm_easy_mesh_t *get_first_dm() override { return m_data_model.get_first_dm(); }
+
+	/**!
+	 * @brief Retrieves the next data model in the agent list.
+	 *
+	 * @param[in] dm Pointer to the current `dm_easy_mesh_t` data model.
+	 *
+	 * @returns A pointer to the next `dm_easy_mesh_t` data model, or nullptr if there are no more dms.
+	 */
+	dm_easy_mesh_t *get_next_dm(dm_easy_mesh_t *dm) override { return m_data_model.get_next_dm(dm); }
+
 	/**!
 	 * @brief Retrieves the data model for a given network ID and optional AL MAC address.
 	 *

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -546,7 +546,32 @@ public:
 	 */
 	virtual void update_network_topology() = 0;
     
-    
+ 
+	/**!
+	 * @brief Retrieves the first data model from the list.
+	 * 
+	 * @note ONLY IMPLEMENTED BY THE CONTROLLER.
+	 *
+	 * @returns A pointer to the first data model in the list.
+	 */
+	virtual dm_easy_mesh_t *get_first_dm() = 0;
+	
+	/**!
+	 * @brief Retrieves the next data model in the list.
+	 *
+	 * This function returns the next data model object from the list of data models.
+	 * 
+	 * @note ONLY IMPLEMENTED BY THE CONTROLLER.
+	 *
+	 * @param[in] dm A pointer to the current data model object.
+	 *
+	 * @returns A pointer to the next data model object in the list.
+	 * @retval nullptr If there is no next data model.
+	 *
+	 * @note Ensure that the input data model pointer is valid before calling this function.
+	 */
+	virtual dm_easy_mesh_t *get_next_dm(dm_easy_mesh_t *dm) = 0;
+
 	/**!
 	 * @brief Retrieves the data model for a given network ID.
 	 *

--- a/inc/em_msg.h
+++ b/inc/em_msg.h
@@ -133,6 +133,35 @@ public:
 	static em_tlv_t *get_tlv(em_tlv_t *tlvs_buff, unsigned int buff_len, em_tlv_type_t type);
 
 	/**
+	 * @brief Get the first TLV from the buffer.
+	 *
+	 * This function retrieves the first TLV (Type-Length-Value) structure from the provided buffer.
+	 *
+	 * @param[in] tlvs_buff The buffer containing the TLV structures.
+	 * @param[in] buff_len The length of the buffer.
+	 *
+	 * @return em_tlv_t* A pointer to the first TLV structure in the buffer, or NULL if the buffer is empty.
+	 *
+	 * @note Ensure that the buffer is properly initialized and contains valid TLV structures before calling this function.
+	 */
+	static em_tlv_t *get_first_tlv(em_tlv_t* tlvs_buff, unsigned int buff_len);
+
+	/**
+	 * @brief Get the next TLV from the buffer.
+	 *
+	 * This function retrieves the next TLV (Type-Length-Value) structure from the provided buffer, starting from a given TLV.
+	 *
+	 * @param[in] tlv The current TLV structure from which to find the next TLV.
+	 * @param[in] tlvs_buff The buffer containing the TLV structures.
+	 * @param[in] buff_len The length of the buffer.
+	 *
+	 * @return em_tlv_t* A pointer to the next TLV structure in the buffer, or NULL if there are no more TLVs.
+	 *
+	 * @note Ensure that the buffer is properly initialized and contains valid TLV structures before calling this function.
+	 */
+	static em_tlv_t *get_next_tlv(em_tlv_t* tlv, em_tlv_t* tlvs_buff, unsigned int buff_len);
+
+	/**
 	 * @brief Add an EOM TLV to the message.
 	 *
 	 * This function appends an End of Message (EOM) Type-Length-Value (TLV) to the provided buffer.

--- a/inc/em_provisioning.h
+++ b/inc/em_provisioning.h
@@ -28,53 +28,6 @@ class em_cmd_t;
 class em_cmd_exec_t;
 class em_provisioning_t {
 
-    
-	/**!
-	 * @brief Creates a BSS configuration request message.
-	 *
-	 * This function initializes a buffer with the necessary data to form a BSS configuration request message.
-	 *
-	 * @param[out] buff Pointer to the buffer where the request message will be stored.
-	 *
-	 * @returns int Status code indicating success or failure of the operation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure the buffer is allocated with sufficient size before calling this function.
-	 */
-	int create_bss_config_req_msg(uint8_t *buff);
-    
-	/**!
-	 * @brief Creates a BSS configuration response message.
-	 *
-	 * This function is responsible for creating a BSS configuration response message
-	 * and storing it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the response message will be stored.
-	 *
-	 * @returns int Status code indicating success or failure of the operation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure the buffer is allocated with sufficient size before calling this function.
-	 */
-	int create_bss_config_rsp_msg(uint8_t *buff);
-    
-	/**!
-	 * @brief Creates a BSS configuration response message.
-	 *
-	 * This function initializes a buffer with the BSS configuration response message.
-	 *
-	 * @param[out] buff Pointer to the buffer where the response message will be stored.
-	 *
-	 * @returns int Status code indicating success or failure.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure the buffer is allocated with sufficient size before calling this function.
-	 */
-	int create_bss_config_res_msg(uint8_t *buff);
-    
 	/**!
 	 * @brief Creates a DPP direct encapsulation message.
 	 *
@@ -124,7 +77,7 @@ class em_provisioning_t {
 	 *
 	 * @note Ensure that the buffer is properly allocated and the length is valid.
 	 */
-	int handle_1905_encap_eapol_msg(uint8_t *buff, unsigned int len);
+	int handle_1905_encap_eapol_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]);
 
 	/**!
 	 * @brief Handles the CCE indication message.
@@ -156,7 +109,7 @@ class em_provisioning_t {
 	 *
 	 * @note Ensure that the buffer is valid and contains the expected data format.
 	 */
-	int handle_dpp_chirp_notif(uint8_t *buff, unsigned int len);
+	int handle_dpp_chirp_notif(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]);
     
 	/**!
 	 * @brief Handles a Proxied Encap DPP Message (EM 17.1.48)
@@ -172,7 +125,7 @@ class em_provisioning_t {
 	 * @note Ensure that the buffer is properly allocated and the length is correctly specified
 	 * before calling this function.
 	 */
-	int handle_proxy_encap_dpp(uint8_t *buff, unsigned int len);
+	int handle_proxy_encap_dpp(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]);
 
 
 	/**!
@@ -188,7 +141,7 @@ class em_provisioning_t {
 	 * @note Ensure that the buffer is properly allocated and the length is correctly specified
 	 * before calling this function.
 	 */
-	int handle_direct_encap_dpp(uint8_t *buff, unsigned int len);
+	int handle_direct_encap_dpp(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]);
 
     // states
     
@@ -513,212 +466,8 @@ protected:
 	 */
 	int send_1905_rekey_msg(uint8_t dest_al_mac[ETH_ALEN]);
 
-	/**!
-	 * @brief Creates a list of enrollee BSTA.
-	 *
-	 * This function generates a cJSON object representing the list of enrollee BSTA
-	 * based on the provided connection context.
-	 *
-	 * @param[in] conn_ctx Pointer to the connection context used to create the list.
-	 * @param[in] pa_al_mac UNUSED
-	 *
-	 * @returns A pointer to a cJSON object representing the enrollee BSTA list.
-	 *
-	 * @note Ensure that the connection context is properly initialized before calling this function.
-	 */
-	cJSON *create_enrollee_bsta_list(ec_connection_context_t *conn_ctx, uint8_t pa_al_mac[ETH_ALEN]);
-    
-	/**!
-	 * @brief Creates a configurator BSTA response object.
-	 *
-	 * This function generates a cJSON object representing the BSTA response
-	 * based on the provided connection context.
-	 *
-	 * @param[in] conn_ctx Pointer to the connection context used to create the response.
-	 * @param[in] pa_al_mac The AL MAC address of the Proxy Agent that is being used to onboard the Enrollee.
-	 *
-	 * @returns A pointer to the created cJSON object representing the BSTA response.
-	 *
-	 * @note Ensure that the connection context is properly initialized before calling this function.
-	 */
-	cJSON *create_configurator_bsta_response_obj(ec_connection_context_t *conn_ctx, uint8_t pa_al_mac[ETH_ALEN]);
-    
-	/**!
-	 * @brief Creates an IEEE 1905 response object.
-	 *
-	 * This function generates a cJSON object that represents an IEEE 1905 response.
-	 *
-	 * @param[in] conn_ctx Pointer to the connection context used for creating the response.
-	 *
-	 * @returns A pointer to the created cJSON object representing the IEEE 1905 response.
-	 *
-	 * @note Ensure that the connection context is properly initialized before calling this function.
-	 */
-	cJSON *create_ieee1905_response_obj(ec_connection_context_t *conn_ctx);
-
-	/**
-	 * @brief Create a fBSS (fronthaul BSS) Configuration response object for DPP STA onboarding
-	 * 
-	 * @param conn_ctx The connection context used to create the response object.
-	 * @return cJSON* Configuration response object on success, nullptr otherwise
-	 */
-	cJSON *create_fbss_response_obj(ec_connection_context_t *conn_ctx);
-
-	/**
-	 * @brief Creates a BSS Configuration Response TLV (17.2.85)
-	 * 
-	 * @param buff The buffer to write the TLV to.
-	 * @return int The length of the TLV created, or -1 on failure.
-	 */
-	int create_bss_conf_rsp_tlv(uint8_t *buff);
-
-	/**
-	 * @brief Creates a BSS Configuration Request TLV (17.2.84)
-	 * 
-	 * @param buff The buffer to write the TLV to.
-	 * @return int The length of the TLV created, or -1 on failure.
-	 */
-	int create_bss_conf_req_tlv(uint8_t *buff);
-
-	/**
-	 * @brief Creates a Backhaul STA Radio Capabilities TLV (17.2.65)
-	 * 
-	 * @param buff The buffer to write the TLV to.
-	 * @return int The length of the TLV created, or -1 on failure.
-	 */
-	int create_bsta_radio_cap_tlv(uint8_t *buff);
-
-	/**
-	 * @brief Creates an AKM Suite Capabilities TLV (17.2.78)
-	 * 
-	 * @param buff The buffer to write the TLV to.
-	 * @return int The length of the TLV created, or -1 on failure.
-	 */
-	int create_akm_suite_cap_tlv(uint8_t *buff);
-
-	/**!
-	 * @brief Creates an AP capability TLV.
-	 *
-	 * This function is responsible for creating an Access Point (AP) capability
-	 * Type-Length-Value (TLV) structure and storing it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
-	 *
-	 * @returns The length of the TLV on success, or -1 on failure
-	 *
-	 * @note Implemented by derived class
-	 */
-	virtual short create_ap_cap_tlv(unsigned char *buff) = 0;
-
-	/**!
-	 * @brief Creates a basic capability for the AP radio.
-	 *
-	 * This function initializes the basic capabilities of the AP radio and stores
-	 * the result in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the basic capability data will be stored.
-	 *
-	 * @return The length of the TLV on success, or -1 on failure.
-	 *
-	 * @note Implemented by derived class
-	 */
-	virtual short create_ap_radio_basic_cap(unsigned char *buff) = 0;
-
-	/**!
-	 * @brief Creates a profile 2 TLV.
-	 *
-	 * This function is responsible for creating a profile 2 TLV (Type-Length-Value) structure
-	 * and storing it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
-	 *
-	 * @return The length of the TLV on success, or -1 on failure
-	 *
-	 * @note: Implemented by derived class
-	 */
-	virtual short create_prof_2_tlv(unsigned char *buff) = 0;
-
-	/**!
-	 * @brief Creates a HT TLV (Type-Length-Value) structure.
-	 *
-	 * This function initializes a HT TLV structure in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the HT TLV will be created.
-	 *
-	 * @return The size of the TLV created on success, or -1 on failure.
-	 *
-	 * @note Implemented by derived class
-	 */
-	virtual short create_ht_tlv(unsigned char *buff) = 0;
-
-	/**!
-	 * @brief Creates a VHT TLV (Very High Throughput Tag Length Value) structure.
-	 *
-	 * This function initializes a VHT TLV structure in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the VHT TLV will be created.
-	 *
-	 * @return The size of the TLV created on success, or -1 on failure.
-	 *
-	 * @note Implemented by derived class
-	 */
-	virtual short create_vht_tlv(unsigned char *buff) = 0;
-
-	/**!
-	 * @brief Retrieves the current profile type.
-	 *
-	 * @returns The current profile type as an em_profile_type_t.
-	 */
-	virtual em_profile_type_t   get_profile_type() = 0;
-
-	/**!
-	 * @brief Creates a WiFi 6 TLV (Type-Length-Value) structure.
-	 *
-	 * This function is responsible for creating a WiFi 6 TLV structure and storing it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
-	 * @return Length of TLV created on success otherwise -1
-	 *
-	 * @note This is a pure virtual function and must be implemented by derived classes.
-	 */
-	virtual short create_wifi6_tlv(unsigned char *buff) = 0;
-
-	/**!
-	 * @brief Creates a WiFi 7 TLV (Type-Length-Value) structure.
-	 *
-	 * This function is responsible for creating a TLV structure specific to WiFi 7.
-	 *
-	 * @param[out] buff A pointer to the buffer where the TLV will be created.
-	 * @return Length of TLV created on success otherwise -1
-	 *
-	 * @note Implemented by derived class
-	 */
-	virtual short create_wifi7_tlv(unsigned char *buff) = 0;
-
-	/**!
-	 * @brief Creates an EHT operations TLV.
-	 *
-	 * This function is responsible for creating an EHT (Extremely High Throughput) operations TLV (Type-Length-Value) structure.
-	 *
-	 * @param[out] buff A pointer to the buffer where the TLV will be created.
-	 * @return Length of TLV created on success otherwise -1
-	 *
-	 * @note Implemented by derived class
-	 */
-	virtual short create_eht_operations_tlv(unsigned char *buff) = 0;
-
-	/**
-	 * @brief Create an AP Radio Advanced Capabilities TLV (EM 17.2.52)
-	 * 
-	 * @param buff The buffer to write the TLV to.
-	 * @return short The length of the TLV on success, -1 on failure
-	 * 
-	 * @note Implemented by derived class
-	 */
-	virtual short create_ap_radio_advanced_cap_tlv(unsigned char *buff) = 0;
-
 public:
-    
+
 	/**!
 	 * @brief Processes a message with the given data and length.
 	 *

--- a/inc/util.h
+++ b/inc/util.h
@@ -200,10 +200,20 @@ namespace util {
 	 * @param[in] mac_str The MAC address string to convert.
 	 * @return A vector of 6 bytes representing the MAC address, or an empty vector if the input is invalid.
 	 */
-	inline std::vector<uint8_t> macstr_to_vector(const std::string& mac_str) {
+	inline std::vector<uint8_t> macstr_to_vector(const std::string& mac_str, const std::string& delim = ":") {
 		std::vector<uint8_t> mac;
+
+		// Special case for empty deliminator since a split cannot be determined
+		if (delim.empty()){
+			mac.resize(ETHER_ADDR_LEN);
+			for (size_t i = 0; i < ETHER_ADDR_LEN; i++) {
+				std::string byte_str = mac_str.substr(i*2, 2);
+				mac[i] = static_cast<uint8_t>(strtol(byte_str.c_str(), nullptr, 16));
+			}
+			return mac;
+		}
 		
-		std::vector<std::string> parts = split_by_delim(mac_str, ':');
+		std::vector<std::string> parts = split_by_delim(mac_str, delim.c_str()[0]);
 		if (parts.size() != 6) return {};
 		for (auto& part : parts) {
 			try {

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -549,54 +549,6 @@ short em_channel_t::create_spatial_reuse_req_tlv(unsigned char *buff)
     return len;
 }
 
-short em_channel_t::create_eht_operations_tlv(unsigned char *buff)
-{
-    short len = 0;
-    unsigned int i = 0, j = 0;
-    unsigned char *tmp = buff;
-    dm_easy_mesh_t  *dm;
-    em_eht_operations_bss_t  *eht_ops_bss;
-
-    dm = get_data_model();
-
-    unsigned char num_radios = static_cast<unsigned char> (dm->get_num_radios());
-    unsigned char num_bss;
-
-    memcpy(tmp, &num_radios, sizeof(unsigned char));
-    tmp += sizeof(unsigned char);
-    len += static_cast<short unsigned int> (sizeof(unsigned char));
-
-    for (i = 0; i < num_radios; i++) {
-        memcpy(tmp, dm->get_radio_by_ref(i).get_radio_interface_mac(), sizeof(mac_address_t));
-        tmp += sizeof(mac_address_t);
-        len += static_cast<short unsigned int> (sizeof(mac_address_t));
-
-        num_bss = static_cast<unsigned char> (dm->get_num_bss());
-
-        memcpy(tmp, &num_bss, sizeof(unsigned char));
-        tmp += sizeof(unsigned char);
-        len += static_cast<short unsigned int> (sizeof(unsigned char));
-
-
-        for (j = 0; j < dm->get_num_bss(); j++) {
-        	if (memcmp(dm->m_bss[j].m_bss_info.ruid.mac, dm->get_radio_by_ref(i).get_radio_interface_mac(), sizeof(mac_address_t)) != 0) {
-            	continue;
-        	}
-
-            memcpy(tmp, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t));
-            tmp += sizeof(mac_address_t);
-            len += static_cast<short unsigned int> (sizeof(mac_address_t));
-
-            eht_ops_bss = &dm->m_bss[j].m_bss_info.eht_ops;
-            memcpy(tmp, eht_ops_bss, sizeof(em_eht_operations_bss_t));
-            tmp += sizeof(em_eht_operations_bss_t);
-            len += static_cast<short unsigned int> (sizeof(em_eht_operations_bss_t));
-        }
-    }
-
-    return len;
-}
-
 int em_channel_t::send_channel_sel_request_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -46,6 +46,8 @@
 #include "em_crypto.h"
 #include "em.h"
 #include "em_cmd_exec.h"
+#include "cjson_util.h"
+#include "ec_ctrl_configurator.h"
 
 // Initialize the static member variables
 unsigned short em_configuration_t::msg_id = 0;
@@ -1053,54 +1055,6 @@ int em_configuration_t::send_topology_response_msg(unsigned char *dst)
     printf("setting state to em_state_agent_topo_synchronized\n");
     set_state(em_state_agent_topo_synchronized);
     return static_cast<int> (len);
-}
-
-unsigned short em_configuration_t::create_eht_operations_tlv(unsigned char *buff)
-{
-    unsigned short len = 0;
-    unsigned int i = 0, j = 0;
-    unsigned char *tmp = buff;
-    dm_easy_mesh_t  *dm;
-    em_eht_operations_bss_t  *eht_ops_bss;
-
-    dm = get_data_model();
-
-    unsigned char num_radios = static_cast<unsigned char> (dm->get_num_radios());
-    unsigned char num_bss;
-
-    memcpy(tmp, &num_radios, sizeof(unsigned char));
-    tmp += sizeof(unsigned char);
-    len += sizeof(unsigned char);
-
-    for (i = 0; i < num_radios; i++) {
-        memcpy(tmp, dm->get_radio_by_ref(i).get_radio_interface_mac(), sizeof(mac_address_t));
-        tmp += sizeof(mac_address_t);
-        len += sizeof(mac_address_t);
-
-        num_bss = static_cast<unsigned char> (dm->get_num_bss());
-
-        memcpy(tmp, &num_bss, sizeof(unsigned char));
-        tmp += sizeof(unsigned char);
-        len += sizeof(unsigned char);
-
-
-        for (j = 0; j < dm->get_num_bss(); j++) {
-        	if (memcmp(dm->m_bss[j].m_bss_info.ruid.mac, dm->get_radio_by_ref(i).get_radio_interface_mac(), sizeof(mac_address_t)) != 0) {
-            	continue;
-        	}
-
-            memcpy(tmp, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t));
-            tmp += sizeof(mac_address_t);
-            len += sizeof(mac_address_t);
-
-            eht_ops_bss = &dm->m_bss[j].m_bss_info.eht_ops;
-            memcpy(tmp, eht_ops_bss, sizeof(em_eht_operations_bss_t));
-            tmp += sizeof(em_eht_operations_bss_t);
-            len += sizeof(em_eht_operations_bss_t);
-        }
-    }
-
-    return len;
 }
 
 int em_configuration_t::send_ap_mld_config_req_msg()
@@ -2349,6 +2303,223 @@ unsigned short em_configuration_t::create_m1_msg(unsigned char *buff)
     return len;
 }
 
+int em_configuration_t::create_bss_config_req_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN])
+{
+    unsigned int len = 0;
+    uint8_t tlv_buff[4096] = {0};
+    em_service_type_t service_type = get_service_type();
+    em_profile_type_t profile_type = get_profile_type();
+    int tlv_size = 0;
+
+    uint8_t* tmp = em_msg_t::add_1905_header(buff, &len, dest_al_mac, get_al_interface_mac(), em_msg_type_bss_config_req);
+
+    // 5.3.8 Fronthaul BSS and Backhaul BSS configuration
+    // If an Enrollee Multi-AP Agent has established a PMK and PTK with the Controller at 1905-layer using the procedures
+    // described in section 5.3.7, it shall request configuration for its fronthaul BSSs and backhaul BSSs by sending a BSS
+    // Configuration Request message to the Controller. The BSS Configuration Request message shall include at least
+
+    //  One Multi-AP Profile TLV.
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_profile, reinterpret_cast<uint8_t *> (&profile_type), sizeof(em_profile_type_t));
+
+    //  One SupportedService TLV.
+    // 1 service type followed by the service type value
+    uint8_t service_type_buff[2] = {1, service_type};
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_supported_service, service_type_buff, sizeof(service_type_buff));
+
+    // One Backhaul STA Radio Capabilities TLV.
+    tlv_size = create_bsta_radio_cap_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_bh_sta_radio_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // One AP capability TLV
+    tlv_size = create_ap_cap_tlv(tlv_buff); //Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_ap_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // One AP Radio Basic Capabilities TLV for each of the supported radios of the Multi-AP Agent.
+    tlv_size = create_ap_radio_basic_cap(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_ap_radio_basic_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //  One AKM Suite Capabilities TLV
+    tlv_size = create_akm_suite_cap_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_akm_suite, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //  One Profile-2 AP Capability TLV.
+    tlv_size = create_prof_2_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_profile_2_ap_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //  One BSS Configuration Request TLV with DPP attribute(s) for all supported radios of the Multi-AP Agent.
+    tlv_size = create_bss_conf_req_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_bss_conf_req, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //  One AP HT Capabilities TLV for each radio that is capable of HT (Wi-Fi 4) operation.
+    tlv_size = create_ht_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_ht_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //  One AP VHT Capabilities TLV for each radio that is capable of VHT (Wi-Fi 5) operation.
+    tlv_size = create_vht_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_vht_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // NOTE: this CMDU is extended in R6 with additional TLVs for Wi-Fi 6/6E and Wi-Fi 7 capabilities.
+    //  One AP Wi-Fi 6 Capabilities TLV for each radio that is capable of HE (Wi-Fi 6) operation
+    tlv_size = create_wifi6_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_ap_wifi6_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //  One AP Radio Advanced Capabilities TLV for each of the supported radios of the Multi-AP Agent
+    tlv_size = create_ap_radio_advanced_cap_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_ap_radio_advanced_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //  If the Agent supports EHT (Wi-Fi 7) operation, one Wi-Fi 7 Agent Capabilities TLV.
+    tlv_size = create_wifi7_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_wifi7_agent_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //  Zero or one EHT Operations TLV (see section 17.2.103)
+    tlv_size = create_eht_operations_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_eht_operations, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // End of message
+    tmp = em_msg_t::add_eom_tlv(tmp, &len);
+
+    return static_cast<int> (len);
+}
+
+int em_configuration_t::create_bss_config_rsp_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN])
+{
+
+    // TODO: Come back to. It's the same as autoconf but in testing that can be wrong
+    dm_easy_mesh_t *dm = get_data_model();
+    EM_ASSERT_NOT_NULL(dm, -1, "Data model is null");
+
+    unsigned int len = 0;
+    uint8_t tlv_buff[sizeof(uint16_t)] = {0};
+    uint16_t tlv_size = 0;
+
+    memset(tlv_buff, 0, sizeof(tlv_buff));
+
+    uint8_t *tmp = em_msg_t::add_1905_header(buff, &len, dest_al_mac, get_al_interface_mac(), em_msg_type_bss_config_rsp);
+
+    // One or more BSS config response tlv 17.2.85
+
+    /* EasyMesh 5.3.8 Fronthaul BSS and Backhaul BSS configuration
+    
+    If a Multi-AP Controller receives a BSS Configuration Request message, it shall respond within one second with a BSS Configuration Response message including one or more BSS Configuration Response TLV(s), 
+    each TLV containing one DPP Configuration Object with DPP Configuration Object attributes for the fronthaul BSS(s) and backhaul BSS(s) to be configured on the Enrollee Multi-AP Agent.
+        
+        - Each TLV has one DPP Configuration Object but there will be multiple TLVs in the BSS Configuration Response message.
+    */
+   
+
+    for (unsigned int i = 0; i < dm->get_num_bss(); i++) {
+        em_bss_info_t *bss_info = dm->get_bss_info(i);
+        if (bss_info == nullptr) continue;
+
+        if (bss_info->id.haul_type != em_haul_type_fronthaul && bss_info->id.haul_type != em_haul_type_backhaul) {
+            continue; // Only process fronthaul and backhaul BSS
+        }
+
+        std::string bssid_str = util::mac_to_string(bss_info->id.bssid);
+
+        auto radio = dm->get_radio(bss_info->ruid.mac);
+        if (!radio) continue;
+        if (!radio->m_radio_info.enabled || !bss_info->enabled) {
+            em_printfout("Skipping BSS ID: %s, radio or BSS is not enabled", bssid_str.c_str());
+            continue;
+        }
+
+        tlv_size = create_bss_conf_resp_tlv(tlv_buff, bss_info, dest_al_mac); // Data
+        if (tlv_size < 0) {
+            em_printfout("Failed to create BSS config response TLV for BSS ID: %s", bssid_str.c_str());
+            continue;
+        }
+        tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_bss_conf_rsp, tlv_buff, static_cast<unsigned int> (tlv_size));
+    }
+
+    // Zero or One default 802.1Q settings tlv 17.2.49
+    // Default 802.1Q settings TLV as used in Auto-Configuration right now
+    memset(tlv_buff, 0, sizeof(em_8021q_settings_t));
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_dflt_8021q_settings, tlv_buff, sizeof(em_8021q_settings_t));
+
+    // Zero or One traffic separation policy tlv 17.2.50
+    tlv_size = create_traffic_separation_policy(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_traffic_separation_policy, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // Zero or one Agent AP MLD Configuration TLV (see section 17.2.96)
+    tlv_size = create_ap_mld_config_tlv(tlv_buff); // TLV
+    tmp = em_msg_t::add_buff_element(tmp, &len, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // Zero or one Backhaul STA MLD Configuration TLV (see section 17.2.97)
+    tlv_size = create_bsta_mld_config_tlv(tlv_buff); // TLV
+    tmp = em_msg_t::add_buff_element(tmp, &len, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    //Zero or one EHT Operations TLV (see section 17.2.103)
+    tlv_size = create_eht_operations_tlv(tlv_buff); // Data
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_eht_operations, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // End of message
+    tmp = em_msg_t::add_eom_tlv(tmp, &len);
+
+    return static_cast<int> (len);
+
+}
+
+int em_configuration_t::create_bss_config_res_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN])
+{
+    unsigned int len = 0;
+    uint8_t *tmp = buff;
+
+    uint8_t tlv_buff[sizeof(uint16_t)] = {0};
+    int tlv_size = 0;
+
+    tmp = em_msg_t::add_1905_header(tmp, &len, dest_al_mac, get_al_interface_mac(), em_msg_type_bss_config_res);
+
+    // One BSS Configuration Report TLV 17.2.75
+    tlv_size = create_bss_config_rprt_tlv(tlv_buff); // TLV
+    EM_ASSERT_MSG_TRUE(tlv_size > 0, -1, "Failed to create BSS Configuration Report TLV");
+    tmp = em_msg_t::add_buff_element(tmp, &len, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // Zero or one Agent AP MLD Configuration TLV (see section 17.2.96)
+    tlv_size = create_ap_mld_config_tlv(tlv_buff); // TLV
+    if (tlv_size > 0) {
+        tmp = em_msg_t::add_buff_element(tmp, &len, tlv_buff, static_cast<unsigned int> (tlv_size));
+    }
+    // Zero or one Backhaul STA MLD Configuration TLV (see section 17.2.97)
+    tlv_size = create_bsta_mld_config_tlv(tlv_buff); // TLV
+    if (tlv_size > 0) {
+        tmp = em_msg_t::add_buff_element(tmp, &len, tlv_buff, static_cast<unsigned int> (tlv_size));
+    }
+
+    // Zero or one EHT Operations TLV (see section 17.2.103)
+    tlv_size = create_eht_operations_tlv(tlv_buff); // Data
+    if (tlv_size > 0) {
+        tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_eht_operations, tlv_buff, static_cast<unsigned int> (tlv_size));
+    }
+
+    // End of message
+    tmp = em_msg_t::add_eom_tlv(tmp, &len);
+
+    return static_cast<int> (len);
+
+}
+
+int em_configuration_t::create_agent_list_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN])
+{
+
+    unsigned int len = 0;
+    uint8_t *tmp = buff;
+    uint8_t tlv_buff[sizeof(uint16_t)] = {0};
+    int tlv_size = 0;
+
+    tmp = em_msg_t::add_1905_header(tmp, &len, dest_al_mac, get_al_interface_mac(), em_msg_type_agent_list);
+
+    // One Agent List TLV 17.2.77
+    tlv_size = create_agent_list_tlv(tlv_buff); // Data
+    EM_ASSERT_MSG_TRUE(tlv_size > 0, -1, "Failed to create Agent List TLV");
+    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_agent_list, tlv_buff, static_cast<unsigned int> (tlv_size));
+
+    // End of message
+    tmp = em_msg_t::add_eom_tlv(tmp, &len);
+
+    return static_cast<int> (len);
+}
+
 unsigned short em_configuration_t::create_error_code_tlv(unsigned char *buff, int val, mac_addr_t sta_mac)
 {
     unsigned short len = 0;
@@ -2371,6 +2542,184 @@ unsigned short em_configuration_t::create_error_code_tlv(unsigned char *buff, in
     len += static_cast<unsigned short int> (sizeof(mac_address_t));
 
     return len;
+}
+
+int em_configuration_t::create_bsta_radio_cap_tlv(uint8_t *buff)
+{
+    ASSERT_NOT_NULL(buff, -1, "%s:%d: Buffer is null\n", __func__, __LINE__);
+    dm_easy_mesh_t *dm = get_data_model();
+    ASSERT_NOT_NULL(dm, -1, "%s:%d: Data model is null\n", __func__, __LINE__);
+
+    int len = sizeof(em_bh_sta_radio_cap_t);
+    em_bh_sta_radio_cap_t *bsta_radio_cap = reinterpret_cast<em_bh_sta_radio_cap_t*>(buff);
+
+    for (unsigned int i = 0; i < dm->get_num_bss(); i++) {
+        auto* bss_info = dm->get_bss_info(i);
+        if (!bss_info) continue;
+        if (bss_info->id.haul_type != em_haul_type_backhaul) continue;
+        memcpy(bsta_radio_cap->bsta_addr, bss_info->bssid.mac, sizeof(mac_address_t));
+        memcpy(bsta_radio_cap->ruid, bss_info->id.ruid, sizeof(mac_address_t));
+        bsta_radio_cap->bsta_mac_present = 1;
+        break;
+    }
+
+    return len;
+}
+
+int em_configuration_t::create_akm_suite_cap_tlv(uint8_t *buff)
+{
+    ASSERT_NOT_NULL(buff, -1, "%s:%d: Buffer is null\n", __func__, __LINE__);
+    dm_easy_mesh_t *dm = get_data_model();
+    ASSERT_NOT_NULL(dm, -1, "%s:%d: Data model is null\n", __func__, __LINE__);
+
+    // TODO: AKM suites are not populated in the data model.
+
+    // Complete this TLV (EasyMesh 12.2.78) when this data is dynamically available.
+
+    return 0;
+}
+
+int em_configuration_t::create_bss_conf_req_tlv(uint8_t *buff)
+{
+    ASSERT_NOT_NULL(buff, -1, "%s:%d: Buffer is null\n", __func__, __LINE__);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "netRole", "mapAgent");
+    cJSON_AddStringToObject(root, "wi-fi_tech", "map");
+    std::string hostname;
+    {
+        constexpr size_t hostname_size = 256;
+        char hostname_buffer[hostname_size];
+        if (gethostname(hostname_buffer, hostname_size) == 0) {
+            hostname = std::string(hostname_buffer);
+        } else {
+            em_printfout("Failed to get hostname: %s", strerror(errno));
+            hostname = "EasyMeshAgentEnrollee";
+        }
+    }
+    cJSON_AddStringToObject(root, "name", hostname.c_str());
+
+    cJSON *bsta_info = create_enrollee_bsta_list(nullptr);
+    if (!bsta_info) {
+        em_printfout("Failed to create enrollee BSTA list");
+        cJSON_Delete(root);
+        return -1;
+    }
+    cJSON_AddItemToObject(root, "bSTAList", bsta_info);
+
+    std::string dpp_config_req_obj_str = cjson_utils::stringify(root);
+    cJSON_Delete(root);
+
+    em_bss_conf_req_t *bss_conf_req = reinterpret_cast<em_bss_conf_req_t *>(buff);
+    memcpy(bss_conf_req->dpp_config_req_obj, dpp_config_req_obj_str.c_str(), dpp_config_req_obj_str.size());
+
+    return static_cast<int>(dpp_config_req_obj_str.size());
+}
+
+int em_configuration_t::create_agent_list_tlv(uint8_t *buff) {
+
+
+    em_mgr_t *em_mgr = get_mgr();
+    EM_ASSERT_NOT_NULL(em_mgr, -1, "EM Manager is NULL, cannot create Agent List TLV");
+    dm_easy_mesh_t *dm = em_mgr->get_first_dm();
+    EM_ASSERT_NOT_NULL(dm, -1, "First DM is NULL, cannot create Agent List TLV");
+
+    /* EasyMesh 17.2.77
+    - Num_Agents: 
+        - MAC Address
+        - Multi-AP Profile
+        - Security
+    */
+
+    em_agent_list_t *agent_list = reinterpret_cast<em_agent_list_t *>(buff);
+    agent_list->num_agents = 0;
+
+    uint8_t* agent_obj_buff = buff + sizeof(em_agent_list_t);
+
+    int tlv_size = sizeof(em_agent_list_t);
+
+    while (dm != NULL) {
+        // 
+        em_agent_list_agent_t *agent_obj = reinterpret_cast<em_agent_list_agent_t *>(agent_obj_buff);
+        memset(agent_obj, 0, sizeof(em_agent_list_agent_t));
+
+        em_profile_type_t profile = dm->get_device()->m_device_info.profile;
+        uint8_t* al_mac = dm->get_agent_al_interface_mac();
+
+        // Double check that all of these values are actually correct given that stuff can be set weird in UWM
+        memcpy(agent_obj->agent_mac, al_mac, ETH_ALEN);
+        agent_obj->multi_ap_profile = static_cast<uint8_t>(profile);
+        agent_obj->security = 0x01; // ALl UWM agents support 1905-layer security
+
+        agent_list->num_agents++;
+
+        agent_obj_buff += sizeof(em_agent_list_agent_t);
+        tlv_size += sizeof(em_agent_list_agent_t);
+        dm = em_mgr->get_next_dm(dm);
+    }
+
+    return tlv_size;
+}
+
+
+int em_configuration_t::create_bss_conf_resp_tlv(uint8_t *buff, em_bss_info_t *bss_info, uint8_t dest_al_mac[ETH_ALEN])
+{
+
+    EM_ASSERT_NOT_NULL(buff, -1, "Buffer is NULL, cannot create BSS Configuration Response TLV");
+    EM_ASSERT_NOT_NULL(bss_info, -1, "BSS info is NULL, cannot create BSS Configuration Response TLV");
+
+    /* EasyMesh 5.3.8 Fronthaul BSS and Backhaul BSS configuration
+    
+    If a Multi-AP Controller receives a BSS Configuration Request message, it shall respond within one second with a BSS Configuration Response message including one or more BSS Configuration Response TLV(s), 
+    each TLV containing one DPP Configuration Object with DPP Configuration Object attributes for the fronthaul BSS(s) and backhaul BSS(s) to be configured on the Enrollee Multi-AP Agent.
+        
+        - Each TLV has one DPP Configuration Object but there will be multiple TLVs in the BSS Configuration Response message.
+    */
+
+    std::string bssid_mac = util::mac_to_string(bss_info->bssid.mac);
+
+    ec_manager_t &ec_mgr = get_ec_mgr();
+    ec_persistent_sec_ctx_t* sec_ctx = ec_mgr.get_sec_ctx();
+    EM_ASSERT_NOT_NULL(sec_ctx, -1, "Security context is NULL, cannot create BSS Configuration Response objects");
+
+    /*
+    In the ideal spec, this would be sent by the enrollee in the BSS Configuration Request. 
+    However, because that is not the case, we have to cache it for now and look it up after the fact.
+    */
+    ec_connection_context_t* conn_ctx = ec_mgr.get_al_conn_ctx(dest_al_mac);
+    EM_ASSERT_NOT_NULL(conn_ctx, -1, "Could not get connection context for destination (peer) AL MAC: " MACSTRFMT, MAC2STR(dest_al_mac));
+    SSL_KEY* enrollee_nak = conn_ctx->enrollee_net_access_key;
+    EM_ASSERT_NOT_NULL(enrollee_nak, -1, "Enrollee NAK is NULL for destination (peer) AL MAC: " MACSTRFMT, MAC2STR(dest_al_mac));
+
+    // false for is_sta_response, false for tear_down_bss
+    scoped_cjson bss_config_obj(create_bss_dpp_response_obj(bss_info, false, false));
+
+    EM_ASSERT_NOT_NULL(bss_config_obj.get(), -1, "Failed to create BSS DPP Configuration Object for BSS ID: %s", bssid_mac.c_str());
+
+    em_haul_type_t haul_type = bss_info->id.haul_type;
+    EM_ASSERT_MSG_TRUE(haul_type == em_haul_type_fronthaul || haul_type == em_haul_type_backhaul, -1,
+                       "BSS ID: %s is neither fronthaul nor backhaul, cannot create DPP Configuration Object", bssid_mac.c_str());
+
+
+    /*
+    The DPP connector created here is used for station onboarding to the BSS.
+    */
+    dpp_config_obj_type_e dpp_conf_obj_type = dpp_config_obj_type_e::dpp_config_obj_none;
+    if (haul_type == em_haul_type_fronthaul) {
+        dpp_conf_obj_type = dpp_config_obj_type_e::dpp_config_obj_fbss_ap;
+    } 
+    if (haul_type == em_haul_type_backhaul) {
+        dpp_conf_obj_type = dpp_config_obj_type_e::dpp_config_obj_backhaul_bss;
+    }
+
+    scoped_cjson final_config_obj(ec_ctrl_configurator_t::finalize_dpp_config_obj(bss_config_obj.get(), dpp_conf_obj_type, sec_ctx, enrollee_nak));
+
+    std::string json_string = cjson_utils::stringify(final_config_obj.get(), true);
+
+    EM_ASSERT_MSG_TRUE(json_string.length() > 0, -1, "Failed to stringify BSS DPP Configuration Object for BSS ID: %s", bssid_mac.c_str());
+
+    memcpy(buff, json_string.c_str(), json_string.length());
+
+    return json_string.length();
 }
 
 int em_configuration_t::compute_keys(unsigned char *remote_pub, unsigned short pub_len, unsigned char *local_priv, unsigned short priv_len)
@@ -3144,6 +3493,487 @@ int em_configuration_t::handle_encrypted_settings()
     return ret;
 }
 
+int em_configuration_t::handle_bss_config_req_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]) {
+    // Controller
+
+    /* EasyMesh 5.3.8 
+    If a Multi-AP Controller receives a BSS Configuration Request message, it shall respond within one second with a BSS
+    Configuration Response message including one or more BSS Configuration Response TLV(s), each TLV containing one
+    DPP Configuration Object with DPP Configuration Object attributes for the fronthaul BSS(s) and backhaul BSS(s) to be
+    configured on the Enrollee Multi-AP Agent.
+    */
+
+    // Despite the amount of TLVs in the BSS Configuration Request message, we only need to respond with a BSS Configuration Response message
+
+    //TODO:  Update DM
+    em_tlv_t *tlv_buff = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    unsigned int tlv_buff_len = len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    em_tlv_t *tlv = em_msg_t::get_first_tlv(tlv_buff, tlv_buff_len);
+    EM_ASSERT_NOT_NULL(tlv, -1, "Failed to get first TLV from BSS Configuration Request message");
+
+    /* EasyMesh 17.1.53
+    • One Multi-AP Profile TLV.
+    • One SupportedService TLV.
+    • If the Agent supports a Backhaul STA, one Backhaul STA Radio Capabilities TLV.
+    • One AP Capability TLV
+    • One AP Radio Basic Capabilities TLV for each of the supported radios of the Multi-AP Agent.
+    • One AKM Suite Capabilities TLV.
+    • One Profile-2 AP Capability TLV.
+    • One BSS Configuration Request TLV with DPP attribute(s) for all supported radios of the Multi-AP Agent.
+    • One AP HT Capabilities TLV for each radio that is capable of HT (Wi-Fi 4) operation.
+    • One AP VHT Capabilities TLV for each radio that is capable of VHT (Wi-Fi 5) operation.
+    • One AP HE Capabilities TLV for each radio that is capable of HE (Wi-Fi 6) operation.
+    • One AP Wi-Fi 6 Capabilities TLV for each radio that is capable of HE (Wi-Fi 6) operation.
+    • One AP Radio Advanced Capabilities TLV for each of the supported radios of the Multi-AP Agent.
+    • If the Agent supports EHT (Wi-Fi 7) operation, one Wi-Fi 7 Agent Capabilities TLV.
+    • Zero or one EHT Operations TLV (see section 17.2.103)
+    */
+
+    em_profile_type_t profile = em_profile_type_reserved;
+    em_service_type_t service_type = em_service_type_none;
+
+    while (tlv != NULL) {
+
+        if (tlv->type == em_tlv_type_eom || tlv->len == 0) {
+            break; // End of message or empty TLV
+        }
+
+        switch (tlv->type) {
+            case em_tlv_type_profile:
+                memcpy(&profile, tlv->value, ntohs(tlv->len));
+                break;
+            case em_tlv_type_supported_service:
+                memcpy(&service_type, &tlv->value[1], sizeof(em_service_type_t));
+                break;
+            case em_tlv_type_bh_sta_radio_cap:
+                 // Not handled by UWM right now? 
+                break;
+            case em_tlv_type_ap_cap:
+                 // Not handled by UWM right now?
+                break;
+            case em_tlv_type_ap_radio_basic_cap:
+                handle_ap_radio_basic_cap(tlv->value, htons(tlv->len));
+                break;
+            case em_tlv_type_akm_suite:
+                 // Not handled by UWM right now?
+                break;
+            case em_tlv_type_profile_2_ap_cap:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_type_bss_conf_req:
+                // Process BSS Configuration Request TLV
+                // This TLV contains DPP Configuration Request Object which does not appear to have any specific use with generating a response 
+                break;
+            case em_tlv_type_ht_cap:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_type_vht_cap:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_type_he_cap:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_type_ap_wifi6_cap:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_type_ap_radio_advanced_cap:
+                handle_ap_radio_advanced_cap(tlv->value, htons(tlv->len));
+                break;
+            case em_tlv_type_wifi7_agent_cap:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_eht_operations:
+                handle_eht_operations_tlv(tlv->value);
+                break;
+            default:
+                em_printfout("Unknown TLV type %d in BSS Configuration Request message", tlv->type);
+                break;
+        } 
+
+        tlv = em_msg_t::get_next_tlv(tlv, tlv_buff, tlv_buff_len);
+    }
+
+
+    uint8_t frame[MAX_EM_BUFF_SZ] = {0};
+
+    int frame_len = create_bss_config_rsp_msg(frame, src_al_mac);
+    EM_ASSERT_MSG_TRUE(frame_len > 0, -1, "Failed to create BSS Configuration Response message");
+
+    // Send the BSS Configuration Response message
+    int ret = send_frame(frame, static_cast<unsigned int>(frame_len), src_al_mac);
+    EM_ASSERT_MSG_TRUE(ret == 0, -1, "Failed to send BSS Configuration Response message to '" MACSTRFMT "'", MAC2STR(src_al_mac));
+
+    em_printfout("Sent BSS Configuration Response message to '" MACSTRFMT "'", MAC2STR(src_al_mac));
+
+    return 0;
+}
+
+
+int em_configuration_t::handle_bss_config_rsp_tlv(em_tlv_t* tlv){
+    // Agent
+
+    EM_ASSERT_NOT_NULL(tlv, -1, "BSS Configuration Response TLV is NULL");
+
+    dm_easy_mesh_t *dm = get_data_model();
+    EM_ASSERT_NOT_NULL(dm, -1, "Data model is NULL");
+
+
+    std::string dpp_config_obj(reinterpret_cast<char*>(tlv->value));
+    EM_ASSERT_MSG_TRUE(dpp_config_obj.length() > 0, -1, "DPP Configuration Object in BSS Configuration Response TLV is empty");
+    scoped_cjson dpp_config_json(cJSON_ParseWithLength(dpp_config_obj.data(), dpp_config_obj.length()));
+
+    EM_ASSERT_NOT_NULL(dpp_config_json.get(), -1, "Failed to parse DPP Configuration Object from BSS Configuration Response TLV");
+    EM_ASSERT_MSG_TRUE(cJSON_IsObject(dpp_config_json.get()), -1, "DPP Configuration Object in BSS Configuration Response TLV is not a JSON object");
+
+
+    scoped_cjson wifi_tech_json(cJSON_GetObjectItemCaseSensitive(dpp_config_json.get(), "wi-fi_tech"));
+    EM_ASSERT_NOT_NULL(wifi_tech_json.get(), -1, "Failed to get 'wi-fi_tech' from DPP Configuration Object in BSS Configuration Response TLV");
+    EM_ASSERT_MSG_TRUE(cJSON_IsString(wifi_tech_json.get()), -1, "'wi-fi_tech' in DPP Configuration Object is not a string");
+
+    std::string wifi_tech(cJSON_GetStringValue(wifi_tech_json.get()));
+    EM_ASSERT_MSG_TRUE(!wifi_tech.empty(), -1, "'wi-fi_tech' in DPP Configuration Object is empty");
+
+    // Determine haul type based on 'wi-fi_tech' according to EasyMesh 5.3.8
+    em_haul_type_t haul_type = em_haul_type_max;
+    if (wifi_tech == "map") {
+        haul_type = em_haul_type_backhaul;
+    }
+    if (wifi_tech == "inframap") {
+        haul_type = em_haul_type_fronthaul;
+    }
+
+    EM_ASSERT_MSG_TRUE(haul_type != em_haul_type_max, -1, "Invalid 'wi-fi_tech' value in DPP Configuration Object: %s", wifi_tech.c_str());
+    em_printfout("Processing BSS Configuration Response TLV with haul type: %d", haul_type);
+
+
+    scoped_cjson discovery_obj(cJSON_GetObjectItem(dpp_config_json.get(), "discovery"));
+    EM_ASSERT_NOT_NULL(discovery_obj.get(), -1, "Failed to get 'discovery' from DPP Configuration Object in BSS Configuration Response TLV");
+    EM_ASSERT_MSG_TRUE(cJSON_IsObject(discovery_obj.get()), -1, "'discovery' in DPP Configuration Object is not a JSON object");
+
+    scoped_cjson ssid_obj(cJSON_GetObjectItemCaseSensitive(discovery_obj.get(), "SSID"));
+    scoped_cjson bssid_obj(cJSON_GetObjectItemCaseSensitive(discovery_obj.get(), "BSSID"));
+    scoped_cjson ruid_obj(cJSON_GetObjectItemCaseSensitive(discovery_obj.get(), "RUID"));
+
+    // RUID must always be present and SSID can be "null" but always present so not NULL/nullptr
+    EM_ASSERT_NOT_NULL(ssid_obj.get(), -1, "Failed to get 'SSID' from 'discovery' in DPP Configuration Object in BSS Configuration Response TLV");
+    EM_ASSERT_NOT_NULL(ruid_obj.get(), -1, "Failed to get 'RUID' from 'discovery' in DPP Configuration Object in BSS Configuration Response TLV");
+
+
+    EM_ASSERT_MSG_TRUE(cJSON_IsString(ruid_obj.get()), -1, "'RUID' in 'discovery' is not a string");
+    std::string ruid = cJSON_GetStringValue(ruid_obj.get());
+
+    std::vector<uint8_t> ruid_mac = util::macstr_to_vector(ruid, "");
+
+    // Begin setting bss configuration in data model
+
+    if (cJSON_IsNull(ssid_obj.get())) {
+
+
+        // "inframap"
+        if (haul_type == em_haul_type_fronthaul && bssid_obj.get() == NULL){
+            /*
+            If a Multi-AP Controller does not want to configure any BSS on a radio of a Multi-AP Agent, it shall include a BSS
+            Configuration Response TLV in the BSS Configuration Response message and shall set the parameters in the DPP
+            Configuration Object fields of the BSS Configuration Response TLV described in Table 6 as follows:
+            • DPP Configuration Object
+                ▪ wi-fi_tech = "inframap"
+            • Discovery Object
+                ▪ SSID: NULL
+                ▪ Radio Unique Identifier of the radio
+            */
+            em_printfout("Received BSS Configuration Response TLV with 'SSID' as NULL for haul type 'inframap', not configuring radio %s", ruid.c_str());
+            return 0;
+        }
+        // "inframap" or "map"
+        if (bssid_obj.get() != NULL) {
+            /*
+            If a Multi-AP Controller wants to tear down an existing BSS on a radio of a Multi-AP Agent, it shall include a BSS
+            Configuration Response TLV in the BSS Configuration Response message and shall set the parameters in the DPP
+            Configuration Object fields of the BSS Configuration Response TLV described in Table 6 as follows:
+            • DPP Configuration Object
+                ▪ wi-fi_tech = "inframap" or "map"
+            • Discovery Object
+                ▪ SSID: NULL
+                ▪ Radio Unique Identifier of the radio
+                ▪ BSSID
+            */
+
+            std::string bssid = cJSON_GetStringValue(bssid_obj.get());
+            std::vector <uint8_t> bssid_mac = util::macstr_to_vector(bssid, "");
+           
+            em_printfout("Received BSS Configuration Response TLV with 'SSID' as NULL, \"tearing down\" (disabling) BSS on radio %s with BSSID %s", 
+                         ruid.c_str(), bssid.c_str());
+
+            dm_bss_t* bss = dm->get_bss(ruid_mac.data(), bssid_mac.data());
+            EM_ASSERT_NOT_NULL(bss, -1, "Failed to get BSS with RUID %s and BSSID %s", ruid.c_str(), bssid.c_str());
+            
+            // Disable BSS
+            bss->m_bss_info.enabled = false;
+            return 0;
+        }
+        
+        // SSID is NULL but not within spec paths, undefined error
+        em_printfout("Received Invalid BSS Configuration Response TLV with 'SSID' as NULL. Failing...");
+        return -1;
+    }
+
+    // Traditional configuration
+    EM_ASSERT_NOT_NULL(bssid_obj.get(), -1, "Failed to get 'BSSID' from 'discovery' in DPP Configuration Object in BSS Configuration Response TLV");
+
+    std::string ssid = cJSON_GetStringValue(ssid_obj.get());
+    EM_ASSERT_MSG_TRUE(!ssid.empty(), -1, "'SSID' in 'discovery' is empty");
+
+    std::string bssid = cJSON_GetStringValue(bssid_obj.get());
+    std::vector <uint8_t> bssid_mac = util::macstr_to_vector(bssid, "");
+
+    em_network_ssid_info_t* ssid_info = dm->get_network_ssid_info_by_haul_type(haul_type);
+    
+    // You're kind of out of luck here. The implementation of UWM assumes that the SSID info is always available for the haul type
+    // Even if BSS infos are not. 1905 Topology Responses creates BSS infos, OneWifi configurations (/nvram/InterfaceMap) which is hardcoded on the router
+    // creates DM SSID infos. Auto-config will return whatever SSIDs are on the DM which then updates OneWifi SSIDs, which then, when the 1905 topology response
+    // occurs, will create the BSS infos with those SSIDs. The SSIDs are not being created in UWM code (besides database sync) so I am not doing that here...
+    EM_ASSERT_NOT_NULL(ssid_info, -1, "Failed to get SSID info for haul type %d", haul_type);
+
+    em_printfout("Received BSS Configuration Response TLV with SSID '%s', BSSID '%s' and haul type %d", ssid.c_str(), bssid.c_str(), haul_type);
+
+    char time_date[EM_DATE_TIME_BUFF_SZ];
+    util::get_date_time_rfc3399(time_date, sizeof(time_date));
+
+    // Copied from em_configuration_t::handle_ap_operational_bss
+    dm_bss_t* dm_bss = dm->get_bss(ruid_mac.data(), bssid_mac.data());
+    if (dm_bss == NULL) {
+        // BSS does not exist, create it
+        dm_bss = &dm->m_bss[dm->m_num_bss];
+
+        // fill up id first
+        strncpy(dm_bss->m_bss_info.id.net_id, dm->m_device.m_device_info.id.net_id, sizeof(em_long_string_t));
+        memcpy(dm_bss->m_bss_info.id.dev_mac, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t));
+        memcpy(dm_bss->m_bss_info.id.ruid, ruid_mac.data(), sizeof(mac_address_t));
+        memcpy(dm_bss->m_bss_info.id.bssid, bssid_mac.data(), sizeof(mac_address_t));
+
+        memcpy(dm_bss->m_bss_info.bssid.mac, bssid_mac.data(), sizeof(mac_address_t));
+        memcpy(dm_bss->m_bss_info.ruid.mac, ruid_mac.data(), sizeof(mac_address_t));
+        dm->set_num_bss(dm->get_num_bss() + 1);
+    }
+    strncpy(dm_bss->m_bss_info.ssid, ssid.c_str(), ssid.length());
+    dm_bss->m_bss_info.enabled = true;
+    strncpy(dm_bss->m_bss_info.timestamp, time_date, sizeof(em_long_string_t));
+
+    /*
+    Theoretically, the main point of this is to set a DPP Connector for STAs to join via non-EasyMesh DPP rather than using a PSK.
+    Since the DPP Connector is not a parameter here and I don't expect it to be for a while, this code will be parsing it with a commented out 
+    setter.
+    */
+
+    scoped_cjson cred_obj(cJSON_GetObjectItemCaseSensitive(dpp_config_json.get(), "cred"));
+    EM_ASSERT_NOT_NULL(cred_obj.get(), -1, "Failed to get 'cred' from DPP Configuration Object in BSS Configuration Response TLV");
+    EM_ASSERT_MSG_TRUE(cJSON_IsObject(cred_obj.get()), -1, "'cred' in DPP Configuration Object is not a JSON object");
+
+
+    scoped_cjson dpp_connector_obj(cJSON_GetObjectItemCaseSensitive(cred_obj.get(), "signedConnector"));
+    EM_ASSERT_NOT_NULL(dpp_connector_obj.get(), -1, "Failed to get 'signedConnector' from 'cred' in DPP Configuration Object in BSS Configuration Response TLV");
+    EM_ASSERT_MSG_TRUE(cJSON_IsString(dpp_connector_obj.get()), -1, "'signedConnector' in 'cred' is not a string");
+
+    std::string dpp_connector = cJSON_GetStringValue(dpp_connector_obj.get());
+
+    scoped_cjson csign_obj(cJSON_GetObjectItemCaseSensitive(cred_obj.get(), "csign"));
+    EM_ASSERT_NOT_NULL(csign_obj.get(), -1, "Failed to get 'csign' from 'cred' in DPP Configuration Object in BSS Configuration Response TLV");
+    EM_ASSERT_MSG_TRUE(cJSON_IsObject(csign_obj.get()), -1, "'csign' is not an object");
+
+    auto [csign_group, csign_pub] = ec_crypto::decode_jwk(csign_obj.get());
+    if (csign_group == NULL || csign_pub == NULL) {
+        em_printfout("Failed to decode C-sign key");
+        if (csign_group) EC_GROUP_free(csign_group);
+        if (csign_pub) EC_POINT_free(csign_pub);
+        return -1;
+    }
+
+    scoped_ssl_key csign_key(em_crypto_t::bundle_ec_key(csign_group, csign_pub));
+    EM_ASSERT_NOT_NULL(csign_key.get(), -1, "Failed to bundle C-sign key");
+
+    // Validate the DPP Connector
+    auto parts = ec_crypto::split_decode_connector(dpp_connector.c_str(), csign_key.get());
+    EM_ASSERT_OPT_HAS_VALUE(parts, -1, "Failed to decode or verify DPP Connector: %s", dpp_connector.c_str());
+
+    /* If DPP Connectors were supported in OneWifi, this would be the place to set it
+    strncpy(dm_bss->m_bss_info.dpp_connector, dpp_connector.c_str(), dpp_connector.length());
+    */
+
+    return 0;
+}
+
+int em_configuration_t::handle_bss_config_rsp_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]) {
+    // Agent
+
+    /*
+    If an Enrollee Multi-AP Agent receives a BSS Configuration Response message from the
+    Multi-AP Controller, it shall configure its fronthaul BSS(s) and backhaul BSS(s) accordingly and send a BSS Configuration
+    Result message to the Multi-AP Controller.
+    */
+
+    // TODO: Update DM to configure fronthaul and backhaul BSSs
+
+    /* EasyMesh 17.1.54
+    • One or more BSS Configuration Response TLV (see section 17.2.85) [Profile-3].
+    • Zero or one Default 802.1Q Settings TLV (see section 17.2.49).
+    • Zero or one Traffic Separation Policy TLV (see section 17.2.50).
+    • Zero or one Agent AP MLD Configuration TLV (see section 17.2.96)
+    • Zero or one Backhaul STA MLD Configuration TLV (see section 17.2.97)
+    • Zero or one EHT Operations TLV (see section 17.2.103)
+    */
+
+    em_tlv_t *tlv_buff = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    unsigned int tlv_buff_len = len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    em_tlv_t *tlv = em_msg_t::get_first_tlv(tlv_buff, tlv_buff_len);
+    EM_ASSERT_NOT_NULL(tlv, -1, "Failed to get first TLV from BSS Configuration Response message");
+
+    std::string bss_dpp_connector = "";
+
+    while (tlv != NULL) {
+
+        if (tlv->type == em_tlv_type_eom || tlv->len == 0) {
+            break; // End of message or empty TLV
+        }
+
+        switch (tlv->type) {
+            case em_tlv_type_bss_conf_rsp: {
+                // Process BSS Configuration Response TLV
+                // Can be more than one for each BSS a classical DPP connector should be assigned to
+                if (handle_bss_config_rsp_tlv(tlv)) return -1;
+                break;
+            }
+            case em_tlv_type_dflt_8021q_settings:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_type_traffic_separation_policy:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_type_ap_mld_config:
+                handle_ap_mld_config_tlv(tlv->value, htons(tlv->len));
+                break;
+            case em_tlv_type_bsta_mld_config:
+                handle_bsta_mld_config_req(tlv->value, htons(tlv->len));
+                break;
+            case em_tlv_eht_operations:
+                handle_eht_operations_tlv(tlv->value);
+                break;
+            default:
+                em_printfout("Unknown TLV type %d in BSS Configuration Response message", tlv->type);
+                break;
+        } 
+
+        tlv = em_msg_t::get_next_tlv(tlv, tlv_buff, tlv_buff_len);
+    }
+
+    uint8_t frame[MAX_EM_BUFF_SZ] = {0};
+
+    int frame_len = create_bss_config_res_msg(frame, src_al_mac);
+    EM_ASSERT_MSG_TRUE(frame_len > 0, -1, "Failed to create BSS Configuration Result message");
+
+    // Send the BSS Configuration Result message
+    int ret = send_frame(frame, static_cast<unsigned int>(frame_len), src_al_mac);
+    EM_ASSERT_MSG_TRUE(ret == 0, -1, "Failed to send BSS Configuration Result message to '" MACSTRFMT "'", MAC2STR(src_al_mac));
+    em_printfout("Sent BSS Configuration Result message to '" MACSTRFMT "'", MAC2STR(src_al_mac));
+
+    return 0;
+}
+
+int em_configuration_t::handle_bss_config_res_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]) {
+    // Controller
+
+    /*
+    If the Multi-AP Controller receives a BSS Configuration Result message, it shall:
+        • send an Agent List message to the newly onboarded Enrollee Multi-AP Agent and all the other existing Multi-AP
+        Agents
+        • include the Agent List TLV with the list of all the Multi-AP Agents that are part of the Multi-AP network (including the
+        newly enrolled Multi-AP Agent itself)
+        • set the Multi-AP Profile field in the Agent List TLV to the value of the Multi-AP Profile field of the Multi-AP Profile TLV
+        received from each Multi-AP Agent (If the Multi-AP Profile field is not received, set to Profile-1)
+        • set the Security field in the Agent List TLV to 1905 Security enabled for all Multi-AP Profile-3 devices onboarded with
+        DPP Onboarding, and set the Security field to 1905 Security not enabled otherwise
+    */
+
+    /* EasyMesh 17.1.55
+    • One BSS Configuration Report TLV (see section 17.2.75) [Profile-3].
+    • Zero or one Agent AP MLD Configuration TLV (see section 17.2.96)
+    • Zero or one Backhaul STA MLD Configuration TLV (see section 17.2.97)
+    • Zero or one EHT Operations TLV (see section 17.2.103)
+    */
+
+    em_tlv_t *tlv_buff = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    unsigned int tlv_buff_len = len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    em_tlv_t *tlv = em_msg_t::get_first_tlv(tlv_buff, tlv_buff_len);
+    EM_ASSERT_NOT_NULL(tlv, -1, "Failed to get first TLV from BSS Configuration Result message");
+
+    while (tlv != NULL) {
+
+        if (tlv->type == em_tlv_type_eom || tlv->len == 0) {
+            break; // End of message or empty TLV
+        }
+
+        switch (tlv->type) {
+            case em_tlv_type_bss_conf_rep:
+                // Process BSS Configuration Report TLV
+                handle_bss_configuration_report(tlv->value, htons(tlv->len));
+                break;
+            case em_tlv_type_ap_mld_config:
+                handle_ap_mld_config_tlv(tlv->value, htons(tlv->len));
+                break;
+            case em_tlv_type_bsta_mld_config:
+                // Not handled by UWM right now?
+                break;
+            case em_tlv_eht_operations:
+                handle_eht_operations_tlv(tlv->value);
+                break;
+            default:
+                em_printfout("Unknown TLV type %d in BSS Configuration Result message", tlv->type);
+                break;
+        } 
+
+        tlv = em_msg_t::get_next_tlv(tlv, tlv_buff, tlv_buff_len);
+    }
+
+    uint8_t frame[MAX_EM_BUFF_SZ] = {0};
+
+    int frame_len = create_agent_list_msg(frame, src_al_mac);
+    EM_ASSERT_MSG_TRUE(frame_len > 0, -1, "Failed to create Agent List message");
+
+    // Send the Agent List message
+    int ret = send_frame(frame, static_cast<unsigned int>(frame_len), src_al_mac);
+    EM_ASSERT_MSG_TRUE(ret == 0, -1, "Failed to send Agent List message to '" MACSTRFMT "'", MAC2STR(src_al_mac));
+    em_printfout("Sent Agent List message to '" MACSTRFMT "'", MAC2STR(src_al_mac));
+
+    return 0;
+}
+
+int em_configuration_t::handle_agent_list_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]) {
+    // Agent
+
+    em_tlv_t *tlv_buff = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    unsigned int tlv_buff_len = len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    em_tlv_t *tlv = em_msg_t::get_tlv(tlv_buff, tlv_buff_len, em_tlv_type_agent_list);
+    EM_ASSERT_NOT_NULL(tlv, -1, "Failed to get Agent List TLV from Agent List message");
+
+
+    em_agent_list_t* agent_list_tlv = reinterpret_cast<em_agent_list_t *>(tlv->value);
+
+    em_agent_list_agent_t* agent_list = reinterpret_cast<em_agent_list_agent_t *>(agent_list_tlv->agents);
+    for (size_t i = 0; i < agent_list_tlv->num_agents; i++) {
+
+        em_agent_list_agent_t* agent = &agent_list[i];
+
+        em_printfout("Agent %zu: MAC: " MACSTRFMT ", Profile: %d, Security: %s", i + 1, MAC2STR(agent->agent_mac), agent->multi_ap_profile,
+                     agent->security ? "Enabled" : "Not Enabled");
+
+        // TODO: DM? I don't think so?
+        // This message is recieved on the agent side so theres no DM agent list to update here, just the DM for this agent
+    }
+}
+
 int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_type_t haul_type)
 {
 	data_elem_attr_t *attr;
@@ -3617,6 +4447,9 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
     tlvs = data + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t);
     tlvs_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) - sizeof(em_cmdu_t));
 
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(data);
+    uint8_t *src_al_mac = hdr->src;
+
     switch (htons(cmdu->type)) {
         case em_msg_type_autoconf_search:
             if (get_service_type() == em_service_type_ctrl) {
@@ -3697,7 +4530,27 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
 
         case em_msg_type_1905_ack:
             handle_ack_msg(data, len);
-
+            break;
+        case em_msg_type_bss_config_req:
+            if ((get_service_type() == em_service_type_ctrl)) {
+                handle_bss_config_req_msg(data, len, src_al_mac);
+            }
+            break;
+        case em_msg_type_bss_config_rsp:
+            if ((get_service_type() == em_service_type_agent)){
+                handle_bss_config_rsp_msg(data, len, src_al_mac);
+            }
+            break;
+        case em_msg_type_bss_config_res:
+            if ((get_service_type() == em_service_type_ctrl)) {
+                handle_bss_config_res_msg(data, len, src_al_mac);
+            }
+            break;
+        case em_msg_type_agent_list:
+            if ((get_service_type() == em_service_type_agent)){
+                handle_agent_list_msg(data, len, src_al_mac);
+            }
+            break;
         default:
             break;
     }

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -292,6 +292,10 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_topo_notif:
         case em_msg_type_ap_mld_config_req:
         case em_msg_type_ap_mld_config_resp:
+        case em_msg_type_bss_config_req:
+        case em_msg_type_bss_config_rsp:
+        case em_msg_type_bss_config_res:
+        case em_msg_type_agent_list:
             em_configuration_t::process_msg(data, len);
             break;
 
@@ -324,9 +328,6 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_proxied_encap_dpp:
         case em_msg_type_direct_encap_dpp:
         case em_msg_type_reconfig_trigger:
-        case em_msg_type_bss_config_req:
-        case em_msg_type_bss_config_rsp:
-        case em_msg_type_bss_config_res:
         case em_msg_type_chirp_notif:
         case em_msg_type_dpp_bootstrap_uri_notif:
         case em_msg_type_1905_rekey_req:
@@ -1078,21 +1079,6 @@ short em_t::create_wifi7_tlv(unsigned char *buff)
     return len;
 }
 
-short em_t::create_eht_operations_tlv(unsigned char *buff)
-{
-    short len = 0;
-    em_radio_cap_info_t* cap_info = get_data_model()->get_radio_cap(get_radio_interface_mac())->get_radio_cap_info();
-    em_eht_operations_t *eht_ops = reinterpret_cast<em_eht_operations_t *>(buff);
-
-    if ((eht_ops == NULL) || (cap_info == NULL)) {
-        printf("%s:%d No data Found\n", __func__, __LINE__);
-        return 0;
-    }
-    memcpy(eht_ops, &cap_info->eht_ops, sizeof(em_eht_operations_t));
-    len = sizeof(em_eht_operations_t);
-    return len;
-}
-
 short em_t::create_channelscan_tlv(unsigned char *buff)
 {
     short len = 0;
@@ -1188,6 +1174,398 @@ short em_t::create_cac_cap_tlv(unsigned char *buff)
     cac->radios_num = 1;
     len = sizeof(em_cac_cap_t);
     return len;
+}
+
+short em_t::create_eht_operations_tlv(unsigned char *buff)
+{
+    unsigned short len = 0;
+    unsigned int i = 0, j = 0;
+    unsigned char *tmp = buff;
+    dm_easy_mesh_t  *dm;
+    em_eht_operations_bss_t  *eht_ops_bss;
+
+    dm = get_data_model();
+
+    unsigned char num_radios = static_cast<unsigned char> (dm->get_num_radios());
+    unsigned char num_bss;
+
+    memcpy(tmp, &num_radios, sizeof(unsigned char));
+    tmp += sizeof(unsigned char);
+    len += sizeof(unsigned char);
+
+    for (i = 0; i < num_radios; i++) {
+        memcpy(tmp, dm->get_radio_by_ref(i).get_radio_interface_mac(), sizeof(mac_address_t));
+        tmp += sizeof(mac_address_t);
+        len += sizeof(mac_address_t);
+
+        num_bss = static_cast<unsigned char> (dm->get_num_bss());
+
+        memcpy(tmp, &num_bss, sizeof(unsigned char));
+        tmp += sizeof(unsigned char);
+        len += sizeof(unsigned char);
+
+
+        for (j = 0; j < dm->get_num_bss(); j++) {
+        	if (memcmp(dm->m_bss[j].m_bss_info.ruid.mac, dm->get_radio_by_ref(i).get_radio_interface_mac(), sizeof(mac_address_t)) != 0) {
+            	continue;
+        	}
+
+            memcpy(tmp, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t));
+            tmp += sizeof(mac_address_t);
+            len += sizeof(mac_address_t);
+
+            eht_ops_bss = &dm->m_bss[j].m_bss_info.eht_ops;
+            memcpy(tmp, eht_ops_bss, sizeof(em_eht_operations_bss_t));
+            tmp += sizeof(em_eht_operations_bss_t);
+            len += sizeof(em_eht_operations_bss_t);
+        }
+    }
+
+    return len;
+}
+
+cJSON *em_t::create_enrollee_bsta_list(uint8_t pa_al_mac[ETH_ALEN])
+{
+    (void) pa_al_mac; // pa_al_mac is not used in this function, but is a requirement for the function signature.
+
+
+    dm_easy_mesh_t *dm = get_data_model();
+    if (dm == nullptr) {
+        em_printfout("Could not get data model handle!");
+        return nullptr;
+    }
+
+    std::string channelList;
+    scoped_cjson bsta_list_obj(cJSON_CreateObject());
+    EM_ASSERT_NOT_NULL(bsta_list_obj.get(), nullptr, "Failed to allocate for bSTAList object!");
+
+    scoped_cjson b_sta_list_arr(cJSON_CreateArray());
+    EM_ASSERT_NOT_NULL(b_sta_list_arr.get(), nullptr, "Failed to allocate for bSTAList array!");
+
+    if (!cJSON_AddStringToObject(bsta_list_obj.get(), "netRole", "mapBackhaulSta")) {
+        em_printfout("Could not add netRole to bSTAList object!");
+        return nullptr;
+    }
+
+    // XXX: TODO: akm is hard-coded. Should come from em_akm_suite_info_t or equivalent, but
+    // not currently populated anywhere in the data model.
+    std::string akms[2] = {"psk", "dpp"};
+    std::string akm_suites = {};
+    for (size_t i = 0; i < std::size(akms); i++) {
+        akm_suites += util::akm_to_oui(akms[i]);
+        if (!akm_suites.empty() && i < std::size(akms) - 1) akm_suites += "+";
+    }
+
+    if (!cJSON_AddStringToObject(bsta_list_obj.get(), "akm", akm_suites.c_str())) {
+        em_printfout("Could not add AKM to bSTAList object!");
+        return nullptr;
+    }
+
+    if (!cJSON_AddNumberToObject(bsta_list_obj.get(), "bSTA_Maximum_Links", 1)) {
+        em_printfout("Could not add bSTA_Maximum_Links to bSTAList object!");
+        return nullptr;
+    }
+
+    if (!cJSON_AddItemToArray(b_sta_list_arr.get(), bsta_list_obj.get())) {
+        em_printfout("Could not add bSTAList object to bSTAList array!");
+        return nullptr;
+    }
+
+    cJSON* bsta_list = bsta_list_obj.release(); // Ownership managed by b_sta_list_arr
+
+    cJSON* radio_list_arr = cJSON_AddArrayToObject(bsta_list, "RadioList");
+    EM_ASSERT_NOT_NULL(radio_list_arr, nullptr, "Could not add RadioList array to bSTAList object!");
+
+    for (unsigned int i = 0; i < dm->get_num_bss(); i++) {
+        em_bss_info_t *bss_info = dm->get_bss_info(i);
+        if (!bss_info) {
+            continue;
+        }
+        // Skip if not backhaul
+        if (bss_info->id.haul_type != em_haul_type_backhaul) {
+            continue;
+        }
+
+        scoped_cjson radioListObj(cJSON_CreateObject());
+        EM_ASSERT_NOT_NULL(radioListObj.get(), nullptr, "Failed to create RadioList object!");
+
+        uint8_t* ruid = bss_info->ruid.mac;
+        if (!cJSON_AddStringToObject(
+                radioListObj.get(), "RUID",
+                util::mac_to_string(ruid, "").c_str())) {
+            em_printfout("Could not add RUID to RadioList object!");
+            return nullptr;
+        }
+
+        std::string radio_channel_list;
+        for (unsigned int j = 0; j < dm->get_num_op_class(); j++) {
+            dm_op_class_t *opclass = dm->get_op_class(j);
+            if (opclass == nullptr) {
+                continue;
+            }
+
+            if (memcmp(ruid, opclass->m_op_class_info.id.ruid, ETH_ALEN) == 0) {
+                em_printfout("Found opclass %d for radio '" MACSTRFMT "'", opclass->m_op_class_info.op_class, MAC2STR(ruid));
+                radio_channel_list += std::to_string(opclass->m_op_class_info.op_class) + "/" +
+                                      std::to_string(opclass->m_op_class_info.channel);
+                if (j != dm->get_num_op_class() - 1)
+                    radio_channel_list += ",";
+            }
+        }
+        channelList += radio_channel_list;
+
+        if (!cJSON_AddStringToObject(radioListObj.get(), "RadioChannelList",
+                                     radio_channel_list.c_str())) {
+            printf("%s:%d: Could not add RadioChannelList to RadioList object!\n", __func__,
+                   __LINE__);
+            return nullptr;
+        }
+
+        if (!cJSON_AddItemToArray(radio_list_arr, radioListObj.get())) {
+            printf("%s:%d: Could not add RadioList object to RadioList array!\n", __func__,
+                   __LINE__);
+            return nullptr;
+        }
+        radioListObj.release(); // Ownership transferred to array
+    }
+
+    if (!cJSON_AddStringToObject(bsta_list, "channelList", channelList.c_str())) {
+        em_printfout("Could not add channelList to bSTAList object!");
+        return nullptr;
+    }
+
+    return b_sta_list_arr.release(); // Ownership transferred to caller
+}
+
+cJSON *em_t::create_fbss_response_obj(uint8_t pa_al_mac[ETH_ALEN]) {
+
+    em_mgr_t* mgr = get_mgr();
+    EM_ASSERT_NOT_NULL(mgr, nullptr, "Manager is NULL, cannot create configurator bSTA response object");
+
+    dm_easy_mesh_t *dm = mgr->get_data_model(GLOBAL_NET_ID, pa_al_mac);
+    EM_ASSERT_NOT_NULL(dm, nullptr, "Data model for PA al MAC (" MACSTRFMT ") is NULL!", MAC2STR(pa_al_mac));
+
+    const em_bss_info_t *bss_info = NULL;
+
+    const em_network_ssid_info_t* network_ssid_info = dm->get_network_ssid_info_by_haul_type(em_haul_type_fronthaul);
+    EM_ASSERT_NOT_NULL(network_ssid_info, nullptr, "Could not get network SSID info for fronthaul BSS");
+
+    for (unsigned int i = 0; i < dm->get_num_bss(); i++) {
+        const dm_bss_t *bss = dm->get_bss(i);
+        if (!bss) continue;
+        if (strncmp(bss->m_bss_info.ssid, network_ssid_info->ssid, strlen(network_ssid_info->ssid)) == 0) {
+            em_printfout("Found BSS with SSID: '%s'", bss->m_bss_info.ssid);
+            bss_info = &bss->m_bss_info;
+            break;
+        }
+    }
+
+    EM_ASSERT_NOT_NULL(bss_info, nullptr, "Could not find BSS with SSID: '%s'", network_ssid_info->ssid);
+
+    // true for is_sta_response, false for tear_down_bss
+    scoped_cjson bss_config_obj (create_bss_dpp_response_obj(bss_info, true, false)); 
+    EM_ASSERT_NOT_NULL(bss_config_obj.get(), nullptr, "Could not create fBSS DPP Configuration Object");
+
+    return bss_config_obj.release(); // Ownership transferred to caller
+}
+
+cJSON *em_t::create_configurator_bsta_response_obj(uint8_t pa_al_mac[ETH_ALEN])
+{
+    em_mgr_t* mgr = get_mgr();
+    EM_ASSERT_NOT_NULL(mgr, nullptr, "Manager is NULL, cannot create configurator bSTA response object");
+
+    dm_easy_mesh_t *dm = mgr->get_data_model(GLOBAL_NET_ID, pa_al_mac);
+    EM_ASSERT_NOT_NULL(dm, nullptr, "Data model for PA al MAC (" MACSTRFMT ") is NULL!", MAC2STR(pa_al_mac));
+
+
+    const em_bss_info_t *bss_info = NULL;
+
+    const em_network_ssid_info_t* network_ssid_info = dm->get_network_ssid_info_by_haul_type(em_haul_type_backhaul);
+    EM_ASSERT_NOT_NULL(network_ssid_info, nullptr, "No backhaul BSS found, cannot create bSTA Configuration Object");
+
+    for (unsigned int i = 0; i < dm->get_num_bss(); i++) {
+        const dm_bss_t *bss = dm->get_bss(i);
+        if (!bss) continue;
+        if (bss->m_bss_info.id.haul_type == em_haul_type_backhaul && strncmp(bss->m_bss_info.ssid, network_ssid_info->ssid, strlen(network_ssid_info->ssid)) == 0) {
+            em_printfout("Found backhaul mesh! '%s'", bss->m_bss_info.ssid);
+            bss_info = &bss->m_bss_info;
+            break;
+        }
+    }
+
+    EM_ASSERT_NOT_NULL(bss_info, nullptr, "Could not find BSS with SSID: '%s'", network_ssid_info->ssid);
+
+    // true for is_sta_response (doesn't change anything on the backhaul), false for tear_down_bss
+    scoped_cjson bss_config_obj (create_bss_dpp_response_obj(bss_info, true, false)); 
+    EM_ASSERT_NOT_NULL(bss_config_obj.get(), nullptr, "Could not create bSTA DPP Configuration Object");
+
+    return bss_config_obj.release(); // Ownership transferred to caller
+}
+
+cJSON *em_t::create_bss_dpp_response_obj(const em_bss_info_t *bss_info, bool is_sta_response, bool tear_down_bss)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    ASSERT_NOT_NULL(dm, nullptr, "%s:%d: Failed to get data model handle.\n", __func__, __LINE__);
+
+    EM_ASSERT_NOT_NULL(bss_info, nullptr, "%s:%d: BSS info is NULL, cannot create DPP Configuration Object", __func__, __LINE__);
+
+    scoped_cjson bss_configuration_object(cJSON_CreateObject());
+    ASSERT_NOT_NULL(bss_configuration_object, nullptr, "%s:%d: Could not create fBSS Configuration Object\n", __func__, __LINE__);
+
+    em_haul_type_t haul_type = bss_info->id.haul_type;
+
+    bool is_fronthaul = (haul_type == em_haul_type_fronthaul);
+    bool is_backhaul = (haul_type == em_haul_type_backhaul);
+
+    if (!is_fronthaul && !is_backhaul) {
+        em_printfout("BSS is neither fronthaul nor backhaul, cannot create DPP Configuration Object");
+        return nullptr;
+    }
+
+    std::string wifi_tech = "";
+    if (is_backhaul) {
+        wifi_tech = "map";
+    }
+    if (is_fronthaul) {
+        if (is_sta_response) {
+            // EasyMesh 5.3.11
+            wifi_tech = "infra";
+        } else {
+            // EasyMesh 5.3.8
+            wifi_tech = "inframap";
+        }
+    }
+
+    EM_ASSERT_MSG_TRUE(wifi_tech.length() > 0, nullptr, "Could not determine 'wi-fi_tech' for BSS Configuration Object");
+
+    if (!cJSON_AddStringToObject(bss_configuration_object.get(), "wi-fi_tech", wifi_tech.c_str())) {
+        em_printfout("Failed to add \"wi-fi_tech\" to Configuration Object");
+        return nullptr;
+    }
+
+
+// START: Discovery Object
+    scoped_cjson discovery_object(cJSON_CreateObject());
+    ASSERT_NOT_NULL(discovery_object.get(), nullptr, "%s:%d: Could not create Discovery Object for DPP Configuration Object\n", __func__, __LINE__);
+
+    const em_network_ssid_info_t* network_ssid_info = dm->get_network_ssid_info_by_haul_type(haul_type);
+    EM_ASSERT_NOT_NULL(network_ssid_info, nullptr, "Could not get network SSID info for fronthaul BSS");
+
+    // XXX: Note: R5 only - R6 introduces MLDs.
+    if (tear_down_bss) {
+        if (!cJSON_AddNullToObject(discovery_object.get(), "SSID")) {
+            em_printfout("Could not add \"SSID\" to fBSS Configuration Object");
+            return nullptr;
+        }
+    } else {
+        if (!cJSON_AddStringToObject(discovery_object.get(), "SSID", network_ssid_info->ssid)) {
+            em_printfout("Could not add \"SSID\" to fBSS Configuration Object");
+            return nullptr;
+        }
+
+        if (!cJSON_AddStringToObject(discovery_object.get(), "BSSID", util::mac_to_string(bss_info->bssid.mac, "").c_str())) {
+            em_printfout("Failed to add \"BSSID\" to fBSS Configuration Object");
+            return nullptr;
+        }
+    }
+    if (!cJSON_AddStringToObject(discovery_object.get(), "RUID", util::mac_to_string(bss_info->ruid.mac, "").c_str())) {
+        em_printfout("Failed to add \"RUID\" to fBSS Configuration Object");
+        return nullptr;
+    }
+
+// END: Discovery Object
+// START: Credential Object
+    scoped_cjson credential_object(cJSON_CreateObject());
+    if (credential_object == nullptr) {
+        em_printfout("Failed to create credential object for DPP Configuration object.");
+        return nullptr;
+    }
+
+    std::string akm_suites = {};
+    bool needs_psk_hex = false;
+    for (unsigned int i = 0; i < network_ssid_info->num_akms; i++) {
+        if (!akm_suites.empty()) akm_suites += "+";
+        akm_suites += util::akm_to_oui(network_ssid_info->akm[i]);
+
+    }
+    // "psk_hex" is a conditional field,
+    // present only if PSK or AKM or SAE is a selected AKM
+    const auto check_needs_psk_hex = [](std::string akm) -> bool {
+        // psk || sae
+        return akm == util::akm_to_oui("psk")
+        || akm == util::akm_to_oui("sae");
+    };
+
+    std::vector<std::string> akms = util::split_by_delim(akm_suites, '+');
+    for (const auto& akm : akms) {
+        if (check_needs_psk_hex(akm)) needs_psk_hex = true;
+    }
+
+    if (!cJSON_AddStringToObject(credential_object.get(), "akm", akm_suites.c_str())) {
+        em_printfout("Failed to add \"akm\" to bSTA DPP Configuration Object");
+        return nullptr;
+    }
+
+    if (needs_psk_hex) {
+        std::vector<uint8_t> psk = ec_crypto::gen_psk(std::string(network_ssid_info->pass_phrase), std::string(network_ssid_info->ssid));
+        if (psk.empty()) {
+            em_printfout("Failed to generate PSK");
+            return nullptr;
+        }
+
+        cJSON_AddStringToObject(credential_object.get(), "psk_hex", em_crypto_t::hash_to_hex_string(psk).c_str());
+    }
+    
+// END: Credential Object
+    if (!cJSON_AddStringToObject(credential_object.get(), "pass", network_ssid_info->pass_phrase)) {
+        em_printfout("Failed to add \"pass\" to bSTA DPP Configuration Object");
+        return nullptr;
+    }
+
+    if (!cJSON_AddItemToObject(bss_configuration_object.get(), "discovery", discovery_object.get())) {
+        em_printfout("Failed to add \"discovery\" to bSTA DPP Configuration Object");
+        return nullptr;
+    }
+    discovery_object.release(); // Ownership transferred to bss_configuration_object
+
+    if (!cJSON_AddItemToObject(bss_configuration_object.get(), "cred", credential_object.get())) {
+        em_printfout("Failed to add \"cred\" to bSTA DPP Configuration Object");
+        return nullptr;
+    }
+    credential_object.release(); // Ownership transferred to bss_configuration_object
+
+    return bss_configuration_object.release(); // Ownership transferred to caller
+}
+
+cJSON *em_t::create_ieee1905_response_obj()
+{
+    scoped_cjson dpp_configuration_object(cJSON_CreateObject());
+    ASSERT_NOT_NULL(dpp_configuration_object, nullptr, "%s:%d: Failed to create 1905 DPP Configuration Object.\n", __func__, __LINE__);
+
+    if (!cJSON_AddStringToObject(dpp_configuration_object.get(), "wi-fi_tech", "dpp")) {
+        em_printfout("Failed to add \"wi-fi_tech\" to 1905 DPP Configuration Object.");
+        return nullptr;
+    }
+
+    if (!cJSON_AddNumberToObject(dpp_configuration_object.get(), "dfCounterThreshold", 42)) {
+        em_printfout("Failed to add \"dfCounterThreshold\" to 1905 DPP Configuration Object.");
+        return nullptr;
+    }
+
+    scoped_cjson credential_object(cJSON_CreateObject());
+    if (!credential_object) {
+        em_printfout("Failed to create Credential object for 1905 DPP Configuration Object.");
+        return nullptr;
+    }
+    if (!cJSON_AddStringToObject(credential_object.get(), "akm", util::akm_to_oui("dpp").c_str())) {
+        em_printfout("Failed to add \"akm\" to 1905 DPP Configuration Object.");
+        return nullptr;
+    }
+
+    cJSON_AddItemToObject(dpp_configuration_object.get(), "cred", credential_object.get());
+    credential_object.release();
+
+    return dpp_configuration_object.release();
 }
 
 int em_t::push_event(em_event_t *evt)
@@ -1366,17 +1744,16 @@ bool em_t::initialize_ec_manager(){
     // Enrollee callbacks
     if (service_type == em_service_type_agent) {
         ops.get_backhaul_sta_info =
-            std::bind(&em_t::create_enrollee_bsta_list, this, std::placeholders::_1, std::placeholders::_2);
+            std::bind(&em_t::create_enrollee_bsta_list, this, std::placeholders::_1);
     }
 
     // Controller Configurator callbacks
     if (service_type == em_service_type_ctrl) {
-        ops.get_1905_info         = std::bind(&em_t::create_ieee1905_response_obj, this,
-                                                std::placeholders::_1);
+        ops.get_1905_info         = std::bind(&em_t::create_ieee1905_response_obj, this);
         ops.get_fbss_info         = std::bind(&em_t::create_fbss_response_obj, this, 
                                                 std::placeholders::_1);
         ops.get_backhaul_sta_info = std::bind(&em_t::create_configurator_bsta_response_obj, 
-                                                this, std::placeholders::_1, std::placeholders::_2);
+                                                this, std::placeholders::_1);
     }
 
     // Read in the persistent security context for the controller or agent

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -285,6 +285,37 @@ em_tlv_t *em_msg_t::get_tlv(em_tlv_t* tlvs_buff, unsigned int buff_len, em_tlv_t
     return NULL;
 }
 
+em_tlv_t *em_msg_t::get_first_tlv(em_tlv_t* tlvs_buff, unsigned int buff_len)
+{
+
+    EM_ASSERT_NOT_NULL(tlvs_buff, NULL, "Buffer is NULL");
+    EM_ASSERT_MSG_TRUE(buff_len > 0, NULL, "Buffer length is zero");
+
+    em_tlv_t    *tlv = tlvs_buff;
+
+    uint16_t tlv_len = ntohs(tlv->len);
+
+    EM_ASSERT_MSG_TRUE(tlv_len > 0, NULL, "First TLV length is zero");
+    EM_ASSERT_MSG_TRUE(tlv_len >= (buff_len - sizeof(em_tlv_t)), NULL, "TLVs buffer cannot fit first TLV"); 
+
+    return tlv;
+}
+
+em_tlv_t *em_msg_t::get_next_tlv(em_tlv_t* tlv, em_tlv_t* tlvs_buff, unsigned int buff_len)
+{
+
+    EM_ASSERT_NOT_NULL(tlv, NULL, "TLV is NULL");
+    EM_ASSERT_NOT_NULL(tlvs_buff, NULL, "Buffer is NULL");
+    EM_ASSERT_MSG_TRUE(buff_len > 0, NULL, "Buffer length is zero");
+
+    size_t offset = reinterpret_cast<uint8_t*>(tlv) - reinterpret_cast<uint8_t*>(tlvs_buff);
+    EM_ASSERT_MSG_TRUE(offset < buff_len, NULL, "TLV offset exceeds buffer length");
+
+    em_tlv_t* offset_tlvs_buff = reinterpret_cast<em_tlv_t*>(reinterpret_cast<uint8_t*>(tlvs_buff) + offset);
+
+    return get_first_tlv(offset_tlvs_buff, buff_len - offset);
+}
+
 unsigned char* em_msg_t::add_buff_element(unsigned char *buff, unsigned int *len, unsigned char *element, unsigned int element_len)
 {
     memcpy(buff, element, element_len);

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -1596,7 +1596,7 @@ std::pair<uint8_t *, size_t> ec_enrollee_t::create_config_request(std::optional<
         return {};
     }
 
-    cJSON *bsta_info = m_get_bsta_info(nullptr, nullptr);
+    cJSON *bsta_info = m_get_bsta_info(nullptr);
     ASSERT_NOT_NULL_FREE(bsta_info, {}, m_eph_ctx().e_nonce, "%s:%d: bSTA info is nullptr!\n", __func__, __LINE__);
     cJSON_AddItemToObject(dpp_config_request_obj, "bSTAList", bsta_info);
 

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -146,7 +146,7 @@ bool ec_manager_t::upgrade_to_onboarded_proxy_agent(uint8_t ctrl_al_mac[ETH_ALEN
         em_printfout("Can't upgrade an enrollee that doesn't exist");
         return false;
     }
-    auto sec_ctx = m_enrollee->get_sec_ctx();
+    auto sec_ctx = *m_enrollee->get_sec_ctx();
     if (sec_ctx.C_signing_key == NULL || sec_ctx.pp_key == NULL || sec_ctx.net_access_key == NULL || sec_ctx.connector == NULL) {
         em_printfout("!!!!Enrollee doesn't have a valid security context, proxy agent won't be 1905 layer secured!!!!");
     }


### PR DESCRIPTION
Implements:
- Handle BSS Configuration Request message
- Create / Handle BSS Configuration Response message
- Create / Handle BSS Configuration Result message
- Create / Handle Agent List message

Other changes:
- Moves implementations for these to `em_configuration*` to re-use existing TLV handlers and creation methods
- Moves EasyMesh DPP callbacks to `em*` for use when creating  BSS Configuration Response messages.
- Adds support for deliminators in `macstr_to_vector`
- Adds iterator functions for tlvs

This currently exists in a vacuum, with no code sending BSS Configuration Requests and therefore BSS Configuration Responses, Results, and Agent Lists not being sent but that should soon change

Regular Ethernet WSC onboarding has been tested with this code 