### PR TITLE
RDKBACCL-1206: TR181 Framework compilation fixes for RPI and OpenWRT

### DIFF
--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -83,7 +83,6 @@ GENERIC_SOURCES = $(ONEWIFI_HOME)/source/utils/collection.c \
 	$(ONEWIFI_EM_SRC)/util_crypto/aes_siv.c \
 	$(ONEWIFI_HOME)/lib/common/util.c \
     $(ONEWIFI_HOME)/source/platform/linux/bus.c \
-	$(ONEWIFI_HOME)/source/platform/common/bus_common.c \
 
 
 CTRL_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \

--- a/build/openwrt/ctrl/makefile
+++ b/build/openwrt/ctrl/makefile
@@ -110,6 +110,7 @@ CTRL_SOURCES = $(wildcard $(ONEWIFI_EM_SRC)/em/*.cpp) \
 	$(wildcard $(ONEWIFI_EM_SRC)/db/*.cpp) \
 	$(wildcard $(ONEWIFI_EM_SRC)/dm/*.cpp) \
 	$(wildcard $(ONEWIFI_EM_SRC)/ctrl/tr_181/*.cpp) \
+	$(wildcard $(ONEWIFI_EM_SRC)/ctrl/tr_181/wfa_data_model/*.cpp) \
 	$(ONEWIFI_EM_SRC)/orch/em_orch.cpp \
 	$(ONEWIFI_EM_SRC)/orch/em_orch_ctrl.cpp \
 	$(wildcard $(ONEWIFI_EM_SRC)/utils/*.cpp) \

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -464,7 +464,7 @@ public:
 
 template <typename T> bus_data_prop_t *tr_181_t::property_init_value(const char *root, unsigned int idx, const char *param, T value)
 {
-    bus_data_prop_t *property = (bus_data_prop_t *)calloc(1, sizeof(bus_data_prop_t));
+    bus_data_prop_t *property = static_cast<bus_data_prop_t *>(calloc(1, sizeof(bus_data_prop_t)));
 
     if (property == NULL) {
         return NULL;
@@ -486,7 +486,7 @@ template <typename T> void tr_181_t::property_append_tail(bus_data_prop_t **prop
     if (*property == NULL) {
         *property = property_init_value(root, idx, param, value);
     } else {
-        tail = (bus_data_prop_t *)calloc(1, sizeof(bus_data_prop_t));
+        tail = static_cast<bus_data_prop_t *>(calloc(1, sizeof(bus_data_prop_t)));
         snprintf(tail->name, sizeof(bus_name_string_t), "%s%d.%s", root, idx, param);
         raw_data_set(&tail->value, value);
         tail->name_len = static_cast<uint32_t>(strlen(tail->name));


### PR DESCRIPTION
Addressing some compilation and linking fixes related to tr-181 framework change associated with RPI and OpenWRT.