### PR TITLE
RDKBACCL-1161: Fill appropriate Message ID in CMDU header as per spec

### DIFF
--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -236,10 +236,11 @@ public:
 	 * @param chirp The DPP chirp.
 	 * @param len The length of the chirp hash (can be 0).
 	 * @param src_mac Where it came from (Enrollee).
+	 * @param msg_id The message ID of the Autoconf Search (extended) message.
 	 * @return true on success, otherwise false.
 	 * 
 	 */
-	virtual bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN]) {
+	virtual bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id) {
 		// impl'd by Controller Configurator only
 		return false;
 	} 

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -89,7 +89,7 @@ public:
 	 * @return true on success, otherwise false.
 	 * 
 	 */
-	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN]) override;
+	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id) override;
 
     
 	/**

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -291,9 +291,9 @@ public:
 	 * @return true on success, otherwise false.
 	 * 
 	 */
-	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN]) {
+	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id) {
 		if (m_configurator) {
-			return m_configurator->handle_autoconf_chirp(chirp, len, src_mac);
+			return m_configurator->handle_autoconf_chirp(chirp, len, src_mac, msg_id);
 		}
 		// Not valid for Enrollee
 		return false;

--- a/inc/ec_ops.h
+++ b/inc/ec_ops.h
@@ -54,7 +54,7 @@ using send_autoconf_search_func = std::function<bool(em_dpp_chirp_value_t *, siz
  * @return True on success otherwise false
  * 
  */
-using send_autoconf_search_resp_func = std::function<bool(em_dpp_chirp_value_t *, size_t, uint8_t[ETH_ALEN])>;
+using send_autoconf_search_resp_func = std::function<bool(em_dpp_chirp_value_t *, size_t, uint8_t[ETH_ALEN], unsigned short msg_id)>;
 
 /**
  * @brief Sends a chirp notification

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -654,10 +654,10 @@ typedef struct {
 } __attribute__((__packed__)) em_cce_indication_t;
 
 typedef struct {
-    unsigned char enrollee_mac_addr_present : 1;
-    unsigned char reserved : 1;
+    unsigned char reserved : 5;
     unsigned char dpp_frame_indicator : 1;
-    unsigned char reserved2 : 5;
+    unsigned char reserved2 : 1;
+    unsigned char enrollee_mac_addr_present : 1;
 /*
     Contains:
         - dest_mac_addr (6 bytes, if enrollee_mac_addr_present)
@@ -695,9 +695,9 @@ typedef struct {
     mac_address_t ruid;
     unsigned char op_lass;
     unsigned char channel;
-    unsigned char cas_method : 3;
-    unsigned char cac_completion_action : 3;
     unsigned char reserved : 2;
+    unsigned char cac_completion_action : 3;
+    unsigned char cas_method : 3;
 }__attribute__((__packed__)) em_cac_req_t;
 
 typedef struct {
@@ -768,8 +768,8 @@ typedef struct {
 } __attribute__((__packed__)) em_channel_scan_req_op_class_t;
 
 typedef struct {
-    unsigned char perform_fresh_scan : 1;
     unsigned char reserved : 7;
+    unsigned char perform_fresh_scan : 1;
     unsigned char num_radios;
     mac_address_t ruid;
     unsigned char num_op_classes;
@@ -816,11 +816,11 @@ typedef struct {
 
 typedef struct {
     bssid_t bssid;
-    unsigned char req_mode : 1;
-    unsigned char btm_dissoc_imminent : 1;
-    unsigned char btm_abridged : 1;
-    unsigned char btm_link_removal_imminent : 1;
     unsigned char reserved : 4;
+    unsigned char btm_link_removal_imminent : 1;
+    unsigned char btm_abridged : 1;
+    unsigned char btm_dissoc_imminent : 1;
+    unsigned char req_mode : 1;
     unsigned short steering_opportunity_window;
     unsigned short btm_dissoc_timer;
     unsigned char sta_list_count;
@@ -973,11 +973,11 @@ typedef struct {
     bssid_t bssid;
     unsigned char channel_util;
     unsigned short num_sta;
-    unsigned char est_service_params_BE_bit : 1;
-    unsigned char est_service_params_BK_bit : 1;
-    unsigned char est_service_params_VO_bit : 1;
-    unsigned char est_service_params_VI_bit : 1;
     unsigned char reserved : 4;
+    unsigned char est_service_params_VI_bit : 1;
+    unsigned char est_service_params_VO_bit : 1;
+    unsigned char est_service_params_BK_bit : 1;
+    unsigned char est_service_params_BE_bit : 1;
     unsigned char est_service_params_BE[3];
     unsigned char est_service_params_BK[3];
     unsigned char est_service_params_VO[3];
@@ -1045,15 +1045,15 @@ typedef struct {
 
 typedef struct {
     mac_address_t ruid;
-    unsigned char reserved1 : 1;
-    unsigned char partial_bss_color : 1;
     unsigned char bss_color : 6;
-    unsigned char reserved2 : 3;
-    unsigned char hesiga_spatial_reuse_value15_allowed : 1;
-    unsigned char srg_info_valid : 1;
-    unsigned char non_srg_offset_valid : 1;
-    unsigned char reserved3 : 1;
+    unsigned char partial_bss_color : 1;
+    unsigned char reserved1 : 1;
     unsigned char psr_disallowed : 1;
+    unsigned char reserved2 : 1;
+    unsigned char non_srg_offset_valid : 1;
+    unsigned char srg_info_valid : 1;
+    unsigned char hesiga_spatial_reuse_value15_allowed : 1;
+    unsigned char reserved3 : 3;
     unsigned char non_srg_obsspd_max_offset;
     unsigned char srg_obsspd_min_offset;
     unsigned char srg_obsspd_max_offset;
@@ -1116,14 +1116,14 @@ typedef struct {
 
 typedef struct {
     mac_address_t ruid;
-    unsigned char reserved1 : 2;
     unsigned char bss_color : 6;
-    unsigned char reserved2 : 3;
-    unsigned char hesiga_spatial_reuse_value15_allowed : 1;
-    unsigned char srg_info_valid : 1;
-    unsigned char non_srg_offset_valid : 1;
-    unsigned char reserved3: 1;
+    unsigned char reserved1: 2;
     unsigned char psr_disallowed : 1;
+    unsigned char reserved2 : 1;
+    unsigned char non_srg_offset_valid : 1;
+    unsigned char srg_info_valid : 1;
+    unsigned char hesiga_spatial_reuse_value15_allowed : 1;
+    unsigned char reserved3 : 3;
     unsigned char non_srg_obsspd_max_offset;
     unsigned char srg_obsspd_min_offset;
     unsigned char srg_obsspd_max_offset;
@@ -1331,8 +1331,8 @@ typedef struct {
 
 typedef struct {
     unsigned short primary_vlan_id;
-    unsigned char  default_pcp : 3;
     unsigned char  reserved : 5;
+    unsigned char  default_pcp : 3;
 } __attribute__((__packed__)) em_8021q_settings_t;
 
 typedef struct {
@@ -1371,8 +1371,8 @@ typedef struct {
 } __attribute__((__packed__)) em_akm_suite_info_t;
 typedef struct {
     mac_address_t  ruid;
-    unsigned char  bsta_mac_present : 1;
     unsigned char  reserved : 7;
+    unsigned char  bsta_mac_present : 1;
     mac_address_t  bsta_addr;
 } __attribute__((__packed__)) em_bh_sta_radio_cap_t;
 
@@ -1384,22 +1384,22 @@ typedef struct {
 typedef struct {
     unsigned char  max_prior_rule;
     unsigned char  reserved1;
-    unsigned char  byte_counter_units : 2;
-    unsigned char  prioritization : 1;
-    unsigned char  dpp_onboarding : 1;
-    unsigned char  traffic_separation : 1;
     unsigned char  reserved2 : 3;
+    unsigned char  traffic_separation : 1;
+    unsigned char  dpp_onboarding : 1;
+    unsigned char  prioritization : 1;
+    unsigned char  byte_counter_units : 2;
     unsigned char  max_vid_count;
 } __attribute__((__packed__)) em_profile_2_ap_cap_t;
 
 typedef struct {
     unsigned int   rule_id;
-    unsigned char  add_rule : 1;
     unsigned char  reserved1 : 7;
+    unsigned char  add_rule : 1;
     unsigned char  rule_precedence;
     unsigned char  rule_output;
-    unsigned char  always_match : 1;
     unsigned char  reserved2 : 7;
+    unsigned char  always_match : 1;
 } __attribute__((__packed__)) em_service_prio_rule_t;
 
 typedef struct {
@@ -1500,74 +1500,76 @@ typedef struct {
 
 typedef struct {
     mac_address_t  ruid;
-    unsigned char  max_sprt_tx_streams : 2;
-    unsigned char  max_sprt_rx_streams : 2;
-    unsigned char  gi_sprt_20mhz : 1;
-    unsigned char  gi_sprt_40mhz : 1;
-    unsigned char  ht_sprt_40mhz : 1;
     unsigned char  reserved : 1;
+    unsigned char  ht_sprt_40mhz : 1;
+    unsigned char  gi_sprt_40mhz : 1;
+    unsigned char  gi_sprt_20mhz : 1;
+    unsigned char  max_sprt_rx_streams : 2;
+    unsigned char  max_sprt_tx_streams : 2;
 } __attribute__((__packed__)) em_ap_ht_cap_t;
 
 typedef struct {
     mac_address_t  ruid;
     unsigned short sprt_tx_mcs;
     unsigned short sprt_rx_mcs;
-    unsigned char  max_sprt_tx_streams : 3;
-    unsigned char  max_sprt_rx_streams : 3;
-    unsigned char  gi_sprt_80mhz : 1;
     unsigned char  gi_sprt_160mhz : 1;
-    unsigned char  sprt_80_80_mhz : 1;
-    unsigned char  sprt_160mhz : 1;
-    unsigned char  su_beamformer_cap : 1;
-    unsigned char  mu_beamformer_cap : 1;
+    unsigned char  gi_sprt_80mhz : 1;
+    unsigned char  max_sprt_rx_streams : 3;
+    unsigned char  max_sprt_tx_streams : 3;
     unsigned char  reserved : 4;
+    unsigned char  mu_beamformer_cap : 1;
+    unsigned char  su_beamformer_cap : 1;
+    unsigned char  sprt_160mhz : 1;
+    unsigned char  sprt_80_80_mhz : 1;
 } __attribute__((__packed__)) em_ap_vht_cap_t;
 
 typedef struct {
     mac_address_t  ruid;
     unsigned char  sprt_mcs_len;
     unsigned short sprt_tx_rx_mcs[MAX_MCS];
-    unsigned char  max_sprt_tx_streams : 3;
-    unsigned char  max_sprt_rx_streams : 3;
-    unsigned char  sprt_80_80_mhz : 1;
     unsigned char  sprt_160mhz : 1;
-    unsigned char  su_beamformer_cap : 1;
-    unsigned char  mu_beamformer_cap : 1;
-    unsigned char  ul_mimo_cap : 1;
-    unsigned char  ul_mimo_ofdma_cap : 1;
-    unsigned char  dl_mimo_ofdma_cap : 1;
-    unsigned char  ul_ofdma_cap : 1;
-    unsigned char  dl_ofdma_cap : 1;
+    unsigned char  sprt_80_80_mhz : 1;
+    unsigned char  max_sprt_rx_streams : 3;
+    unsigned char  max_sprt_tx_streams : 3;
     unsigned char  reserved : 1;
+    unsigned char  dl_ofdma_cap : 1;
+    unsigned char  ul_ofdma_cap : 1;
+    unsigned char  dl_mimo_ofdma_cap : 1;
+    unsigned char  ul_mimo_ofdma_cap : 1;
+    unsigned char  ul_mimo_cap : 1;
+    unsigned char  mu_beamformer_cap : 1;
+    unsigned char  su_beamformer_cap : 1;
 } __attribute__((__packed__))em_ap_he_cap_t;
 
 
 typedef struct {
-    unsigned char  agent_role : 2;
-    unsigned char  he_160 : 1;
-    unsigned char  he_8080 : 1;
+    mac_address_t  ruid;
+    unsigned char  num_role;
     unsigned char  mcs_nss_num : 4;
+    unsigned char  he_8080 : 1;
+    unsigned char  he_160 : 1;
+    unsigned char  agent_role : 2;
     unsigned short mcs_nss[MAX_MCS_NSS];
-    unsigned char  su_beam_former : 1;
-    unsigned char  su_beam_formee : 1;
-    unsigned char  mu_beam_former : 1;
-    unsigned char  beam_formee_sts_l80 : 1;
-    unsigned char  beam_formee_sts_g80 : 1;
-    unsigned char  ul_mumimo : 1;
-    unsigned char  ul_ofdma : 1;
     unsigned char  dl_ofdma : 1;
-    unsigned char  max_dl_mumimo_tx : 4;
+    unsigned char  ul_ofdma : 1;
+    unsigned char  ul_mumimo : 1;
+    unsigned char  beam_formee_sts_g80 : 1;
+    unsigned char  beam_formee_sts_l80 : 1;
+    unsigned char  mu_beam_former : 1;
+    unsigned char  su_beam_formee : 1;
+    unsigned char  su_beam_former : 1;
     unsigned char  max_ul_mumimo_rx : 4;
+    unsigned char  max_dl_mumimo_tx : 4;
     unsigned char  max_dl_ofdma_tx;
     unsigned char  max_ul_ofdma_rx;
-    unsigned char  rts : 1;
-    unsigned char  mu_rts : 1;
-    unsigned char  multi_bssid : 1;
-    unsigned char  mu_edca : 1;
-    unsigned char  twt_req : 1;
-    unsigned char  twt_resp : 1;
+    unsigned char  anticipated_channel_usage : 1;
     unsigned char  spatial_reuse : 1;
-    unsigned char  reserved : 1;
+    unsigned char  twt_resp : 1;
+    unsigned char  twt_req : 1;
+    unsigned char  mu_edca : 1;
+    unsigned char  multi_bssid : 1;
+    unsigned char  mu_rts : 1;
+    unsigned char  rts : 1;
 } __attribute__((__packed__)) em_radio_wifi6_cap_data_t;
 
 typedef struct {
@@ -1578,8 +1580,8 @@ typedef struct {
 
 typedef struct {
     mac_address_t ruid;
-    unsigned char freq_sep : 5;
     unsigned char reserved : 3;
+    unsigned char freq_sep : 5;
 } __attribute__((__packed__)) em_radio_wifi7_freq_record_t;
 
 typedef struct {
@@ -1589,26 +1591,26 @@ typedef struct {
 
 typedef struct {
     unsigned char max_num_mlds;
-    unsigned char ap_max_links : 4;
-    unsigned char bsta_max_links : 4;
-    unsigned char tid_link_mapping_cap : 2;
     unsigned char reserved1 : 6;
+    unsigned char tid_link_mapping_cap : 2;
+    unsigned char bsta_max_links : 4;
+    unsigned char ap_max_links : 4;
     unsigned char reserved2[13];
 } __attribute__((__packed__)) em_radio_wifi7_cap_data_t;
 
 typedef struct {
     mac_address_t ruid;
     unsigned char reserved3[24];
-    unsigned char ap_str_support : 1;
-    unsigned char ap_nstr_support : 1;
-    unsigned char ap_emlsr_support : 1;
-    unsigned char ap_emlmr_support : 1;
     unsigned char reserved4 : 4;
-    unsigned char bsta_str_support : 1;
-    unsigned char bsta_nstr_support : 1;
-    unsigned char bsta_emlrs_support : 1;
-    unsigned char bsta_emlmr_support : 1;
+    unsigned char ap_emlmr_support : 1;
+    unsigned char ap_emlsr_support : 1;
+    unsigned char ap_nstr_support : 1;
+    unsigned char ap_str_support : 1;
     unsigned char reserved5 : 4;
+    unsigned char bsta_emlmr_support : 1;
+    unsigned char bsta_emlsr_support : 1;
+    unsigned char bsta_nstr_support : 1;
+    unsigned char bsta_str_support : 1;
     em_radio_wifi7_freq_records_t ap_str;
     em_radio_wifi7_freq_records_t ap_nstr;
     em_radio_wifi7_freq_records_t ap_emlsr;
@@ -1627,12 +1629,12 @@ typedef struct {
 
 typedef struct {
     mac_address_t bssid;
-    unsigned char op_info_valid : 1;
-    unsigned char disabled_subchannel_valid : 1;
-    unsigned char default_pe_duration : 1;
-    unsigned char group_addr_bu_ind_limit : 1;
-    unsigned char group_addr_bu_ind_exp : 2;
     unsigned char reserved1 : 2;
+    unsigned char group_addr_bu_ind_exp : 2;
+    unsigned char group_addr_bu_ind_limit : 1;
+    unsigned char default_pe_duration : 1;
+    unsigned char disabled_subchannel_valid : 1;
+    unsigned char op_info_valid : 1;
     unsigned char eht_msc_nss_set[4];
     unsigned char control;
     unsigned char ccfs0;
@@ -1664,8 +1666,9 @@ typedef struct {
 
 typedef struct {
     mac_address_t  ruid;
-    unsigned char  boot_only : 1;
+    unsigned char  reserved : 5;
     unsigned char  scan_impact : 2;
+    unsigned char  boot_only : 1;
     unsigned int   min_scan_interval;
     unsigned char  op_classes_num;
     em_op_class_t  op_classes[EM_MAX_OP_CLASS];
@@ -1733,21 +1736,21 @@ typedef struct {
 } __attribute__((__packed__)) em_metric_rprt_policy_t;
 
 typedef struct {
-   unsigned char rprt_ind_ch_scan : 1;
    unsigned char reserved : 7;
+   unsigned char rprt_ind_ch_scan : 1;
 } __attribute__((__packed__)) em_channel_scan_rprt_policy_t;
 
 typedef struct {
-    unsigned char  rprt_flag : 1;
     unsigned char  reserved : 7;
+    unsigned char  rprt_flag : 1;
     unsigned int   max_rprt_rate;
 } __attribute__((__packed__)) em_unsuccessful_assoc_policy_t;
 
 typedef struct {
     mac_address_t  bssid;
-    unsigned char  p1_bsta_disallowed : 1;
-    unsigned char  p2_bsta_disallowed : 1;
     unsigned char  reserved : 6;
+    unsigned char  p2_bsta_disallowed : 1;
+    unsigned char  p1_bsta_disallowed : 1;
 } __attribute__((__packed__)) em_bh_bss_config_t;
 
 typedef struct {
@@ -1785,7 +1788,8 @@ typedef struct {
 } __attribute__((__packed__)) em_searched_service_t;
 
 typedef struct {
-    unsigned char   reserved:5;
+    unsigned char   reserved:4;
+    unsigned char   m8_bsta_reconfiguration:1;
     unsigned char   rcpi_steering:1;
     unsigned char   unassociated_client_link_metrics_non_op_channels:1;
     unsigned char   unassociated_client_link_metrics_op_channels:1;
@@ -1794,13 +1798,14 @@ typedef struct {
 
 typedef struct {
     mac_address_t   ruid;
-    unsigned char   comb_front_back : 1;
-    unsigned char   comp_prof1_prof2 : 1;
-    unsigned char   mscs : 1;
-    unsigned char   scs : 1;
-    unsigned char   qos_map : 1;
+    unsigned char   reserved : 1;
+    unsigned char   qm_scs_traffic_description : 1;
     unsigned char   dscp_policy : 1;
-    unsigned char   reserved : 2;
+    unsigned char   qos_map : 1;
+    unsigned char   scs : 1;
+    unsigned char   mscs : 1;
+    unsigned char   comp_prof1_prof2 : 1;
+    unsigned char   comb_front_back : 1;
 } __attribute__((__packed__)) em_ap_radio_advanced_cap_t;
 
 typedef enum {
@@ -1816,9 +1821,9 @@ typedef enum {
 } em_media_type_t;
 
 typedef struct {
-    uint8_t mac_present : 1;  // Bit 7: Enrollee MAC Address Present
-    uint8_t hash_valid : 1;   // Bit 6: Hash Validity
     uint8_t reserved : 6;     // Bits 5-0: Reserved
+    uint8_t hash_valid : 1;   // Bit 6: Hash Validity
+    uint8_t mac_present : 1;  // Bit 7: Enrollee MAC Address Present
     uint8_t data[0];           // Flexible array for MAC address (if present) + hash length + hash value
 } __attribute__((__packed__)) em_dpp_chirp_value_t;
 
@@ -2496,9 +2501,9 @@ typedef struct {
 } __attribute__((__packed__)) em_ap_mld_ssids_t;
 
 typedef struct {
-    unsigned char affiliated_mac_addr_valid : 1;
+    unsigned char reserved1 : 6;
     unsigned char link_id_valid : 1;
-    unsigned char reseverd1 : 6;
+    unsigned char affiliated_mac_addr_valid : 1;
     mac_address_t ruid;
     mac_addr_t affiliated_mac_addr;
     unsigned char link_id;
@@ -2506,16 +2511,16 @@ typedef struct {
 } __attribute__((__packed__)) em_affiliated_ap_mld_t;
 
 typedef struct {
-    unsigned char ap_mld_mac_addr_valid : 1;
     unsigned char reserved1 : 7;
+    unsigned char ap_mld_mac_addr_valid : 1;
     unsigned char ssid_len;
     ssid_t ssid;
     mac_addr_t ap_mld_mac_addr;
-    unsigned char str : 1;
-    unsigned char nstr : 1;
-    unsigned char emlsr : 1;
+    unsigned char reserved2 : 4;
     unsigned char emlmr : 1;
-    unsigned char reseverd2 : 4;
+    unsigned char emlsr : 1;
+    unsigned char nstr : 1;
+    unsigned char str : 1;
     unsigned char reserved3[20];
     unsigned char num_affiliated_ap;
     em_affiliated_ap_mld_t affiliated_ap_mld[0];
@@ -2527,24 +2532,24 @@ typedef struct {
 } __attribute__((__packed__)) em_ap_mld_config_t;
 
 typedef struct {
+    unsigned char reserved1 : 7;
     unsigned char affiliated_bsta_mac_addr_valid : 1;
-    unsigned char reseverd1 : 7;
     mac_address_t ruid;
     mac_addr_t affiliated_bsta_mac_addr;
     unsigned char reserved2[19];
 } __attribute__((__packed__)) em_affiliated_bsta_mld_t;
 
 typedef struct {
-    unsigned char bsta_mld_mac_addr_valid : 1;
-    unsigned char ap_mld_mac_addr_valid : 1;
     unsigned char reserved1 : 6;
+    unsigned char ap_mld_mac_addr_valid : 1;
+    unsigned char bsta_mld_mac_addr_valid : 1;
     mac_addr_t bsta_mld_mac_addr;
     mac_addr_t ap_mld_mac_addr;
-    unsigned char str : 1;
-    unsigned char nstr : 1;
-    unsigned char emlsr : 1;
-    unsigned char emlmr : 1;
     unsigned char reseverd2 : 4;
+    unsigned char emlmr : 1;
+    unsigned char emlsr : 1;
+    unsigned char nstr : 1;
+    unsigned char str : 1;
     unsigned char reserved3[17];
     unsigned char num_affiliated_bsta;
     em_affiliated_bsta_mld_t affiliated_bsta_mld[0];
@@ -2564,11 +2569,11 @@ typedef struct {
 typedef struct {
     mac_addr_t sta_mld_mac_addr;
     mac_addr_t ap_mld_mac_addr;
-    unsigned char str : 1;
-    unsigned char nstr : 1;
-    unsigned char emlsr : 1;
+    unsigned char reserved1 : 4;
     unsigned char emlmr : 1;
-    unsigned char reseverd1 : 4;
+    unsigned char emlsr : 1;
+    unsigned char nstr : 1;
+    unsigned char str : 1;
     unsigned char reserved2[18];
     unsigned char num_affiliated_sta;
     em_affiliated_sta_mld_t affiliated_sta_mld[0];
@@ -2580,15 +2585,15 @@ typedef struct {
 } __attribute__((__packed__)) em_assoc_sta_mld_config_report_t;
 
 typedef struct {
-    unsigned char add_remove : 1;
     unsigned char reserved4 : 7;
+    unsigned char add_remove : 1;
     mac_addr_t sta_mld_mac_addr;
-    unsigned char direction : 2;
-    unsigned char default_link_mapping : 1;
-    unsigned char map_switch_time_present : 1;
-    unsigned char exp_dur_present : 1;
-    unsigned char link_map_size : 1;
     unsigned char reserved5 : 2;
+    unsigned char link_map_size : 1;
+    unsigned char exp_dur_present : 1;
+    unsigned char map_switch_time_present : 1;
+    unsigned char default_link_mapping : 1;
+    unsigned char direction : 2;
     unsigned char link_map_presence_ind;
     unsigned char expected_duration[3];
     unsigned char tid_to_link_map[0];
@@ -2596,11 +2601,11 @@ typedef struct {
 } __attribute__((__packed__)) em_tid_to_link_mapping_t;
 
 typedef struct {
-    unsigned char is_bsta_config : 1;
     unsigned char reserved1 : 7;
+    unsigned char is_bsta_config : 1;
     mac_addr_t mld_mac_addr;
-    unsigned char tid_to_link_map_negotiation : 1;
     unsigned char reserved2 : 7;
+    unsigned char tid_to_link_map_negotiation : 1;
     unsigned char reserved3[22];
     unsigned char num_mapping;
     em_tid_to_link_mapping_t tid_to_link_mapping[0];

--- a/inc/em_capability.h
+++ b/inc/em_capability.h
@@ -43,7 +43,18 @@ class em_capability_t {
 	 * @note This is a pure virtual function and must be implemented by derived classes.
 	 */
 	virtual int send_frame(unsigned char *buff, unsigned int len, bool multicast = false) = 0;
-    
+
+	/**!
+	 * @brief Retrieves the manager instance.
+	 *
+	 * This function is a pure virtual function that must be implemented by derived classes.
+	 *
+	 * @returns A pointer to the em_mgr_t instance.
+	 *
+	 * @note This function does not take any parameters and returns a non-null pointer to the manager instance.
+	 */
+	virtual em_mgr_t *get_mgr() = 0;
+
 	/**!
 	 * @brief Retrieves the data model.
 	 *
@@ -444,6 +455,7 @@ class em_capability_t {
 	 *
 	 * @param[in] sta The MAC address of the client station.
 	 * @param[in] bss The BSSID to which the report message is sent.
+	 * @param[in] msg_id The message ID for the report message.
 	 *
 	 * @returns int
 	 * @retval 0 on success
@@ -451,7 +463,7 @@ class em_capability_t {
 	 *
 	 * @note Ensure that the MAC address and BSSID are valid before calling this function.
 	 */
-	int send_client_cap_report_msg(mac_address_t sta, bssid_t bss);
+	int send_client_cap_report_msg(mac_address_t sta, bssid_t bss, unsigned short msg_id);
     
 	/**!
 	 * @brief Creates an AP capability report message.

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -38,6 +38,7 @@ class em_configuration_t {
 	 * @param[out] buff Pointer to the buffer where the response message will be stored.
 	 * @param[in] band The frequency band for which the response message is being created.
 	 * @param[in] dst Pointer to the destination address for the response message.
+	 * @param[in] msg_id The message ID of the original request being responded to.
 	 * @param[in] chirp Optional pointer to a DPP chirp value to include in the message.
 	 * @param[in] hash_len Length of the hash to be included in the chirp (can be 0 if no chirp is present).
 	 *
@@ -45,7 +46,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the buffer is adequately sized to hold the response message.
 	 */
-	int create_autoconfig_resp_msg(unsigned char *buff, em_freq_band_t band, unsigned char *dst, em_dpp_chirp_value_t *chirp = nullptr, size_t hash_len = 0);
+	int create_autoconfig_resp_msg(unsigned char *buff, em_freq_band_t band, unsigned char *dst, unsigned short msg_id, em_dpp_chirp_value_t *chirp = nullptr, size_t hash_len = 0);
     
 	/**!
 	 * @brief Creates an auto-configuration search message.
@@ -86,6 +87,7 @@ class em_configuration_t {
 	 * @param[out] buff Pointer to the buffer where the generated message will be stored.
 	 * @param[in] haul_type Array of haul types used in the configuration.
 	 * @param[in] num_hauls Number of haul types in the array.
+	 * @param[in] msg_id The message ID of the original request being responded to.
 	 *
 	 * @returns int Status code indicating success or failure of the message creation.
 	 * @retval 0 on success.
@@ -93,7 +95,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the buffer is adequately sized to hold the generated message.
 	 */
-	int create_autoconfig_wsc_m2_msg(unsigned char *buff, em_haul_type_t haul_type[], unsigned int num_hauls);
+	int create_autoconfig_wsc_m2_msg(unsigned char *buff, em_haul_type_t haul_type[], unsigned int num_hauls, unsigned short msg_id);
     
 	/**!
 	 * @brief Creates a BSS configuration request message.
@@ -119,6 +121,8 @@ class em_configuration_t {
 	 *
 	 * @param[out] buff Pointer to the buffer where the response message will be stored.
 	 * @param[in] dest_al_mac  The destination AL MAC address for the message.
+	 * @param[in] enrollee_nak Pointer to an SSL_KEY structure containing the enrollee's NAK information.
+	 * @param[in] msg_id The message ID of the original request being responded to.
 	 *
 	 * @returns int Status code indicating success or failure of the operation.
 	 * @retval the size of the response message on success.
@@ -126,7 +130,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure the buffer is allocated with sufficient size before calling this function.
 	 */
-	int create_bss_config_rsp_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN], SSL_KEY* enrollee_nak);
+	int create_bss_config_rsp_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN], SSL_KEY* enrollee_nak, unsigned short msg_id);
     
 	/**!
 	 * @brief Creates a BSS configuration response message.
@@ -135,6 +139,7 @@ class em_configuration_t {
 	 *
 	 * @param[out] buff Pointer to the buffer where the response message will be stored.
 	 * @param[in] dest_al_mac  The destination AL MAC address for the message.
+	 * @param[in] msg_id The message ID of the original request being responded to.
 	 *
 	 * @returns int Status code indicating success or failure.
 	 * @retval the size of the response message on success.
@@ -142,7 +147,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure the buffer is allocated with sufficient size before calling this function.
 	 */
-	int create_bss_config_res_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN]);
+	int create_bss_config_res_msg(uint8_t *buff, uint8_t dest_al_mac[ETH_ALEN], unsigned short msg_id);
 
 
 	/**!
@@ -436,6 +441,7 @@ class em_configuration_t {
 	 * This function is responsible for sending a topology response message to the specified destination.
 	 *
 	 * @param[in] dst Pointer to the destination address where the message will be sent.
+	 * @param[in] msg_id The message ID of the original request being responded to.
 	 *
 	 * @returns int
 	 * @retval 0 on success
@@ -443,7 +449,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the destination address is valid before calling this function.
 	 */
-	int send_topology_response_msg(unsigned char *dst);
+	int send_topology_response_msg(unsigned char *dst, unsigned short msg_id);
     
 	/**!
 	 * @brief Sends a topology notification by client.
@@ -514,6 +520,7 @@ class em_configuration_t {
 	 * This function is responsible for sending a configuration response message to the specified destination.
 	 *
 	 * @param[in] dst Pointer to the destination address where the message will be sent.
+	 * @param[in] msg_id The message ID of the original request being responded to.
 	 *
 	 * @returns int
 	 * @retval 0 on success
@@ -521,7 +528,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the destination address is valid and properly initialized before calling this function.
 	 */
-	int send_ap_mld_config_resp_msg(unsigned char *dst);
+	int send_ap_mld_config_resp_msg(unsigned char *dst, unsigned short msg_id);
     
 	/**!
 	 * @brief Sends a 1905 acknowledgment message to a specified station.
@@ -532,6 +539,7 @@ class em_configuration_t {
 	 *
 	 * @param[in] sta_mac The MAC address of the station to which the acknowledgment
 	 * message is to be sent.
+	 * @param[in] msg_id The message ID of the original message being acknowledged.
 	 *
 	 * @returns int
 	 * @retval 0 on success
@@ -540,7 +548,7 @@ class em_configuration_t {
 	 * @note Ensure that the MAC address is valid and the station is reachable
 	 * before calling this function.
 	 */
-	int send_1905_ack_message(mac_addr_t sta_mac);
+	int send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_id);
     
 	
 
@@ -1568,7 +1576,7 @@ public:
 
 	bool send_autoconf_search_ext_chirp(em_dpp_chirp_value_t *chirp, size_t hash_len);
 
-	bool send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN]);
+	bool send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN], unsigned short msg_id);
 
 	bool send_bss_config_req_msg(uint8_t dest_al_mac[ETH_ALEN]);
     

--- a/inc/em_discovery.h
+++ b/inc/em_discovery.h
@@ -172,7 +172,18 @@ class em_discovery_t {
 	virtual em_cmd_t *get_current_cmd() = 0;
     
 public:
-    
+
+	/**!
+	 * @brief Retrieves the manager instance.
+	 *
+	 * This function returns a pointer to the manager instance associated with the steering module.
+	 *
+	 * @returns A pointer to the manager instance of type `em_mgr_t`.
+	 *
+	 * @note This is a pure virtual function and must be implemented by derived classes.
+	 */
+	virtual em_mgr_t *get_mgr() = 0;
+
 	/**!
 	 * @brief Processes a message with the given data and length.
 	 *

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -22,6 +22,7 @@
 #include "em_base.h"
 #include "dm_easy_mesh.h"
 
+class em_mgr_t;
 class em_metrics_t {
 
     
@@ -131,6 +132,7 @@ class em_metrics_t {
 	 * associated with a specific station identified by its MAC address.
 	 *
 	 * @param[in] sta_mac The MAC address of the station for which the link metrics response is to be sent.
+	 * @param[in] msg_id The message ID associated with the link metrics response.
 	 *
 	 * @returns int Status code indicating the success or failure of the operation.
 	 * @retval 0 on success.
@@ -139,7 +141,7 @@ class em_metrics_t {
 	 * @note Ensure that the MAC address provided is valid and that the system is
 	 * capable of sending the response before calling this function.
 	 */
-	int send_associated_link_metrics_response(mac_address_t sta_mac);
+	int send_associated_link_metrics_response(mac_address_t sta_mac, unsigned short msg_id);
 
 	/**!
 	 * @brief Sends link metrics message for associated stations.
@@ -525,6 +527,17 @@ class em_metrics_t {
 	short create_assoc_wifi6_sta_sta_report_tlv(unsigned char *buff, const dm_sta_t *const sta);
 
 public:
+
+	/**!
+	 * @brief Retrieves the manager instance.
+	 *
+	 * This function returns a pointer to the manager instance associated with the steering module.
+	 *
+	 * @returns A pointer to the manager instance of type `em_mgr_t`.
+	 *
+	 * @note This is a pure virtual function and must be implemented by derived classes.
+	 */
+	virtual em_mgr_t *get_mgr() = 0;
     
 	/**!
 	 * @brief Processes a message.

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -29,6 +29,7 @@ class em_mgr_t {
     bool m_exit;
     em_queue_t  m_queue;
 	unsigned int m_tick_demultiplex;
+	unsigned short m_msg_id;
 
 public:
 	pthread_mutex_t m_mutex;
@@ -244,7 +245,7 @@ public:
 	 * this function to avoid unexpected behavior.
 	 */
 	int reset_listeners();
-    
+
 	/**!
 	 * @brief Handles the timeout event.
 	 *
@@ -256,7 +257,17 @@ public:
 	 */
 	void handle_timeout();
 
-    
+	/**!
+	 * @brief Returns the next msg_id to be updated in the cmdu header of the 1905 request.
+	 *
+	 * This function provides the next message ID to be used in the CMDU header.
+	 *
+	 * @returns An unsigned short representing the next message ID.
+	 *
+	 * @note The message ID is incremented with each call and wraps around at 0xFFFF.
+	 */
+	unsigned short get_next_msg_id();
+
 	/**!
 	 * @brief Listens to manager nodes.
 	 *
@@ -272,7 +283,7 @@ public:
 	 * calling this function.
 	 */
 	static void *mgr_nodes_listen(void *arg);
-    
+
 	/**!
 	 * @brief Listens for input events in the manager.
 	 *
@@ -287,7 +298,6 @@ public:
 	 */
 	static void *mgr_input_listen(void *arg);
 
-    
 	/**
 	 * @brief Refresh the OneWifi subdoc with current information + provided data and send to OneWifi.
 	 *

--- a/inc/em_msg.h
+++ b/inc/em_msg.h
@@ -186,12 +186,13 @@ public:
 	* @param[in] dst The destination MAC address.
 	* @param[in] src The source MAC address.
 	* @param[in] msg_type The type of message to be added.
+	* @param[in] msg_id The message ID.
 	*
 	* @return unsigned char* A pointer to the new buffer with the added header.
 	*
 	* @note Ensure that the buffer has enough space to accommodate the new header.
 	*/
-	static unsigned char* add_1905_header(unsigned char *buff, unsigned int *len, mac_addr_t dst, mac_addr_t src, em_msg_type_t msg_type);
+	static unsigned char* add_1905_header(unsigned char *buff, unsigned int *len, mac_addr_t dst, mac_addr_t src, em_msg_type_t msg_type, unsigned short msg_id);
 
     
 	/**!

--- a/inc/em_steering.h
+++ b/inc/em_steering.h
@@ -93,6 +93,7 @@ class em_steering_t {
 	 *
 	 * @param[in] sta_mac The MAC address of the station to which the acknowledgment
 	 * message will be sent.
+	 * @param[in] msg_id The message ID of the original message being acknowledged.
 	 *
 	 * @returns int
 	 * @retval 0 on success
@@ -101,7 +102,7 @@ class em_steering_t {
 	 * @note Ensure that the MAC address is valid and the station is reachable
 	 * before calling this function.
 	 */
-	int send_1905_ack_message(mac_addr_t sta_mac);
+	int send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_id);
     
 	/**!
 	 * @brief Handles the client steering request.

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1450,7 +1450,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 
 		if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
 			len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_al_mac_address(ruid) == false) {
-			printf("%s:%d: Could not find radio_id for em_msg_type_topo_query\n", __func__, __LINE__);
+			printf("%s:%d: Could not find radio_id for em_msg_type_autoconf_renew\n", __func__, __LINE__);
 			return NULL;
 		}
 		dm_easy_mesh_t::macbytes_to_string(ruid, al_mac_str);

--- a/src/cmd/em_cmd_exec.cpp
+++ b/src/cmd/em_cmd_exec.cpp
@@ -367,30 +367,30 @@ void em_cmd_exec_t::deinit()
 
 int em_cmd_exec_t::init()
 {
-	const SSL_METHOD *method;
+    const SSL_METHOD *method;
 
     pthread_cond_init(&m_cond, NULL);
     pthread_mutex_init(&m_lock, NULL);
 
-	OpenSSL_add_all_algorithms();
+    OpenSSL_add_all_algorithms();
     SSL_load_error_strings();
-    
-	method = TLSv1_2_server_method();
+
+    method = TLS_server_method();
     if ((m_ssl_ctx = SSL_CTX_new(method)) == NULL) {
         printf("%s:%d: Failed to create SSL context\n", __func__, __LINE__);
-		return -1;
+        return -1;
     }
-	
-	SSL_CTX_set_cipher_list(m_ssl_ctx, "ALL:eNULL");
+    SSL_CTX_set_min_proto_version(m_ssl_ctx, TLS1_2_VERSION);
+    SSL_CTX_set_cipher_list(m_ssl_ctx, "ALL:eNULL");
 
     if (SSL_CTX_load_verify_locations(m_ssl_ctx, EM_CERT_FILE, EM_KEY_FILE) != 1) {
-		printf("%s:%d: Failed to verify certificate locations\n", __func__, __LINE__);
+        printf("%s:%d: Failed to verify certificate locations\n", __func__, __LINE__);
         SSL_CTX_free(m_ssl_ctx);
         return -1;
     }
 
     if (SSL_CTX_set_default_verify_paths(m_ssl_ctx) != 1) {
-		printf("%s:%d: Failed to verify paths\n", __func__, __LINE__);
+        printf("%s:%d: Failed to verify paths\n", __func__, __LINE__);
         SSL_CTX_free(m_ssl_ctx);
         return -1;
     }
@@ -406,8 +406,7 @@ int em_cmd_exec_t::init()
         SSL_CTX_free(m_ssl_ctx);
         return -1;
     }
-	
-	return 0;
+    return 0;
 }
 
 em_cmd_exec_t::em_cmd_exec_t()

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -608,7 +608,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
             }
 
             dm_easy_mesh_t::macbytes_to_string(intf.mac, mac_str1);
-            printf("%s:%d: Received autoconfig search from agenti al mac: %s\n", __func__, __LINE__, mac_str1);
+            printf("%s:%d: Received autoconfig search from agent al mac: %s\n", __func__, __LINE__, mac_str1);
             if ((dm = get_data_model(GLOBAL_NET_ID, const_cast<const unsigned char *> (intf.mac))) == NULL) {
                 if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)), len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_profile(&profile) == false) {
                     profile = em_profile_type_1;

--- a/src/db/db_easy_mesh.cpp
+++ b/src/db/db_easy_mesh.cpp
@@ -73,7 +73,7 @@ bool db_easy_mesh_t::is_table_empty(db_client_t& db_client)
 
 int db_easy_mesh_t::get_strings_by_token(char *parent, int token, unsigned int argc, char *argv[])
 {
-    unsigned int num = 0, i;
+    unsigned int num = 0, i, max_len;
     em_2xlong_string_t str_copy;
     char *tmp, *orig;
 
@@ -88,18 +88,19 @@ int db_easy_mesh_t::get_strings_by_token(char *parent, int token, unsigned int a
     snprintf(str_copy, sizeof(str_copy), "%s", parent);
     tmp = str_copy;
     orig = str_copy;
+    max_len = sizeof(em_short_string_t) - 1;
 
     while (tmp != NULL) {
         if ((tmp = strchr(orig, token)) != NULL) {
             *tmp = 0;
             assert (num < argc - 1 && "number of extracted values exceeds the limit");
-            snprintf(argv[num], sizeof(em_short_string_t), "%s", orig);
+            snprintf(argv[num], sizeof(em_short_string_t), "%.*s", max_len, orig);
             tmp++; num++;
             orig = tmp;
         }
     }
 
-    snprintf(argv[num], sizeof(em_short_string_t), "%s", orig);
+    snprintf(argv[num], sizeof(em_short_string_t), "%.*s", max_len, orig);
     num++;
 
     return static_cast<int> (num);

--- a/src/dm/dm_bss_list.cpp
+++ b/src/dm/dm_bss_list.cpp
@@ -326,7 +326,7 @@ int dm_bss_list_t::sync_db(db_client_t& db_client, void *ctx)
         info.r2_disallowed = db_client.get_number(ctx, 18);
         info.multi_bssid = db_client.get_number(ctx, 19);
         info.transmitted_bssid = db_client.get_number(ctx, 20);
-        info.vlan_id = db_client.get_number(ctx, 21);
+        info.vlan_id = static_cast<unsigned int> (db_client.get_number(ctx, 21));
 
         update_list(dm_bss_t(&info), dm_orch_type_db_insert);
     }

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2818,7 +2818,7 @@ void dm_easy_mesh_t::update_ap_mld_info(em_ap_mld_info_t *ap_mld_info)
 
     // Find existing MLD by MAC
     em_printfout("m_num_ap_mld %d", m_num_ap_mld);
-    for (int i = 0; i < m_num_ap_mld; i++) {
+    for (unsigned int i = 0; i < m_num_ap_mld; i++) {
         if (memcmp(m_ap_mld[i].m_ap_mld_info.mac_addr, ap_mld_info->mac_addr, sizeof(mac_address_t)) == 0) {
             target_mld = &m_ap_mld[i].m_ap_mld_info;
             em_printfout("Found existing MLD at index %d", i);

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -208,7 +208,7 @@ int em_channel_t::send_channel_scan_request_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    unsigned short  msg_id = em_msg_type_channel_scan_req;
+    unsigned short  msg_type = em_msg_type_channel_scan_req;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
@@ -234,8 +234,8 @@ int em_channel_t::send_channel_scan_request_msg()
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 0;
 
@@ -431,7 +431,7 @@ short em_channel_t::create_channel_scan_res_tlv(unsigned char *buff, unsigned in
 int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
-    unsigned short  msg_id = em_msg_type_channel_scan_rprt;
+    unsigned short  msg_type = em_msg_type_channel_scan_rprt;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
@@ -460,8 +460,8 @@ int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 0;
 
@@ -553,7 +553,7 @@ int em_channel_t::send_channel_sel_request_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    unsigned short  msg_id = em_msg_type_channel_sel_req;
+    unsigned short  msg_type = em_msg_type_channel_sel_req;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
@@ -579,8 +579,8 @@ int em_channel_t::send_channel_sel_request_msg()
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 0;
 
@@ -617,7 +617,7 @@ int em_channel_t::send_channel_sel_request_msg()
     // Zero or one EHT Operations TLV (see section 17.2.103)
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_eht_operations;
-    sz = create_eht_operations_tlv(tlv->value);
+    sz = static_cast<short> (create_eht_operations_tlv(tlv->value));
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
@@ -813,7 +813,7 @@ int em_channel_t::send_operating_channel_report_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    unsigned short  msg_id = em_msg_type_op_channel_rprt;
+    unsigned short  msg_type = em_msg_type_op_channel_rprt;
     short sz;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
@@ -840,8 +840,8 @@ int em_channel_t::send_operating_channel_report_msg()
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 0;
 
@@ -869,7 +869,7 @@ int em_channel_t::send_operating_channel_report_msg()
     // Zero or more EHT Operations TLV (see section 17.2.103)
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_eht_operations;
-    sz = create_eht_operations_tlv(tlv->value);
+    sz = static_cast<short> (create_eht_operations_tlv(tlv->value));
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += sizeof(em_tlv_t) + static_cast<short unsigned int> (sz);
@@ -901,7 +901,7 @@ int em_channel_t::send_channel_pref_query_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    unsigned short  msg_id = em_msg_type_channel_pref_query;
+    unsigned short  msg_type = em_msg_type_channel_pref_query;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
@@ -926,8 +926,8 @@ int em_channel_t::send_channel_pref_query_msg()
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 0;
 
@@ -1223,7 +1223,7 @@ int em_channel_t::send_channel_pref_report_msg()
     // Zero or one EHT Operations TLV (see section 17.2.103)
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_eht_operations;
-    sz = create_eht_operations_tlv(tlv->value);
+    sz = static_cast<short> (create_eht_operations_tlv(tlv->value));
     tlv->len = htons(static_cast<uint16_t> (sz));
 
     tmp += (sizeof(em_tlv_t) + static_cast<long unsigned int> (sz));
@@ -1256,7 +1256,7 @@ int em_channel_t::send_available_spectrum_inquiry_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    unsigned short  msg_id = em_msg_type_avail_spectrum_inquiry;
+    unsigned short  msg_type = em_msg_type_avail_spectrum_inquiry;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
@@ -1282,8 +1282,8 @@ int em_channel_t::send_available_spectrum_inquiry_msg()
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 0;
 
@@ -1464,6 +1464,11 @@ int em_channel_t::handle_eht_operations_tlv_ctrl(unsigned char *buff, unsigned i
     unsigned char num_radios;
     unsigned char num_bss;
 
+    // 32 octets are reserved for future use, so skip 32 octets
+    unsigned int reserved_octets = 32;
+    tmp += reserved_octets;
+    tmp_len += reserved_octets;
+
     memcpy(&num_radios, tmp, sizeof(unsigned char));
     tmp += sizeof(unsigned char);
     tmp_len += sizeof(unsigned char);
@@ -1633,10 +1638,8 @@ int em_channel_t::handle_eht_operations_tlv(unsigned char *buff, em_eht_operatio
 
 int em_channel_t::handle_channel_pref_query(unsigned char *buff, unsigned int len)
 {
-    em_cmdu_t *cmdu;
     em_bus_event_type_channel_pref_query_params_t params;
-
-    cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
 
     memcpy(params.mac, get_radio_interface_mac(), sizeof(mac_address_t));
     params.msg_id = ntohs(cmdu->id);
@@ -1896,9 +1899,7 @@ int em_channel_t::handle_channel_scan_rprt(unsigned char *buff, unsigned int len
 
 void em_channel_t::process_msg(unsigned char *data, unsigned int len)
 {
-    em_cmdu_t *cmdu;
-    
-    cmdu = reinterpret_cast<em_cmdu_t *> (data + sizeof(em_raw_hdr_t));
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (data + sizeof(em_raw_hdr_t));
     switch (htons(cmdu->type)) {
         case em_msg_type_channel_pref_query:
 		if (get_service_type() == em_service_type_agent) {
@@ -1929,7 +1930,7 @@ void em_channel_t::process_msg(unsigned char *data, unsigned int len)
         case em_msg_type_channel_sel_req:
             if ((get_service_type() == em_service_type_agent)  && ((get_state() < em_state_agent_channel_select_configuration_pending) || (get_state() >= em_state_agent_configured))) {
                 handle_channel_sel_req(data, len);
-                send_channel_sel_response_msg(em_chan_sel_resp_code_type_accept, htons(cmdu->id));
+                send_channel_sel_response_msg(em_chan_sel_resp_code_type_accept, ntohs(cmdu->id));
             }
             break;
 

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -334,8 +334,10 @@ uint8_t em_crypto_t::platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *ke
 
     /* Release resources */
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    EVP_PKEY_free(pkey);
-    EVP_MD_CTX_free(ctx);
+    if (pkey)
+        EVP_PKEY_free(pkey);
+    if (ctx)
+        EVP_MD_CTX_free(ctx);
 #elif OPENSSL_VERSION_NUMBER >= 0x10100000L
     HMAC_CTX_free(ctx);
 #else
@@ -346,8 +348,10 @@ uint8_t em_crypto_t::platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *ke
 
 bail:
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    EVP_PKEY_free(pkey);
-    EVP_MD_CTX_free(ctx);
+    if (pkey)
+        EVP_PKEY_free(pkey);
+    if (ctx)
+        EVP_MD_CTX_free(ctx);
 #elif OPENSSL_VERSION_NUMBER >= 0x10100000L
     HMAC_CTX_free(ctx);
 #else

--- a/src/em/disc/em_discovery.cpp
+++ b/src/em/disc/em_discovery.cpp
@@ -42,7 +42,7 @@
 
 unsigned int em_discovery_t::create_topo_query_msg(unsigned char *buff)
 {
-    unsigned short	msg_id = em_msg_type_topo_query;
+    unsigned short	msg_type = em_msg_type_topo_query;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
@@ -64,8 +64,8 @@ unsigned int em_discovery_t::create_topo_query_msg(unsigned char *buff)
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
 
     tmp += sizeof(em_cmdu_t);
@@ -92,7 +92,7 @@ unsigned int em_discovery_t::create_topo_query_msg(unsigned char *buff)
 
 unsigned int em_discovery_t::create_topo_discovery_msg(unsigned char *buff)
 {
-    unsigned short	msg_id = em_msg_type_topo_disc;
+    unsigned short	msg_type = em_msg_type_topo_disc;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
@@ -115,8 +115,8 @@ unsigned int em_discovery_t::create_topo_discovery_msg(unsigned char *buff)
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
 
     tmp += sizeof(em_cmdu_t);

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1180,6 +1180,12 @@ unsigned short em_t::create_eht_operations_tlv(unsigned char *buff)
     unsigned char num_radios = static_cast<unsigned char> (dm->get_num_radios());
     unsigned char num_bss;
 
+    // 32 octets are reserved for future use, so skip 32 octets
+    unsigned int reserved_octets = 32;
+    memset(tmp, 0, reserved_octets);
+    tmp += reserved_octets;
+    len += reserved_octets;
+
     memcpy(tmp, &num_radios, sizeof(unsigned char));
     tmp += sizeof(unsigned char);
     len += sizeof(unsigned char);
@@ -1219,7 +1225,7 @@ unsigned short em_t::create_eht_operations_tlv(unsigned char *buff)
         }
     }
 
-    return static_cast<short> (len);
+    return len;
 }
 
 cJSON *em_t::create_enrollee_bsta_list(uint8_t pa_al_mac[ETH_ALEN])
@@ -1820,7 +1826,7 @@ bool em_t::initialize_ec_manager(){
                                                 this, std::placeholders::_1);
         ops.send_autoconf_search_resp =
             std::bind(&em_t::send_autoconf_search_resp_ext_chirp, this, std::placeholders::_1,
-                      std::placeholders::_2, std::placeholders::_3);
+                      std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
     }
 
     // Read in the persistent security context for the controller or agent

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -491,6 +491,15 @@ void em_mgr_t::handle_timeout()
 
 }
 
+unsigned short em_mgr_t::get_next_msg_id()
+{
+    m_msg_id++;
+    if (m_msg_id == 0) {
+        m_msg_id = 1;
+    }
+    return m_msg_id;
+}
+
 int em_mgr_t::start()
 {
     int rc;
@@ -576,6 +585,7 @@ int em_mgr_t::init(const char *data_model_path)
     pthread_cond_init(&m_queue.cond, NULL);
 
     m_queue.timeout = EM_MGR_TOUT;
+    m_msg_id = 0;
 
     orch_init();
     return data_model_init(data_model_path);

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -354,11 +354,10 @@ unsigned char* em_msg_t::add_tlv(unsigned char *buff, unsigned int *len, em_tlv_
     return buff + (sizeof(em_tlv_t) + value_len);
     
 }
-unsigned char* em_msg_t::add_1905_header(unsigned char *buff, unsigned int *len, mac_addr_t dst, mac_addr_t src, em_msg_type_t msg_type)
+unsigned char* em_msg_t::add_1905_header(unsigned char *buff, unsigned int *len, mac_addr_t dst, mac_addr_t src, em_msg_type_t msg_type, unsigned short msg_id)
 {
 
     uint16_t type = htons(ETH_P_1905);
-    uint16_t  msg_id = msg_type;
 
     unsigned char* tmp = buff;
     tmp = em_msg_t::add_buff_element(tmp, len, reinterpret_cast<uint8_t *>(dst), sizeof(mac_address_t));
@@ -368,7 +367,7 @@ unsigned char* em_msg_t::add_1905_header(unsigned char *buff, unsigned int *len,
     em_cmdu_t cmdu = {
         .ver = 0,
         .reserved = 0,
-        .type = htons(msg_id),
+        .type = htons(msg_type),
         .id = htons(msg_id),
         .frag_id = 0,
         .reserved_field = 0,

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -295,7 +295,7 @@ int em_policy_cfg_t::send_policy_cfg_request_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    unsigned short  msg_id = em_msg_type_map_policy_config_req;
+    unsigned short  msg_type = em_msg_type_map_policy_config_req;
     size_t len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
@@ -321,8 +321,8 @@ int em_policy_cfg_t::send_policy_cfg_request_msg()
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(static_cast<uint16_t> (msg_id));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 0;
 
@@ -511,9 +511,7 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
 
 void em_policy_cfg_t::process_msg(unsigned char *data, unsigned int len)
 {
-    em_cmdu_t *cmdu;
-    
-    cmdu = reinterpret_cast<em_cmdu_t *> (data + sizeof(em_raw_hdr_t));
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (data + sizeof(em_raw_hdr_t));
     
     switch (htons(cmdu->type)) {
 		case em_msg_type_map_policy_config_req:

--- a/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
@@ -322,7 +322,7 @@ bool ec_ctrl_configurator_t::process_direct_encap_dpp_msg(uint8_t* dpp_frame, ui
     return did_finish;
 }
 
-bool ec_ctrl_configurator_t::handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN])
+bool ec_ctrl_configurator_t::handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id)
 {
     em_printfout("Received Autoconf Search (extended) chirp from Enrollee '%s'", util::mac_to_string(src_mac).c_str());
     if (!chirp) {
@@ -372,7 +372,7 @@ bool ec_ctrl_configurator_t::handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, 
         return false;
     }
 
-    if (!m_send_autoconf_resp_fn(resp_chirp, resp_chirp_len, src_mac)) {
+    if (!m_send_autoconf_resp_fn(resp_chirp, resp_chirp_len, src_mac, msg_id)) {
         em_printfout("Failed to send Autoconf Response (extended) with Chirp TLV");
         free(resp_chirp);
         return false;

--- a/src/validation_test.cpp
+++ b/src/validation_test.cpp
@@ -79,7 +79,7 @@ em_testValidation_t::em_testValidation_t(unsigned char *buff, unsigned int &len)
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
     unsigned char *tmp = buff; 
-    unsigned short  msg_id = em_msg_type_autoconf_search;
+    unsigned short  msg_type = em_msg_type_autoconf_search;
     unsigned short type = htons(ETH_P_1905);
     mac_address_t   multi_addr = {0x01, 0x80, 0xc2, 0x00, 0x00, 0x13};
     mac_address_t   src_addr = {0x02, 0x10, 0xc1, 0x00, 0x00, 0x13};
@@ -99,8 +99,8 @@ em_testValidation_t::em_testValidation_t(unsigned char *buff, unsigned int &len)
     cmdu = (em_cmdu_t *)tmp;
 
     memset(tmp, 0, sizeof(em_cmdu_t));
-    cmdu->type = htons(msg_id);
-    cmdu->id = htons(msg_id);
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 1;
 


### PR DESCRIPTION
This change addresses filling of appropriate Message Id in CMDU header as per the specification. The responses to the Query or Request messages to have the same Message ID as that of Query is addressed as well with this commit.
This commit also addresses correcting the bit field definitions of structures to be compliant with GCC compiler and also some warning fixes.

Test Procedure:
Tested Basic easymesh scenario of configuration, SSID change and channel change on RPI.