### PR TITLE
RDKBACCL-1340: Encode Haul type attribute as vendor_extension

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -174,6 +174,7 @@ extern "C"
 #define EM_KEY_FILE	"/nvram//test_cert.key"
 
 #define EM_CFG_FILE "/nvram/EasymeshCfg.json"
+#define EM_VENDOR_OUI_SIZE 3
 
 #define EM_MAX_SSID_LEN                33 
 #define EM_MAX_WIFI_PASSWORD_LEN       65 
@@ -1918,9 +1919,13 @@ typedef enum {
     attr_id_vendor_ext,
     attr_id_version,
     attr_id_primary_device_type = 0x1054,
-    attr_id_haul_type,
-    attr_id_no_of_haul_type,
 } data_elem_attr_id_t;
+
+typedef enum {
+    // Vendor Extension Attribute for Haul Type with data
+    // of 1 byte having value corresponding to em_haul_type_t
+    vendor_ext_attr_id_haul_type = 0x01,
+} vendor_ext_attr_id_t;
 
 typedef enum {
     em_state_agent_unconfigured,

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -615,9 +615,6 @@ typedef enum {
     em_tlv_type_vendor_sta_metrics = 0xf1,
     em_tlv_vendor_plolicy_cfg = 0xf2,
     em_tlv_type_vendor_operational_bss = 0xf3,
-
-	// RDK Proprietary TLV values
-	em_tlv_type_rdk_radio_enable = 0xfe,
 } em_tlv_type_t;
 
 typedef struct {

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -57,7 +57,7 @@ short em_channel_t::create_channel_pref_tlv_agent(unsigned char *buff, unsigned 
 
     dm = get_data_model();
     pref = reinterpret_cast<em_channel_pref_t *> (buff);
-    memcpy(pref->ruid, dm-> get_radio_by_ref(index).get_radio_interface_mac(), sizeof(mac_address_t));
+    memcpy(pref->ruid, dm->get_radio_by_ref(index).get_radio_interface_mac(), sizeof(mac_address_t));
     pref_op_class = pref->op_classes;
     pref->op_classes_num = 0;
 

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -3215,10 +3215,9 @@ int em_configuration_t::create_autoconfig_wsc_m2_msg(unsigned char *buff, unsign
     unsigned char *tmp = buff;
     unsigned short sz = 0;
     unsigned short type = htons(ETH_P_1905);
-	dm_radio_t *radio, *pradio;
+    dm_radio_t *radio;
 
-	radio = get_radio_from_dm();
-	pradio = get_radio_from_dm(true);
+    radio = get_radio_from_dm();
 
     // first compute keys
     if (compute_keys(get_e_public(), static_cast<short unsigned int> (get_e_public_len()), get_r_private(), static_cast<short unsigned int> (get_r_private_len())) != 1) {
@@ -3256,22 +3255,6 @@ int em_configuration_t::create_autoconfig_wsc_m2_msg(unsigned char *buff, unsign
     
     tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
     len += static_cast<int> (sizeof(em_tlv_t) + sizeof(mac_address_t));
-
-	// RDK proprietary tlv for radio enable/disable
-	tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_rdk_radio_enable;
-	
-	if (pradio != NULL) {
-    	memcpy(tlv->value, &pradio->m_radio_info.enabled, sizeof(unsigned char));
-		radio->m_radio_info.enabled = pradio->m_radio_info.enabled;
-	} else {
-    	memcpy(tlv->value, &radio->m_radio_info.enabled, sizeof(unsigned char));
-	}
-
-    tlv->len = htons(sizeof(unsigned char));
-    
-    tmp += (sizeof(em_tlv_t) + sizeof(unsigned char));
-    len += static_cast<int> (sizeof(em_tlv_t) + sizeof(unsigned char));
 
     // Add as many wsc tlv in M2 as number of BSS associated with this radio
     if (radio && radio->m_radio_info.number_of_bss < num_hauls) {
@@ -4773,7 +4756,7 @@ int em_configuration_t::create_encrypted_settings(unsigned char *buff, em_haul_t
 
     // key wrap
     keywrap_data_addr[0] = plain;
-    keywrap_data_length[0] = len;
+    keywrap_data_length[0] = static_cast<size_t> (len);
     if (em_crypto_t::platform_hmac_SHA256(m_auth_key, WPS_AUTHKEY_LEN, 1, keywrap_data_addr, keywrap_data_length, hash) != 1) {
 	    printf("%s:%d: Authenticator create failed\n", __func__, __LINE__);
 	    return 0;

--- a/tests/test_l1_em_msg.cpp
+++ b/tests/test_l1_em_msg.cpp
@@ -154,8 +154,6 @@ em_tlv_type_t types[] = {
     em_tlv_type_vendor_sta_metrics,
     em_tlv_vendor_plolicy_cfg,
     em_tlv_type_vendor_operational_bss,
-    // RDK Proprietary TLV values
-    em_tlv_type_rdk_radio_enable,
 };
 
 #define TLV_TYPE_COUNT 123


### PR DESCRIPTION
Encode and decode haul type attribute as per the vendor extension format. Remove usage of Num Haul type attribute as it is not required now, as WSC will have one haul type only.