### PR TITLE
EasyMesh: Set relay_ind flag for AP_AUTOCONFIGURATION_SEARCH messages

### DIFF
--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -364,6 +364,19 @@ unsigned char* em_msg_t::add_1905_header(unsigned char *buff, unsigned int *len,
     tmp = em_msg_t::add_buff_element(tmp, len, reinterpret_cast<uint8_t *>(src), sizeof(mac_address_t));
     tmp = em_msg_t::add_buff_element(tmp, len, reinterpret_cast<uint8_t *> (&type), sizeof(uint16_t));
 
+    // Set relay_ind based on message type
+    uint8_t relay_ind = 0;
+    switch (msg_type) {
+        case em_msg_type_autoconf_search:
+        case em_msg_type_autoconf_renew:
+        case em_msg_type_topo_notif:
+            relay_ind = 1;
+            break;
+        default:
+            relay_ind = 0;
+            break;
+    }
+
     em_cmdu_t cmdu = {
         .ver = 0,
         .reserved = 0,
@@ -371,7 +384,7 @@ unsigned char* em_msg_t::add_1905_header(unsigned char *buff, unsigned int *len,
         .id = htons(msg_id),
         .frag_id = 0,
         .reserved_field = 0,
-        .relay_ind = 0,
+        .relay_ind = relay_ind,
         .last_frag_ind = 1
     };
 


### PR DESCRIPTION
Added logic in add_1905_header() to set the relay_ind field to 1 for AP_AUTOCONFIGURATION_SEARCH messages, enabling proper relay indication in CMDU headers as per IEEE 1905.1 relay behavior.

Introduced a switch-case structure to allow easy extension for other message types that require relay indication. To support additional messages, simply add a new case for the corresponding message type.

closes: RDKBACCL-1164
Signed-off-by: Sundram Patel <sundram.p@tataelxsi.co.in>