### PR TITLE
RDKBACCL-1329 : TLV Length correction for AP Autoconfiguration M2

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -177,6 +177,12 @@ extern "C"
 
 #define EM_MAX_SSID_LEN                33 
 #define EM_MAX_WIFI_PASSWORD_LEN       65 
+
+/* WSC Message TLV LENs */
+#define EM_CONN_TYPE_FLAGS_LEN         0x01
+#define EM_PRIMARY_DEV_TYPE_LEN        0x08
+#define EM_OS_VERSION_LEN              0x04
+
 /* Disallowed STAList */
 #define EM_MSCS_DISALLOWED_STA      10
 #define EM_SCS_DISALLOWED_STA       10

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2024,8 +2024,9 @@ unsigned short em_configuration_t::create_m2_msg(unsigned char *buff, em_haul_ty
     // connection type flags    
     attr = reinterpret_cast<data_elem_attr_t *> (tmp);
     attr->id = htons(attr_id_conn_type_flags);
-    size = sizeof(unsigned short);
+    size = EM_CONN_TYPE_FLAGS_LEN;
     attr->len = htons(size);
+    memset(attr->val, 0, size);
     //memcpy(attr->val, &get_device_info()->sec_1905.conn_flags, size);
     
     len += static_cast<unsigned short int> (sizeof(data_elem_attr_t) + size);
@@ -2087,7 +2088,7 @@ unsigned short em_configuration_t::create_m2_msg(unsigned char *buff, em_haul_ty
     // primary device type
     attr = reinterpret_cast<data_elem_attr_t *> (tmp);
     attr->id = htons(attr_id_primary_device_type);
-    size = sizeof(em_short_string_t);
+    size = EM_PRIMARY_DEV_TYPE_LEN;
     attr->len = htons(size);
     memcpy(attr->val, get_primary_device_type(), size);
     
@@ -2148,9 +2149,10 @@ unsigned short em_configuration_t::create_m2_msg(unsigned char *buff, em_haul_ty
     // os version   
     attr = reinterpret_cast<data_elem_attr_t *> (tmp);
     attr->id = htons(attr_id_os_version);
-    size = sizeof(unsigned short);
+    size = EM_OS_VERSION_LEN;
     attr->len = htons(size);
-    memcpy(attr->val, &rf_band, sizeof(attr->val));
+    memset(attr->val, 0, size);
+    //memcpy(attr->val, &rf_band, sizeof(attr->val));
     
     len += static_cast<unsigned short int> (sizeof(data_elem_attr_t) + size);
     tmp += (sizeof(data_elem_attr_t) + size);
@@ -2438,9 +2440,10 @@ unsigned short em_configuration_t::create_m1_msg(unsigned char *buff)
     // connection type flags    
     attr = reinterpret_cast<data_elem_attr_t *> (tmp);
     attr->id = htons(attr_id_conn_type_flags);
-    size = sizeof(unsigned short);
+    size = EM_CONN_TYPE_FLAGS_LEN;
     attr->len = htons(size);
-    memcpy(attr->val, &get_device_info()->sec_1905.conn_flags, size);
+    memset(attr->val, 0, size);
+    //memcpy(attr->val, &get_device_info()->sec_1905.conn_flags, size);
 
     len += static_cast<unsigned short int> (sizeof(data_elem_attr_t) + size);
     tmp += (sizeof(data_elem_attr_t) + size);
@@ -2512,7 +2515,7 @@ unsigned short em_configuration_t::create_m1_msg(unsigned char *buff)
     // primary device type
     attr = reinterpret_cast<data_elem_attr_t *> (tmp);
     attr->id = htons(attr_id_primary_device_type);
-    size = sizeof(em_short_string_t);
+    size = EM_PRIMARY_DEV_TYPE_LEN;
     attr->len = htons(size);
     memcpy(attr->val, get_current_cmd()->get_primary_device_type(), size);
 
@@ -2574,9 +2577,10 @@ unsigned short em_configuration_t::create_m1_msg(unsigned char *buff)
     // os version   
     attr = reinterpret_cast<data_elem_attr_t *> (tmp);
     attr->id = htons(attr_id_os_version);
-    size = sizeof(unsigned short);
+    size = EM_OS_VERSION_LEN;
     attr->len = htons(size);
-    memcpy(attr->val, &rf_band, sizeof(attr->val));
+    memset(attr->val, 0, size);
+    //memcpy(attr->val, &rf_band, sizeof(attr->val));
 
     len += static_cast<unsigned short int> (sizeof(data_elem_attr_t) + size);
     tmp += (sizeof(data_elem_attr_t) + size);


### PR DESCRIPTION
1. Connection type flag len changed to 1B
2. Primary Device type len changed to 8B
3. OS Version Len changed to 4B