### PR TITLE
[DPP] Removing the macro FEATURE_RECV_FREQ_ACT_SUB

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -40,18 +40,6 @@ extern "C"
 
 #include "wifi_webconfig.h"
 
-/**
- * @brief Temporary until halinterface, rdk-wifi-hal, and OneWifi PRs are merged
- * 
- * If defined, the frequency (and other wifi data) is recieved along with the action frame
- * in the action frame subscription handler.
- * 
- * halinterface PR #49: https://github.com/rdkcentral/rdkb-halif-wifi/pull/49
- * rdk-wifi-hal PR #344: https://github.com/rdkcentral/rdk-wifi-hal/pull/344
- * OneWifi PR #576: https://github.com/rdkcentral/OneWifi/pull/576
- */
-//#define FEATURE_RECV_FREQ_ACT_SUB 
-
 // Enable support for 1905-layer securing on a colocated agent (onboarding using WSC onboarding)
 // This is enabled right now since currently the layer is not encrypted so functionality won't be broken
 // but when SoftHSM is hooked up and the layer is encrypted, this can commented out to disable the feature

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -560,7 +560,6 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
     size_t frame_len = evt->data_len;
     unsigned int recv_freq = 0;
 
-    #ifdef FEATURE_RECV_FREQ_ACT_SUB
     // The frequency (and other wifi data) is prepended to the action frame data
     auto* frame_info = reinterpret_cast<wifi_frame_t*>(evt->u.raw_buff);
     em_printfout("Received WFA action frame at frequency %d MHz", frame_info->recv_freq);
@@ -568,7 +567,6 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
     mgmt_frame_buff += sizeof(wifi_frame_t);
     frame_len       -= sizeof(wifi_frame_t);
     recv_freq        = frame_info->recv_freq;
-    #endif
 
     const size_t mgmt_hdr_len = offsetof(struct ieee80211_mgmt, u);
     const size_t fixed_full_header_len = 
@@ -1226,12 +1224,10 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *u
 
     uint8_t* mgmt_frame_data = (uint8_t*)data->raw_data.bytes;
     unsigned int mgmt_hdr_len = data->raw_data_len;
-    #ifdef FEATURE_RECV_FREQ_ACT_SUB
+
     // The frequency (and other wifi data) is prepended to the action frame data
-    // skip it
     mgmt_frame_data += sizeof(wifi_frame_t);
     mgmt_hdr_len -= sizeof(wifi_frame_t);
-    #endif
 
     struct ieee80211_mgmt *mgmt_frame = (struct ieee80211_mgmt *)mgmt_frame_data;
     

--- a/src/em/prov/easyconnect/ec_enrollee.cpp
+++ b/src/em/prov/easyconnect/ec_enrollee.cpp
@@ -134,7 +134,6 @@ void ec_enrollee_t::generate_bss_channel_list(bool is_reconfig_list){
     // Clear existing channel list
     freq_list.erase(freq_list.begin(), freq_list.end());
     
-    #ifdef FEATURE_RECV_FREQ_ACT_SUB // Only use CCE channels if we can't get the frequency from the action frame subscription handler
     // This step is not present in EC-Reconfig for some reason (likely because of the SSID check)
     if (!is_reconfig_list) {
         /* EC #1
@@ -168,7 +167,7 @@ void ec_enrollee_t::generate_bss_channel_list(bool is_reconfig_list){
     freq_list.insert(5220); // 5 GHz: Channel 44 (5.220 GHz)
     freq_list.insert(60480); // 60 GHz: Channel 2 (60.48 GHz)
     freq_list.insert(920); // 920 MHz: Channel 37 
-    #endif
+
     /* EC-Reconfig #2
 
     For each channel on which the Enrollee detects the SSID for which it is currently configured, 
@@ -586,9 +585,8 @@ bool ec_enrollee_t::handle_auth_request(ec_frame_t *frame, size_t len, uint8_t s
     em_printfout("Recieved a DPP Authentication Request from '" MACSTRFMT "', stopping Presence Announcement\n", MAC2STR(src_mac));
     // Halt presence announcement once DPP Authentication frame is received.
     m_received_auth_frame.store(true);
-    #ifdef FEATURE_RECV_FREQ_ACT_SUB
     m_selected_freq = static_cast<uint32_t>(recv_freq);
-    #endif
+
     if (m_send_pres_announcement_thread.joinable()) m_send_pres_announcement_thread.join();
     size_t attrs_len = len - EC_FRAME_BASE_SIZE;
 


### PR DESCRIPTION
Reason for change : Removed the macro FEATURE_RECV_FREQ_ACT_SUB since all the action frame - frequency related changes were merged.