### PR TITLE
RDKBACCL-1334:Interop - Encrypted settings TLV in M2-WSC is not padded as per spec

### DIFF
--- a/inc/em_crypto.h
+++ b/inc/em_crypto.h
@@ -336,7 +336,7 @@ public:
 	 * @note Ensure that the key and iv are correctly set before calling this function.
 	 */
 	static uint8_t platform_aes_128_cbc_decrypt(uint8_t *key, uint8_t *iv, uint8_t *data, uint32_t data_len){
-        return platform_cipher_decrypt(EVP_aes_128_cbc(), key, iv, data, data_len);
+        return platform_cipher_decrypt(EVP_aes_128_cbc(), key, iv, data, data_len, false);
     }
     
     
@@ -355,7 +355,7 @@ public:
 	 * @return 1 on success, 0 on failure.
 	 */
 	static uint8_t platform_aes_128_cbc_encrypt(uint8_t *key, uint8_t *iv, uint8_t *plain, uint32_t plain_len, uint8_t *cipher_text, uint32_t *cipher_len){
-        return platform_cipher_encrypt(EVP_aes_128_cbc(), key, iv, plain, plain_len, cipher_text, cipher_len);
+        return platform_cipher_encrypt(EVP_aes_128_cbc(), key, iv, plain, plain_len, cipher_text, cipher_len, false);
     }
 
 

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -4803,7 +4803,7 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 
 	memcpy(buff, iv, AES_BLOCK_SIZE);
 
-	plain_len = static_cast<unsigned int> (len + (AES_BLOCK_SIZE - len%AES_BLOCK_SIZE));
+	plain_len = static_cast<unsigned int> (len);
 
 	// encrypt the m2 data
 	if (em_crypto_t::platform_aes_128_cbc_encrypt(m_key_wrap_key, iv, plain, plain_len, buff + AES_BLOCK_SIZE, &cipher_len) != 1) {


### PR DESCRIPTION
[Changes]
Enabled padding in encryption and decryption API's to support PKCS#7 padding method.