### PR TITLE
Radio Identifier should not be present in Topology query

### DIFF
--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -332,15 +332,6 @@ int em_configuration_t::send_topology_query_msg()
     tmp += sizeof(em_cmdu_t);
     len += static_cast<unsigned int> (sizeof(em_cmdu_t));
 
-    // One AP Radio Identifier tlv 17.2.3
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_radio_id;
-    memcpy(tlv->value, get_radio_interface_mac(), sizeof(mac_address_t));
-    tlv->len = htons(sizeof(mac_address_t));
-
-    tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
-    len += static_cast<unsigned int> (sizeof(em_tlv_t) + sizeof(mac_address_t));
-
     // One multiAP profile tlv 17.2.47
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_profile;


### PR DESCRIPTION
Remove adding of radio identifier in the topology query message to be in sync with Easymesh standard.