### PR TITLE
RDKBACCL-1332 : Interop - Version TLV is missing as incorrect TypeID is used WSC.  

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -1908,6 +1908,7 @@ typedef enum {
     attr_id_totalPnetworks,
     attr_id_uuid_e, 
     attr_id_uuid_r, 
+    attr_id_vendor_ext,
     attr_id_version,
     attr_id_primary_device_type = 0x1054,
 	attr_id_haul_type,


### PR DESCRIPTION
Updating the TLV ID as per standard by adding missing vendor extension tlv type in the enum.

Current TLV Type:  0x1049 

As per Spec TLV Type: 0x104A (Pg 103) 