### PR TITLE
RDKBACCL-1207: Updates in network topology encode

### DIFF
--- a/src/ctrl/em_network_topo.cpp
+++ b/src/ctrl/em_network_topo.cpp
@@ -70,10 +70,13 @@ void em_network_topo_t::encode(cJSON *parent)
 				sta_list_obj = cJSON_AddArrayToObject(bss_obj, "STAList");
 				dm_easy_mesh_ctrl_t *dm_ctrl = reinterpret_cast<dm_easy_mesh_ctrl_t *>(g_ctrl.get_data_model(GLOBAL_NET_ID));
 				if (dm_ctrl != NULL) {
-					// Get the Station associated with this bss
-					std::string bss_mac_str = util::mac_to_string(m_data_model->m_bss[j].m_bss_info.bssid.mac);
-					dm_ctrl->dm_sta_list_t::get_config(sta_list_obj, static_cast<void*>(const_cast<char*> (bss_mac_str.c_str())),
-						em_get_sta_list_reason_topology);
+					// Get the Station associated with this bss only if vap mode is ap
+					if (m_data_model->m_bss[j].m_bss_info.vap_mode == em_vap_mode_ap) {
+						std::string bss_mac_str = util::mac_to_string(m_data_model->m_bss[j].m_bss_info.bssid.mac);
+						dm_ctrl->dm_sta_list_t::get_config(sta_list_obj,
+							static_cast<void*>(const_cast<char*> (bss_mac_str.c_str())),
+							em_get_sta_list_reason_topology);
+					}
 				}
 				cJSON_AddItemToArray(bss_list_obj, bss_obj);
 			}

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1528,8 +1528,10 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 		dev->m_device_info.id.media = dm->m_network.m_net_info.media;
 		//TODO: Monitor Checks
 		//memcpy(dev->m_device_info.backhaul_mac.mac, al_intf->mac, sizeof(mac_address_t));
-		printf("Backhaul mac updated to : %s\n", util::mac_to_string(dev->m_device_info.backhaul_mac.mac).c_str());
 		dev->m_device_info.backhaul_mac.media = dm->m_network.m_net_info.media;
+		em_printfout("Backhaul mac updated to :%s device media:%d backhaul media:%d",
+			util::mac_to_string(dev->m_device_info.backhaul_mac.mac).c_str(),
+			dev->m_device_info.id.media, dev->m_device_info.backhaul_mac.media);
 		//Update the easymesh configuration file
 		dev->update_easymesh_json_cfg(colocated);
 	}

--- a/src/dm/dm_network.cpp
+++ b/src/dm/dm_network.cpp
@@ -194,6 +194,8 @@ int dm_network_t::init()
 
 	memset(&m_net_info, 0, sizeof(em_network_info_t)); 
 	strncpy(m_net_info.timestamp, date_time, EM_DATE_TIME_BUFF_SZ);
+	// set the default media to Ethernet
+	m_net_info.media = em_media_type_ieee8023ab;
 	return 0;
 }
 

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -88,6 +88,7 @@ static pthread_once_t init_once = PTHREAD_ONCE_INIT;
 em_crypto_t::em_crypto_t() {
 
     #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    memset(&m_crypto_info, 0, sizeof(em_crypto_info_t));
     pthread_once(&init_once, []() {
         if (OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL) == 0) {
             fprintf(stderr, "OpenSSL initialization failed\n");


### PR DESCRIPTION
Reason for Change: Network topology sta list was wrongly being
added for sta vap mode. Also, the media type of network node
was not having correct default value. This commit addresses
these two changes.
Test Procedure: Checked that the topology update is not having
sta list printed for sta vap mode on rpi and bpi.