### PR TITLE
RDKBACCL-1192, RDKB-61233: Easymesh [BPI] - WPA3-Personal-Transition Update

### DIFF
--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -4721,11 +4721,7 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 		if (get_band() == 2) {
 			auth_type = 0x0200; // WPA3-Personal
 		} else {
-			if (haul_type == em_haul_type_fronthaul) {
-				auth_type = 0x0400; // WPA3-Personal-Transition
-			} else {
-				auth_type = 0x0010; // WPA2-Personal
-			}
+			auth_type = 0x0400; // WPA3-Personal-Transition
 		}
 
 		// haultype


### PR DESCRIPTION
RDKBACCL-1192, RDKB-61233: Easymesh [BPI] - WPA3-Personal-Transition Update

Reason for change: Updated security mode from WPA2-Personal to WPA3-Personal-Transition to support WiFi 7 SLO/MLO in Easymesh for BPI.
Test Procedure: Ensure basic easymesh configuration and client connectivity works including extender backhaul connection.
Risks: Medium
Priority: P1