### PR TITLE
RDKBACCL-1221: Channel preference report to contain information of all radios.

### DIFF
--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -222,6 +222,7 @@ public:
 	 * TLV (Type-Length-Value) and storing it in the provided buffer.
 	 *
 	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
+	 * @param[in] index The index of the radio operation restriction to be created.
 	 *
 	 * @returns A short integer indicating the success or failure of the operation.
 	 * @retval 0 on success.
@@ -229,7 +230,7 @@ public:
 	 *
 	 * @note Ensure that the buffer is properly allocated before calling this function.
 	 */
-	short create_radio_op_restriction_tlv(unsigned char *buff);
+	short create_radio_op_restriction_tlv(unsigned char *buff, unsigned int index);
     
 	/**!
 	 * @brief Creates a complete CAC report TLV.
@@ -265,6 +266,7 @@ public:
 	 * This function is responsible for creating a channel preference TLV agent using the provided buffer.
 	 *
 	 * @param[out] buff Pointer to the buffer where the channel preference TLV agent will be created.
+	 * @param[in] index The index of the channel preference TLV agent to be created.
 	 *
 	 * @returns short
 	 * @retval 0 on success
@@ -272,7 +274,7 @@ public:
 	 *
 	 * @note Ensure that the buffer is properly allocated before calling this function.
 	 */
-	short create_channel_pref_tlv_agent(unsigned char *buff);
+	short create_channel_pref_tlv_agent(unsigned char *buff, unsigned int index);
     
 	/**!
 	 * @brief Creates a TLV for transmit power limit.

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -386,11 +386,6 @@ int dm_easy_mesh_agent_t::analyze_channel_pref_query(em_bus_event_t *evt, em_cmd
     em_bus_event_type_channel_pref_query_params_t *params;
     
     params = reinterpret_cast<em_bus_event_type_channel_pref_query_params_t *> (evt->u.raw_buff);
-    dm.set_num_radios(1);
-    radio = dm.get_radio_info(0);
-    if (radio != NULL) {
-        memcpy(&radio->intf.mac, &params->mac, sizeof(mac_address_t));
-    }
     dm.set_msg_id(params->msg_id);
     pcmd[num] = new em_cmd_channel_pref_query_t(em_service_type_agent, evt->params, dm);
     num++;

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1491,34 +1491,15 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 			break;
 
         case em_msg_type_topo_query:
+        case em_msg_type_channel_pref_query:
             em_string_t al_mac_str;
             dm_easy_mesh_t::macbytes_to_string(hdr->dst, al_mac_str);
             strcat(al_mac_str, "_al");
             if ((em = (em_t *)hash_map_get(m_em_map, al_mac_str)) != NULL) {
-                em_printfout("Received topo query, found al_mac agent:%s", al_mac_str);
+                em_printfout("Received query message, found al_mac agent:%s", al_mac_str);
             } else {
-                em_printfout("Discarding topo query, al_mac agent:%s not found",
+                em_printfout("Discarding query message, al_mac agent:%s not found",
                     al_mac_str);
-                return NULL;
-            }
-            break;
-
-        case em_msg_type_channel_pref_query:
-            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
-                	len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_radio_id(&ruid) == false) {
-                printf("%s:%d: Could not find radio_id for em_msg_type_channel_pref_query\n", __func__, __LINE__);
-                return NULL;
-            }
-
-            dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
-            if ((em = (em_t *)hash_map_get(m_em_map, mac_str1)) != NULL) {
-                if (em->is_al_interface_em() == false) {
-                        printf("%s:%d: Received channel preference query recv, found existing radio:%s\n", __func__, __LINE__, mac_str1);
-                } else {
-                        return NULL;
-                }
-            } else {
-                printf("%s:%d: Could not find em for em_msg_type_channel_pref_query\n", __func__, __LINE__);
                 return NULL;
             }
             break;

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -629,6 +629,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
     em_2xlong_string_t key;
     unsigned int i;
     bool found;
+    em_string_t al_mac_str;
     mac_addr_str_t mac_str1, mac_str2, dev_mac_str, radio_mac_str;
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
@@ -853,7 +854,6 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
         break;
 
         case em_msg_type_bh_sta_cap_rprt:
-            em_string_t al_mac_str;
             dm_easy_mesh_t::macbytes_to_string(hdr->src, al_mac_str);
             strcat(al_mac_str, "_al");
             if ((em = (em_t *)hash_map_get(m_em_map, al_mac_str)) != NULL) {

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -502,7 +502,6 @@ int em_capability_t::send_bsta_cap_query_msg()
     unsigned int len = 0;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
-    em_enum_type_t profile;
     unsigned char *tmp = buff;
     unsigned short type = htons(ETH_P_1905);
     dm_easy_mesh_t* dm = NULL;
@@ -569,7 +568,6 @@ int em_capability_t::send_bsta_cap_report_msg(unsigned short msg_id)
     short sz = 0;
     unsigned short type = htons(ETH_P_1905);
     dm_easy_mesh_t *dm = get_data_model();
-    mac_addr_str_t mac_str;
 
     memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
@@ -766,7 +764,6 @@ int em_capability_t::handle_bsta_radio_cap(unsigned char *buff, unsigned int len
 {
     dm_easy_mesh_t *dm = get_data_model();
     em_bh_sta_radio_cap_t *bsta_radio_cap = reinterpret_cast<em_bh_sta_radio_cap_t*>(buff);
-    mac_addr_str_t mac_str, r_str;
 
     em_printfout("Rcvd Backhaul STA Radio Capabilities received, sta mac: %s for radio: %s, mac present?: %d",
         util::mac_to_string(bsta_radio_cap->bsta_addr).c_str(),
@@ -792,12 +789,6 @@ int em_capability_t::handle_bsta_cap_report(unsigned char *buff, unsigned int le
 {
     em_tlv_t *tlv;
     unsigned int tmp_len;
-    int ret = 0;
-    char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    bool found_op_bss = false;
-    bool found_profile = false;
-    bool found_bss_config_rprt = false;
-    em_profile_type_t profile = em_profile_type_reserved;
     dm_easy_mesh_t *dm;
 
     dm = get_data_model();

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -423,19 +423,12 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
                 }
                 break;
 			case em_cmd_type_channel_pref_query:
-				if (!(em->is_al_interface_em())) {
-					radio = pcmd->m_data_model.get_radio(static_cast<unsigned int> (0));
-					if (radio == NULL) {
-						printf("%s:%d em_cmd_type_channel_pref_query radio cannot be found.\n", __func__, __LINE__);
-						break;
-					}
-
-					if ((memcmp(radio->get_radio_interface_mac(),em->get_radio_interface_mac(),sizeof(mac_address_t)) == 0)
-							&& (em->get_state() >= em_state_agent_topo_synchronized)
+				if ((em->is_al_interface_em())) {
+					if ((em->get_state() >= em_state_agent_topo_synchronized)
 							&& (em->get_state() < em_state_agent_configured)) {
 						queue_push(pcmd->m_em_candidates, em);
 						count++;
-						dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), dst_mac_str);
+						dm_easy_mesh_t::macbytes_to_string(em->get_al_interface_mac(), dst_mac_str);
 						printf("%s:%d em_cmd_type_channel_pref_query build candidate MAC=%s\n", __func__, __LINE__,dst_mac_str);
 					}
 				}


### PR DESCRIPTION
 The channel preference and selection messages were dependent on presence of radio id.
 Modified to message based on the AL mac of the agent and updated TLVs based on IEEE1905 standard.

 Test report: Verified the channel preference and selection messages and TLVs based on ieee1905 formats