### PR TITLE
RDKBACCL-1375 : Reordering of IEEE1905 message

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -1934,6 +1934,7 @@ typedef enum {
     em_state_agent_onewifi_bssconfig_ind,
 	em_state_agent_autoconfig_renew_pending,
     em_state_agent_topo_synchronized,
+    em_state_agent_ap_cap_report,
 	em_state_agent_channel_pref_query,
 	em_state_agent_channel_selection_pending,
 	em_state_agent_channel_select_configuration_pending,
@@ -1943,7 +1944,6 @@ typedef enum {
 	
 	// Transient agent stats
     em_state_agent_topology_notify,
-    em_state_agent_ap_cap_report,
     em_state_agent_client_cap_report,
     em_state_agent_sta_link_metrics_pending,
     em_state_agent_steer_btm_res_pending,

--- a/src/cmd/em_cmd_em_config.cpp
+++ b/src/cmd/em_cmd_em_config.cpp
@@ -48,9 +48,9 @@ em_cmd_em_config_t::em_cmd_em_config_t(em_cmd_params_t param, dm_easy_mesh_t& dm
     m_num_orch_desc = 10;
     m_orch_desc[0].op = dm_orch_type_bss_delete;
     m_orch_desc[0].submit = false;
-    m_orch_desc[1].op = dm_orch_type_ap_cap_query;
+    m_orch_desc[1].op = dm_orch_type_topo_sync;
     m_orch_desc[1].submit = true;
-    m_orch_desc[2].op = dm_orch_type_topo_sync;
+    m_orch_desc[2].op = dm_orch_type_ap_cap_query;
     m_orch_desc[2].submit = true;
     m_orch_desc[3].op = dm_orch_type_channel_pref;
     m_orch_desc[3].submit = true;

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -1317,7 +1317,7 @@ void em_capability_t::process_msg(unsigned char *data, unsigned int len)
                 get_mgr()->get_all_em_for_al_mac(hdr->dst, em_radios);
                 for (auto &em : em_radios){
                     em_printfout(" em_msg_type_ap_cap_query received, state: %s\n", em_t::state_2_str(em->get_state()));
-                    if ((em->get_service_type() == em_service_type_agent) && (em->get_state() < em_state_agent_onewifi_bssconfig_ind)){
+                    if ((em->get_service_type() == em_service_type_agent) && (em->get_state() < em_state_agent_topo_synchronized)){
                         em_printfout("radio %s is not configured, ignoring", util::mac_to_string(em->get_radio_interface_mac()).c_str());
                         em_radios.clear();
                         return;

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -5190,7 +5190,7 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
                 std::vector<em_t*> em_radios;
                 get_mgr()->get_all_em_for_al_mac(hdr->dst, em_radios);
                 for (auto &em : em_radios) {
-                    if ((em->get_service_type() == em_service_type_agent) && (em->get_state() < em_state_agent_ap_cap_report)) {
+                    if ((em->get_service_type() == em_service_type_agent) && (em->get_state() < em_state_agent_onewifi_bssconfig_ind)) {
                         em_printfout("radio %s is not configured, ignoring", util::mac_to_string(em->get_radio_interface_mac()).c_str());
                         em_radios.clear();
                         return;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -151,11 +151,11 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             em_printfout("%s(%s) state: %s radio mac:%s", em_cmd_t::get_orch_op_str(pcmd->get_orch_op()),
                     em_cmd_t::get_cmd_type_str(pcmd->m_type), em_t::state_2_str(get_state()),
                     util::mac_to_string(em_t::get_radio_interface_mac()).c_str());
-            if ((pcmd->get_orch_op() == dm_orch_type_ap_cap_query) && (m_sm.get_state() == em_state_ctrl_wsc_m2_sent)) {
-                m_sm.set_state(em_state_ctrl_ap_cap_query_pending);
-            } else if ((pcmd->get_orch_op() == dm_orch_type_topo_sync) && (m_sm.get_state() == em_state_ctrl_ap_cap_report_received)) {
+            if ((pcmd->get_orch_op() == dm_orch_type_topo_sync) && (m_sm.get_state() == em_state_ctrl_wsc_m2_sent)) {
                 m_sm.set_state(em_state_ctrl_topo_sync_pending);
-            } else if ((pcmd->get_orch_op() == dm_orch_type_channel_pref) && (m_sm.get_state() == em_state_ctrl_topo_synchronized)) {
+            } else if ((pcmd->get_orch_op() == dm_orch_type_ap_cap_query) && (m_sm.get_state() == em_state_ctrl_topo_synchronized)) {
+                m_sm.set_state(em_state_ctrl_ap_cap_query_pending);
+            } else if ((pcmd->get_orch_op() == dm_orch_type_channel_pref) && (m_sm.get_state() == em_state_ctrl_ap_cap_report_received)) {
                 m_sm.set_state(em_state_ctrl_channel_query_pending);
             } else if ((pcmd->get_orch_op() == dm_orch_type_channel_sel) && (m_sm.get_state() == em_state_ctrl_channel_queried)) {
                 m_sm.set_state(em_state_ctrl_channel_select_pending);
@@ -185,7 +185,7 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             break;
 
         case em_cmd_type_channel_pref_query:
-	    if (m_sm.get_state() == em_state_agent_topo_synchronized) {
+	    if (m_sm.get_state() == em_state_agent_ap_cap_report) {
 		    m_sm.set_state(em_state_agent_channel_pref_query);
 	    }
             break;

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -83,7 +83,7 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
         case em_cmd_type_onewifi_cb:
-            if (em->get_state() == em_state_agent_ap_cap_report) {
+            if (em->get_state() == em_state_agent_topo_synchronized) {
                 return true;
             }
             break;
@@ -161,7 +161,7 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         return true;
     } else if (pcmd->m_type == em_cmd_type_ap_cap_query) {
         return true;
-    } else if ((pcmd->m_type == em_cmd_type_channel_pref_query) && (em->get_state() >= em_state_agent_topo_synchronized)) {
+    } else if ((pcmd->m_type == em_cmd_type_channel_pref_query) && (em->get_state() >= em_state_agent_ap_cap_report)) {
 		return true;
     } else if (pcmd->m_type == em_cmd_type_op_channel_report) {
         return true;
@@ -424,7 +424,7 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
                 break;
 			case em_cmd_type_channel_pref_query:
 				if ((em->is_al_interface_em())) {
-					if ((em->get_state() >= em_state_agent_topo_synchronized)
+					if ((em->get_state() >= em_state_agent_ap_cap_report)
 							&& (em->get_state() < em_state_agent_configured)) {
 						queue_push(pcmd->m_em_candidates, em);
 						count++;


### PR DESCRIPTION
Reordering of topology message and AP capability message.

After M2 message is sent out from controller, topology query should be sent to the agent. After topology is synchronized, AP capability query should be sent out.