### PR TITLE
RDKBACCL-1311: Changed the static folder path to static for rdkbcli

### DIFF
--- a/build/rdkb-cli/makefile
+++ b/build/rdkb-cli/makefile
@@ -24,6 +24,8 @@ include ../makefile.inc
 
 PROGRAM = $(INSTALLDIR)/bin/onewifi_em_rdkbcli
 EM_CLI_LIBRARY = $(INSTALLDIR)/lib/libemcli.so
+STATIC_SRC_DIR ?= $(ONEWIFI_EM_SRC)/rdkb-cli/static
+STATIC_DST_DIR ?= $(NVRAM_DIR)/static
 EM_CERT_SRC = $(INSTALLDIR)/config/test_cert.crt
 EM_KEY_SRC  = $(INSTALLDIR)/config/test_cert.key
 CERT_TARGETS = $(NVRAM_DIR)/test_cert.crt $(NVRAM_DIR)/test_cert.key
@@ -85,7 +87,7 @@ CLI_OBJECTS = $(CLI_SOURCES:.cpp=.o)
 GENERIC_OBJECTS = $(GENERIC_SOURCES:.c=.o) 
 EMCLIOBJECTS = $(CLI_OBJECTS) $(GENERIC_OBJECTS)
 
-all: $(EM_CLI_LIBRARY) $(PROGRAM) $(CERT_TARGETS)
+all: $(EM_CLI_LIBRARY) $(PROGRAM) $(CERT_TARGETS) copy-static
 
 $(EM_CLI_LIBRARY): $(EMCLIOBJECTS)
 	$(CXX) -shared -o $@ $(EMCLIOBJECTS)
@@ -116,6 +118,12 @@ $(NVRAM_DIR)/test_cert.crt: $(EM_CERT_SRC) | $(NVRAM_DIR)
 
 $(NVRAM_DIR)/test_cert.key: $(EM_KEY_SRC) | $(NVRAM_DIR)
 	$(CP) $< $@
+
+# Copy entire static directory to /nvram/static
+.PHONY: copy-static
+copy-static: $(NVRAM_DIR)
+	@echo "Syncing $(STATIC_SRC_DIR) -> $(STATIC_DST_DIR)"
+	@sudo rsync -a --delete "$(STATIC_SRC_DIR)/" "$(STATIC_DST_DIR)/"
 
 # Clean target: "make -f Makefile.Linux clean" to remove unwanted objects and executables.
 #

--- a/src/rdkb-cli/main.go
+++ b/src/rdkb-cli/main.go
@@ -548,7 +548,7 @@ func initDefaultFloorPlans() {
 	defaultPlan := &FloorPlan{
 		ID:        "1st-floor",
 		Name:      "1st Floor",
-		URL:       "../../src/rdkb-cli/static/floorplans/1st-floor.jpg",
+		URL:       "/nvram/static/floorplans/1st-floor.jpg",
 		Width:     1000,
 		Height:    600,
 		Scale:     0.1, // 10cm per pixel
@@ -2461,7 +2461,7 @@ func getDefaultAdvancedSettings() *AdvancedWirelessSettings {
 
 
 func loadDevices() {
-	file, err := os.Open("../../src/rdkb-cli/devices.json")
+	file, err := os.Open("/nvram/static/devices.json")
 	if err != nil {
 		log.Printf("Warning: Could not load devices.json: %v", err)
 		devices = getDefaultDevices()
@@ -2478,7 +2478,7 @@ func loadDevices() {
 }
 
 func loadClients() {
-	file, err := os.Open("../../src/rdkb-cli/clients.json")
+	file, err := os.Open("/nvram/static/clients.json")
 	if err != nil {
 		log.Printf("Warning: Could not load clients.json: %v", err)
 		clients = getSampleClients()
@@ -2524,7 +2524,7 @@ func main() {
 	router := mux.NewRouter()
 
 	// Serve static files
-	router.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("../../src/rdkb-cli/static/"))))
+	router.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("/nvram/static/"))))
 	router.HandleFunc("/", serveIndex).Methods("GET")
 
 	// API Routes
@@ -2666,7 +2666,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 // ===== HANDLERS =====
 
 func serveIndex(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "../../src/rdkb-cli/static/index.html")
+	http.ServeFile(w, r, "/nvram/static/index.html")
 }
 
 func controllerIPHandler(w http.ResponseWriter, r *http.Request) {
@@ -3901,10 +3901,10 @@ func parseSTA(node *C.em_network_node_t) STA {
 
 func getTestJSONFile() string {
     files := []string{
-        "../../src/rdkb-cli/static/example/topology.json",
-        "../../src/rdkb-cli/static/example/topology1.json",
-        "../../src/rdkb-cli/static/example/topology2.json",
-        "../../src/rdkb-cli/static/example/topology3.json",
+        "/nvram/static/example/topology.json",
+        "/nvram/static/example/topology1.json",
+        "/nvram/static/example/topology2.json",
+        "/nvram/static/example/topology3.json",
     }
     index := (timerCount) % len(files)
     return files[index]


### PR DESCRIPTION
changes the static file path to absolute to make common for openwrt and rdkb build.