### PR TITLE
RDKB-61233, RDKBACCL-1130: EasyMesh : Update security Mode Fix for fronthaul VAP alone

### DIFF
--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -4698,12 +4698,6 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 		}
 	}
 
-	if (get_band() == 2) {
-		auth_type = 0x0200; // WPA3-Personal
-	} else {
-		auth_type = 0x0400; // WPA3-Personal-Transition
-	}
-
 	printf("%s:%d No of haultype=%d radio no of bss=%d \n", __func__, __LINE__,no_of_haultype, radio->m_radio_info.number_of_bss);
 
 	// haultype
@@ -4727,6 +4721,16 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 			continue;
 		}
 		printf("%s:%d: ssid: %s, passphrase: %s\n", __func__, __LINE__, net_ssid_info->ssid, net_ssid_info->pass_phrase);
+
+		if (get_band() == 2) {
+			auth_type = 0x0200; // WPA3-Personal
+		} else {
+			if (haul_type == em_haul_type_fronthaul) {
+				auth_type = 0x0400; // WPA3-Personal-Transition
+			} else {
+				auth_type = 0x0010; // WPA2-Personal
+			}
+		}
 
 		// haultype
 		attr = reinterpret_cast<data_elem_attr_t *> (tmp);


### PR DESCRIPTION
RDKB-61233, RDKBACCL-1130: EasyMesh : Update security Mode Fix for fronthaul VAP alone

Reason for change: To support WiFi7 enabled VAPs configure WPA3-Personal-Transition for fronthaul and WPA2-Personal backhaul VAPS for 2.4GHz and 5GHz radios
Test Procedure: Ensure proper security modes are set after easymesh configuration applied to all VAPs.
Risks: Medium
Priority: P1