### PR TITLE
TR-181: Converting xYANG path to TR-181 path

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -60,6 +60,7 @@ public:
     dm_device_t *get_dm_dev(mac_address_t dev_mac, mac_address_t bmac);
     dm_radio_t *get_dm_radio(dm_easy_mesh_t *dm, char *instance, bool is_num);
     dm_sta_t *get_dm_bh_sta(dm_easy_mesh_t *dm, dm_radio_t *radio);
+    const char* get_table_instance(const char *src, char *instance, size_t max_len, bool *is_num);
 
     bus_error_t network_get(char *event_name, raw_data_t *p_data);
     static bus_error_t network_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
@@ -68,6 +69,9 @@ public:
     static bus_error_t device_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     bus_error_t device_tget(char *event_name, raw_data_t *p_data);
     static bus_error_t device_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
+    bus_error_t policy_get(char* event_name, raw_data_t* p_data);
+    static bus_error_t policy_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
 
     bus_error_t radio_get(char* event_name, raw_data_t* p_data);
     static bus_error_t radio_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -47,9 +47,22 @@ typedef struct bus_data_cb_func {
     bus_callback_table_t  cb_func;
 } bus_data_cb_func_t;
 
+struct yang_to_tr181_map {
+    const char* yang;
+    const char* tr181;
+};
 
-// #define DATAELEMS_NETWORK       "Device.WiFi.DataElements.Network."
-#define DATAELEMS_NETWORK       "Network."
+static const yang_to_tr181_map g_yang_map[] = {
+    { "DeviceList", "Device" },
+    { "RadioList", "Radio" },
+    { "BSSList", "BSS" },
+    { "STAList", "STA" },
+    { "NetworkSSIDList", "SSID" },
+
+    { nullptr, nullptr } // Default case
+};
+
+#define DATAELEMS_NETWORK       "Device.WiFi.DataElements.Network."
 
 #define MAX_INSTANCE_LEN        32
 #define MAX_CAPS_STR_LEN        32
@@ -63,9 +76,8 @@ typedef struct bus_data_cb_func {
 #define DE_NETWORK_DEVNOE       DATAELEMS_NETWORK       "NumberOfDevices"
 #define DE_NETWORK_SETSSID      DATAELEMS_NETWORK       "SetSSID()"
 /* Device.WiFi.DataElements.Network.SSID */
-// #define DE_NETWORK_SSID         DATAELEMS_NETWORK       "SSID.{i}."
-#define DE_NETWORK_SSID         DATAELEMS_NETWORK       "NetworkSSIDList.{i}."
-#define DE_SSID_TABLE           DATAELEMS_NETWORK       "NetworkSSIDList.{i}"
+#define DE_NETWORK_SSID         DATAELEMS_NETWORK       "SSID.{i}."
+#define DE_SSID_TABLE           DATAELEMS_NETWORK       "SSID.{i}"
 #define DE_SSID_SSID            DE_NETWORK_SSID         "SSID"
 #define DE_SSID_BAND            DE_NETWORK_SSID         "Band"
 #define DE_SSID_ENABLE          DE_NETWORK_SSID         "Enable"
@@ -76,9 +88,8 @@ typedef struct bus_data_cb_func {
 #define DE_SSID_MOBDOMAIN       DE_NETWORK_SSID         "MobilityDomain"
 #define DE_SSID_HAULTYPE        DE_NETWORK_SSID         "HaulType"
 /* Device.WiFi.DataElements.Network.Device */
-// #define DE_NETWORK_DEVICE       DATAELEMS_NETWORK       "Device.{i}."
-#define DE_NETWORK_DEVICE       DATAELEMS_NETWORK       "DeviceList.{i}."
-#define DE_DEVICE_TABLE         DATAELEMS_NETWORK       "DeviceList.{i}"
+#define DE_NETWORK_DEVICE       DATAELEMS_NETWORK       "Device.{i}."
+#define DE_DEVICE_TABLE         DATAELEMS_NETWORK       "Device.{i}"
 #define DE_DEVICE_ID            DE_NETWORK_DEVICE       "ID"
 #define DE_DEVICE_MAPCAP        DE_NETWORK_DEVICE       "MultiAPCapabilities"
 #define DE_DEVICE_NUMRADIO      DE_NETWORK_DEVICE       "NumberOfRadios"
@@ -97,6 +108,8 @@ typedef struct bus_data_cb_func {
 #define DE_DEVICE_MAXVIDS       DE_NETWORK_DEVICE       "MaxVIDs"
 #define DE_DEVICE_BPRIO         DE_NETWORK_DEVICE       "BasicPrioritization"
 #define DE_DEVICE_EPRIO         DE_NETWORK_DEVICE       "EnhancedPrioritization"
+#define DE_DEVICE_DE8021QPVID   DE_NETWORK_DEVICE       "Default8021Q.PrimaryVID"
+#define DE_DEVICE_DE8021QDPCP   DE_NETWORK_DEVICE       "Default8021Q.DefaultPCP"
 #define DE_DEVICE_TSEPPOLI      DE_NETWORK_DEVICE       "TrafficSeparationPolicy"
 #define DE_DEVICE_STVMAP        DE_NETWORK_DEVICE       "SSIDtoVIDMapping"
 #define DE_DEVICE_DSCPM         DE_NETWORK_DEVICE       "DSCPMap"
@@ -159,9 +172,8 @@ typedef struct bus_data_cb_func {
 #define DE_MDBHSTATS_LSTDTADLR  DE_MAPDEVBH_STATS       "LastDataDownlinkRate"
 #define DE_MDBHSTATS_LSTDTAULR  DE_MAPDEVBH_STATS       "LastDataUplinkRate"
 /* Device.WiFi.DataElements.Network.Device.Radio */
-// #define DE_DEVICE_RADIO         DE_NETWORK_DEVICE       "Radio.{i}."
-#define DE_DEVICE_RADIO         DE_NETWORK_DEVICE       "RadioList.{i}."
-#define DE_RADIO_TABLE          DATAELEMS_NETWORK       "RadioList.{i}"
+#define DE_DEVICE_RADIO         DE_NETWORK_DEVICE       "Radio.{i}."
+#define DE_RADIO_TABLE          DATAELEMS_NETWORK       "Radio.{i}"
 #define DE_RADIO_ID             DE_DEVICE_RADIO         "ID"
 #define DE_RADIO_ENABLED        DE_DEVICE_RADIO         "Enabled"
 #define DE_RADIO_NUMCUROPCLASS  DE_DEVICE_RADIO         "NumberOfCurrOpClass"
@@ -271,9 +283,8 @@ typedef struct bus_data_cb_func {
 #define DE_RADIO_NUM_OPCLSCANS   DE_CAPS_SCANCAP          "NumberOfOpClassScans"
 #define DE_RADIO_SCAN_TS         DE_CAPS_SCANCAP          "TimeStamp"
 /* Device.WiFi.DataElements.Network.Device.Radio.BSS */
-// #define DE_RADIO_BSS            DE_DEVICE_RADIO         "BSS.{i}."
-#define DE_RADIO_BSS            DE_DEVICE_RADIO         "BSSList.{i}."
-#define DE_BSS_TABLE            DATAELEMS_NETWORK       "BSSList.{i}"
+#define DE_RADIO_BSS            DE_DEVICE_RADIO         "BSS.{i}."
+#define DE_BSS_TABLE            DATAELEMS_NETWORK       "BSS.{i}"
 #define DE_BSS_BSSID            DE_RADIO_BSS            "BSSID"
 #define DE_BSS_SSID             DE_RADIO_BSS            "SSID"
 #define DE_BSS_ENABLED          DE_RADIO_BSS            "Enabled"
@@ -348,6 +359,7 @@ typedef struct bus_data_cb_func {
 
 #define CALLBACK_ADD_ROW(f)          {NULL, NULL, f, NULL, NULL, NULL}
 #define CB(...)                      (bus_callback_table_t){ __VA_ARGS__ }
+#define CALLBACK_GETTER(f)           {f, NULL, NULL, NULL, NULL, NULL}
 #define ELEMENT(n, f)                {const_cast<char*>(n), f}
 #define ELEMENT_TABLE_ROW(n, f)      {const_cast<char*>(n), f}
 
@@ -420,6 +432,9 @@ public:
     static bus_error_t device_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t device_table_add_row_handler(const char* table_name, const char* alias_name, uint32_t* instance_number);
 
+    //Policy Callbacks
+    static bus_error_t policy_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
     //Radio
     static bus_error_t radio_get(char* event_name, raw_data_t* p_data, struct bus_user_data* user_data);
     static bus_error_t radio_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
@@ -453,6 +468,7 @@ public:
     void register_cjson_namespace(cJSON *node, const std::string &prefix);
 
     //Data_Elements_JSON_Schema_v3.0 parsing related functions
+    std::string yang_to_tr181_path(const std::string& in);
     cJSON* follow_ref_if_any(cJSON* root, cJSON* node);
     cJSON* resolve_ref(cJSON* root, const char* refStr);
     void parse_property_constraints(cJSON* schemaNode, data_model_properties_t& props);

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -2214,6 +2214,12 @@ bus_error_t dm_easy_mesh_ctrl_t::device_tget(char *event_name, raw_data_t *p_dat
     return bus_get_cb_fwd(event_name, p_data, device_tget_inner);
 }
 
+bus_error_t dm_easy_mesh_ctrl_t::policy_get(char *event_name, raw_data_t *p_data)
+{
+    em_printfout("Inside");
+    return bus_get_cb_fwd(event_name, p_data, policy_get_inner);
+}
+
 bus_error_t dm_easy_mesh_ctrl_t::radio_get(char *event_name, raw_data_t *p_data)
 {
     return bus_get_cb_fwd(event_name, p_data, radio_get_inner);
@@ -2262,6 +2268,34 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get(char *event_name, raw_data_t *p_data)
 bus_error_t dm_easy_mesh_ctrl_t::sta_tget(char *event_name, raw_data_t *p_data)
 {
     return bus_get_cb_fwd(event_name, p_data, sta_tget_inner);
+}
+
+const char* dm_easy_mesh_ctrl_t::get_table_instance(const char *src, char *instance, size_t max_len, bool *is_num)
+{
+	char *dst = instance;
+	size_t len = 0;
+
+    src = strstr(src, ".");
+    ++src;
+
+	if (*src == '[') {
+		*is_num = false;
+		++src;
+		while (*src && *src != ']' && ++len < max_len) {
+			*dst++ = *src++;
+		}
+		*dst++ = 0;
+		src += 2;
+	} else {
+		*is_num = true;
+		while (*src && *src != '.' && ++len < max_len) {
+			*dst++ = *src++;
+		}
+		*dst++ = 0;
+		src++;
+	}
+
+	return src;
 }
 
 bus_error_t dm_easy_mesh_ctrl_t::network_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
@@ -2321,18 +2355,12 @@ bus_error_t dm_easy_mesh_ctrl_t::device_get_inner(char *event_name, raw_data_t *
     (void) user_data;
     const char *name = event_name;
     const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0;
     bus_error_t rc;
 
     if (!name || !p_data) {
-        return bus_error_invalid_input;
-    }
-
-    if(sscanf(event_name, "Network.DeviceList.%d", &device_instance) == 1) {
-        em_printfout("Extracted device index:%d", device_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
         return bus_error_invalid_input;
     }
 
@@ -2342,7 +2370,12 @@ bus_error_t dm_easy_mesh_ctrl_t::device_get_inner(char *event_name, raw_data_t *
     }
     ++param;
 
+
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -2574,7 +2607,7 @@ bus_error_t dm_easy_mesh_ctrl_t::device_tget_inner(char *event_name, raw_data_t 
         dm_ctrl->property_append_tail(&property, root, idx, "IntegrityAlgorithm", sec_cap->integrity_algo);
         dm_ctrl->property_append_tail(&property, root, idx, "EncryptionAlgorithm", sec_cap->encryption_algo);
 
-        snprintf(path, sizeof(path) - 1, "%s%d.RadioList.", root, idx);
+        snprintf(path, sizeof(path) - 1, "%s%d.Radio.", root, idx);
         dm_ctrl->radio_tget_params(dm, path, &property);
 
         dm = dm_ctrl->get_next_dm(dm);
@@ -2587,24 +2620,18 @@ bus_error_t dm_easy_mesh_ctrl_t::device_tget_inner(char *event_name, raw_data_t 
     return rc;
 }
 
-bus_error_t dm_easy_mesh_ctrl_t::ssid_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+bus_error_t dm_easy_mesh_ctrl_t::policy_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     (void) user_data;
     const char *name = event_name;
     const char *param;
-    char val_str[1024] = { 0 };
-    unsigned int ssid_instance = 0;
-    bus_error_t rc;
+    unsigned int count = 0;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    int device_instance = 0;
+    bus_error_t rc = bus_error_success;
 
     if (!name || !p_data) {
-        return bus_error_invalid_input;
-    }
-
-    if(sscanf(event_name, "Network.NetworkSSIDList.%d", &ssid_instance) == 1) {
-        em_printfout("Extracted ssid index:%d", ssid_instance);
-    }
-    else {
-        em_printfout("Unable to extract the index");
         return bus_error_invalid_input;
     }
 
@@ -2615,6 +2642,79 @@ bus_error_t dm_easy_mesh_ctrl_t::ssid_get_inner(char *event_name, raw_data_t *p_
     ++param;
 
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
+    dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
+    if (dm == NULL || (dm->get_id() != device_instance)) {
+        dm = dm_ctrl->get_next_dm(dm);
+    }
+
+    dm_device_t *dev = dm->get_device();
+    if (dev == NULL) {
+        em_printfout("NULL dev");
+        return bus_error_invalid_input;
+    }
+
+    em_device_info_t *di = dev->get_device_info();
+    if (memcmp(di->intf.mac, ZERO_MAC_ADDR, sizeof(di->intf.mac)) == 0) {
+        em_printfout("NULL dev_info");
+        return bus_error_invalid_input;
+    }
+
+    dm_policy_t *pi = &dm->m_policy[count];
+    em_printfout("num_policy:%d", dm->m_num_policy);
+    while (pi == NULL && count < dm->m_num_policy) {
+        em_printfout("policy is NULL, checking next:%d", count);
+        count++;
+        pi = &dm->m_policy[count];
+    }
+
+    if(pi == NULL) {
+        em_printfout("policy is NULL");
+        return bus_error_invalid_input;
+    }
+    em_8021q_settings_policy_t *policy = &pi->m_policy.def_8021q_settings;
+
+    if (strcmp(param, "PrimaryVID") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, policy->primary_vid);
+    } else if (strcmp(param, "DefaultPCP") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, policy->default_pcp);
+    } else {
+        em_printfout("Invalid param: %s", param);
+        rc = bus_error_invalid_input;
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::ssid_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    char val_str[1024] = { 0 };
+    unsigned int ssid_instance = 0;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        return bus_error_invalid_input;
+    }
+    ++param;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    ssid_instance = is_num ? static_cast<unsigned int>(atoi(instance)) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -2757,18 +2857,12 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p
     (void) user_data;
     const char *name = event_name;
     const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0;
     bus_error_t rc;
 
     if (!name || !p_data) {
-        return bus_error_invalid_input;
-    }
-
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d", &device_instance, &radio_instance) == 2) {
-        em_printfout("Extracted device index:%d radio index:%d", device_instance, radio_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
         return bus_error_invalid_input;
     }
 
@@ -2779,6 +2873,10 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p
     ++param;
 
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -2789,6 +2887,8 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
@@ -2836,6 +2936,8 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_inner(char *event_name, raw_data_t *
     const char *name = event_name;
     const char *root = name;
     int device_instance = 0;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     bus_data_prop_t *property = NULL;
     bus_error_t rc;
 
@@ -2843,15 +2945,11 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_inner(char *event_name, raw_data_t *
         return bus_error_invalid_input;
     }
 
-    if(sscanf(event_name, "Network.DeviceList.%d", &device_instance) == 1) {
-        em_printfout("Extracted device index:%d", device_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
-        return bus_error_invalid_input;
-    }
-
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -2930,7 +3028,7 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_params(dm_easy_mesh_t *dm, const cha
         snprintf(path, sizeof(path) - 1, "%s%d.CurrentOperatingClassProfile.", root, idx);
         dm_ctrl->curops_tget_params(dm, path, ri, property);
 
-        snprintf(path, sizeof(path) - 1, "%s%d.BSSList.", root, idx);
+        snprintf(path, sizeof(path) - 1, "%s%d.BSS.", root, idx);
         dm_ctrl->bss_tget_params(dm, path, ri, property);
     }
 
@@ -2942,6 +3040,8 @@ bus_error_t dm_easy_mesh_ctrl_t::rbhsta_get_inner(char *event_name, raw_data_t *
     (void) user_data;
     const char *name = event_name;
     const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0;
     bus_error_t rc;
 
@@ -2955,15 +3055,11 @@ bus_error_t dm_easy_mesh_ctrl_t::rbhsta_get_inner(char *event_name, raw_data_t *
     }
     ++param;
 
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d", &device_instance, &radio_instance) == 2) {
-        em_printfout("Extracted device index:%d radio index:%d", device_instance, radio_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
-        return bus_error_invalid_input;
-    }
-
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -2974,6 +3070,8 @@ bus_error_t dm_easy_mesh_ctrl_t::rbhsta_get_inner(char *event_name, raw_data_t *
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
@@ -3003,18 +3101,12 @@ bus_error_t dm_easy_mesh_ctrl_t::rcaps_get_inner(char *event_name, raw_data_t *p
     const char *name = event_name;
     const char *param;
     char caps_str[MAX_CAPS_STR_LEN] = { 0 };
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0;
     bus_error_t rc;
 
     if (!name || !p_data) {
-        return bus_error_invalid_input;
-    }
-
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d", &device_instance, &radio_instance) == 2) {
-        em_printfout("Extracted device index:%d radio index:%d", device_instance, radio_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
         return bus_error_invalid_input;
     }
 
@@ -3025,6 +3117,10 @@ bus_error_t dm_easy_mesh_ctrl_t::rcaps_get_inner(char *event_name, raw_data_t *p
     ++param;
 
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -3035,6 +3131,8 @@ bus_error_t dm_easy_mesh_ctrl_t::rcaps_get_inner(char *event_name, raw_data_t *p
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
@@ -3096,19 +3194,12 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_get_inner(char *event_name, raw_data_t *
     (void) user_data;
     const char *name = event_name;
     const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0, curop_class_instance = 0;
     bus_error_t rc;
 
     if (!name || !p_data) {
-        return bus_error_invalid_input;
-    }
-
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d.CurrentOperatingClasses.%d", 
-        &device_instance, &radio_instance, &curop_class_instance) == 3) {
-        em_printfout("Extracted device index:%d radio index:%d", device_instance, radio_instance, curop_class_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
         return bus_error_invalid_input;
     }
 
@@ -3119,6 +3210,10 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_get_inner(char *event_name, raw_data_t *
     ++param;
 
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -3129,12 +3224,16 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_get_inner(char *event_name, raw_data_t *
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    curop_class_instance = is_num ? atoi(instance) : 0;
     dm_op_class_t *op_class = dm_ctrl->get_dm_curop(dm, radio, curop_class_instance);
     if (op_class == NULL) {
         em_printfout("op_class is NULL\n");
@@ -3162,6 +3261,8 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_tget_inner(char *event_name, raw_data_t 
     const char *name = event_name;
     const char *root = name;
     bus_data_prop_t *property = NULL;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0;
     bus_error_t rc;
 
@@ -3169,15 +3270,11 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_tget_inner(char *event_name, raw_data_t 
         return bus_error_invalid_input;
     }
 
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d", &device_instance, &radio_instance) == 2) {
-        em_printfout("Extracted device index:%d radio index:%d", device_instance, radio_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
-        return bus_error_invalid_input;
-    }
-
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -3188,6 +3285,8 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_tget_inner(char *event_name, raw_data_t 
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
@@ -3265,18 +3364,12 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_get_inner(char *event_name, raw_data_t *p_d
     char val_str[1024] = { 0 };
     unsigned int i = 0;
     int count = 0;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0, bss_instance = 0;
     bus_error_t rc;
 
     if (!name || !p_data) {
-        return bus_error_invalid_input;
-    }
-
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d.BSSList.%d", &device_instance, &radio_instance, &bss_instance) == 3) {
-        em_printfout("Extracted device index:%d radio index:%d bss index:%d", device_instance, radio_instance, bss_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
         return bus_error_invalid_input;
     }
 
@@ -3287,6 +3380,10 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_get_inner(char *event_name, raw_data_t *p_d
     ++param;
 
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -3297,6 +3394,8 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_get_inner(char *event_name, raw_data_t *p_d
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
@@ -3306,6 +3405,8 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_get_inner(char *event_name, raw_data_t *p_d
     em_bss_info_t *bi;
     mac_addr_str_t  radio_str, bss_str;
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    bss_instance = is_num ? atoi(instance) : 0;
     for(i = 0; i < dm->m_num_bss; i++) {
         bi = dm->get_bss_info(i);
         dm_easy_mesh_t::macbytes_to_string(bi->ruid.mac, bss_str);
@@ -3398,6 +3499,8 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_tget_inner(char *event_name, raw_data_t *p_
     const char *name = event_name;
     const char *root = name;
     bus_data_prop_t *property = NULL;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0;
     bus_error_t rc;
 
@@ -3405,15 +3508,11 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_tget_inner(char *event_name, raw_data_t *p_
         return bus_error_invalid_input;
     }
 
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d.", &device_instance, &radio_instance) == 2) {
-        em_printfout("Extracted device index:%d radio index:%d", device_instance, radio_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
-        return bus_error_invalid_input;
-    }
-
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -3424,6 +3523,8 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_tget_inner(char *event_name, raw_data_t *p_
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
@@ -3489,18 +3590,10 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_d
     const char *param;
     unsigned int i = 0;
     int count = 0;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0, bss_instance = 0, sta_instance = 0;
     bus_error_t rc;
-
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d.BSSList.%d.STAList.%d", 
-        &device_instance, &radio_instance, &bss_instance, &sta_instance) == 4) {
-        em_printfout("Extracted device index:%d radio index:%d bss index:%d sta index:%d", 
-            device_instance, radio_instance, bss_instance, sta_instance);
-    }
-    else {
-        em_printfout("Unable to extract the device index");
-        return bus_error_invalid_input;
-    }
 
     param = strrchr(name, '.');
     if (param == NULL) {
@@ -3509,6 +3602,10 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_d
     ++param;
 
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -3519,6 +3616,8 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_d
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
@@ -3528,6 +3627,8 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_d
     em_bss_info_t *bi;
     mac_addr_str_t  radio_str, bss_str;
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    bss_instance = is_num ? atoi(instance) : 0;
     for(i = 0; i < dm->m_num_bss; i++) {
         bi = dm->get_bss_info(i);
         dm_easy_mesh_t::macbytes_to_string(bi->ruid.mac, bss_str);
@@ -3540,6 +3641,8 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_d
         }
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    sta_instance = is_num ? atoi(instance) : 0;
     dm_sta_t *sta = dm_ctrl->get_dm_sta(dm, bi, sta_instance);
     if (sta == NULL) {
         em_printfout("sta is NULL\n");
@@ -3611,6 +3714,8 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_tget_inner(char *event_name, raw_data_t *p_
     const char *name = event_name;
     const char *root = name;
     bus_data_prop_t *property = NULL;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
     int device_instance = 0, radio_instance = 0, bss_instance = 0;
     unsigned int i = 0;
     int count = 0;
@@ -3620,17 +3725,11 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_tget_inner(char *event_name, raw_data_t *p_
         return bus_error_invalid_input;
     }
 
-    if(sscanf(event_name, "Network.DeviceList.%d.RadioList.%d.BSSList.%d", 
-        &device_instance, &radio_instance, &bss_instance) == 3) {
-        em_printfout("Extracted device index:%d radio index:%d bss index:%d", 
-            device_instance, radio_instance, bss_instance);
-    }
-    else {
-        em_printfout("Unable to extract index");
-        return bus_error_invalid_input;
-    }
-
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    device_instance = is_num ? atoi(instance) : 0;
+
     dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
     if (dm == NULL || (dm->get_id() != device_instance)) {
         dm = dm_ctrl->get_next_dm(dm);
@@ -3641,6 +3740,8 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_tget_inner(char *event_name, raw_data_t *p_
         return bus_error_invalid_input;
     }
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
     dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
     if (radio == NULL) {
         em_printfout("radio is NULL\n");
@@ -3650,6 +3751,8 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_tget_inner(char *event_name, raw_data_t *p_
     em_bss_info_t *bi;
     mac_addr_str_t  radio_str, bss_str;
 
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    bss_instance = is_num ? atoi(instance) : 0;
     for(i = 0; i < dm->m_num_bss; i++) {
         bi = dm->get_bss_info(i);
         dm_easy_mesh_t::macbytes_to_string(bi->ruid.mac, bss_str);

--- a/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
@@ -62,147 +62,148 @@ void tr_181_t::init(void* ptr)
 int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_callback_table_t *cb_table)
 {
     bus_data_cb_func_t bus_data_cb[] = {
-        ELEMENT(DE_NETWORK_ID, CB(.get_handler = network_get)),
-        ELEMENT(DE_NETWORK_CTRLID, CB(.get_handler = network_get)),
-        ELEMENT(DE_NETWORK_COLAGTID, CB(.get_handler = network_get)),
-        ELEMENT(DE_NETWORK_DEVNOE, CB(.get_handler = network_get)),
-        ELEMENT(DE_SSID_TABLE, CB(.get_handler = ssid_tget)),
-        ELEMENT(DE_SSID_SSID, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_SSID_BAND, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_SSID_ENABLE, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_SSID_AKMALLOWE, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_SSID_SUITESEL, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_SSID_ADVENABLED, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_SSID_MFPCONFIG, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_SSID_MOBDOMAIN, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_SSID_HAULTYPE, CB(.get_handler = ssid_get)),
-        ELEMENT(DE_DEVICE_TABLE, CB(.get_handler = device_tget)),
-        ELEMENT(DE_RADIO_TABLE, CB(.get_handler = radio_tget)),
-        ELEMENT(DE_BSS_TABLE, CB(.get_handler = bss_tget)),
-        ELEMENT(DE_STA_TABLE, CB(.get_handler = sta_tget)),
-        ELEMENT(DE_DEVICE_ID, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MAPCAP,    CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_NUMRADIO,  CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_COLLINT,   CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_RUASSOC,   CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MAXRRATE,  CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MAPPROF,   CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_APMERINT,  CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MANUFACT,  CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_SERIALNO,  CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MFCMODEL,  CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_SWVERSION, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_EXECENV, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_LSDSTALIST, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BTMSDSTALIST, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MAXVIDS, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BPRIO, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_EPRIO, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_TSEPPOLI, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_STVMAP, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_DSCPM, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MAXPRIRULE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_COUNTRCODE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_PRIOSUPP, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_REPINDSCAN, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_TRASEPALW, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_SERPRIOALW, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_STASDISALW, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_DFSENABLE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MAXUSASSOCREPRATE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_STASSTATE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_COORCACALW, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_CONOPMODE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BHMACADDR, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BHDMACADDR, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BHPHYRATE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_TRSEPCAP, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_EASYCCAP, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_TESTCAP, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BSTAMLDMACLINK, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_MACNUMMLDS, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BHALID, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_TIDLMAP, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_ASSOCSTAREPINT, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BHMEDIATYPE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_RADIONOE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_CACSTATNOE, CB(.get_handler = device_get)),
-        ELEMENT(DE_DEVICE_BHDOWNNOE, CB(.get_handler = device_get)),
-        ELEMENT(DE_RADIO_ID,          CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_ENABLED,     CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_NOISE,       CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_UTILIZATION, CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_TRANSMIT,    CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_RECEIVESELF, CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_RECEIVEOTHER,CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_CHIPVENDOR,  CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_CURROPNOE,   CB(.get_handler = radio_get)),
-        ELEMENT(DE_RADIO_BSSNOE,      CB(.get_handler = radio_get)),
-        ELEMENT(DE_RCAPS_HTCAPS,      CB(.get_handler = rcaps_get)),
-        ELEMENT(DE_RCAPS_VHTCAPS,     CB(.get_handler = rcaps_get)),
-        ELEMENT(DE_RCAPS_CAPOPNOE,    CB(.get_handler = rcaps_get)),
-        ELEMENT(DE_CUROP_TABLE,       CB(.get_handler = curops_tget)),
-        ELEMENT(DE_CUROP_CLASS,       CB(.get_handler = curops_get)),
-        ELEMENT(DE_CUROP_CHANNEL,     CB(.get_handler = curops_get)),
-        ELEMENT(DE_CUROP_TXPOWER,     CB(.get_handler = curops_get)),
-        ELEMENT(DE_BSS_BSSID,         CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_SSID,          CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_ENABLED,       CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_LASTCHG,       CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_TS,            CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_UCAST_TX,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_UCAST_RX,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_MCAST_TX,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_MCAST_RX,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_BCAST_TX,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_BCAST_RX,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_EST_BE,        CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_EST_BK,        CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_EST_VI,        CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_EST_VO,        CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_BYTCNTUNITS,   CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_PROF1_DIS,     CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_PROF2_DIS,     CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_ASSOC_STAT,    CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_BHAULUSE,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_FHAULUSE,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_R1_DIS,        CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_R2_DIS,        CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_MULTI_BSSID,   CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_TX_BSSID,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_FHAULAKMS,     CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_BHAULAKMS,     CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_QM_DESC,       CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_NUM_STA,       CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_LINK_IMM,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_FH_SUITE,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_BSS_BH_SUITE,      CB(.get_handler = bss_get)),
-        ELEMENT(DE_STA_MACADDR,       CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_HTCAPS,        CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_VHTCAPS,       CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_CLIENTCAPS,    CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_LSTDTADLR,     CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_LSTDTAULR,     CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_UTILRECV,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_UTILTRMT,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_ESTMACDTARDL,  CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_ESTMACDTARUL,  CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_SIGNALSTR,     CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_LASTCONNTIME,  CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_BYTESSNT,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_BYTESRCV,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_PCKTSSNT,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_PCKTSRCV,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_ERRSSNT,       CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_ERRSRCV,       CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_RETRANSCNT,    CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_IPV4ADDR,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_IPV6ADDR,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_HOSTNAME,      CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_PAIRWSAKM,     CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_PAIRWSCIPHER,  CB(.get_handler = sta_get)),
-        ELEMENT(DE_STA_RSNCAPS,       CB(.get_handler = sta_get))
+        ELEMENT(DE_NETWORK_ID,            CALLBACK_GETTER(network_get)),
+        ELEMENT(DE_NETWORK_CTRLID,        CALLBACK_GETTER(network_get)),
+        ELEMENT(DE_NETWORK_COLAGTID,      CALLBACK_GETTER(network_get)),
+        ELEMENT(DE_NETWORK_DEVNOE,        CALLBACK_GETTER(network_get)),
+        ELEMENT(DE_SSID_TABLE,            CALLBACK_GETTER(ssid_tget)),
+        ELEMENT(DE_SSID_SSID,             CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_SSID_BAND,             CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_SSID_ENABLE,           CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_SSID_AKMALLOWE,        CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_SSID_SUITESEL,         CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_SSID_ADVENABLED,       CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_SSID_MFPCONFIG,        CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_SSID_MOBDOMAIN,        CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_SSID_HAULTYPE,         CALLBACK_GETTER(ssid_get)),
+        ELEMENT(DE_DEVICE_TABLE,          CALLBACK_GETTER(device_tget)),
+        ELEMENT(DE_RADIO_TABLE,           CALLBACK_GETTER(radio_tget)),
+        ELEMENT(DE_BSS_TABLE,             CALLBACK_GETTER(bss_tget)),
+        ELEMENT(DE_STA_TABLE,             CALLBACK_GETTER(sta_tget)),
+        ELEMENT(DE_DEVICE_ID,                     CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MAPCAP,                 CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_NUMRADIO,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_COLLINT,                CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_RUASSOC,                CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MAXRRATE,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MAPPROF,                CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_APMERINT,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MANUFACT,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_SERIALNO,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MFCMODEL,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_SWVERSION,              CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_EXECENV,                CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_LSDSTALIST,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BTMSDSTALIST,           CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MAXVIDS,                CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BPRIO,                  CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_EPRIO,                  CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_TSEPPOLI,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_STVMAP,                 CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_DSCPM,                  CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MAXPRIRULE,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_COUNTRCODE,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_PRIOSUPP,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_REPINDSCAN,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_TRASEPALW,              CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_SERPRIOALW,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_STASDISALW,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_DFSENABLE,              CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MAXUSASSOCREPRATE,      CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_STASSTATE,              CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_COORCACALW,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_CONOPMODE,              CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BHMACADDR,              CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BHDMACADDR,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BHPHYRATE,              CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_TRSEPCAP,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_EASYCCAP,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_TESTCAP,                CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BSTAMLDMACLINK,         CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MACNUMMLDS,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BHALID,                 CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_TIDLMAP,                CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_ASSOCSTAREPINT,         CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BHMEDIATYPE,            CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_RADIONOE,               CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_CACSTATNOE,             CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BHDOWNNOE,              CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_RADIO_ID,               CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_ENABLED,          CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_NOISE,            CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_UTILIZATION,      CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_TRANSMIT,         CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_RECEIVESELF,      CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_RECEIVEOTHER,     CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_CHIPVENDOR,       CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_CURROPNOE,        CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_BSSNOE,           CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RCAPS_HTCAPS,           CALLBACK_GETTER(rcaps_get)),
+        ELEMENT(DE_RCAPS_VHTCAPS,          CALLBACK_GETTER(rcaps_get)),
+        ELEMENT(DE_RCAPS_CAPOPNOE,         CALLBACK_GETTER(rcaps_get)),
+        ELEMENT(DE_CUROP_TABLE,            CALLBACK_GETTER(curops_tget)),
+        ELEMENT(DE_CUROP_CLASS,            CALLBACK_GETTER(curops_get)),
+        ELEMENT(DE_CUROP_CHANNEL,          CALLBACK_GETTER(curops_get)),
+        ELEMENT(DE_CUROP_TXPOWER,          CALLBACK_GETTER(curops_get)),
+        ELEMENT(DE_BSS_BSSID,              CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_SSID,               CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_ENABLED,            CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_LASTCHG,            CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_TS,                 CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_UCAST_TX,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_UCAST_RX,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_MCAST_TX,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_MCAST_RX,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_BCAST_TX,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_BCAST_RX,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_EST_BE,             CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_EST_BK,             CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_EST_VI,             CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_EST_VO,             CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_BYTCNTUNITS,        CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_PROF1_DIS,          CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_PROF2_DIS,          CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_ASSOC_STAT,         CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_BHAULUSE,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_FHAULUSE,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_R1_DIS,             CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_R2_DIS,             CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_MULTI_BSSID,        CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_TX_BSSID,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_FHAULAKMS,          CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_BHAULAKMS,          CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_QM_DESC,            CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_NUM_STA,            CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_LINK_IMM,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_FH_SUITE,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_BH_SUITE,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_STA_MACADDR,            CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_HTCAPS,             CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_VHTCAPS,            CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_CLIENTCAPS,         CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_LSTDTADLR,          CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_LSTDTAULR,          CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_UTILRECV,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_UTILTRMT,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_ESTMACDTARDL,       CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_ESTMACDTARUL,       CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_SIGNALSTR,          CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_LASTCONNTIME,       CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_BYTESSNT,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_BYTESRCV,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_PCKTSSNT,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_PCKTSRCV,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_ERRSSNT,            CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_ERRSRCV,            CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_RETRANSCNT,         CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_IPV4ADDR,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_IPV6ADDR,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_HOSTNAME,           CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_PAIRWSAKM,          CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_PAIRWSCIPHER,       CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_RSNCAPS,            CALLBACK_GETTER(sta_get))
     };
+
 
     bus_data_cb_func_t bus_default_data_cb = { const_cast<char*>(" "),
         { default_get_param_value, default_set_param_value, default_table_add_row_handler,
@@ -485,6 +486,20 @@ bus_error_t tr_181_t::device_tget(char *event_name, raw_data_t *p_data, bus_user
     return bus_error_general;
 }
 
+bus_error_t tr_181_t::policy_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_printfout("Inside");
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL)
+    {
+        em_ctrl->get_dm_ctrl()->policy_get(event_name, p_data);
+        return bus_error_success;
+    }
+
+    return bus_error_general;
+}
+
 bus_error_t tr_181_t::radio_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
@@ -623,6 +638,35 @@ bus_error_t tr_181_t::wifi_elem_num_of_table_row(char* event_name, uint32_t* tab
     }
 
     return bus_error_success;
+}
+
+//Helper to convert YANG path to TR-181 path
+std::string tr_181_t::yang_to_tr181_path(const std::string& in)
+{
+    std::string out = in;
+    em_printfout("Converting YANG path: %s", in.c_str());
+
+    for (int i = 0; g_yang_map[i].yang; ++i) {
+        const std::string from = g_yang_map[i].yang;
+        const std::string to = g_yang_map[i].tr181;
+
+        size_t pos = 0;
+        while ((pos = out.find(from, pos)) != std::string::npos) {
+            /* ensure whole-token replacement */
+            bool left_ok = (pos == 0 || out[pos - 1] == '.');
+            bool right_ok = (pos + from.size() == out.size() ||
+                              out[pos + from.size()] == '.');
+
+            if (left_ok && right_ok) {
+                out.replace(pos, from.size(), to);
+                pos += to.size();
+            } else {
+                pos += from.size();
+            }
+        }
+    }
+
+    return out;
 }
 
 // Resolve $ref if present on the node; otherwise return the node itself.
@@ -775,13 +819,13 @@ void tr_181_t::handle_property_node(cJSON* root, const std::string& fullPath, cJ
     if (schema_has_type(effective, "array")) {
         std::string tableName = fullPath + ".{i}";
 
-        // register table namespace
-        wfa_set_bus_callbackfunc_pointers(tableName.c_str(), &cbTable);
         // reset and fill constraints for the array property itself
         memset(&data_model_value, 0, sizeof(data_model_value));
         parse_property_constraints(effective, data_model_value);
         parse_readwrite(effective, data_model_value);
-        wfa_bus_register_namespace(const_cast<char*>(tableName.c_str()), bus_element_type_table, cbTable, data_model_value, 1);
+        std::string tr181Path = yang_to_tr181_path(tableName);
+        wfa_set_bus_callbackfunc_pointers(tr181Path.c_str(), &cbTable);
+        wfa_bus_register_namespace(const_cast<char*>(tr181Path.c_str()), bus_element_type_table, cbTable, data_model_value, 1);
 
         // now inspect items
         cJSON* items = cJSON_GetObjectItem(effective, "items");
@@ -799,8 +843,9 @@ void tr_181_t::handle_property_node(cJSON* root, const std::string& fullPath, cJ
             memset(&data_model_value, 0, sizeof(data_model_value));
             parse_property_constraints(itemsEff, data_model_value);
             parse_readwrite(itemsEff, data_model_value);
-            wfa_set_bus_callbackfunc_pointers(tableName.c_str(), &cbTable);
-            wfa_bus_register_namespace(const_cast<char*>(tableName.c_str()), bus_element_type_property, cbTable, data_model_value, 1);
+            std::string tr181Path = yang_to_tr181_path(tableName);
+            wfa_set_bus_callbackfunc_pointers(tr181Path.c_str(), &cbTable);
+            wfa_bus_register_namespace(const_cast<char*>(tr181Path.c_str()), bus_element_type_property, cbTable, data_model_value, 1);
         }
         return;
     }
@@ -812,8 +857,9 @@ void tr_181_t::handle_property_node(cJSON* root, const std::string& fullPath, cJ
         memset(&data_model_value, 0, sizeof(data_model_value));
         parse_property_constraints(effective, data_model_value);
         parse_readwrite(effective, data_model_value);
-        wfa_set_bus_callbackfunc_pointers(fullPath.c_str(), &cbTable);
-        wfa_bus_register_namespace(const_cast<char*>(fullPath.c_str()), bus_element_type_property, cbTable, data_model_value, 1);
+        std::string tr181Path = yang_to_tr181_path(fullPath);
+        wfa_set_bus_callbackfunc_pointers(tr181Path.c_str(), &cbTable);
+        wfa_bus_register_namespace(const_cast<char*>(tr181Path.c_str()), bus_element_type_property, cbTable, data_model_value, 1);
         return;
     }
 
@@ -821,8 +867,9 @@ void tr_181_t::handle_property_node(cJSON* root, const std::string& fullPath, cJ
     memset(&data_model_value, 0, sizeof(data_model_value));
     parse_property_constraints(effective, data_model_value);
     parse_readwrite(effective, data_model_value);
-    wfa_set_bus_callbackfunc_pointers(fullPath.c_str(), &cbTable);
-    wfa_bus_register_namespace(const_cast<char*>(fullPath.c_str()), bus_element_type_property, cbTable, data_model_value, 1);
+    std::string tr181Path = yang_to_tr181_path(fullPath);
+    wfa_set_bus_callbackfunc_pointers(tr181Path.c_str(), &cbTable);
+    wfa_bus_register_namespace(const_cast<char*>(tr181Path.c_str()), bus_element_type_property, cbTable, data_model_value, 1);
 }
 
 // ------------------------------------------------------------
@@ -894,7 +941,7 @@ bool tr_181_t::parse_and_register_schema(const char *filename)
         if (child->string &&
             std::string(child->string).find("Network") != std::string::npos)
         {
-            traverse_schema(root, child, "Network");
+            traverse_schema(root, child, "Device.WiFi.DataElements.Network");
             break;
         }
         child = child->next;


### PR DESCRIPTION
Reason for change : Both the namespace registration and querying should be done in TR_181 path but the schema has it as xYANG path. Hence converted it and done some warning fixes.