### PR TITLE
RDKBACCL-1340: Correct WSC attributes in M2 message

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -1917,8 +1917,8 @@ typedef enum {
     attr_id_vendor_ext,
     attr_id_version,
     attr_id_primary_device_type = 0x1054,
-	attr_id_haul_type,
-	attr_id_no_of_haul_type,
+    attr_id_haul_type,
+    attr_id_no_of_haul_type,
 } data_elem_attr_id_t;
 
 typedef enum {

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -705,6 +705,7 @@ class em_configuration_t {
 	 *
 	 * @param[in] buff Pointer to the buffer containing the WSC M2 message.
 	 * @param[in] len Length of the buffer.
+	 * @param[in] index Index of the WSC TLV.
 	 *
 	 * @returns int
 	 * @retval 0 on success.
@@ -712,7 +713,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the buffer is properly allocated and contains a valid WSC M2 message before calling this function.
 	 */
-	int handle_wsc_m2(unsigned char *buff, unsigned int len);
+	int handle_wsc_m2(unsigned char *buff, unsigned int len, unsigned int index);
     
 	/**!
 	 * @brief Handles the renewal of auto-configuration.
@@ -1565,10 +1566,10 @@ private:
     size_t m_m1_length;
     size_t m_m2_length;
 
-    unsigned char m_m2_authenticator[SHA256_MAC_LEN];
-    unsigned int m_m2_authenticator_len;
-    unsigned char m_m2_encrypted_settings[MAX_EM_BUFF_SZ];
-    unsigned int m_m2_encrypted_settings_len;
+    unsigned char m_m2_authenticator[em_haul_type_max][SHA256_MAC_LEN];
+    unsigned int m_m2_authenticator_len[em_haul_type_max];
+    unsigned char m_m2_encrypted_settings[em_haul_type_max][MAX_EM_BUFF_SZ];
+    unsigned int m_m2_encrypted_settings_len[em_haul_type_max];
 
 public:
 
@@ -1664,7 +1665,7 @@ public:
 	 * @note Ensure that the encryption keys are properly initialized
 	 * before calling this function.
 	 */
-	int handle_encrypted_settings();
+	int handle_encrypted_settings(unsigned int wsc_tlv_count);
     
 	/**!
 	 * @brief Creates encrypted settings based on the provided buffer and haul type.

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -85,8 +85,6 @@ class em_configuration_t {
 	 * This function generates a WSC (Wi-Fi Simple Configuration) M2 message for auto-configuration purposes.
 	 *
 	 * @param[out] buff Pointer to the buffer where the generated message will be stored.
-	 * @param[in] haul_type Array of haul types used in the configuration.
-	 * @param[in] num_hauls Number of haul types in the array.
 	 * @param[in] msg_id The message ID of the original request being responded to.
 	 *
 	 * @returns int Status code indicating success or failure of the message creation.
@@ -95,7 +93,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the buffer is adequately sized to hold the generated message.
 	 */
-	int create_autoconfig_wsc_m2_msg(unsigned char *buff, em_haul_type_t haul_type[], unsigned int num_hauls, unsigned short msg_id);
+	int create_autoconfig_wsc_m2_msg(unsigned char *buff, unsigned short msg_id);
     
 	/**!
 	 * @brief Creates a BSS configuration request message.

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -354,30 +354,27 @@ void dm_easy_mesh_list_t::put_radio(const char *key, const dm_radio_t *radio)
 {
     dm_radio_t *pradio = NULL;
     dm_easy_mesh_t	*dm = NULL;
-    mac_addr_str_t  dev_mac;
     em_t *em = NULL;
 
-    //em_printfout("%s:%d: Radio: %s", __func__, __LINE__, key);
+    //em_printfout("Radio: %s", key);
 
     if ((pradio = get_radio(key)) == NULL) {
         dm = get_data_model(radio->m_radio_info.id.net_id, radio->m_radio_info.id.dev_mac);
-        dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (radio->m_radio_info.id.dev_mac), dev_mac);
-		//em_printfout("%s:%d: dm: %p net: %s device: %s", __func__, __LINE__, dm, radio->m_radio_info.id.net_id, dev_mac);
+        //em_printfout("dm: %p net: %s device: %s", dm, radio->m_radio_info.id.net_id,
+        //      util::mac_to_string(radio->m_radio_info.id.dev_mac).c_str());
         if (dm == NULL) {
             return;
         }
 
-        //em_printfout("%s:%d: Current Number of Radios: %d", __func__, __LINE__, dm->get_num_radios());
+        //em_printfout("Current Number of Radios: %d", dm->get_num_radios());
         dm->set_num_radios(dm->get_num_radios() + 1);
         pradio = dm->get_radio(dm->get_num_radios() - 1);
     }
     *pradio = *radio;
-    em_printfout("Radio dev_id is:%s", radio->m_radio_info.id.dev_mac);
-
-    dm_easy_mesh_t::macbytes_to_string(pradio->m_radio_info.id.dev_mac, dev_mac);
+    em_printfout("Radio dev_id is:%s", util::mac_to_string(pradio->m_radio_info.id.dev_mac).c_str());
     if ((em = m_mgr->create_node(&pradio->m_radio_info.intf, static_cast<em_freq_band_t> (pradio->m_radio_info.media_data.band), dm, false,
             em_profile_type_3, em_service_type_ctrl)) != NULL) {
-        em_printfout("Node created successfully for radio:%s almac:%s", key, dev_mac);
+        em_printfout("Node created successfully for radio:%s almac:%s", key, util::mac_to_string(pradio->m_radio_info.id.dev_mac).c_str());
     }
 }
 

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -3611,14 +3611,14 @@ int em_configuration_t::create_autoconfig_search_msg(unsigned char *buff, em_dpp
     return static_cast<int>(len);
 }
 
-int em_configuration_t::handle_wsc_m2(unsigned char *buff, unsigned int len)
+int em_configuration_t::handle_wsc_m2(unsigned char *buff, unsigned int len, unsigned int index)
 {
     data_elem_attr_t    *attr;
     int ret = 0;
     unsigned int tmp_len;
     unsigned short id;
 
-    printf("%s:%d: Parsing m2 message, len: %d\n", __func__, __LINE__, len);
+    em_printfout("Parsing m2 message, index: %d, len: %d", index, len);
 
     m_m2_length = len - 12;
     memcpy(m_m2_msg, buff, m_m2_length);
@@ -3639,11 +3639,11 @@ int em_configuration_t::handle_wsc_m2(unsigned char *buff, unsigned int len)
         } else if (id == attr_id_public_key) {
             set_r_public(attr->val, htons(attr->len));
         } else if (id == attr_id_encrypted_settings) {
-            memcpy(m_m2_encrypted_settings, attr->val, htons(attr->len));
-            m_m2_encrypted_settings_len = htons(attr->len);
-            m_m2_encrypted_settings_len = sizeof(m_m2_encrypted_settings); //work around
+            memcpy(&m_m2_encrypted_settings[index][0], attr->val, htons(attr->len));
+            m_m2_encrypted_settings_len[index] = htons(attr->len);
+            //em_printfout("Copied encrypted setting[%d] len:%d", index, htons(attr->len));
         } else if (id == attr_id_authenticator) {
-            memcpy(m_m2_authenticator, attr->val, htons(attr->len));
+            memcpy(m_m2_authenticator[index], attr->val, htons(attr->len));
         }
 
         tmp_len -= static_cast<unsigned int> (sizeof(data_elem_attr_t) + htons(attr->len));
@@ -3789,8 +3789,8 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
 {
     em_tlv_t *tlv;
     int tmp_len;
+    unsigned int wsc_tlv_count = 0;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    bool found_wsc = false;
     unsigned char hash[SHA256_MAC_LEN];
     dm_easy_mesh_t *dm;
     dm_network_t network;
@@ -3806,67 +3806,45 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
     tmp_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
 
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type != em_tlv_type_wsc) {
-            tmp_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
-            tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        if (tlv->type == em_tlv_type_ap_mld_config) {
+            em_printfout("Found AP MLD details in message");
+            handle_ap_mld_config_tlv(tlv->value, htons(tlv->len));
+        } else if (tlv->type == em_tlv_type_wsc) {
+            em_printfout("Handle wsc TLV, count: %d", wsc_tlv_count);
+            //Storing m2 address and length in static variable;
+            set_e_mac(get_radio_interface_mac());
+            handle_wsc_m2(tlv->value, htons(tlv->len), wsc_tlv_count);
 
-            continue;
+            // first compute keys
+            if (compute_keys(get_r_public(), static_cast<short unsigned int> (get_r_public_len()), get_e_private(), static_cast<short unsigned int> (get_e_private_len())) != 1) {
+                printf("%s:%d: Keys computation failed\n", __func__, __LINE__);
+                return -1;
+            }
 
-        } else {
-            // TBD: Handle multiple TLV's here
-            found_wsc = true;
-            break; 
+            if (create_authenticator(hash) == -1) {
+                printf("%s:%d: Authenticator create failed\n", __func__, __LINE__);
+                return -1;
+            } else {
+                printf("%s:%d: Authenticator verification succeeded\n", __func__, __LINE__);
+            }
+
+            if (memcmp(m_m2_authenticator[wsc_tlv_count], hash, AUTHENTICATOR_LEN) != 0) {
+                printf("%s:%d: Authenticator validation failed\n", __func__, __LINE__);
+                //return -1;
+            }
+            wsc_tlv_count++;
         }
+        tmp_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
     }
 
-    if (found_wsc == false) {
-        printf("%s:%d: Could not find wsc, failing message\n", __func__, __LINE__);
-        return -1;
-    }
-            
-    //Storing m2 address and length in static variable;
-
-    set_e_mac(get_radio_interface_mac());
-    handle_wsc_m2(tlv->value, htons(tlv->len));
-
-    bool found_ap_mld = false;
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type != em_tlv_type_ap_mld_config) {
-            tmp_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
-            tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-
-            continue;
-
-        } else {
-            found_ap_mld = true;
-            break;
-       }
-    }
-    if (found_ap_mld == true) {
-        em_printfout("Found AP MLD details in message");
-        handle_ap_mld_config_tlv(tlv->value, htons(tlv->len));
-    }
-
-    // first compute keys
-    if (compute_keys(get_r_public(), static_cast<short unsigned int> (get_r_public_len()), get_e_private(), static_cast<short unsigned int> (get_e_private_len())) != 1) {
-        printf("%s:%d: Keys computation failed\n", __func__, __LINE__);
+    if (wsc_tlv_count == 0) {
+        em_printfout("Could not find wsc, failing message");
         return -1;
     }
 
-    if (create_authenticator(hash) == -1) {
-        printf("%s:%d: Authenticator create failed\n", __func__, __LINE__);
-        return -1;
-    } else {
-        printf("%s:%d: Authenticator verification succeeded\n", __func__, __LINE__);
-    }
-
-    if (memcmp(m_m2_authenticator, hash, AUTHENTICATOR_LEN) != 0) {
-        printf("%s:%d: Authenticator validation failed\n", __func__, __LINE__);
-        //return -1;
-    }
-
-    if (handle_encrypted_settings() == -1) {
-        printf("%s:%d: Error in decrypting settings\n", __func__, __LINE__);
+    if (handle_encrypted_settings(wsc_tlv_count) == -1) {
+        em_printfout("Error in decrypting settings wsc_tlv_count:%d", wsc_tlv_count);
         return -1;
     }
 
@@ -3884,75 +3862,74 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
                 get_ec_mgr().start_secure_1905_layer(hdr->src);
             }
 #endif
-
         }
     }
     return 0;
 }
 
-int em_configuration_t::handle_encrypted_settings()
+int em_configuration_t::handle_encrypted_settings(unsigned int wsc_tlv_count)
 {
     data_elem_attr_t    *attr;
     int tmp_len, ret = 0;
     unsigned short id;
     char pass[64] = {0};
-    mac_addr_str_t mac_str;
     unsigned char *plain;
     unsigned short plain_len;
     unsigned short auth_type;
-    int index = -1;
     m2ctrl_radioconfig radioconfig;
-    plain = m_m2_encrypted_settings + AES_BLOCK_SIZE;
-    plain_len = static_cast<short unsigned int> (m_m2_encrypted_settings_len - AES_BLOCK_SIZE);
+
+    memset(&radioconfig, 0, sizeof(m2ctrl_radioconfig));
     radioconfig.noofbssconfig = 0;
 
-    // first decrypt the encrypted m2 data
+    em_printfout("Total wsc_tlv_count:%d for radio:%s", wsc_tlv_count, util::mac_to_string(get_radio_interface_mac()).c_str());
+    for(unsigned int wsc_index = 0;((wsc_index < wsc_tlv_count) && (wsc_index < EM_MAX_BSS_PER_RADIO)); wsc_index++) {
+        plain = static_cast<unsigned char *> (m_m2_encrypted_settings[wsc_index]) + AES_BLOCK_SIZE;
+        plain_len = static_cast<short unsigned int> (m_m2_encrypted_settings_len[wsc_index]) - AES_BLOCK_SIZE;
+        em_printfout("##handle_encrypted_settings wsc_index:%d plain_len: %d", wsc_index, plain_len);
 
-    if (em_crypto_t::platform_aes_128_cbc_decrypt(m_key_wrap_key, m_m2_encrypted_settings, plain, plain_len) != 1) {
-        printf("%s:%d: platform decrypt failed\n", __func__, __LINE__);
-        return 0;
-    }
-
-    attr = reinterpret_cast<data_elem_attr_t *> (plain);
-    tmp_len = plain_len;
-
-    while (tmp_len > 0) {
-
-        id = htons(attr->id);
-        if (id == attr_id_no_of_haul_type) {
-            radioconfig.noofbssconfig	 = attr->val[0];
-            printf("%s:%d: noofbss configuration recv=%d\n", __func__, __LINE__,radioconfig.noofbssconfig);
-        } else if (id == attr_id_haul_type) {
-            index++;
-            radioconfig.haultype[index] = static_cast<em_haul_type_t> (attr->val[0]);
-        } else if (id == attr_id_ssid) {
-        //If controller does not support no of haultype parameter
-            if (index == -1) {
-                index = 0;
-            }
-            memcpy(radioconfig.ssid[index], attr->val, sizeof(radioconfig.ssid[index]));
-            radioconfig.enable[index] = true;
-            printf("%s:%d: ssid attrib: %s\n", __func__, __LINE__, radioconfig.ssid[index]);
-            memcpy(radioconfig.radio_mac[index], get_radio_interface_mac(), sizeof(mac_address_t));
-        } else if (id == attr_id_auth_type) {
-            memcpy(reinterpret_cast<char *> (&auth_type), reinterpret_cast<unsigned char *> (attr->val), htons(attr->len));
-            radioconfig.authtype[index] = static_cast<unsigned int>(auth_type);
-        } else if (id == attr_id_encryption_type) {
-            printf("%s:%d: encr type attrib\n", __func__, __LINE__);
-        } else if (id == attr_id_network_key) {
-            memcpy(pass, attr->val, htons(attr->len));
-            memcpy(radioconfig.password[index], attr->val, htons(attr->len));
-            printf("%s:%d: network key attrib: %s\n", __func__, __LINE__, pass);
-        } else if (id == attr_id_mac_address) {
-            dm_easy_mesh_t::macbytes_to_string(attr->val, mac_str);
-            printf("%s:%d: mac address attrib: %s\n", __func__, __LINE__, mac_str);
-            memcpy(radioconfig.radio_mac[index], attr->val, sizeof(mac_address_t));
-        } else if (id == attr_id_key_wrap_authenticator) {
-            printf("%s:%d: key wrap auth attrib\n", __func__, __LINE__);
-            radioconfig.key_wrap_authenticator[index] = attr->val[0];
+        // first decrypt the encrypted m2 data
+        if (em_crypto_t::platform_aes_128_cbc_decrypt(m_key_wrap_key, &m_m2_encrypted_settings[wsc_index][0], plain, plain_len) != 1) {
+            em_printfout("Platform decrypt failed for wsc_tlv:%d", wsc_index);
+            return 0;
         }
-        tmp_len -= static_cast<int> (sizeof(data_elem_attr_t) + htons(attr->len));
-        attr = reinterpret_cast<data_elem_attr_t *> (reinterpret_cast<unsigned char *>(attr) + sizeof(data_elem_attr_t) + htons(attr->len));
+
+        attr = reinterpret_cast<data_elem_attr_t *> (plain);
+        tmp_len = plain_len;
+
+        while (tmp_len > 0) {
+
+            id = htons(attr->id);
+            if (id == attr_id_no_of_haul_type) {
+                radioconfig.noofbssconfig += attr->val[0];
+                em_printfout("##num bss configuration=%d", radioconfig.noofbssconfig);
+            } else if (id == attr_id_haul_type) {
+                radioconfig.haultype[wsc_index] = static_cast<em_haul_type_t> (attr->val[0]);
+            } else if (id == attr_id_ssid) {
+                //If controller does not support no of haultype parameter
+                memcpy(radioconfig.ssid[wsc_index], attr->val, sizeof(radioconfig.ssid[wsc_index]));
+                radioconfig.enable[wsc_index] = true;
+                em_printfout("##ssid attrib[%d]: %s", wsc_index, radioconfig.ssid[wsc_index]);
+                memcpy(radioconfig.radio_mac[wsc_index], get_radio_interface_mac(), sizeof(mac_address_t));
+            } else if (id == attr_id_auth_type) {
+                memcpy(reinterpret_cast<char *> (&auth_type), reinterpret_cast<unsigned char *> (attr->val), htons(attr->len));
+                radioconfig.authtype[wsc_index] = static_cast<unsigned int>(auth_type);
+                em_printfout("##authtype[%d]: %x", wsc_index, radioconfig.authtype[wsc_index]);
+            } else if (id == attr_id_encryption_type) {
+                em_printfout("##encr type attrib for wsc_index:%d", wsc_index);
+            } else if (id == attr_id_network_key) {
+                memcpy(pass, attr->val, htons(attr->len));
+                memcpy(radioconfig.password[wsc_index], attr->val, htons(attr->len));
+                em_printfout("##network key[%d]: %s", wsc_index, pass);
+            } else if (id == attr_id_mac_address) {
+                memcpy(radioconfig.radio_mac[wsc_index], attr->val, sizeof(mac_address_t));
+                em_printfout("##mac address[%d]: %s", wsc_index, util::mac_to_string(radioconfig.radio_mac[wsc_index]).c_str());
+            } else if (id == attr_id_key_wrap_authenticator) {
+                radioconfig.key_wrap_authenticator[wsc_index] = attr->val[0];
+                em_printfout("##key wrap auth[%d]: %u", wsc_index, radioconfig.key_wrap_authenticator[wsc_index]);
+            }
+            tmp_len -= static_cast<int> (sizeof(data_elem_attr_t) + htons(attr->len));
+            attr = reinterpret_cast<data_elem_attr_t *> (reinterpret_cast<unsigned char *>(attr) + sizeof(data_elem_attr_t) + htons(attr->len));
+        }
     }
 
     for (unsigned int i = 0; i < radioconfig.noofbssconfig; i++){
@@ -4713,7 +4690,8 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 		// encoding a single haul type
 		no_of_haultype = 1;
 	}
-	em_printfout("haul_type=%d radio no of bss=%d", haul_type, radio->m_radio_info.number_of_bss);
+    em_printfout("radio:%s haul_type=%d radio no of bss=%d",
+        util::mac_to_string(get_radio_interface_mac()).c_str(), haul_type, radio->m_radio_info.number_of_bss);
 
     if ((net_ssid_info = get_network_ssid_info_by_haul_type(haul_type)) == NULL) {
         em_printfout("Could not find network ssid information for haul type %d", haul_type);
@@ -4811,6 +4789,8 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 		return 0;
 	}
 
+    em_printfout("Encrypted for radio:%s haul_type:%d length:%u plain_len:%u",
+        util::mac_to_string(get_radio_interface_mac()).c_str(), haul_type, cipher_len + AES_BLOCK_SIZE, plain_len);
 	return static_cast<int> (cipher_len) + AES_BLOCK_SIZE;
 }
 


### PR DESCRIPTION
Correct the earlier implementation of multiple haultype configuration present in a single WSC tlv to add multiple WSC attributes.