### PR TITLE
RDKBACCL-1407: Changes related to Channel pref, AP capability messages

### DIFF
--- a/build/makefile.inc
+++ b/build/makefile.inc
@@ -38,3 +38,4 @@ CC ?= gcc
 AR ?= ar cr
 RM = -rm -rf
 CP = cp
+CXXFLAGS += -D_PLATFORM_RASPBERRYPI_

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -159,6 +159,9 @@ extern "C"
 #define EM_CONN_ESS 0x01
 #define EM_CONN_IBSS 0x02
 
+/* Channel Preference Flags*/
+#define EM_CH_PREF_NON_OPERABLE 0x00
+
 #define EM_MAX_BANDS    3
 #define EM_MAX_BSSS     EM_MAX_BANDS*8  
 #define EM_MAX_AKMS     10
@@ -625,6 +628,23 @@ typedef enum {
     em_tlv_vendor_plolicy_cfg = 0xf2,
     em_tlv_type_vendor_operational_bss = 0xf3,
 } em_tlv_type_t;
+
+typedef enum {
+    em_channel_pref_reason_unspecified = 0x00,
+    em_channel_pref_reason_proximate_non_80211_interferer = 0x01,
+    em_channel_pref_reason_intra_network_obss_interference_mgmt = 0x02,
+    em_channel_pref_reason_external_network_obss_interference_mgmt = 0x03,
+    em_channel_pref_reason_reduced_coverage = 0x04,
+    em_channel_pref_reason_reduced_throughput = 0x05,
+    em_channel_pref_reason_in_device_interferer = 0x06,
+    em_channel_pref_reason_operation_disallowed_dfs_radar_detection = 0x07,
+    em_channel_pref_reason_operation_prevent_backhaul_shared_radio = 0x08,
+    em_channel_pref_reason_immediate_operation_possible_dfs = 0x09,
+    em_channel_pref_reason_dfs_state_unknown_cac_not_run_or_expired = 0x0a,
+    em_channel_pref_reason_controller_dfs_clear_indication = 0x0b,
+    em_channel_pref_reason_operation_disallowed_regulatory_restriction = 0x0c,
+    em_channel_pref_reason_change_due_to_available_spectrum_inquiry = 0x0d
+} em_channel_pref_reason_t;
 
 typedef struct {
     unsigned short qmid;

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -216,23 +216,6 @@ public:
 	short create_spatial_reuse_report_tlv(unsigned char *buff);
     
 	/**!
-	 * @brief Creates a radio operation restriction TLV.
-	 *
-	 * This function is responsible for creating a radio operation restriction
-	 * TLV (Type-Length-Value) and storing it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
-	 * @param[in] index The index of the radio operation restriction to be created.
-	 *
-	 * @returns A short integer indicating the success or failure of the operation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure that the buffer is properly allocated before calling this function.
-	 */
-	short create_radio_op_restriction_tlv(unsigned char *buff, unsigned int index);
-    
-	/**!
 	 * @brief Creates a complete CAC report TLV.
 	 *
 	 * This function generates a complete CAC (Channel Access Control) report TLV (Type-Length-Value) and stores it in the provided buffer.

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -1031,6 +1031,11 @@ int em_capability_t::handle_eht_operations_tlv(unsigned char *buff)
 
     dm = get_data_model();
 
+    // 32 octets are reserved for future use, so skip 32 octets
+    short reserved_octets = 32;
+    tmp += reserved_octets;
+    len += reserved_octets;
+
     memcpy(&num_radios, tmp, sizeof(unsigned char));
     
     if (num_radios > EM_MAX_RADIO_PER_AGENT) {
@@ -1063,6 +1068,10 @@ int em_capability_t::handle_eht_operations_tlv(unsigned char *buff)
             tmp += sizeof(em_eht_operations_bss_t);
             len += static_cast<short> (sizeof(em_eht_operations_bss_t));
         }
+        // 25 octets are reserved for future use in radio, so skip 25 octets
+        short radio_reserved_octets = 25;
+        tmp += radio_reserved_octets;
+        len += radio_reserved_octets;
     }
 
     bool found_radio = false;
@@ -1245,22 +1254,8 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
             }
         }
         else if (tlv->type == em_tlv_type_metric_cltn_interval){
-        } else if (tlv->type == em_tlv_type_device_inventory){
-            em_device_inventory_t *invent = reinterpret_cast<em_device_inventory_t *>(tlv->value);
-            if (invent != NULL){
-                for (unsigned int index = 0; index < dm->get_num_radios(); index++)
-                {
-                    dm_radio_t *radio = dm->get_radio(invent->radios[index].ruid);
-                    if (radio == NULL) {
-                        continue;
-                    }
-                    em_radio_info_t *radio_info = radio->get_radio_info();
-
-                    if ((radio_info != NULL)){
-                        memcpy(&radio_info->inventory_info, invent, sizeof(em_device_inventory_t));
-                    }
-                }
-            }
+        } else if (tlv->type == em_tlv_type_device_inventory) {
+            //TBD: Address handling of device inventory TLV appropriately
         } else if (tlv->type == em_tlv_type_ap_radio_advanced_cap){
             uint16_t value_len = ntohs(tlv->len);
 

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1192,17 +1192,61 @@ short em_t::create_prof_2_tlv(unsigned char *buff)
 short em_t::create_device_inventory_tlv(unsigned char *buff)
 {
     short len = 0;
+    dm_easy_mesh_t* dm;
     dm_radio_t* radio = get_data_model()->get_radio(get_radio_interface_mac());
     em_radio_info_t* radio_info = radio->get_radio_info();
-    em_device_inventory_t *invent = reinterpret_cast<em_device_inventory_t *>(buff);
+    unsigned char *tmp = buff;
 
-    if ((invent == NULL) || (radio_info == NULL)) {
+    if ((radio_info == NULL)) {
         em_printfout("No data Found");
         return 0;
     }
 
-    memcpy(invent, &radio_info->inventory_info, sizeof(em_device_inventory_t));
-    len = sizeof(em_device_inventory_t);
+    memcpy(tmp, &radio_info->inventory_info.serial_len, sizeof(unsigned char));
+    tmp += sizeof(unsigned char);
+    if (radio_info->inventory_info.serial_len) {
+        memcpy(tmp, radio_info->inventory_info.serial, radio_info->inventory_info.serial_len);
+        tmp += radio_info->inventory_info.serial_len;
+    }
+    len += static_cast<short>(sizeof(unsigned char) + radio_info->inventory_info.serial_len);
+
+    memcpy(tmp, &radio_info->inventory_info.ver_len, sizeof(unsigned char));
+    tmp += sizeof(unsigned char);
+    if (radio_info->inventory_info.ver_len) {
+        memcpy(tmp, radio_info->inventory_info.version, radio_info->inventory_info.ver_len);
+        tmp += radio_info->inventory_info.ver_len;
+    }
+    len += static_cast<short>(sizeof(unsigned char) + radio_info->inventory_info.ver_len);
+
+    memcpy(tmp, &radio_info->inventory_info.envi_len, sizeof(unsigned char));
+    tmp += sizeof(unsigned char);
+    if (radio_info->inventory_info.envi_len) {
+        memcpy(tmp, radio_info->inventory_info.environment, radio_info->inventory_info.envi_len);
+        tmp += radio_info->inventory_info.envi_len;
+    }
+    len += static_cast<short>(sizeof(unsigned char) + radio_info->inventory_info.envi_len);
+
+    dm = get_data_model();
+
+    unsigned char num_radios = static_cast<unsigned char> (dm->get_num_radios());
+    memcpy(tmp, &num_radios, sizeof(unsigned char));
+    tmp += sizeof(unsigned char);
+    len += static_cast<short>(sizeof(unsigned char));
+
+    for (unsigned int i = 0; i < num_radios; i++) {
+        unsigned char* ruid = dm->get_radio_by_ref(i).get_radio_interface_mac();
+        memcpy(tmp, ruid, sizeof(mac_address_t));
+        tmp += sizeof(mac_address_t);
+        len += static_cast<short>(sizeof(mac_address_t));
+
+        memcpy(tmp, &radio_info->inventory_info.radios[i].vendor_len, sizeof(unsigned char));
+        tmp += sizeof(unsigned char);
+        if(radio_info->inventory_info.radios[i].vendor_len) {
+            memcpy(tmp, radio_info->inventory_info.radios[i].vendor, radio_info->inventory_info.radios[i].vendor_len);
+            tmp += radio_info->inventory_info.radios[i].vendor_len;
+        }
+        len += static_cast<short>(sizeof(unsigned char) + radio_info->inventory_info.radios[i].vendor_len);
+    }
     return len;
 }
 
@@ -1309,7 +1353,7 @@ unsigned short em_t::create_eht_operations_tlv(unsigned char *buff)
     len += sizeof(unsigned char);
 
     for (i = 0; i < num_radios; i++) {
-        uint8_t* ruid = dm->get_radio_info(i)->id.ruid;
+        unsigned char* ruid = dm->get_radio_by_ref(i).get_radio_interface_mac();
         memcpy(tmp, ruid, sizeof(mac_address_t));
         tmp += sizeof(mac_address_t);
         len += sizeof(mac_address_t);
@@ -1328,19 +1372,19 @@ unsigned short em_t::create_eht_operations_tlv(unsigned char *buff)
 
 
         for (j = 0; j < dm->get_num_bss(); j++) {
-        	if (memcmp(dm->m_bss[j].m_bss_info.ruid.mac, ruid, sizeof(mac_address_t)) != 0) {
-            	continue;
-        	}
-
-            memcpy(tmp, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t));
-            tmp += sizeof(mac_address_t);
-            len += sizeof(mac_address_t);
-
-            eht_ops_bss = &dm->m_bss[j].m_bss_info.eht_ops;
-            memcpy(tmp, eht_ops_bss, sizeof(em_eht_operations_bss_t));
-            tmp += sizeof(em_eht_operations_bss_t);
-            len += sizeof(em_eht_operations_bss_t);
+            if (memcmp(dm->m_bss[j].m_bss_info.ruid.mac, ruid, sizeof(mac_address_t)) == 0) {
+                memcpy(dm->m_bss[j].m_bss_info.eht_ops.bssid, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t));
+                eht_ops_bss = &dm->m_bss[j].m_bss_info.eht_ops;
+                memcpy(tmp, eht_ops_bss, sizeof(em_eht_operations_bss_t));
+                tmp += sizeof(em_eht_operations_bss_t);
+                len += sizeof(em_eht_operations_bss_t);
+            }
         }
+        // 25 octets are reserved for future use in radio, so skip 25 octets
+        unsigned int radio_reserved_octets = 25;
+        memset(tmp, 0, radio_reserved_octets);
+        tmp += radio_reserved_octets;
+        len += radio_reserved_octets;
     }
 
     return len;


### PR DESCRIPTION
Below changes addressed:
1) Channel preference report message corrected to indicate non-operable channel as part of channel preference tlv.
2) Removed inclusion of not needed radio restriction tlv in channel preference report.
3) EHT operations TLV includes appropriate reserved padding in radio information. 
4) auth type updated to the supported auth type as per Raspberry PI.
5) Corrected device inventory tlv creation in AP capability report.

Tests addressed:
1) Tested SSID change on RPI and BPI-openwrt
2) Checked packet capture for Channel preference report, selection request and response, operating channel report and response on Wireshark