### PR TITLE
RDKBACCL-1429 Fixed security type html changes broke due PR-556

### DIFF
--- a/src/rdkb-cli/static/index.html
+++ b/src/rdkb-cli/static/index.html
@@ -740,14 +740,12 @@
                         </div>
                         <div class="form-group">
                             <label class="form-label">Security Type</label>
-                            <select id="profile-security" class="form-select" disabled>
-                                <option value="WPA3-SAE">WPA3-SAE</option>
-                                <option value="WPA3-Enterprise">WPA3-Enterprise</option>
-                                <option value="WPA2-PSK">WPA2-PSK (Legacy)</option>
-                                <option value="Enhanced-Open">Enhanced Open</option>
-                                <option value="WPA2 Personal">WPA2 Personal</option>
-                                <option value="WPA3 Transition/ WPA3 Personal">WPA3 Transitional/ WPA3 Personal</option>
+                            <select id="profile-security" class="form-select">
                                 <option value="Open">Open</option>
+                                <option value="WPA2 Personal">WPA2 Personal</option>
+                                <option value="Enhanced Open">Enhanced Open</option>
+                                <option value="WPA3 Personal">WPA3 Personal</option>
+                                <option value="WPA3 Transition">WPA3 Transition</option>
                             </select>
                         </div>
                         <div class="form-group" id="passphrase-group">


### PR DESCRIPTION
Fixed the security type html changes which got reverted to older one due to PR-556, which broke the security type change feature from CLI.