### PR TITLE
Enrollee: handle DPP_STATUS_CONFIGURE_PENDING and DPP_STATUS_NEW_KEY_NEEDED

### DIFF
--- a/inc/ec_crypto.h
+++ b/inc/ec_crypto.h
@@ -1156,6 +1156,17 @@ public:
 	 * @endcode
 	 */
 	static bool add_common_jwk_fields(cJSON *json_obj, const EC_GROUP* key_group, const EC_POINT *key_point);
+
+    /**
+     * @brief Validate that an EC_POINT is on the expected curve.
+     *
+     * @param ctx The connection context containing the BN context
+     * @param point The EC_POINT to validate
+     * @param expected_nid The expected NID of the curve
+     *
+     * @return true if the point is on the expected curve, false otherwise
+     */
+    static bool validate_point_is_on_curve(ec_connection_context_t& ctx, const EC_POINT* point, int expected_nid);
 };
 
 #endif // EC_CRYPTO_H

--- a/inc/ec_enrollee.h
+++ b/inc/ec_enrollee.h
@@ -511,12 +511,13 @@ private:
 	 *
 	 * This function generates a configuration request and returns it as a pair consisting of a pointer to the data and its size.
 	 * @param (optional) reconfiguration flags if being called during Reconfiguration
+	 * @param (optional) POP tag (Auth-I if DPP_STATUS_NEW_KEY_NEEDED received during Configuration Response handling)
 	 * @returns A pair containing a pointer to the configuration request data and its size.
 	 * @retval std::pair<uint8_t*, size_t> A pair where the first element is a pointer to the data and the second element is the size of the data.
 	 *
 	 * @note Ensure that the returned pointer is managed properly to avoid memory leaks.
 	 */
-	std::pair<uint8_t*, size_t> create_config_request(std::optional<ec_dpp_reconfig_flags_t> recfg_flags = std::nullopt);
+	std::pair<uint8_t*, size_t> create_config_request(std::optional<ec_dpp_reconfig_flags_t> recfg_flags = std::nullopt, std::optional<std::vector<uint8_t>> pop_tag = std::nullopt);
 
     
 	/**

--- a/src/em/prov/easyconnect/ec_crypto.cpp
+++ b/src/em/prov/easyconnect/ec_crypto.cpp
@@ -1224,3 +1224,20 @@ bool ec_crypto::add_common_jwk_fields(cJSON *json_obj, const EC_GROUP* key_group
 
     return true;
 }
+
+bool ec_crypto::validate_point_is_on_curve(ec_connection_context_t& ctx, const EC_POINT* point, int expected_nid)
+{
+    if (!point) {
+        em_printfout("Point is nullptr");
+        return false;
+    }
+
+    scoped_ec_group point_group(EC_GROUP_new_by_curve_name(expected_nid));
+    if (!point_group) {
+        em_printfout("Could not create EC_GROUP for expected NID: %d", expected_nid);
+        return false;
+    }
+
+    int on_curve = EC_POINT_is_on_curve(point_group.get(), point, ctx.bn_ctx);
+    return on_curve == 1;
+}


### PR DESCRIPTION
This improves interop with non-RDK Configurators. `DPP_STATUS_CSR_BAD` is a large cans of worms and will be a different PR.