### PR TITLE
Secure co-located agent with 1905 layer

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -52,6 +52,11 @@ extern "C"
  */
 //#define FEATURE_RECV_FREQ_ACT_SUB 
 
+// Enable support for 1905-layer securing on a colocated agent (onboarding using WSC onboarding)
+// This is enabled right now since currently the layer is not encrypted so functionality won't be broken
+// but when SoftHSM is hooked up and the layer is encrypted, this can commented out to disable the feature
+#define ENABLE_COLOCATED_1905_SECURE
+
 // START: Hardcoded EasyConnect values
 #define DPP_VERSION 0x02
 #define DPP_URI_TXT_PATH "/nvram/DPPURI.txt"

--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -25,7 +25,7 @@ public:
 	 * @param sec_ctx The existing security context. Either generated elsewhere or imported from the enrollee.
 	 * @param is_colocated_agent True if this is a co-located agent, false if it is a non-colocated agent or a controller.
 	 */
-	ec_configurator_t(const std::string& al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t& sec_ctx, bool is_colocated_agent);
+	ec_configurator_t(const std::string& al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t& sec_ctx, bool is_colocated_agent, handshake_completed_handler handshake_complete);
     
 	/**!
 	 * @brief Destructor for ec_configurator_t class.

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -29,7 +29,7 @@ public:
 	 * @param[in] sec_ctx The security context containing C-signing key, PPK, NAK, and Connector.
 	 * @note This constructor initializes the base class ec_configurator_t with the provided parameters.
 	 */
-	ec_ctrl_configurator_t(const std::string& al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t sec_ctx);
+	ec_ctrl_configurator_t(const std::string& al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t sec_ctx, handshake_completed_handler handshake_complete);
 
 	/**
 	 * @brief Handle a chirp notification message TLV and direct it to the 1905 agent.

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -23,7 +23,7 @@ public:
 	 * @param is_controller Whether the EM node holding this manager is the mesh controller or not.
 	 * @param sec_ctx The existing security context for the node.
 	 */
-	ec_manager_t(const std::string& al_mac_addr, ec_ops_t& ops, bool is_controller, std::optional<ec_persistent_sec_ctx_t> sec_ctx);
+	ec_manager_t(const std::string& al_mac_addr, ec_ops_t& ops, bool is_controller, std::optional<ec_persistent_sec_ctx_t> sec_ctx, handshake_completed_handler cfg_handshake_complete);
     
 	/**!
 	 * @brief Destructor for ec_manager_t class.
@@ -383,6 +383,7 @@ private:
     std::unique_ptr<ec_configurator_t> m_configurator;
     std::unique_ptr<ec_enrollee_t> m_enrollee;
     toggle_cce_func m_toggle_cce_fn;
+	handshake_completed_handler m_handshake_complete;
 };
 
 #endif // EC_MANAGER_H

--- a/inc/ec_pa_configurator.h
+++ b/inc/ec_pa_configurator.h
@@ -25,7 +25,7 @@ public:
 	 *
 	 * @note This constructor is part of the ec_pa_configurator_t class which extends ec_configurator_t.
 	 */
-	ec_pa_configurator_t(const std::string& al_mac_addr, const std::vector<uint8_t>& ctrl_al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t& sec_ctx, bool is_colocated);
+	ec_pa_configurator_t(const std::string& al_mac_addr, const std::vector<uint8_t>& ctrl_al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t& sec_ctx, bool is_colocated, handshake_completed_handler handshake_complete);
     
 	/**
 	 * @brief Handles a presence announcement 802.11 frame, performing the necessary actions and possibly passing to 1905.

--- a/inc/em.h
+++ b/inc/em.h
@@ -38,6 +38,12 @@
 #include <set>
 #include <string>
 
+enum peer_1905_security_status {
+	PEER_1905_SECURITY_NOT_STARTED = 0,
+	PEER_1905_SECURITY_IN_PROGRESS,
+	PEER_1905_SECURITY_SECURED
+};
+
 class em_mgr_t;
 class em_cmd_exec_t;
 
@@ -66,7 +72,8 @@ class em_t :
 
 	bool m_is_dpp_onboarding = false;
 
-    
+	std::map<std::string, peer_1905_security_status> m_1905_layer_peer_security_statuses;
+
 	/**!
 	 * @brief Executes the protocol run sequence.
 	 *
@@ -1234,6 +1241,23 @@ public:
 
 	bool get_devteststatus(){return dev_test_enable;}
 	void set_devteststatus(bool enable ) { dev_test_enable = enable;} 
+
+
+	void cfg_1905_handshake_complete_handler(uint8_t peer_al_mac[ETH_ALEN], bool is_group_key);
+
+	peer_1905_security_status get_peer_1905_security_status(uint8_t peer_al_mac[ETH_ALEN]){
+		std::string mac_str = util::mac_to_string(peer_al_mac);
+		if(m_1905_layer_peer_security_statuses.find(mac_str) != m_1905_layer_peer_security_statuses.end()){
+			return m_1905_layer_peer_security_statuses[mac_str];
+		}
+		return peer_1905_security_status::PEER_1905_SECURITY_NOT_STARTED;
+	}
+
+	void set_peer_1905_security_status(uint8_t peer_al_mac[ETH_ALEN], peer_1905_security_status status){
+		std::string mac_str = util::mac_to_string(peer_al_mac);
+		m_1905_layer_peer_security_statuses[mac_str] = status;
+	}
+
 	/**!
 	 * @brief Initializes the EasyMesh interface with the specified parameters.
 	 *

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -3761,8 +3761,16 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
     if ((dm != NULL) && (hdr != NULL)) {
         memcpy(&network.m_net_info.ctrl_id.mac, &hdr->src, sizeof(mac_address_t));
         dm->set_network(network);
-        if (get_mgr()->get_al_node() != NULL) {
+        em_t* al_node = get_mgr()->get_al_node();
+        if (al_node != NULL) {
             get_ec_mgr().upgrade_to_onboarded_proxy_agent(hdr->src);
+#ifdef ENABLE_COLOCATED_1905_SECURE
+            if (al_node->get_peer_1905_security_status(hdr->src) == peer_1905_security_status::PEER_1905_SECURITY_NOT_STARTED) {
+                al_node->set_peer_1905_security_status(hdr->src, peer_1905_security_status::PEER_1905_SECURITY_IN_PROGRESS);
+                get_ec_mgr().start_secure_1905_layer(hdr->src);
+            }
+#endif
+
         }
     }
     return 0;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1911,9 +1911,16 @@ bool em_t::initialize_ec_manager(){
         mac_address,
         ops,
         service_type == em_service_type_ctrl,
-        ctx
+        ctx,
+        std::bind(&em_t::cfg_1905_handshake_complete_handler, this, 
+                  std::placeholders::_1, std::placeholders::_2)
     );
     return true;
+}
+
+void em_t::cfg_1905_handshake_complete_handler(uint8_t peer_al_mac[ETH_ALEN], bool is_group_key){
+    // TODO: I'm sure more is needed here
+    set_peer_1905_security_status(peer_al_mac, peer_1905_security_status::PEER_1905_SECURITY_SECURED);
 }
 
 em_t::em_t(em_interface_t *ruid, em_freq_band_t band, dm_easy_mesh_t *dm, em_mgr_t *mgr, em_profile_type_t profile, em_service_type_t type, bool is_al_em): m_data_model(), m_mgr(mgr), m_orch_state(), m_cmd(), m_sm(), m_service_type(), m_fd(0), m_ruid(*ruid), m_band(band), m_profile_type(profile), m_iq(), m_tid(), m_exit(), m_is_al_em(is_al_em)

--- a/src/em/prov/easyconnect/ec_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_configurator.cpp
@@ -3,7 +3,7 @@
 #include "ec_util.h"
 #include "util.h"
 
-ec_configurator_t::ec_configurator_t(const std::string &al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t& sec_ctx, bool is_colocated_agent)
+ec_configurator_t::ec_configurator_t(const std::string &al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t& sec_ctx, bool is_colocated_agent, handshake_completed_handler handshake_complete)
     : m_al_mac_addr(al_mac_addr), m_is_colocated_agent(is_colocated_agent)
 {
     m_send_chirp_notification    = ops.send_chirp;
@@ -22,8 +22,7 @@ ec_configurator_t::ec_configurator_t(const std::string &al_mac_addr, ec_ops_t& o
         al_mac_addr, 
         ops.send_dir_encap_dpp, 
         ops.send_1905_eapol_encap,
-        std::bind(&ec_configurator_t::handle_1905_handshake_completed, 
-                  this, std::placeholders::_1, std::placeholders::_2));
+        handshake_complete);
 
     if (!sec_ctx.C_signing_key || !sec_ctx.pp_key || !sec_ctx.net_access_key || !sec_ctx.connector) {
         em_printfout("Key(s) missing, cannot secure 1905 layer!");

--- a/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
@@ -8,8 +8,8 @@
 #include "em_crypto.h"
 #include <netinet/in.h>
 
-ec_ctrl_configurator_t::ec_ctrl_configurator_t(const std::string& al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t sec_ctx) :
-                                               ec_configurator_t(al_mac_addr, ops, sec_ctx, false)
+ec_ctrl_configurator_t::ec_ctrl_configurator_t(const std::string& al_mac_addr, ec_ops_t& ops, ec_persistent_sec_ctx_t sec_ctx, handshake_completed_handler handshake_complete) :
+                                               ec_configurator_t(al_mac_addr, ops, sec_ctx, false, handshake_complete)
 {
 
     // Generate completely random GMK on startup.

--- a/src/em/prov/easyconnect/ec_manager.cpp
+++ b/src/em/prov/easyconnect/ec_manager.cpp
@@ -6,8 +6,8 @@
 
 #include <memory>
 
-ec_manager_t::ec_manager_t(const std::string& al_mac_addr, ec_ops_t& ops, bool is_controller, std::optional<ec_persistent_sec_ctx_t> sec_ctx)
-    : m_is_controller(is_controller),  m_ops(ops), m_stored_al_mac_addr(al_mac_addr) {
+ec_manager_t::ec_manager_t(const std::string& al_mac_addr, ec_ops_t& ops, bool is_controller, std::optional<ec_persistent_sec_ctx_t> sec_ctx, handshake_completed_handler cfg_handshake_complete)
+    : m_is_controller(is_controller),  m_ops(ops), m_stored_al_mac_addr(al_mac_addr), m_handshake_complete(cfg_handshake_complete) {
 
     printf("EC Manager created with MAC: %s\n", al_mac_addr.c_str());  
     if (m_is_controller) {
@@ -17,7 +17,7 @@ ec_manager_t::ec_manager_t(const std::string& al_mac_addr, ec_ops_t& ops, bool i
         }
 
         m_configurator = std::unique_ptr<ec_ctrl_configurator_t>(
-            new ec_ctrl_configurator_t(al_mac_addr, ops, *sec_ctx)
+            new ec_ctrl_configurator_t(al_mac_addr, ops, *sec_ctx, cfg_handshake_complete)
         );
     } else {
         m_enrollee = std::unique_ptr<ec_enrollee_t>(
@@ -161,7 +161,7 @@ bool ec_manager_t::upgrade_to_onboarded_proxy_agent(uint8_t ctrl_al_mac[ETH_ALEN
     
     // Create a new proxy agent configurator
     std::vector<uint8_t> ctrl_al_mac_vec(ctrl_al_mac, ctrl_al_mac + ETH_ALEN);
-    m_configurator = std::unique_ptr<ec_pa_configurator_t>(new ec_pa_configurator_t(m_stored_al_mac_addr, ctrl_al_mac_vec, m_ops, sec_ctx, is_colocated));
+    m_configurator = std::unique_ptr<ec_pa_configurator_t>(new ec_pa_configurator_t(m_stored_al_mac_addr, ctrl_al_mac_vec, m_ops, sec_ctx, is_colocated, m_handshake_complete));
     em_printfout("Upgraded enrollee agent to proxy agent");
     return true;
 }

--- a/src/em/prov/easyconnect/ec_pa_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_pa_configurator.cpp
@@ -3,8 +3,8 @@
 #include "ec_util.h"
 
 ec_pa_configurator_t::ec_pa_configurator_t(const std::string& al_mac_addr, const std::vector<uint8_t>& ctrl_al_mac_addr,
-                                           ec_ops_t& ops, ec_persistent_sec_ctx_t& sec_ctx, bool is_colocated)
-                                            : ec_configurator_t(al_mac_addr, ops, sec_ctx, is_colocated)
+                                           ec_ops_t& ops, ec_persistent_sec_ctx_t& sec_ctx, bool is_colocated, handshake_completed_handler handshake_complete)
+                                            : ec_configurator_t(al_mac_addr, ops, sec_ctx, is_colocated, handshake_complete)
 {
     m_toggle_cce = ops.toggle_cce;
     m_send_chirp_notification = ops.send_chirp;
@@ -372,7 +372,12 @@ bool ec_pa_configurator_t::process_direct_encap_dpp_msg(uint8_t* dpp_frame, uint
         case ec_frame_type_recfg_auth_req: {
             break;
         }
+        case ec_frame_type_peer_disc_req: {
+            did_finish = handle_peer_disc_req_frame(ec_frame, dpp_frame_len, src_mac);
+            break;
+        }
         case ec_frame_type_peer_disc_rsp: {
+            did_finish = handle_peer_disc_resp_frame(ec_frame, dpp_frame_len, src_mac);
             break;
         }
         default:


### PR DESCRIPTION
Since the keys are currently not installed into SoftHSM (not sending keys to the IEEE1906 layer) this does not break any current functionality (no traffic is encrypted). 

When those keys do become installed, then all non-colocated devices will need to be onboarded with DPP (Ethernet or wireless). Preemptively, when that point is reached, the `ENABLE_COLOCATED_1905_SECURE` macro can be disabled to allow for the current un-encrypted traffic method to work (although they won't be able to communicate with DPP devices in any case due to spec constraints)