### PR TITLE
Enabling AL_SAP by default in OpenWRT and updating current class and channel in network topology

### DIFF
--- a/build/openwrt/makefile.inc
+++ b/build/openwrt/makefile.inc
@@ -19,7 +19,7 @@
 OS = $(shell uname)
 PLATFORM = $(shell uname -a)
 
-WITH_SAP ?= 0
+WITH_SAP ?= 1
 ENABLE_DEBUG_MODE ?= OFF
 
 BASE = $(shell pwd)


### PR DESCRIPTION
Two commits added as part of this PR
1) In OpenWRT makefile enabling AL_SAP by default to use ieee1905 rust.
2) Add current operating class and channel in network topology encode