### PR TITLE
RDKBACCL-1330: Updated current tx_power in operating channel report TLV

### DIFF
--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -746,6 +746,7 @@ short em_channel_t::create_operating_channel_report_tlv(unsigned char *buff)
 	em_op_class_ch_rprt_t *rprt_channel;
 	dm_op_class_t	*op_class;	
 	unsigned char *tmp;
+	int8_t curr_txpwr_dbm = 0;
 
 	dm = get_data_model();
 
@@ -766,14 +767,14 @@ short em_channel_t::create_operating_channel_report_tlv(unsigned char *buff)
 			len += static_cast<short unsigned int> (sizeof(em_op_class_ch_rprt_t));
 			tmp += sizeof(em_op_class_ch_rprt_t);
 
-			len += static_cast<short unsigned int> (sizeof(unsigned char));
-			tmp += sizeof(unsigned char);	
-
 			rprt_channel = reinterpret_cast<em_op_class_ch_rprt_t *> (tmp);
 
 			rprt_op_class->op_classes_num++;
 		}
 	}	
+	curr_txpwr_dbm = static_cast<int8_t>(op_class->m_op_class_info.tx_power);
+	memcpy(buff + len, &curr_txpwr_dbm, sizeof(curr_txpwr_dbm));
+	len += static_cast<short>(sizeof(curr_txpwr_dbm));
 
 	return len;
 }


### PR DESCRIPTION
- Updated TX power in Unified Mesh `em_op_class_info_t` from onewifi.
- Populate TX power in Operating Channel Report TLV within the Operating Channel Report message

Closes: RDKBACCL-1330
Signed-off-by: Sundram Patel <sundram.p@tataelxsi.co.in>
