### PR TITLE
Addition of Backhaul mac address using Backhaul sta capability query/report

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -592,7 +592,24 @@ public:
 	 */
 	int analyze_mld_reconfig(em_cmd_t *pcmd[]);
 
-    
+	/**!
+	 * @brief Analyzes the Backhaul STA capability query command.
+	 *
+	 * This function processes the Backhaul STA capability query command provided in the
+	 * em_cmd_t structure array.
+	 *
+	 * @param[in] evt Pointer to the event structure containing event details.
+	 * @param[in] pcmd Array of command structures to be analyzed.
+	 *
+	 * @returns int
+	 * @retval 0 on success
+	 * @retval non-zero error code on failure
+	 *
+	 * @note Ensure that the pcmd array is properly initialized before calling
+	 * this function.
+	 */
+	int analyze_bsta_cap_req(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
 	/**!
 	 * @brief Resets the configuration to its default state.
 	 *

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -1961,6 +1961,7 @@ typedef enum {
     em_state_ctrl_bsta_mld_config_pending,
     em_state_ctrl_ap_mld_req_ack_rcvd,
     em_state_ctrl_avail_spectrum_inquiry_pending,
+    em_state_ctrl_bsta_cap_pending,
 
     em_state_max,
 } em_state_t;
@@ -2011,6 +2012,7 @@ typedef enum {
     em_cmd_type_beacon_report,
     em_cmd_type_ap_metrics_report,
     em_cmd_type_get_reset,
+    em_cmd_type_bsta_cap,
 
     em_cmd_type_max,
 } em_cmd_type_t;
@@ -2690,6 +2692,7 @@ typedef enum {
     em_bus_event_type_bss_info,
     em_bus_event_type_get_reset,
     em_bus_event_type_recv_csa_beacon_frame,
+    em_bus_event_type_bsta_cap_req,
 
     em_bus_event_type_max
 } em_bus_event_type_t;
@@ -2775,7 +2778,8 @@ typedef enum {
     dm_orch_type_sta_disassoc,
     dm_orch_type_policy_cfg,
     dm_orch_type_mld_reconfig,
-    dm_orch_type_beacon_report
+    dm_orch_type_beacon_report,
+    dm_orch_type_bsta_cap_query
 } dm_orch_type_t;
 
 typedef struct {

--- a/inc/em_capability.h
+++ b/inc/em_capability.h
@@ -24,6 +24,8 @@
 #include "em.h"
 
 class em_cmd_t;
+class em_mgr_t;
+
 class em_capability_t {
 
     
@@ -464,7 +466,35 @@ class em_capability_t {
 	 * @note Ensure that the MAC address and BSSID are valid before calling this function.
 	 */
 	int send_client_cap_report_msg(mac_address_t sta, bssid_t bss, unsigned short msg_id);
-    
+
+	/**!
+	 * @brief Sends a backhaul sta capability query message.
+	 *
+	 * This function is responsible for sending a backhaul sta capability query message for a Node.
+	 * 
+	 * @returns int
+	 * @retval 0 on success
+	 * @retval -1 on failure
+	 * 
+	 * @note This is called when a new device joins into the network.
+	 */
+	int send_bsta_cap_query_msg();
+
+	/**!
+	 * @brief Sends a backhaul sta capability report message.
+	 *
+	 * This function is responsible for sending a backhaul sta capability report message.
+	 *
+	 * @param[in] msg_id The message ID for the report message.
+	 *
+	 * @returns int
+	 * @retval 0 on success
+	 * @retval -1 on failure
+	 *
+	 * @note Ensure Sta mac address and BSSID are valid within the call of this function.
+	 */
+	int send_bsta_cap_report_msg(unsigned short msg_id);
+
 	/**!
 	 * @brief Creates an AP capability report message.
 	 *
@@ -575,6 +605,22 @@ class em_capability_t {
 	 */
 	short create_client_info_tlv(unsigned char *buff, mac_address_t sta, bssid_t bssid);
 
+	/**!
+	 * @brief Creates a backhaul sta radio capability information TLV
+	 * (Type-Length-Value) structure.
+	 *
+	 * This function constructs a TLV structure containing backhaul sta radio
+	 * capability information and stores it in the provided buffer.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the notification data.
+	 *
+	 * @returns A short integer indicating the success or failure of the operation.
+	 * @retval 0 on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note Ensure that the buffer is large enough to hold the TLV structure.
+	 */
+	int create_bsta_radio_cap_tlv(uint8_t *buff);
     
 	/**!
 	 * @brief Handles the client capability query.
@@ -604,6 +650,45 @@ class em_capability_t {
 	 */
 	int handle_client_cap_report(unsigned char *data, unsigned int len);
 
+	/**!
+	 * @brief Handles the backhaul sta capability query.
+	 *
+	 * This function processes the capability query received from the controller.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the notification data.
+	 * @param[in] len Length of the data received.
+	 * 
+	 * @returns int Status code indicating success or failure.
+	 * @retval 0 on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
+	 */
+	int handle_bsta_cap_query(unsigned char *buff, unsigned int len);
+
+	/**!
+	 * @brief Handles the backhaul sta capability report.
+	 *
+	 * This function processes the capability report received from the Extender.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the notification data.
+	 * @param[in] len Length of the data received.
+	 *
+	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
+	 */
+	int handle_bsta_cap_report(unsigned char *buff, unsigned int len);
+
+	/**!
+	 * @brief Handles the backhaul sta radio capability TLV
+	 *
+	 * This function processes the backhaul sta radio capability TLV.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the TLV data.
+	 * @param[in] len Length of the data received.
+	 *
+	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
+	 */
+	int handle_bsta_radio_cap(unsigned char *buff, unsigned int len);
 public:
     
 	/**!
@@ -627,7 +712,15 @@ public:
 	 */
 	void    process_agent_state();
 
-    
+	/**!
+	* @brief Processes the control state.
+	*
+	* This function is responsible for handling the current state of the control mechanism.
+	*
+	* @note Ensure that the control state is initialized before calling this function.
+	*/
+	void    process_ctrl_state();
+
 	/**!
 	 * @brief Retrieves the capability query transmission count.
 	 *

--- a/inc/em_cmd_bsta_cap.h
+++ b/inc/em_cmd_bsta_cap.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_BSTA_CAP_H
+#define EM_CMD_BSTA_CAP_H
+
+#include "em_cmd.h"
+
+class em_cmd_bsta_cap_t : public em_cmd_t {
+
+public:
+    
+	/**!
+	 * @brief 
+	 *
+	 * This function processes the BTM report based on the provided parameters.
+	 *
+	 * @param[in] params The parameters required to generate the BTM report.
+	 *
+	 * @returns em_cmd_btm_report_t The generated BTM report.
+	 *
+	 * @note Ensure that the parameters are correctly initialized before calling this function.
+	 */
+	em_cmd_bsta_cap_t(em_cmd_params_t param, dm_easy_mesh_t& dm);
+};
+
+#endif

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -428,6 +428,16 @@ public:
 	 */
 	void handle_mld_reconfig(em_bus_event_t *evt);
 
+	/**!
+	 * @brief Handles the Backhaul STA capability request event.
+	 *
+	 * This function processes the Backhaul STA capability request event received on the bus.
+	 *
+	 * @param[in] evt Pointer to the event structure containing Backhaul STA capability request details.
+	 *
+	 * @note Ensure that the event structure is properly initialized before calling this function.
+	 */
+	void handle_bsta_cap_req(em_bus_event_t *evt);
     
 	/**!
 	 * @brief 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1675,6 +1675,21 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case em_msg_type_topo_disc:
             em = NULL;
             break;
+
+        case em_msg_type_bh_sta_cap_query:
+            em = (em_t *)hash_map_get_first(m_em_map);
+            while (em != NULL) {
+                if ((em->is_al_interface_em() == true)) {
+                    em_printfout("Rcvd bsta cap Query");
+                    break;
+                }
+                em = (em_t *)hash_map_get_next(m_em_map, em);
+            }
+            break;
+
+        case em_msg_type_bh_sta_cap_rprt:
+            break;
+
         default:
             printf("%s:%d: Frame: %d not handled in agent\n", __func__, __LINE__, htons(cmdu->type));
             em = NULL;

--- a/src/cmd/em_cmd_bsta_cap.cpp
+++ b/src/cmd/em_cmd_bsta_cap.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "em_cmd_bsta_cap.h"
+
+em_cmd_bsta_cap_t::em_cmd_bsta_cap_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
+{
+   em_cmd_ctx_t ctx;
+
+   m_type = em_cmd_type_bsta_cap;
+   memcpy(&m_param, &param, sizeof(em_cmd_params_t));
+
+   memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+
+   m_orch_op_idx = 0;
+   m_num_orch_desc = 1;
+   m_orch_desc[0].op = dm_orch_type_bsta_cap_query;
+   m_orch_desc[0].submit = true;
+
+   strncpy(m_name, "bsta_cap", strlen("bsta_cap") + 1);
+   m_svc = em_service_type_ctrl;
+   init(dm);
+
+   memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+   ctx.type = m_orch_desc[0].op;
+   m_data_model.set_cmd_ctx(&ctx);
+}
+

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -95,6 +95,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_beacon_report.cpp \
      $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
      $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_bsta_cap.cpp \
      $(top_srcdir)/src/ctrl/dm_easy_mesh_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_cmd_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_ctrl.cpp \

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -57,6 +57,7 @@
 #include "em_cmd_sta_disassoc.h"
 #include "em_cmd_get_mld_config.h"
 #include "em_cmd_mld_reconfig.h"
+#include "em_cmd_bsta_cap.h"
 
 extern em_network_topo_t *g_network_topology;
 
@@ -1017,6 +1018,24 @@ int dm_easy_mesh_ctrl_t::analyze_mld_reconfig(em_cmd_t *pcmd[])
     return num;
 }*/
 
+int dm_easy_mesh_ctrl_t::analyze_bsta_cap_req(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    int num = 0;
+    em_cmd_t *tmp;
+    dm_easy_mesh_t dm = *this;
+
+    em_printfout("analyze radio mac '%s' for bsta cap request", evt->u.raw_buff);
+
+    evt->params.u.args.num_args = 1;
+    strncpy(evt->params.u.args.args[0], (const char *)evt->u.raw_buff, sizeof(mac_addr_str_t));
+
+    pcmd[num] = new em_cmd_bsta_cap_t(evt->params, dm);
+    tmp = pcmd[num];
+    num++;
+
+    return num;
+}
+
 int dm_easy_mesh_ctrl_t::set_op_class_list(cJSON *op_class_list_obj, mac_address_t *radio_mac)
 {
     dm_op_class_list_t::set_config(m_db_client, op_class_list_obj, radio_mac);
@@ -1532,7 +1551,7 @@ void dm_easy_mesh_ctrl_t::get_config(em_long_string_t net_id, em_subdoc_info_t *
     }
 
     tmp = cJSON_Print(parent);
-    //printf("%s:%d: Subdoc: %s\n", __func__, __LINE__, tmp);
+    printf("%s:%d: Subdoc: %s\n", __func__, __LINE__, tmp);
     strncpy(subdoc->buff, tmp, strlen(tmp) + 1);
     cJSON_free(parent);
 }

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1526,7 +1526,9 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
     strncpy(dev->m_device_info.id.net_id, net_id, strlen(net_id) + 1);
 	if (colocated == true) {
 		dev->m_device_info.id.media = dm->m_network.m_net_info.media;
-		memcpy(dev->m_device_info.backhaul_mac.mac, al_intf->mac, sizeof(mac_address_t));
+		//TODO: Monitor Checks
+		//memcpy(dev->m_device_info.backhaul_mac.mac, al_intf->mac, sizeof(mac_address_t));
+		printf("Backhaul mac updated to : %s\n", util::mac_to_string(dev->m_device_info.backhaul_mac.mac).c_str());
 		dev->m_device_info.backhaul_mac.media = dm->m_network.m_net_info.media;
 		//Update the easymesh configuration file
 		dev->update_easymesh_json_cfg(colocated);

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -239,6 +239,10 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_agent_ap_metrics_pending);
             break;
 
+        case em_cmd_type_bsta_cap:
+            m_sm.set_state(em_state_ctrl_bsta_cap_pending);
+            break;
+
         default:
             break;
 
@@ -335,6 +339,12 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
 
         case em_msg_type_map_policy_config_req:
             em_policy_cfg_t::process_msg(data, len);
+            break;
+
+        case em_msg_type_bh_sta_cap_query:
+        case em_msg_type_bh_sta_cap_rprt:
+            em_printfout("  proto_process, type rcvd: %d", htons(cmdu->type));
+            em_capability_t::process_msg(data, len);
             break;
 
         default:
@@ -479,6 +489,10 @@ void em_t::handle_ctrl_state()
 
         case em_cmd_type_mld_reconfig:
             em_configuration_t::process_ctrl_state();
+            break;
+
+        case em_cmd_type_bsta_cap:
+            em_capability_t::process_ctrl_state();
             break;
 
         default:
@@ -1733,6 +1747,7 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_ctrl_bsta_mld_config_pending)
         EM_STATE_2S(em_state_ctrl_ap_mld_req_ack_rcvd)
         EM_STATE_2S(em_state_ctrl_avail_spectrum_inquiry_pending)
+        EM_STATE_2S(em_state_ctrl_bsta_cap_pending)
         EM_STATE_2S(em_state_agent_unconfigured)
         EM_STATE_2S(em_state_agent_autoconfig_rsp_pending)
         EM_STATE_2S(em_state_agent_wsc_m2_pending)


### PR DESCRIPTION
Addition of Backhaul mac address using Backhaul sta capability query/report

Tested in RDK build, where Controller database should reflect proper entries in DeviceList for BackhaulMac, Backhaul_ALID and BackhaulSTA mac addresses for a device node in the network.