### PR TITLE
RDKBACCL-1193: Initial Controller framework to support tr181 parameters callback, trigger orchestrate and test code!

### DIFF
--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -100,6 +100,7 @@ CTRL_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
 	$(wildcard $(ONEWIFI_EM_SRC)/ctrl/*.cpp) \
 	$(wildcard $(ONEWIFI_EM_SRC)/db/*.cpp) \
 	$(wildcard $(ONEWIFI_EM_SRC)/dm/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/ctrl/TR_181/*.cpp) \
 	$(ONEWIFI_EM_SRC)/orch/em_orch.cpp \
 	$(ONEWIFI_EM_SRC)/orch/em_orch_ctrl.cpp \
 	$(ONEWIFI_EM_SRC)/utils/util.cpp \

--- a/build/network_optimiser/makefile
+++ b/build/network_optimiser/makefile
@@ -1,0 +1,99 @@
+##########################################################################
+ # Copyright 2023 Comcast Cable Communications Management, LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+ # SPDX-License-Identifier: Apache-2.0
+##########################################################################
+
+include ../makefile.inc
+
+#
+# program
+#
+
+PROGRAM = $(INSTALLDIR)/bin/onewifi_em_network_optimiser
+
+INCLUDEDIRS = \
+        -I$(ONEWIFI_EM_HOME)/inc \
+        -I$(ONEWIFI_EM_HOME)/src/utils \
+        -I$(ONEWIFI_HAL_INTF_HOME) \
+        -I$(ONEWIFI_HOME)/source/utils \
+        -I$(ONEWIFI_HOME)/include \
+        -I$(ONEWIFI_BUS_LIB_HOME)/inc \
+        -I$(ONEWIFI_HOME)/lib/log \
+        -I$(ONEWIFI_HOME)/lib/ds \
+        -I$(ONEWIFI_HOME)/source/platform/linux \
+        -I$(ONEWIFI_HOME)/source/platform/common \
+        -I$(ONEWIFI_HOME)/source/platform/linux/he_bus/inc \
+        -I$(ONEWIFI_EM_HOME)/src/util_crypto \
+        -I$(ONEWIFI_HOME)/source/ccsp
+ifeq ($(WITH_SAP), 1)
+INCLUDEDIRS += -I$(AL_SAP_HOME)/include
+endif
+
+CXXFLAGS += $(INCLUDEDIRS) -g -DEASY_MESH_NODE -DEM_APP -Wall -Wextra -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Werror -O2
+ifeq ($(WITH_SAP), 1)
+CXXFLAGS += -DAL_SAP
+endif
+LDFLAGS += $(LIBDIRS) $(LIBS) -fsanitize=address -fsanitize=undefined
+
+LIBDIRS = \
+    -L$(INSTALLDIR)/lib \
+    -L$(ONEWIFI_HOME)/install/lib/
+ifeq ($(WITH_SAP), 1)
+LIBDIRS += -L$(AL_SAP_HOME)/
+endif
+
+LIBS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwebconfig -lhebus
+ifeq ($(WITH_SAP), 1)
+LIBS += -lalsap
+endif
+
+GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c \
+    $(ONEWIFI_EM_SRC)/util_crypto/aes_siv.c \
+    $(ONEWIFI_HOME)/lib/common/util.c \
+    $(ONEWIFI_HOME)/source/platform/linux/bus.c
+
+SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/network_optimiser/*.cpp) \
+
+OBJECTS = $(SOURCES:.cpp=.o)
+GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 
+ALLOBJECTS = $(OBJECTS) $(GENERIC_OBJECTS)
+
+all: $(BUS_LIBRARY) $(PROGRAM)
+
+$(PROGRAM): $(ALLOBJECTS)
+	$(CXX) -o $@ $(ALLOBJECTS) $(LDFLAGS)
+
+$(GENERIC_OBJECTS): %.o: %.c
+	$(CC) $(CXXFLAGS) -o $@ -c $<
+
+$(OBJECTS): %.o: %.cpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+# Clean target: "make -f Makefile.Linux clean" to remove unwanted objects and executables.
+#
+
+clean:
+	$(RM) $(ALLOBJECTS) $(PROGRAM)
+
+#
+# Run target: "make -f Makefile.Linux run" to execute the application
+#             You will need to add $(VARIABLE_NAME) for any command line parameters 
+#             that you defined earlier in this file.
+# 
+
+run:
+	./$(PROGRAM) 
+

--- a/build/openwrt/network_optimiser/makefile
+++ b/build/openwrt/network_optimiser/makefile
@@ -1,0 +1,99 @@
+##########################################################################
+ # Copyright 2023 Comcast Cable Communications Management, LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+ # SPDX-License-Identifier: Apache-2.0
+##########################################################################
+
+include ../makefile.inc
+
+#
+# program
+#
+
+PROGRAM = $(INSTALLDIR)/bin/onewifi_em_network_optimiser
+
+INCLUDEDIRS = \
+        -I$(ONEWIFI_EM_HOME)/inc \
+        -I$(ONEWIFI_EM_HOME)/src/utils \
+        -I$(ONEWIFI_HAL_INTF_HOME) \
+        -I$(ONEWIFI_HOME)/source/utils \
+        -I$(ONEWIFI_HOME)/include \
+        -I$(ONEWIFI_BUS_LIB_HOME)/inc \
+        -I$(ONEWIFI_HOME)/lib/log \
+        -I$(ONEWIFI_HOME)/lib/ds \
+        -I$(ONEWIFI_HOME)/source/platform/linux \
+        -I$(ONEWIFI_HOME)/source/platform/common \
+        -I$(ONEWIFI_HOME)/source/platform/linux/he_bus/inc \
+        -I$(ONEWIFI_EM_HOME)/src/util_crypto \
+        -I$(ONEWIFI_HOME)/source/ccsp
+ifeq ($(WITH_SAP), 1)
+INCLUDEDIRS += -I$(AL_SAP_HOME)/include
+endif
+
+CXXFLAGS += $(INCLUDEDIRS) -g -DEASY_MESH_NODE -DEM_APP -Wall -Wextra -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wconversion -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Werror -O2
+ifeq ($(WITH_SAP), 1)
+CXXFLAGS += -DAL_SAP
+endif
+LDFLAGS += $(LIBDIRS) $(LIBS) -fsanitize=address -fsanitize=undefined
+
+LIBDIRS = \
+    -L$(INSTALLDIR)/lib \
+    -L$(ONEWIFI_HOME)/install/lib/
+ifeq ($(WITH_SAP), 1)
+LIBDIRS += -L$(AL_SAP_HOME)/
+endif
+
+LIBS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwebconfig -lhebus
+ifeq ($(WITH_SAP), 1)
+LIBS += -lalsap
+endif
+
+GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c \
+    $(ONEWIFI_EM_SRC)/util_crypto/aes_siv.c \
+    $(ONEWIFI_HOME)/lib/common/util.c \
+    $(ONEWIFI_HOME)/source/platform/linux/bus.c
+
+SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/network_optimiser/*.cpp) \
+
+OBJECTS = $(SOURCES:.cpp=.o)
+GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 
+ALLOBJECTS = $(OBJECTS) $(GENERIC_OBJECTS)
+
+all: $(BUS_LIBRARY) $(PROGRAM)
+
+$(PROGRAM): $(ALLOBJECTS)
+	$(CXX) -o $@ $(ALLOBJECTS) $(LDFLAGS)
+
+$(GENERIC_OBJECTS): %.o: %.c
+	$(CC) $(CXXFLAGS) -o $@ -c $<
+
+$(OBJECTS): %.o: %.cpp
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
+
+# Clean target: "make -f Makefile.Linux clean" to remove unwanted objects and executables.
+#
+
+clean:
+	$(RM) $(ALLOBJECTS) $(PROGRAM)
+
+#
+# Run target: "make -f Makefile.Linux run" to execute the application
+#             You will need to add $(VARIABLE_NAME) for any command line parameters 
+#             that you defined earlier in this file.
+# 
+
+run:
+	./$(PROGRAM) 
+

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,7 @@ AC_FUNC_MALLOC
  
 AC_CONFIG_FILES(
     src/cli/Makefile
+    src/network_optimiser/Makefile
     src/al-sap/Makefile
     src/ctrl/Makefile
     src/agent/Makefile

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -602,6 +602,39 @@ public:
 	 */
 	em_t *find_em_for_msg_type(unsigned char *data, unsigned int len, em_t *al_em);
 
+	/**!
+	* @brief Callback registered for getting colocated agent ID
+	*
+	* He bus calls this API for Device.WiFi.DataElements.Network.ColocatedAgentID
+	* @param[in] name of the event
+	* @param[i] p_data pointer to get the data
+	* @param[i] user_data get the bus handle
+	*/
+	static bus_error_t get_device_wifi_dataelements_network_colocated_agentid (char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
+	/**!
+	*
+	* @brief Callback registered for getting controller ID
+	* He bus calls this API for Device.WiFi.DataElements.Network.ControllerID
+	* @param[in] name of the event
+	* @param[i] p_data pointer to get the data
+	* @param[i] user_data get the bus handle
+	*/
+	static bus_error_t get_device_wifi_dataelements_network_controllerid (char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
+
+	/**!
+	*
+	* @brief Callback registered for command setSSID()
+	* He bus calls this API for Device.WiFi.DataElements.Network.SetSSID
+	* @param[in] name of the event
+	* @param[i] input_data pointer to get the data
+	* @param[i] output pointer to send dta
+	* @param[i] user_data get the bus handle
+	*/
+	//static bus_error_t cmd_setssid (const char *event_name, bus_data_prop_t const *input_data, bus_data_prop_t *output_data, void *user_data);
+
+
 #ifdef AL_SAP
     
 	/**!

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TR_181_H
+#define TR_181_H
+
+#include "em_ctrl.h"
+
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_COLOCATEDAGENTID	"Device.WiFi.DataElements.Network.ColocatedAgentID"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_CONTROLLERID		"Device.WiFi.DataElements.Network.ControllerID"
+//#define DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD "Device.WiFi.DataElements.Network.SetSSID()"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD		"Device.WiFi.DataElements.Network.SetSSID"
+
+typedef struct {
+	em_short_string_t ssid;
+	bool enable;
+	em_short_string_t add_remove_change;
+	em_short_string_t passphrase;
+	em_short_string_t band;
+	em_short_string_t akms_allowed;
+	bool advertisement_enabled;
+	em_short_string_t mfp_config;
+	em_short_string_t mobility_domain;
+	em_short_string_t haul_type;
+} tr_cmd_setssid;
+#endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,6 @@
 if EM_EXTENDER
 SUBDIRS = al-sap agent
 else
-SUBDIRS = cli al-sap ctrl agent
+SUBDIRS = cli al-sap ctrl agent network_optimiser
 endif
 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1069,7 +1069,7 @@ void em_agent_t::input_listener()
     raw_data_t data;
     int num_retry = 0;
     bus_error_t bus_error_val;
-    char service_name[] = "EasyMesh_service";
+    char service_name[] = "EasyMesh_service_agent";
 
     bus_init(&m_bus_hdl);
 

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -101,6 +101,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/ctrl/em_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_network_topo.cpp \
      $(top_srcdir)/src/ctrl/em_dev_test_ctrl.cpp \
+     $(top_srcdir)/src/ctrl/TR_181/tr_181_param.cpp \
      $(top_srcdir)/src/db/db_client.cpp \
      $(top_srcdir)/src/db/db_column.cpp \
      $(top_srcdir)/src/db/db_easy_mesh.cpp \

--- a/src/ctrl/TR_181/tr_181_cmd_setssid.cpp
+++ b/src/ctrl/TR_181/tr_181_cmd_setssid.cpp
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "em_ctrl.h"
+#include "tr_181.h"
+
+extern em_ctrl_t g_ctrl;
+extern char *global_netid;
+
+#define MAX_PARAM_LEN 128
+
+#if 0
+//TODO: Rbus abstraction needed for this async method call, it will be enabled once its ready
+bus_error_t em_ctrl_t::cmd_setssid(const char *event_name, bus_data_prop_t const *input_data, bus_data_prop_t *output_data, void *user_data)
+{
+    em_subdoc_info_t *subdoc = NULL;
+    unsigned char buff[EM_IO_BUFF_SZ];
+    cJSON *json = NULL, *root = NULL, *new_json = NULL, *ssid_list = NULL, *target = NULL, *item = NULL, *ssid_item = NULL, *child = NULL, *next = NULL, *band_arr = NULL, *akm_arr = NULL, *json_obj = NULL;
+    char *jsonbuff = NULL, *updated_json = NULL, *new_json_str = NULL;
+    bus_data_prop_t const *prop = NULL;
+    char ssid[MAX_PARAM_LEN] = {0};
+    char passphrase[MAX_PARAM_LEN] = {0};
+    char band[MAX_PARAM_LEN] = {0};
+    char akms[MAX_PARAM_LEN] = {0};
+    char addremove[MAX_PARAM_LEN] = {0};
+    int idx = 0;
+    size_t json_len = 0;
+    
+    em_printfout("Received parameters in cmd_setssid");
+    
+    prop = input_data;
+    while (prop) {
+        em_printfout("Param %d: name='%s', value='%s', len=%u", idx, prop->name, (char*)prop->value.raw_data.bytes, prop->value.raw_data_len);
+        prop = prop->next_data;
+        idx++;
+    }
+
+    // Extract parameters from input_data
+    prop = input_data;
+    while (prop) {
+        em_printfout("name='%s', value='%.*s', len=%u", prop->name, (int)prop->value.raw_data_len, (char*)prop->value.raw_data.bytes, prop->value.raw_data_len);
+        if (strcmp(prop->name, "SSID") == 0) {
+            strncpy(ssid, (char*)prop->value.raw_data.bytes, MAX_PARAM_LEN - 1);
+            ssid[MAX_PARAM_LEN - 1] = '\0';
+        } else if (strcmp(prop->name, "PassPhrase") == 0) {
+            strncpy(passphrase, (char*)prop->value.raw_data.bytes, MAX_PARAM_LEN - 1);
+            passphrase[MAX_PARAM_LEN - 1] = '\0';
+        } else if (strcmp(prop->name, "Band") == 0) {
+            strncpy(band, (char*)prop->value.raw_data.bytes, MAX_PARAM_LEN - 1);
+            band[MAX_PARAM_LEN - 1] = '\0';
+        } else if (strcmp(prop->name, "AKMsAllowed") == 0) {
+            strncpy(akms, (char*)prop->value.raw_data.bytes, MAX_PARAM_LEN - 1);
+            akms[MAX_PARAM_LEN - 1] = '\0';
+        } else if (strcmp(prop->name, "AddRemoveChange") == 0) {
+            strncpy(addremove, (char*)prop->value.raw_data.bytes, MAX_PARAM_LEN - 1);
+            addremove[MAX_PARAM_LEN - 1] = '\0';
+        }
+        prop = prop->next_data;
+    }
+    
+    if (ssid[0] == '\0' || passphrase[0] == '\0' || band[0] == '\0' || akms[0] == '\0' || addremove[0] == '\0') {
+        em_printfout("ERROR: Missing required parameters in cmd_setssid");
+        return bus_error_invalid_input;
+    }
+
+    subdoc = (em_subdoc_info_t *)buff;
+    strncpy(subdoc->name, "NetworkSSIDList", strlen("NetworkSSIDList"));
+    g_ctrl.m_data_model.get_config("OneWifiMesh", subdoc);
+    em_printfout("%s:%d: buff=%s \n", __func__, __LINE__, subdoc->buff );
+    json = cJSON_Parse(subdoc->buff);
+    if (json == NULL) {
+        em_printfout("ERROR: Failed to parse JSON from subdoc");
+        return bus_error_invalid_input;
+    }
+
+    root = cJSON_CreateObject();
+    // Add "ID" to the beginning of the JSON object
+    new_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(new_json, "ID", "OneWifiMesh");
+
+    // Move all items from the original json to new_json
+    child = json->child;
+    while (child) {
+        next = child->next;
+        cJSON_DetachItemViaPointer(json, child);
+        cJSON_AddItemToObject(new_json, child->string, child);
+        child = next;
+    }
+    cJSON_Delete(json);
+    json = new_json;
+
+    cJSON_AddItemToObject(root, "wfa-dataelements:SetSSID", json);
+    jsonbuff = cJSON_Print(root);
+    em_printfout("%s:%d root: %s\n", __func__, __LINE__, jsonbuff);
+    free(jsonbuff);
+
+    // Find or add the SSID entry
+    ssid_list = cJSON_GetObjectItem(json, "NetworkSSIDList");
+    if (ssid_list == NULL || !cJSON_IsArray(ssid_list)) {
+        em_printfout("ERROR: NetworkSSIDList not found or is not an array");
+        cJSON_Delete(json);
+        return bus_error_invalid_input;
+    }
+    cJSON_ArrayForEach(item, ssid_list) {
+        ssid_item = cJSON_GetObjectItem(item, "SSID");
+        if (ssid_item && ssid && strcmp(ssid_item->valuestring, ssid) == 0) {
+            target = item;
+            em_printfout("Matching SSID found: %s", ssid_item->valuestring);
+            break;
+        }
+        //TBD: If not found, update fronthaul for now
+        //check if ssid named private_ssdid exists
+        ssid_item = cJSON_GetObjectItem(item, "SSID");
+        if (ssid_item && ssid && strcmp(ssid_item->valuestring, "private_ssid") == 0) {
+            target = item;
+            em_printfout("private_ssid found: %s\n", ssid_item->valuestring);
+            break;
+        }
+    }
+    em_printfout("Target SSID entry: %s", target ? "Found" : "Not Found");
+    if (target) {
+        em_printfout("Replace existing SSID");
+        // Replace all fields for the existing SSID entry
+        if (ssid[0]) {
+            cJSON_ReplaceItemInObject(target, "SSID", cJSON_CreateString(ssid));
+        }
+        if (passphrase[0]) {
+            cJSON_ReplaceItemInObject(target, "PassPhrase", cJSON_CreateString(passphrase));
+        }
+        if (band[0]) {
+            band_arr = cJSON_CreateArray();
+            cJSON_AddItemToArray(band_arr, cJSON_CreateString(band));
+            cJSON_ReplaceItemInObject(target, "Band", band_arr);
+        }
+        if (akms[0]) {
+            akm_arr = cJSON_CreateArray();
+            cJSON_AddItemToArray(akm_arr, cJSON_CreateString(akms));
+            cJSON_ReplaceItemInObject(target, "AKMsAllowed", akm_arr);
+        }
+    } else if (addremove[0] && strcmp(addremove, "Add") == 0) {
+        em_printfout("ADD (new SSID)");
+        // Add new entry if SSID does not exist
+        target = cJSON_CreateObject();
+        cJSON_AddItemToArray(ssid_list, target);
+        if (ssid[0]) {
+            cJSON_AddStringToObject(target, "SSID", ssid);
+        }
+        if (passphrase[0]) {
+            cJSON_AddStringToObject(target, "PassPhrase", passphrase);
+        }
+        if (band[0]) {
+            band_arr = cJSON_CreateArray();
+            cJSON_AddItemToArray(band_arr, cJSON_CreateString(band));
+            cJSON_AddItemToObject(target, "Band", band_arr);
+        }
+        if (akms[0]) {
+            akm_arr = cJSON_CreateArray();
+            cJSON_AddItemToArray(akm_arr, cJSON_CreateString(akms));
+            cJSON_AddItemToObject(target, "AKMsAllowed", akm_arr);
+        }
+    }
+
+    updated_json = cJSON_PrintUnformatted(root);
+    json_len = strlen(updated_json);
+    if (json_len >= EM_IO_BUFF_SZ) {
+        em_printfout("ERROR: JSON too large for buffer!");
+        free(updated_json);
+        cJSON_Delete(json);
+        return bus_error_invalid_input;
+    }
+    
+    memcpy(subdoc->buff, updated_json, json_len);
+    subdoc->buff[json_len] = '\0';
+    json_obj = cJSON_Parse(subdoc->buff);
+    if (json_obj) {
+        char *new_json = cJSON_Print(json_obj);
+        em_printfout("Updated and formatted JSON:\n%s", new_json);
+        free(new_json);
+        cJSON_Delete(json_obj);
+    } else {
+        em_printfout("Invalid JSON in subdoc->buff");
+    }
+
+    g_ctrl.io_process(em_bus_event_type_set_ssid, subdoc->buff, strlen(subdoc->buff));
+    free(updated_json);
+    cJSON_Delete(json);
+
+    return bus_error_success;
+}
+#endif

--- a/src/ctrl/TR_181/tr_181_param.cpp
+++ b/src/ctrl/TR_181/tr_181_param.cpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "em_ctrl.h"
+#include "tr_181.h"
+
+extern em_ctrl_t g_ctrl;
+
+bus_error_t em_ctrl_t::get_device_wifi_dataelements_network_colocated_agentid (char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_interface_t  *intf;
+    mac_addr_str_t  al_mac_str;
+    int len = 0;
+    
+    intf = g_ctrl.m_data_model.get_ctrl_al_interface(const_cast<char *> (GLOBAL_NET_ID));
+    
+    dm_easy_mesh_t::macbytes_to_string(intf->mac, al_mac_str);
+    p_data->data_type    = bus_data_type_string;
+    len = strlen(al_mac_str) + 1;
+    p_data->raw_data.bytes = malloc(len);
+    if (p_data->raw_data.bytes == NULL) {
+        em_printfout("Memory allocation is failed:%d\r", len);
+        return bus_error_out_of_resources;
+    }
+    snprintf((char*)p_data->raw_data.bytes, len, "%s", al_mac_str);
+    p_data->raw_data_len = len;
+
+    return bus_error_success;
+}
+
+bus_error_t em_ctrl_t::get_device_wifi_dataelements_network_controllerid (char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_interface_t  *intf;
+    int len = 0;
+    mac_addr_str_t  ctrl_mac;
+
+    dm_easy_mesh_t::macbytes_to_string(g_ctrl.m_data_model.get_network(GLOBAL_NET_ID)->get_network_info()->ctrl_id.mac, ctrl_mac);
+    em_printfout("Ctrlr mac: %s", ctrl_mac);
+    len = strlen(ctrl_mac) + 1;
+    p_data->data_type = bus_data_type_string;
+    p_data->raw_data.bytes = malloc(len);
+    if (p_data->raw_data.bytes == NULL) {
+        em_printfout("Memory allocation is failed:%d\r", len);
+        return bus_error_out_of_resources;
+    }
+    snprintf((char*)p_data->raw_data.bytes, len, "%s", ctrl_mac);
+    p_data->raw_data_len = len;
+    em_printfout("Descriptor value=%s, len=%d\n", (char *)p_data->raw_data.bytes, p_data->raw_data_len);
+
+    return bus_error_success;
+}

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -45,6 +45,7 @@
 #include "em_orch_ctrl.h"
 #include "util.h"
 #include "wifi_util.h"
+#include "tr_181.h"
 
 #ifdef AL_SAP
 #include "al_service_access_point.h"
@@ -861,6 +862,20 @@ void em_ctrl_t::start_complete()
 	mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 	char service_name[] = "EasyMesh_Ctrl_Service";
 	int i = 0;
+	bus_error_t bus_error_val;
+	int num_elements = 0;
+
+	bus_data_element_t dataElements[] = {
+		{ DEVICE_WIFI_DATAELEMENTS_NETWORK_COLOCATEDAGENTID, bus_element_type_method,
+			{ get_device_wifi_dataelements_network_colocated_agentid, NULL , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
+			{ bus_data_type_string, false, 0, 0, 0, NULL } },
+		{ DEVICE_WIFI_DATAELEMENTS_NETWORK_CONTROLLERID, bus_element_type_method,
+			{ get_device_wifi_dataelements_network_controllerid, NULL , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
+		// 	{ bus_data_type_string, false, 0, 0, 0, NULL } },
+		// { DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD, bus_element_type_method,
+		// 	{ NULL, NULL, NULL, NULL, NULL, cmd_setssid}, slow_speed, ZERO_TABLE,
+			{ bus_data_type_string, true, 0, 0, 0, NULL } }
+	};
 
 	if (m_data_model.is_initialized() == false) {
 		printf("%s:%d: Database not initialized ... needs reset\n", __func__, __LINE__);
@@ -891,6 +906,12 @@ void em_ctrl_t::start_complete()
    	} else {
        	printf("%s:%d Collocated agent ID: %s publish  fail\n",__func__, __LINE__, al_mac_str);
    	}
+
+	num_elements = (sizeof(dataElements) / sizeof(bus_data_element_t));
+	bus_error_val = desc->bus_reg_data_element_fn(&m_bus_hdl, dataElements, num_elements);
+	if (bus_error_val != bus_error_success) {
+		printf("%s:%d bus: bus_regDataElements failed\n", __func__, __LINE__);
+	}
 
 	// build initial network topology
 	init_network_topology();

--- a/src/network_optimiser/Makefile.am
+++ b/src/network_optimiser/Makefile.am
@@ -1,0 +1,51 @@
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+AM_CFLAGS = -D_ANSC_LINUX
+AM_CFLAGS += -D_ANSC_USER
+AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
+ 
+ACLOCAL_AMFLAGS = -I m4
+hardware_platform = i686-linux-gnu
+bin_PROGRAMS = onewifi_em_network_optimser
+ 
+onewifi_em_network_optimser_CPPFLAGS = \
+    -I$(top_srcdir)/inc \
+    -I$(top_srcdir)/src/utils \
+    -I$(top_srcdir)/src/util \
+    -I$(top_srcdir)/src/util_crypto \
+    -I$(top_srcdir)/OneWifi/include \
+    -I$(top_srcdir)/OneWifi/lib/log  \
+    -I$(top_srcdir)/OneWifi/lib/ds  \
+    -I$(top_srcdir)/OneWifi/source/utils \
+    -I$(top_srcdir)/OneWifi/source/platform/rdkb \
+    -I$(top_srcdir)/OneWifi/source/platform/common \
+    -DUNIT_TEST
+
+onewifi_em_network_optimser_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Wconversion -Werror -O2
+
+onewifi_em_network_optimser_SOURCES =  \
+     $(top_srcdir)/src/network_optimiser/test_tr181.cpp \
+     $(top_srcdir)/OneWifi/source/utils/collection.c \
+     $(top_srcdir)/OneWifi/lib/common/util.c \
+     $(top_srcdir)/OneWifi/source/platform/rdkb/bus.c \ 
+     $(top_srcdir)/OneWifi/source/platform/common/bus_common.c
+ 
+ 
+onewifi_em_network_optimser_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lwifi_bus -lrbus #-lwifi_webconfig
+onewifi_em_network_optimser_LDADD = $(top_builddir)/src/al-sap/libalsap.la
+

--- a/src/network_optimiser/test_tr181.cpp
+++ b/src/network_optimiser/test_tr181.cpp
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <signal.h>
+#include "bus.h"
+#include "bus_common.h"
+#include "tr_181.h"
+
+typedef enum{
+    CONTROLLERID,
+    COLOCATEDAGENTID,
+    SETSSID
+}test_tr;
+
+void print_options()
+{
+    printf("\n ---------------------------------------------------");
+    printf("\n Test TR-Param");
+    printf("\nDEVICE_WIFI_DATAELEMENTS_NETWORK_CONTROLLERID:%d",CONTROLLERID);
+    printf("\nDEVICE_WIFI_DATAELEMENTS_NETWORK_COLOCATEDAGENTID:%d",COLOCATEDAGENTID);
+    printf("\nDEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD:%d",SETSSID);
+    printf("\n ---------------------------------------------------");
+    printf("\n");
+}
+
+void output_cb(char const* methodName, bus_error_t error, bus_data_prop_t *params, void *userData)
+{
+    printf("	OUTPUT Callback status: %d, params:%s, userData: %s\n", error, params, userData);
+    //check wheter config is successfully applied to all agents or not
+    //wait all devices are online and check ssid details of all devices
+}
+
+
+int main()
+{
+    wifi_bus_desc_t *desc;
+    bus_handle_t m_bus_hdl;
+    memset(&m_bus_hdl, 0, sizeof(bus_handle_t));
+    raw_data_t data;
+
+    int num_retry = 0;
+    bus_error_t bus_error_val;
+    int rc = bus_error_success;
+    char service_name[] = "Test_TR181";
+    int input = 0;
+    //cmdsetssid add_ssid;
+    bus_data_prop_t *prop_data;
+
+
+    bus_init(&m_bus_hdl);
+    if((desc = get_bus_descriptor()) == NULL) {
+        printf("%s:%d descriptor is null\n", __func__, __LINE__);
+    }
+    if (desc->bus_open_fn(&m_bus_hdl, service_name) != 0) {
+        printf("%s:%d bus open failed\n",__func__, __LINE__);
+        return 0;
+    }
+    printf("%s:%d he_bus open success\n", __func__, __LINE__);
+    memset(&data, 0, sizeof(raw_data_t));
+
+    while(1) {
+        print_options();
+        printf("\n Enter number to test: \n");
+        scanf("%d", &input);
+        memset(&data, 0, sizeof(raw_data_t));
+        printf("%s:%d input=%d\n",__func__, __LINE__, input);
+        
+        if (input == CONTROLLERID) {
+            if((bus_error_val = desc->bus_data_get_fn(&m_bus_hdl, DEVICE_WIFI_DATAELEMENTS_NETWORK_CONTROLLERID, &data)) != bus_error_success ) {
+                printf("%s:%d bus_data_get_fn failed with error: %d\n", __func__, __LINE__, bus_error_val);
+            }
+            if (data.raw_data.bytes != NULL) {
+                printf("\n%s:%d recv data: CONTROLLERID=%s\n", __func__, __LINE__, (char *)data.raw_data.bytes);
+                get_bus_descriptor()->bus_data_free_fn(&data);
+            } else
+                printf("\n%s:%d recv data: CONTROLLERID is NULL: %s\n", __func__, __LINE__, (char *)data.raw_data.bytes);
+        } else if (input == COLOCATEDAGENTID) { 
+            if((bus_error_val = desc->bus_data_get_fn(&m_bus_hdl, DEVICE_WIFI_DATAELEMENTS_NETWORK_COLOCATEDAGENTID, &data)) != bus_error_success ) {
+                printf("%s:%d bus_data_get_fn failed with error: %d\n", __func__, __LINE__, bus_error_val);
+            }
+            printf("\n%s:%d recv data:COLOCATEDAGENTID=%s\n", __func__, __LINE__, (char *)data.raw_data.bytes);
+            get_bus_descriptor()->bus_data_free_fn(&data);
+        } else if (input == SETSSID) {
+            printf("\n%s:%d SET SSID start\n", __func__, __LINE__);
+            bus_data_obj_t *input_data = (bus_data_obj_t*)calloc(1, sizeof(bus_data_obj_t));
+            // Allocate on heap
+            bus_data_prop_t *add_prop  = (bus_data_prop_t*)calloc(1, sizeof(bus_data_prop_t));
+            bus_data_prop_t *band_prop = (bus_data_prop_t*)calloc(1, sizeof(bus_data_prop_t));
+            bus_data_prop_t *pass_prop = (bus_data_prop_t*)calloc(1, sizeof(bus_data_prop_t));
+            bus_data_prop_t *akm_prop  = (bus_data_prop_t*)calloc(1, sizeof(bus_data_prop_t));
+
+            raw_data_t *p_raw_data = (raw_data_t*)calloc(1, sizeof(raw_data_t));
+            input_data->data_prop.value.data_type = bus_data_type_string;
+            input_data->data_prop.value.raw_data.bytes = strdup("private_ssid"); // strdup allocates and copies string
+            input_data->data_prop.value.raw_data_len = strlen("private_ssid") + 1;
+
+            //1st prop
+            memset(&input_data->data_prop, 0, sizeof(bus_data_prop_t));
+            strncpy(input_data->data_prop.name, "SSID", BUS_MAX_NAME_LENGTH);
+            input_data->data_prop.name_len = strlen("SSID") + 1;
+            input_data->data_prop.value.data_type = bus_data_type_string;
+            input_data->data_prop.value.raw_data.bytes = strdup("atest");
+            input_data->data_prop.value.raw_data_len = strlen("atest") + 1;
+            input_data->data_prop.next_data = add_prop;
+
+            //2nd prop
+            // AddRemoveChange
+            add_prop->value.data_type = bus_data_type_string;
+            strncpy(add_prop->name, "AddRemoveChange", BUS_MAX_NAME_LENGTH);
+            add_prop->name_len = strlen("AddRemoveChange") + 1;
+            add_prop->value.raw_data.bytes = strdup("Add");
+            add_prop->value.raw_data_len = strlen("Add") + 1;
+            add_prop->next_data = band_prop;
+
+            //3rd prop
+            // Band
+            band_prop->value.data_type = bus_data_type_string;
+            strncpy(band_prop->name, "Band", BUS_MAX_NAME_LENGTH);
+            band_prop->name_len = strlen("Band") + 1;
+            band_prop->value.raw_data.bytes = strdup("2.4");
+            band_prop->value.raw_data_len = strlen("2.4") + 1;
+            band_prop->next_data = pass_prop;
+
+            // PassPhrase
+            pass_prop->value.data_type = bus_data_type_string;
+            strncpy(pass_prop->name, "PassPhrase", BUS_MAX_NAME_LENGTH);
+            pass_prop->name_len = strlen("PassPhrase") + 1;
+            pass_prop->value.raw_data.bytes = strdup("rdk@1234");
+            pass_prop->value.raw_data_len = strlen("rdk@1234") + 1;
+            pass_prop->next_data = akm_prop;
+
+            // AKMsAllowed
+            akm_prop->value.data_type = bus_data_type_string;
+                strncpy(akm_prop->name, "AKMsAllowed", BUS_MAX_NAME_LENGTH);
+            akm_prop->name_len = strlen("AKMsAllowed") + 1;
+            akm_prop->value.raw_data.bytes = strdup("psk");
+            akm_prop->value.raw_data_len = strlen("psk") + 1;
+            akm_prop->next_data = NULL;
+
+            // Fill input_data
+            input_data->num_prop = 5;
+
+            bus_data_prop_t *prop = &input_data->data_prop;
+            bus_data_prop_t *next;
+            int idx = 0;
+            printf("Total params: %d\n", idx);
+            while (prop) {
+                printf("  Param %d: name='%s', value='%s', len=%u\n", idx, prop->name, (char*)prop->value.raw_data.bytes, prop->value.raw_data_len);
+                prop = prop->next_data;
+                idx++;
+            }
+            if((bus_error_val = desc->bus_method_async_invoke_fn(&m_bus_hdl, \
+                (char const *) DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD, \
+                ( char const *)DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD, \
+                input_data, output_cb, BUS_METHOD_SET)) != bus_error_success ) {
+                printf("%s:%d bus_set_fn failed with error: %d\n", __func__, __LINE__, bus_error_val);
+            }
+
+            printf("%s:%d bus_set_fn SUCCESS: %d\n", __func__, __LINE__, bus_error_val);
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
Added initial framework for tr181 parameters as below, includes controller callback, trigger orchestrate and test code!
    - "Device.WiFi.DataElements.Network.ColocatedAgentID"
    - "Device.WiFi.DataElements.Network.ControllerID"

Also, enabled support for test code to work on RDKB builds

Tested using the test code: Network optimizer binary(Tested in linux/Rpi and RDKB/BPI)