### PR TITLE
Changed DPP URI handling from JSON to standard URI

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -54,7 +54,7 @@ extern "C"
 
 // START: Hardcoded EasyConnect values
 #define DPP_VERSION 0x02
-#define DPP_URI_JSON_PATH "/nvram/DPPURI.json"
+#define DPP_URI_TXT_PATH "/nvram/DPPURI.txt"
 #define DPP_BOOT_PEM_PATH "/nvram/DPPURI.pem"
 #define DPP_SEC_CTX_DIR_PATH "/nvram"
 

--- a/src/cli/meshViews.go
+++ b/src/cli/meshViews.go
@@ -786,11 +786,11 @@ func (m *MeshViews) execSelectedCommand(cmdStr string, cmdType int) {
 	switch cmdType {
 	case GET:
 		if value.Title == DeviceOnboardingCmd {
-			nodes, err := readJSONFile("/tmp/DPPURI.json")
+			nodes, err := readDPPUriTxtFileToNodes("/tmp/DPPURI.txt")
 			if err != nil {
 				// fallback
-				spew.Fprintf(m.dump, "Error reading /tmp/DPPURI.json, trying current working directory: %v\n", err)
-				nodes, err = readJSONFile("DPPURI.json")
+				spew.Fprintf(m.dump, "Error reading /tmp/DPPURI.txt, trying current working directory: %v\n", err)
+				nodes, err = readDPPUriTxtFileToNodes("DPPURI.txt")
 				if err != nil {
 					spew.Fprintf(m.dump, "Error reading fallback DPPURI.json: %v\n", err)
 					return

--- a/src/cli/utils.go
+++ b/src/cli/utils.go
@@ -122,6 +122,8 @@ func readJSONFile(filePath string) ([]etree.Node, error) {
 	return nodes, nil
 }
 
+
+
 // convertNodesToJSON converts an etree.Node structure back into a generic interface{}
 // that can be marshaled to JSON. It handles objects, arrays, strings, numbers and booleans.
 //
@@ -185,6 +187,55 @@ func convertNodesToJSON(nodes []etree.Node) interface{} {
     }
     
     return nil
+}
+
+
+
+// readTextFileToNodes reads a text file, wraps its content in a JSON structure
+// with the "URI" key, and converts it to etree.Node structure.
+//
+// Parameters:
+//   - filePath: string path to the text file
+//
+// Returns:
+//   - []etree.Node: slice of nodes representing the JSON structure with URI key
+//   - error: any error encountered during file reading or conversion
+//
+// Example:
+//   If text file contains "DPP:C:81/1:some-key-here;"
+//   The resulting JSON structure will be:
+//   {
+//     "URI": "DPP:C:81/1:some-key-here;"
+//   }
+func readDPPUriTxtFileToNodes(filePath string) ([]etree.Node, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening file: %v", err)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file: %v", err)
+	}
+
+	// Trim whitespace/newlines from the content
+	uriContent := strings.TrimSpace(string(content))
+
+	// Create JSON structure with URI object containing URI key
+	jsonData := map[string]interface{}{
+		"URI": map[string]interface{}{
+			"URI": uriContent,
+		},
+	}
+
+	// Convert to nodes using existing function
+	nodes := convertJSONToNodes(jsonData)
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no nodes created from text file content")
+	}
+
+	return nodes, nil
 }
 
 // writeJSONFile writes an etree.Node structure to a JSON file.

--- a/src/dm/dm_dpp.cpp
+++ b/src/dm/dm_dpp.cpp
@@ -64,9 +64,21 @@ int dm_dpp_t::decode(const cJSON *obj, void *parent_id, void* user_info)
     if (user_info != NULL) {
         country_code = std::string(static_cast<char*>(user_info));
     }
+
+    // DPP Object is: 
+    /*
+    {
+    "URI" : "{DPP URI string here}"
+    }
+    */
+
+    cJSON* uri_json = cJSON_GetObjectItem(obj, "URI");
+    EM_ASSERT_NOT_NULL(uri_json, -1, "Failed to get URI from DPP JSON object");
+    char* uri_str = cJSON_GetStringValue(uri_json);
+    EM_ASSERT_NOT_NULL(uri_str, -1, "Failed to get URI string from DPP JSON object");
 		
-    if (!ec_util::decode_bootstrap_data_json(obj, &m_dpp_info, country_code)){
-        printf("%s:%d: Failed to decode DPP data\n", __func__, __LINE__);
+    if (!ec_util::decode_bootstrap_data_uri(std::string(uri_str), &m_dpp_info, country_code)){
+        em_printfout("Failed to decode DPP data");
         return -1;
     }
 		


### PR DESCRIPTION
Note: There still has to be some use of JSON because the "CLI" uses JSON when sending data but the actual URI is saved and read as the normal format. 

For example. 
```bash
root@OpenWrt:~# cat /nvram/DPPURI.txt
DPP:V:2;M:a22efd60e5c9;C:81/12;K:MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1oFWzqZ0mQF6HQt5ulPzAZUgHM8w75SWpFSxdSmxHsoFJG1Mufln+7BTYUiH4kXghol1hX6hxO5VhfPzTnm8QA==;;
```
