### PR TITLE
Send topology response without dependency on radio identifier

### DIFF
--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -220,7 +220,13 @@ public:
 	*/
 	em_t *get_phy_al_node();
 
-    
+	/**
+	* @brief Get vector of em's associated with the al_mac
+	* In other words, the actual `em_t` nodes of radios that is associated with a particular al_mac.
+	*
+	*/
+	void get_all_em_for_al_mac(mac_address_t mac, std::vector<em_t*> &em_radios);
+
 	/**!
 	 * @brief Listener for node events.
 	 *

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -276,15 +276,15 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
     if (webconfig_init(&config) != webconfig_error_none) {
-        printf( "[%s]:%d Init WiFi Web Config  fail\n",__func__,__LINE__);
+        em_printfout( "Init WiFi Web Config  fail");
         return 0;
     }
 
     if ((webconfig_easymesh_decode(&config, reinterpret_cast<char *> (evt->u.raw_buff),
             &ext, &type)) == webconfig_error_none) {
-        printf("%s:%d Private subdoc decode success\n",__func__, __LINE__);
+        em_printfout("Private subdoc decode success");
     } else {
-        printf("%s:%d Private subdoc decode fail\n",__func__, __LINE__);
+        em_printfout("Private subdoc decode fail");
     }
 
 	if (dm.get_num_bss() != 0) {
@@ -295,19 +295,19 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
 	} else {
 		cJSON *json = cJSON_Parse(json_data);
 		if (json == NULL) {
-			printf("%s:%d Error parsing JSON\n", __func__, __LINE__);
+			em_printfout("Error parsing JSON");
 			return 0;
 		}
 		cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
 		if (cJSON_IsString(subdoc_name) && (subdoc_name->valuestring != NULL)) {
 			if (strcmp(subdoc_name->valuestring, "Vap_5G") == 0) {
 				freq_band = em_freq_band_5 ;
-				printf("%s:%d Found SubDocName:Vap 5G recv\n", __func__, __LINE__);
+				em_printfout("Found SubDocName:Vap 5G recv");
 			} else if (strcmp(subdoc_name->valuestring, "Vap_2.4G") == 0) {
-				printf("%s:%d Found SubDocName:Vap 2.4G recv\n", __func__, __LINE__);
+				em_printfout("Found SubDocName:Vap 2.4G recv");
 				freq_band = em_freq_band_24;
 			} else if (strcmp(subdoc_name->valuestring, "Vap_6G") == 0) {
-				printf("%s:%d Found SubDocName:Vap 6G recv\n", __func__, __LINE__);
+				em_printfout("Found SubDocName:Vap 6G recv");
 				freq_band = em_freq_band_60;
 			}
 		}
@@ -320,7 +320,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
 		}
 	}
 	dm_easy_mesh_t::macbytes_to_string(dm.get_bss(index)->get_bss_info()->ruid.mac, mac_str);
-	printf("%s:%d %s in owconfig\n", __func__, __LINE__,mac_str);
+	em_printfout("%s in owconfig", mac_str);
 	pcmd[num] = new em_cmd_ow_cb_t(evt->params, dm);
 	tmp = pcmd[num];
 	num++;

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1495,20 +1495,14 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 			break;
 
         case em_msg_type_topo_query:
-            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
-                len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_radio_id(&ruid) == false) {
-                printf("%s:%d: Could not find radio_id for em_msg_type_topo_query\n", __func__, __LINE__);
-                return NULL;
-            }
-
-            dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
-            if (((em = (em_t *)hash_map_get(m_em_map, mac_str1)) != NULL)  && (em->get_state() == em_state_agent_onewifi_bssconfig_ind)) {
-                printf("%s:%d: Received topo query, found existing radio:%s\n", __func__, __LINE__, mac_str1);
+            em_string_t al_mac_str;
+            dm_easy_mesh_t::macbytes_to_string(hdr->dst, al_mac_str);
+            strcat(al_mac_str, "_al");
+            if ((em = (em_t *)hash_map_get(m_em_map, al_mac_str)) != NULL) {
+                em_printfout("Received topo query, found al_mac agent:%s", al_mac_str);
             } else {
- 				if (em != NULL) {
-					em_printfout("em_msg_type_topo_query :em mac=%s is in incorrect state state=%d",
-                        mac_str1, em->get_state());
-				}
+                em_printfout("Discarding topo query, al_mac agent:%s not found",
+                    al_mac_str);
                 return NULL;
             }
             break;

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -333,7 +333,7 @@ void dm_easy_mesh_list_t::put_radio(const char *key, const dm_radio_t *radio)
 {
     dm_radio_t *pradio = NULL;
     dm_easy_mesh_t	*dm = NULL;
-    mac_addr_str_t	radio_mac, dev_mac;
+    mac_addr_str_t  dev_mac;
     em_t *em = NULL;
 
     //printf("%s:%d: Radio: %s\n", __func__, __LINE__, key);
@@ -341,7 +341,7 @@ void dm_easy_mesh_list_t::put_radio(const char *key, const dm_radio_t *radio)
     if ((pradio = get_radio(key)) == NULL) {
         dm = get_data_model(radio->m_radio_info.id.net_id, radio->m_radio_info.id.dev_mac);
         dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (radio->m_radio_info.id.dev_mac), dev_mac);
-		//printf("%s:%d: dm: %p net: %s device: %s\n", __func__, __LINE__, dm, radio->m_radio_info.net_id, dev_mac);
+		//printf("%s:%d: dm: %p net: %s device: %s\n", __func__, __LINE__, dm, radio->m_radio_info.id.net_id, dev_mac);
         if (dm == NULL) {
             return;
         }
@@ -352,14 +352,11 @@ void dm_easy_mesh_list_t::put_radio(const char *key, const dm_radio_t *radio)
     }
     *pradio = *radio;
 
+    dm_easy_mesh_t::macbytes_to_string(pradio->m_radio_info.id.dev_mac, dev_mac);
     if ((em = m_mgr->create_node(&pradio->m_radio_info.intf, static_cast<em_freq_band_t> (pradio->m_radio_info.media_data.band), dm, false,
             em_profile_type_3, em_service_type_ctrl)) != NULL) {
-        printf("%s:%d Node created successfully\n", __func__, __LINE__);
+        em_printfout("Node created successfully for radio:%s almac:%s", key, dev_mac);
     }
-
-    dm_easy_mesh_t::macbytes_to_string(pradio->m_radio_info.intf.mac, radio_mac);
-    dm_easy_mesh_t::macbytes_to_string(pradio->m_radio_info.id.dev_mac, dev_mac);
-
 }
 
 dm_radio_t *dm_easy_mesh_list_t::get_first_radio(const char *net_id, mac_address_t al_mac)

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -148,9 +148,9 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             break;
 
         case em_cmd_type_em_config:
-            printf("%s:%d: %s(%s) state: %s\n", __func__, __LINE__,
-                    em_cmd_t::get_orch_op_str(pcmd->get_orch_op()), em_cmd_t::get_cmd_type_str(pcmd->m_type),
-					em_t::state_2_str(get_state()));
+            em_printfout("%s(%s) state: %s radio mac:%s", em_cmd_t::get_orch_op_str(pcmd->get_orch_op()),
+                    em_cmd_t::get_cmd_type_str(pcmd->m_type), em_t::state_2_str(get_state()),
+                    util::mac_to_string(em_t::get_radio_interface_mac()).c_str());
             if ((pcmd->get_orch_op() == dm_orch_type_topo_sync) && (m_sm.get_state() == em_state_ctrl_wsc_m2_sent)) {
                 m_sm.set_state(em_state_ctrl_topo_sync_pending);
             } else if ((pcmd->get_orch_op() == dm_orch_type_channel_pref) && (m_sm.get_state() == em_state_ctrl_topo_synchronized)) {

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -279,6 +279,25 @@ em_t *em_mgr_t::get_phy_al_node()
     return phy_al_em;
 }
 
+void em_mgr_t::get_all_em_for_al_mac(mac_address_t mac, std::vector<em_t*> &em_radios)
+{
+    em_t* em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+    std::string mac_str = util::mac_to_string(mac);
+    //em_printfout("*****al_mac:%s******", util::mac_to_string(mac).c_str());
+    while (em != NULL) {
+        dm_easy_mesh_t* dm = em->get_data_model();
+        unsigned char* al_mac = dm->get_device()->get_dev_interface_mac();
+        if (!(em->is_al_interface_em()) && (memcmp(al_mac, mac, MAC_ADDR_LEN) == 0)) {
+            em_radios.push_back(em);
+            //em_printfout("Added em with radio_mac:%s",
+            //    util::mac_to_string(em->get_radio_interface_mac()).c_str());
+        }
+        em = static_cast<em_t*>(hash_map_get_next(m_em_map, em));
+    }
+    //em_printfout("******end*******");
+}
+
+
 void *em_mgr_t::mgr_input_listen(void *arg)
 {
     size_t stack_size2;


### PR DESCRIPTION
The topology response was dependent on presence of radio id in topology query. Modified to respond based on the AL mac of the agent and updated TLVs based on IEEE1905 standard.

Test report: Verified the topology response and TLVs based on ieee1905 formats