### PR TITLE
RDKBACCL-1207: Topology updates to orchestrator

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -83,8 +83,13 @@ public:
     unsigned int    m_num_assoc_sta_mld;
     dm_assoc_sta_mld_t m_assoc_sta_mld[EM_MAX_ASSOC_STA_MLD];
     dm_tid_to_link_t m_tid_to_link;
+    bool m_topo_changed = false;
 
 public:
+
+	bool get_topo_state() { return m_topo_changed; }
+	void set_topo_state(bool state) { m_topo_changed = state; }
+
 	static em_e4_table_t m_e4_table[];
 	
 	/**!

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -700,6 +700,10 @@ public:
 	 */
 	int tr181_reg_data_elements(bus_handle_t *bus_handle);
 
+	static bus_error_t get_node_sync(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+	static bus_error_t set_node_sync(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+	static bus_error_t policy_config(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
 #ifdef AL_SAP
     
 	/**!

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -21,12 +21,14 @@
 
 #include "em_ctrl.h"
 
-#define DEVICE_WIFI_DATAELEMENTS_NETWORK_COLOCATEDAGENTID	"Device.WiFi.DataElements.Network.ColocatedAgentID"
-#define DEVICE_WIFI_DATAELEMENTS_NETWORK_CONTROLLERID		"Device.WiFi.DataElements.Network.ControllerID"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_COLOCATEDAGENTID   "Device.WiFi.DataElements.Network.ColocatedAgentID"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_CONTROLLERID       "Device.WiFi.DataElements.Network.ControllerID"
 //#define DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD "Device.WiFi.DataElements.Network.SetSSID()"
-#define DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD		"Device.WiFi.DataElements.Network.SetSSID"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD        "Device.WiFi.DataElements.Network.SetSSID"
 //Orchestrator
-#define DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY			"Device.WiFi.DataElements.Network.Topology"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY           "Device.WiFi.DataElements.Network.Topology"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC          "Device.WiFi.DataElements.Network.NodeSynchronize"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY    "Device.WiFi.DataElements.Network.NodeConfigurePolicy"
 
 typedef struct {
 	em_short_string_t ssid;

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -575,6 +575,7 @@ const char *em_cmd_t::get_orch_op_str(dm_orch_type_t type)
         ORCH_TYPE_2S(dm_orch_type_sta_disassoc)
         ORCH_TYPE_2S(dm_orch_type_policy_cfg)
         ORCH_TYPE_2S(dm_orch_type_mld_reconfig)
+        ORCH_TYPE_2S(dm_orch_type_topo_publish)
 
         default:
            break;

--- a/src/cmd/em_cmd_sta_assoc.cpp
+++ b/src/cmd/em_cmd_sta_assoc.cpp
@@ -45,9 +45,11 @@ em_cmd_sta_assoc_t::em_cmd_sta_assoc_t(em_cmd_params_t param, dm_easy_mesh_t& dm
 	memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
 
     m_orch_op_idx = 0;
-    m_num_orch_desc = 1;
+    m_num_orch_desc = 2;
     m_orch_desc[0].op = dm_orch_type_sta_cap;
     m_orch_desc[0].submit = true;
+    m_orch_desc[1].op = dm_orch_type_topo_publish;
+    m_orch_desc[1].submit = true;
 
     strncpy(m_name, "sta_assoc", strlen("sta_assoc") + 1);
     m_svc = em_service_type_ctrl;

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -153,6 +153,8 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
         return -1;
     }
 
+    pdm->set_topo_state(true);
+
     for (i = 0; i < pdm->get_num_radios(); i++) {
         found = true;
         pbss = pdm->get_bss(pdm->get_radio_info(i)->id.ruid, params->assoc.bssid);
@@ -192,7 +194,7 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
 
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
     if ((get_sta(key) != NULL) && (params->assoc.assoc_event == false)){
-        desc.op = dm_orch_type_sta_update;
+        desc.op = dm_orch_type_topo_update;
         desc.submit = false;
         pcmd[num - 1]->override_op(0, &desc);
     }

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -892,14 +892,14 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
         break;
 
         case em_msg_type_bh_sta_cap_rprt:
-            dm_easy_mesh_t::macbytes_to_string(hdr->src, al_mac_str);
-            strcat(al_mac_str, "_al");
-            if ((em = (em_t *)hash_map_get(m_em_map, al_mac_str)) != NULL) {
-                em_printfout("Received bsta report, found al_mac em:%s", al_mac_str);
-            } else {
-                em_printfout("Discarding bsta report, al_mac em :%s not found",
-                    al_mac_str);
+            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
+                len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_radio_id(&ruid) == false) {
                 return NULL;
+            }
+
+            dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
+            if ((em = static_cast<em_t *> (hash_map_get(m_em_map, mac_str1))) != NULL) {
+                em_printfout("Received bsta report, found em:%s", mac_str1);
             }
             break;
 
@@ -945,9 +945,15 @@ void em_ctrl_t::start_complete()
 		// { DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD, bus_element_type_method,
 		// 	{ NULL, NULL, NULL, NULL, NULL, cmd_setssid}, slow_speed, ZERO_TABLE,
 		//	{ bus_data_type_string, true, 0, 0, 0, NULL } },
-		{ DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY, bus_element_type_method,
-			{ NULL, NULL , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
-			{ bus_data_type_string, false, 0, 0, 0, NULL } },
+        { DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY, bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
+            { bus_data_type_string, false, 0, 0, 0, NULL } },
+        { DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC, bus_element_type_method,
+            { get_node_sync,  set_node_sync , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
+            { bus_data_type_string, false, 0, 0, 0, NULL } },
+        { DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, bus_element_type_method,
+            { NULL, policy_config , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
+            { bus_data_type_string, false, 0, 0, 0, NULL } },
 	};
 
 	if (m_data_model.is_initialized() == false) {

--- a/src/ctrl/tr_181/tr_181_param.cpp
+++ b/src/ctrl/tr_181/tr_181_param.cpp
@@ -39,6 +39,60 @@ bus_error_t curops_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_in
 bus_error_t bss_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property);
 bus_error_t sta_tget_params(dm_easy_mesh_t *dm, const char *root, em_bss_info_t *bi, bus_data_prop_t **property);
 
+mac_addr_str_t g_temp_node_mac = {0};
+
+bus_error_t em_ctrl_t::get_node_sync(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    p_data->data_type       = bus_data_type_string;
+    p_data->raw_data.bytes  = malloc(sizeof(mac_addr_str_t));
+    if (p_data->raw_data.bytes == NULL) {
+        em_printfout("Memory allocation is failed");
+        return bus_error_out_of_resources;
+    }
+    em_printfout(" get_node_sync: node mac len: %d", sizeof(mac_addr_str_t));
+
+    strncpy((char *)p_data->raw_data.bytes, (const char *)g_temp_node_mac, sizeof(g_temp_node_mac));
+    p_data->raw_data_len    = sizeof(mac_addr_str_t);
+
+    em_printfout(" get_node_sync: node mac: %s", p_data->raw_data.bytes);
+
+    return bus_error_success;
+}
+
+bus_error_t em_ctrl_t::set_node_sync(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    wifi_bus_desc_t *desc = NULL;
+    raw_data_t raw;
+
+    em_printfout(" Event rcvd: %s for node mac: %s", event_name, p_data->raw_data.bytes);
+
+    snprintf(g_temp_node_mac, sizeof(mac_addr_str_t), "%s", (char *)p_data->raw_data.bytes);
+
+    if((desc = get_bus_descriptor()) == NULL) {
+        em_printfout("descriptor is null");
+    }
+
+    //TODO: Temp code to publish node sync once received
+    raw.data_type    = bus_data_type_string;
+    raw.raw_data.bytes = reinterpret_cast<unsigned char *> (g_temp_node_mac);
+    raw.raw_data_len = static_cast<unsigned int> (strlen(g_temp_node_mac));
+
+    if (desc->bus_event_publish_fn(&g_ctrl.m_bus_hdl, DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC, &raw)== 0) {
+        em_printfout("Node sync published successfull");
+    } else {
+        em_printfout("Node sync publish fail");
+    }
+
+    return bus_error_success;
+}
+
+bus_error_t em_ctrl_t::policy_config(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_printfout(" Event rcvd: %s\n Policy cfg is: \n%s", event_name, p_data->raw_data.bytes);
+
+    return bus_error_success;
+}
+
 bus_error_t em_ctrl_t::get_device_wifi_dataelements_network_colocated_agentid (char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     em_interface_t  *intf;
@@ -52,7 +106,7 @@ bus_error_t em_ctrl_t::get_device_wifi_dataelements_network_colocated_agentid (c
     len = strlen(al_mac_str) + 1;
     p_data->raw_data.bytes = malloc(len);
     if (p_data->raw_data.bytes == NULL) {
-        em_printfout("Memory allocation is failed:%d\r", len);
+        em_printfout("Memory allocation is failed:%d", len);
         return bus_error_out_of_resources;
     }
     snprintf((char*)p_data->raw_data.bytes, len, "%s", al_mac_str);
@@ -73,12 +127,12 @@ bus_error_t em_ctrl_t::get_device_wifi_dataelements_network_controllerid (char *
     p_data->data_type = bus_data_type_string;
     p_data->raw_data.bytes = malloc(len);
     if (p_data->raw_data.bytes == NULL) {
-        em_printfout("Memory allocation is failed:%d\r", len);
+        em_printfout("Memory allocation is failed:%d", len);
         return bus_error_out_of_resources;
     }
     snprintf((char*)p_data->raw_data.bytes, len, "%s", ctrl_mac);
     p_data->raw_data_len = len;
-    em_printfout("Descriptor value=%s, len=%d\n", (char *)p_data->raw_data.bytes, p_data->raw_data_len);
+    em_printfout("Descriptor value=%s, len=%d", (char *)p_data->raw_data.bytes, p_data->raw_data_len);
 
     return bus_error_success;
 }

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -888,6 +888,10 @@ void em_capability_t::process_ctrl_state()
             send_bsta_cap_query_msg();
             break;
 
+        case em_state_ctrl_sta_cap_pending:
+            send_client_cap_query();
+            break;
+
         default:
             printf("%s:%d: unhandled case %s\n", __func__, __LINE__, em_t::state_2_str(get_state()));
             break;
@@ -904,12 +908,6 @@ void em_capability_t::process_agent_state()
             break;
 
         case em_state_agent_client_cap_report:
-            break;
-
-        case em_state_ctrl_sta_cap_pending:
-            if (get_service_type() == em_service_type_ctrl) {
-                send_client_cap_query();
-            }
             break;
 
         default:

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -175,7 +175,11 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_agent_onewifi_bssconfig_ind);
             break;
         case em_cmd_type_sta_assoc:
-            m_sm.set_state(em_state_ctrl_sta_cap_pending);
+            if ((pcmd->get_orch_op() == dm_orch_type_topo_publish) && (m_sm.get_state() == em_state_ctrl_configured)) {
+                m_sm.set_state(em_state_ctrl_topo_publish_pending);
+            } else {
+                m_sm.set_state(em_state_ctrl_sta_cap_pending);
+            }
             break;
 
         case em_cmd_type_channel_pref_query:
@@ -470,7 +474,8 @@ void em_t::handle_ctrl_state()
             break;
 
         case em_cmd_type_sta_assoc:
-            em_capability_t::process_agent_state();
+            em_capability_t::process_ctrl_state();
+            em_configuration_t::process_ctrl_state();
             break;
 
         case em_cmd_type_sta_link_metrics:

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -201,6 +201,9 @@ bool em_msg_t::get_radio_id(mac_address_t *mac)
 		} else if (tlv->type == em_tlv_type_radio_metric) {
             memcpy(mac, tlv->value, sizeof(mac_address_t));
             return true;
+        } else if (tlv->type == em_tlv_type_bh_sta_radio_cap) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
         }
 
         len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -123,11 +123,13 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_sta_assoc:
             if (em->get_cap_query_tx_count() >= EM_MAX_CAP_QUERY_TX_THRESH) {
                 em->set_cap_query_tx_count(0);
-                printf("%s:%d: Maximum renew tx threshold crossed, transitioning to fini\n", __func__, __LINE__);
+                em_printfout("Maximum renew tx threshold crossed, transitioning to fini");
                 em->set_state(em_state_ctrl_configured);
                 return true;
             } else if (em->get_state() == em_state_ctrl_sta_cap_confirmed) {
                 em->set_state(em_state_ctrl_configured);
+                return true;
+            } else if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             }
             break;
@@ -380,12 +382,14 @@ bool em_orch_ctrl_t::pre_process_orch_op(em_cmd_t *pcmd)
 			mgr_dm->set_db_cfg_param(db_cfg_type_bss_list_delete, criteria);
 			break;
 
-		case dm_orch_type_topo_update:
-			if (pcmd->get_type() != em_cmd_type_em_config) {
-				break;
-			}
-			break;
+        case dm_orch_type_topo_update:
+            if (pcmd->get_type() == em_cmd_type_em_config) {
+                break;
+            }
+            m_mgr->update_network_topology();
+            break;
 
+        case dm_orch_type_topo_publish:
         case dm_orch_type_bsta_cap_query:
 			break;
 


### PR DESCRIPTION
- Topology update on a client assoc/disassoc and publish to orchestrator is enabled.
- Method to receive policy and node sync is also enabled.