### PR TITLE
RDKBACCL-1366 : Fix controller not sending channel pref query

### DIFF
--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -2023,7 +2023,7 @@ void em_channel_t::process_ctrl_state()
 {
     switch (get_state()) {
         case em_state_ctrl_channel_query_pending:
-			if(get_service_type() == em_service_type_ctrl) {
+            if(get_service_type() == em_service_type_ctrl) {
                 std::vector<em_t *> em_radios;
                 dm_easy_mesh_t *dm = get_data_model();
                 get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
@@ -2044,8 +2044,7 @@ void em_channel_t::process_ctrl_state()
 				    send_channel_pref_query_msg();
                 }
                 em_radios.clear();
-				set_state(em_state_ctrl_channel_pref_report_pending);
-			}
+            }
             break;
 
         case em_state_ctrl_channel_select_pending:


### PR DESCRIPTION
Controller is not sending the channel pref query message as it wrongly moved to channel pref report pending state without sending channel pref query message. This commit addresses that issue.