### PR TITLE
RDKBACCL-1340: Correct WSC attributes in M2 message 

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -1917,8 +1917,8 @@ typedef enum {
     attr_id_vendor_ext,
     attr_id_version,
     attr_id_primary_device_type = 0x1054,
-	attr_id_haul_type,
-	attr_id_no_of_haul_type,
+    attr_id_haul_type,
+    attr_id_no_of_haul_type,
 } data_elem_attr_id_t;
 
 typedef enum {

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -705,6 +705,7 @@ class em_configuration_t {
 	 *
 	 * @param[in] buff Pointer to the buffer containing the WSC M2 message.
 	 * @param[in] len Length of the buffer.
+	 * @param[in] index Index of the WSC TLV.
 	 *
 	 * @returns int
 	 * @retval 0 on success.
@@ -712,7 +713,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the buffer is properly allocated and contains a valid WSC M2 message before calling this function.
 	 */
-	int handle_wsc_m2(unsigned char *buff, unsigned int len);
+	int handle_wsc_m2(unsigned char *buff, unsigned int len, unsigned int index);
     
 	/**!
 	 * @brief Handles the renewal of auto-configuration.
@@ -1565,10 +1566,10 @@ private:
     size_t m_m1_length;
     size_t m_m2_length;
 
-    unsigned char m_m2_authenticator[SHA256_MAC_LEN];
-    unsigned int m_m2_authenticator_len;
-    unsigned char m_m2_encrypted_settings[MAX_EM_BUFF_SZ];
-    unsigned int m_m2_encrypted_settings_len;
+    unsigned char m_m2_authenticator[em_haul_type_max][SHA256_MAC_LEN];
+    unsigned int m_m2_authenticator_len[em_haul_type_max];
+    unsigned char m_m2_encrypted_settings[em_haul_type_max][MAX_EM_BUFF_SZ];
+    unsigned int m_m2_encrypted_settings_len[em_haul_type_max];
 
 public:
 
@@ -1664,7 +1665,7 @@ public:
 	 * @note Ensure that the encryption keys are properly initialized
 	 * before calling this function.
 	 */
-	int handle_encrypted_settings();
+	int handle_encrypted_settings(unsigned int wsc_tlv_count);
     
 	/**!
 	 * @brief Creates encrypted settings based on the provided buffer and haul type.

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -85,8 +85,6 @@ class em_configuration_t {
 	 * This function generates a WSC (Wi-Fi Simple Configuration) M2 message for auto-configuration purposes.
 	 *
 	 * @param[out] buff Pointer to the buffer where the generated message will be stored.
-	 * @param[in] haul_type Array of haul types used in the configuration.
-	 * @param[in] num_hauls Number of haul types in the array.
 	 * @param[in] msg_id The message ID of the original request being responded to.
 	 *
 	 * @returns int Status code indicating success or failure of the message creation.
@@ -95,7 +93,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the buffer is adequately sized to hold the generated message.
 	 */
-	int create_autoconfig_wsc_m2_msg(unsigned char *buff, em_haul_type_t haul_type[], unsigned int num_hauls, unsigned short msg_id);
+	int create_autoconfig_wsc_m2_msg(unsigned char *buff, unsigned short msg_id);
     
 	/**!
 	 * @brief Creates a BSS configuration request message.

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -354,30 +354,27 @@ void dm_easy_mesh_list_t::put_radio(const char *key, const dm_radio_t *radio)
 {
     dm_radio_t *pradio = NULL;
     dm_easy_mesh_t	*dm = NULL;
-    mac_addr_str_t  dev_mac;
     em_t *em = NULL;
 
-    //em_printfout("%s:%d: Radio: %s", __func__, __LINE__, key);
+    //em_printfout("Radio: %s", key);
 
     if ((pradio = get_radio(key)) == NULL) {
         dm = get_data_model(radio->m_radio_info.id.net_id, radio->m_radio_info.id.dev_mac);
-        dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (radio->m_radio_info.id.dev_mac), dev_mac);
-		//em_printfout("%s:%d: dm: %p net: %s device: %s", __func__, __LINE__, dm, radio->m_radio_info.id.net_id, dev_mac);
+        //em_printfout("dm: %p net: %s device: %s", dm, radio->m_radio_info.id.net_id,
+        //      util::mac_to_string(radio->m_radio_info.id.dev_mac).c_str());
         if (dm == NULL) {
             return;
         }
 
-        //em_printfout("%s:%d: Current Number of Radios: %d", __func__, __LINE__, dm->get_num_radios());
+        //em_printfout("Current Number of Radios: %d", dm->get_num_radios());
         dm->set_num_radios(dm->get_num_radios() + 1);
         pradio = dm->get_radio(dm->get_num_radios() - 1);
     }
     *pradio = *radio;
-    em_printfout("Radio dev_id is:%s", radio->m_radio_info.id.dev_mac);
-
-    dm_easy_mesh_t::macbytes_to_string(pradio->m_radio_info.id.dev_mac, dev_mac);
+    em_printfout("Radio dev_id is:%s", util::mac_to_string(pradio->m_radio_info.id.dev_mac).c_str());
     if ((em = m_mgr->create_node(&pradio->m_radio_info.intf, static_cast<em_freq_band_t> (pradio->m_radio_info.media_data.band), dm, false,
             em_profile_type_3, em_service_type_ctrl)) != NULL) {
-        em_printfout("Node created successfully for radio:%s almac:%s", key, dev_mac);
+        em_printfout("Node created successfully for radio:%s almac:%s", key, util::mac_to_string(pradio->m_radio_info.id.dev_mac).c_str());
     }
 }
 


### PR DESCRIPTION
Correct the earlier implementation of multiple haultype
configuration present in a single WSC tlv to add multiple
WSC attributes.