### PR TITLE
RDKBACCL-1326: Observed the crash on ssl_write while setting the ssid…

### DIFF
--- a/src/rdkb-cli/em_cmd_cli.cpp
+++ b/src/rdkb-cli/em_cmd_cli.cpp
@@ -186,6 +186,7 @@ int em_cmd_cli_t::execute(char *result)
     param = get_param();
 
     evt->type = em_event_type_bus;
+    evt->u.bevt.data_len = 0;
     bevt = &evt->u.bevt;
     memcpy(&bevt->params, param, sizeof(em_cmd_params_t));
 


### PR DESCRIPTION
Observed the evt->u.bevt.data_len is not initialized which is being set and garbage value and causing the crash or ssl_write failed.