### PR TITLE
RDKBWIFI-323: Policy fixes and changes for single AP Metrics Report

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -549,6 +549,7 @@ public:
 	 * This function processes the M2 transmission event and updates the command array accordingly.
 	 *
 	 * @param[in] evt Pointer to the event structure containing the M2 transmission details.
+	 * @param[in] evt_status Indicates if the same event for this command type is already executing.
 	 * @param[out] cmd Array of command pointers to be updated based on the event analysis.
 	 *
 	 * @returns int Status code indicating success or failure of the analysis.
@@ -557,7 +558,7 @@ public:
 	 *
 	 * @note Ensure that the event and command pointers are valid before calling this function.
 	 */
-	int analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *cmd[]);
+	int analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *cmd[], bool evt_status);
     
 	/**!
 	 * @brief Analyzes the station association event.
@@ -733,6 +734,8 @@ public:
 	 * @param[in] parent The JSON object containing the station configurations.
 	 * @param[in] key The key used to identify the specific station configuration.
 	 * @param[in] reason The reason for retrieving the station list, default is none.
+	 * @param[in] subdoc buffer pointer to the structure where the sub-document information
+	 * will be stored.
 	 *
 	 * @returns int Status code of the operation.
 	 * @retval 0 on success.
@@ -740,7 +743,7 @@ public:
 	 *
 	 * @note Ensure that the JSON object and key are valid before calling this function.
 	 */
-	int get_sta_config(cJSON *parent, char *key, em_get_sta_list_reason_t reason = em_get_sta_list_reason_none);
+	int get_sta_config(cJSON *parent, char *key, em_get_sta_list_reason_t reason = em_get_sta_list_reason_none, char *data = NULL);
     
 	/**!
 	 * @brief Retrieves the BSS configuration from a JSON object.

--- a/inc/dm_easy_mesh_list.h
+++ b/inc/dm_easy_mesh_list.h
@@ -394,6 +394,8 @@ public:
 	 * @note Ensure that the input BSS is valid and part of a list before calling this function.
 	 */
 	dm_bss_t *get_next_bss(dm_bss_t *bss);
+	dm_bss_t *get_first_bss(mac_addr_t al_mac);
+	dm_bss_t *get_next_bss(mac_addr_t al_mac, dm_bss_t *bss);
     
 	/**!
 	 * @brief Retrieves the BSS (Basic Service Set) associated with the given key.

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -453,7 +453,9 @@ public:
 	 * @note Ensure that the event structure is properly initialized before calling this function.
 	 */
 	void handle_bsta_cap_req(em_bus_event_t *evt);
-    
+
+	void handle_link_stats_alarm_report(em_bus_event_t *evt);
+
 	/**!
 	 * @brief 
 	 * This function handles input/output operations.

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -309,6 +309,8 @@ class em_metrics_t {
 	 */
 	int handle_ap_metrics_tlv(unsigned char *buff, bssid_t bssid);
 
+	int handle_link_stats_alarm_rprt_tlv(unsigned char *buff, short len);
+
 	/**!
 	 * @brief Creates an association station link metrics TLV.
 	 *
@@ -491,7 +493,7 @@ class em_metrics_t {
 	 *
 	 * @note Ensure that the buffer is large enough to hold the TLV.
 	 */
-	short create_radio_metrics_tlv(unsigned char *buff);
+	short create_radio_metrics_tlv(unsigned char *buff, int index);
     
 	/**!
 	 * @brief Creates an associated station traffic statistics TLV.
@@ -525,6 +527,8 @@ class em_metrics_t {
 	 * @note Ensure that the buffer is adequately sized to hold the TLV report.
 	 */
 	short create_assoc_wifi6_sta_sta_report_tlv(unsigned char *buff, const dm_sta_t *const sta);
+
+	short create_link_stats_alarm_tlv(unsigned char *buff);
 
 public:
 

--- a/inc/em_orch.h
+++ b/inc/em_orch.h
@@ -281,7 +281,10 @@ public:
 	 *
 	 * @returns True if the command type is in progress, false otherwise.
 	 */
-        bool is_cmd_type_renew_in_progress(em_bus_event_t *evt); 
+	bool is_cmd_in_progress_by_radio(em_bus_event_t *evt);
+
+	bool is_cmd_in_progress_by_type(em_bus_event_t *evt);
+
 	/**!
 	 * @brief Orchestrates the execution of a command within the em context.
 	 *

--- a/inc/em_policy_cfg.h
+++ b/inc/em_policy_cfg.h
@@ -256,7 +256,9 @@ public:
 	 * calling this function.
 	 */
 	short create_vendor_policy_cfg_tlv(unsigned char *buff);
-    
+
+	short create_vendor_policy_cfg_alarm_tlv(unsigned char *buff);
+
 	/**!
 	 * @brief Sends a policy configuration request message.
 	 *

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -34,6 +34,7 @@
 #define DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY           "Device.WiFi.DataElements.Network.Topology"
 #define DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC          "Device.WiFi.DataElements.Network.NodeSynchronize"
 #define DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY    "Device.WiFi.DataElements.Network.NodeConfigurePolicy"
+#define DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_LINKSTATS_ALARM    "Device.WiFi.DataElements.Network.NodeLinkStatsAlarm"
 
 #define LIST_OF_DEFINITION_NAME "List_Of_Def"
 #define MAX_NUM_OF_OBJECTS_NAME "Num_Of_Objects"
@@ -511,6 +512,7 @@ public:
 
     //Policy Callbacks
     static bus_error_t policy_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t subs_policy_config(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
 
     //Radio
     static bus_error_t radio_get(char* event_name, raw_data_t* p_data, struct bus_user_data* user_data);
@@ -543,6 +545,11 @@ public:
     //AffiliatedAP
     static bus_error_t affap_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t affap_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
+    //Orchestrator
+    static bus_error_t get_node_sync(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t set_node_sync(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t policy_config(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
 
     virtual bus_error_t network_get(char *event_name, raw_data_t *p_data) = 0;
     virtual bus_error_t device_get(char *event_name, raw_data_t *p_data) = 0;

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -457,6 +457,11 @@ void em_cmd_t::init()
             m_svc = em_service_type_ctrl;
             break;
 
+        case em_cmd_type_get_link_stats_alarm_report:
+            strncpy(m_name, "get_alarm_report", strlen("get_alarm_report") + 1);
+            m_svc = em_service_type_ctrl;
+            break;
+
         default:
             break;
 
@@ -489,6 +494,7 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_start_dpp)
         BUS_EVENT_TYPE_2S(em_bus_event_type_dev_init)
         BUS_EVENT_TYPE_2S(em_bus_event_type_cfg_renew)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_m2_tx)
         BUS_EVENT_TYPE_2S(em_bus_event_type_radio_config)
         BUS_EVENT_TYPE_2S(em_bus_event_type_vap_config)
         BUS_EVENT_TYPE_2S(em_bus_event_type_sta_list)
@@ -500,6 +506,7 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_mld_config)
         BUS_EVENT_TYPE_2S(em_bus_event_type_mld_reconfig)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_reset)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_link_stats_alarm_report)
        
         default:
            break;
@@ -631,6 +638,7 @@ const char *em_cmd_t::get_cmd_type_str(em_cmd_type_t type)
         CMD_TYPE_2S(em_cmd_type_beacon_report)
         CMD_TYPE_2S(em_cmd_type_ap_metrics_report)
         CMD_TYPE_2S(em_cmd_type_get_reset)
+        CMD_TYPE_2S(em_cmd_type_get_link_stats_alarm_report)
 
         default:
            break;
@@ -749,6 +757,7 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
 	        break;
 
         case em_bus_event_type_topo_sync:
+        case em_bus_event_type_m2_tx:
             type = em_cmd_type_em_config;
             break;
 
@@ -770,6 +779,10 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
 
         case em_bus_event_type_get_reset:
             type = em_cmd_type_get_reset;
+            break;
+
+        case em_bus_event_type_link_stats_alarm_report:
+            type = em_cmd_type_get_link_stats_alarm_report;
             break;
 
         default:

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -209,13 +209,14 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     return num;
 }
 
-int dm_easy_mesh_ctrl_t::analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *pcmd[])
+int dm_easy_mesh_ctrl_t::analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *pcmd[], bool evt_status)
 {
     mac_addr_str_t  radio_str, al_str;
     em_bus_event_type_m2_tx_params_t *params;
     int num = 0;
     dm_easy_mesh_t  dm;
     em_cmd_t *tmp;
+    em_orch_desc_t desc;
 
     if (evt == NULL) {
         printf("%s:%d: NULL event\n", __func__, __LINE__);
@@ -233,6 +234,22 @@ int dm_easy_mesh_ctrl_t::analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *pcmd[])
     pcmd[num] = new em_cmd_em_config_t(evt->params, dm);
     tmp = pcmd[num];
     num++;
+
+    em_printfout("type: %s, cmd ip: :%d", em_cmd_t::get_bus_event_type_str(evt->type), evt_status);
+    // If event_status is true, this command type is already in progress.
+    // This event is generated per radio on the device, but for orchestration
+    // types like policy, we should not re-create or re-send the command.
+    // Therefore, if event_status is true, skip policy orchestration and send
+    // the command only once, even if multiple M2 TX events are received.
+    if (evt_status == true) {
+        for (unsigned int i = 0; i < pcmd[num - 1]->m_num_orch_desc; i++) {
+            if (pcmd[num - 1]->m_orch_desc[i].op == dm_orch_type_policy_cfg) {
+                desc.submit = false;
+                pcmd[num - 1]->override_op(i, &desc);
+                break;
+            }
+        }
+    }
 
     while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
         tmp = pcmd[num];
@@ -605,47 +622,76 @@ int dm_easy_mesh_ctrl_t::analyze_dpp_start(em_bus_event_t *evt, em_cmd_t *cmd[])
 
 int dm_easy_mesh_ctrl_t::analyze_set_policy(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
-	int ret;
-	unsigned int num = 0, num_devices = 0;
-	em_subdoc_info_t *subdoc;
-	dm_easy_mesh_t dm;
-	unsigned int i = 0;
-    em_cmd_t *tmp;
-	dm_radio_t *radio;
-	mac_addr_str_t mac_str;
-	
-	subdoc = &evt->u.subdoc;
+    int ret;
+    unsigned int num = 0, num_devices = 0;
+    em_subdoc_info_t *subdoc;
+    dm_easy_mesh_t dm, *dev_dm;
+    unsigned int i = 0;
+    dm_radio_t *radio;
+    mac_addr_str_t mac_str;
+    int policy_changed = 0;
 
-	do {
-		dm.reset();
+    subdoc = &evt->u.subdoc;
 
-		if ((ret = dm.decode_config(subdoc, "SetPolicy", i, &num_devices)) < 0) {
-        	return ret;
-    	}
-			
-		dm_easy_mesh_t::macbytes_to_string(dm.m_device.m_device_info.intf.mac, mac_str);
-		//printf("%s:%d: Network: %s\tDevice MAC: %s\n", __func__, __LINE__, dm.m_network.m_net_info.id, mac_str);
+    em_printfout("Received SetPolicy event: \n%s", subdoc->buff);
+    do {
+        dm.reset();
 
-		radio = m_data_model_list.get_first_radio(dm.m_network.m_net_info.id, dm.m_device.m_device_info.intf.mac);
-		while (radio != NULL) {
-			memcpy(dm.m_radio[dm.m_num_radios].m_radio_info.intf.mac, radio->m_radio_info.intf.mac, sizeof(mac_address_t));
-			dm.m_num_radios++;
-			radio = m_data_model_list.get_next_radio(dm.m_network.m_net_info.id, dm.m_device.m_device_info.intf.mac, radio);
-		}
-		dm.set_db_cfg_param(db_cfg_type_policy_list_update, "");
-   		pcmd[num] = new em_cmd_set_policy_t(evt->params, dm);
-   		tmp = pcmd[num];
-   		num++;
+        if ((ret = dm.decode_config(subdoc, "SetPolicy", i, &num_devices)) < 0) {
+            em_printfout("Failed to decode SetPolicy config: %d", ret);
+            return ret;
+        }
 
-   		while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
-       		tmp = pcmd[num];
-       		num++;
-   		}
+        //em_printfout("Decoded SetPolicy for device number-%d", i);
+        dm_easy_mesh_t::macbytes_to_string(dm.m_device.m_device_info.intf.mac, mac_str);
+        em_printfout("Network: %s\tDevice MAC: %s", dm.m_network.m_net_info.id, mac_str);
 
-		i++;
-	} while (i < num_devices);
+        dev_dm = get_data_model(GLOBAL_NET_ID, dm.m_device.m_device_info.intf.mac);
+        if (dev_dm != NULL) {
+            //compare if policy has changed for this device, create cmd only if a policy chnage is detected
+            for (unsigned int j = 0; j < dev_dm->get_num_policy(); j++) {
+                if ((dev_dm->m_policy[j] == dm.m_policy[j]) == false) {
+                    policy_changed++;
+                    break;
+                }
+            }
+        } else {
+            em_printfout("Device with MAC: %s not found in data model, so considering as policy changed", mac_str);
+            return 0;
+        }
 
-	return static_cast<int> (num);
+        //TODO: once colocated agent fix is merged, remove this check
+        if(dev_dm->get_colocated() == true) {
+            //em_printfout("Colocated(%s), represent contoller device, so skipping....", mac_str);
+            i++;
+            continue;
+        }
+
+        if (policy_changed == 0) {
+            em_printfout("No Policy change detected for device with MAC: %s", mac_str);
+            i++;
+            continue;
+        } else {
+            em_printfout("Policy change detected for device with MAC: %s", mac_str);
+        }
+        radio = m_data_model_list.get_first_radio(dm.m_network.m_net_info.id, dm.m_device.m_device_info.intf.mac);
+        while (radio != NULL) {
+            memcpy(dm.m_radio[dm.m_num_radios].m_radio_info.intf.mac, radio->m_radio_info.intf.mac, sizeof(mac_address_t));
+            dm.m_num_radios++;
+            radio = m_data_model_list.get_next_radio(dm.m_network.m_net_info.id, dm.m_device.m_device_info.intf.mac, radio);
+        }
+        dm.set_db_cfg_param(db_cfg_type_policy_list_update, "");
+        pcmd[num] = new em_cmd_set_policy_t(evt->params, dm);
+        num++;
+
+        em_printfout("Setting policy for Device number-%d with MAC: %s", i, mac_str);
+
+        i++;
+    } while (i < num_devices);
+
+    //em_printfout("Total cmnds formed for policy change is : %d", num);
+
+    return static_cast<int> (num);
 }
 
 int dm_easy_mesh_ctrl_t::analyze_scan_channel(em_bus_event_t *evt, em_cmd_t *pcmd[])
@@ -1279,15 +1325,52 @@ int dm_easy_mesh_ctrl_t::get_policy_config(cJSON *parent, char *net_id)
 
 }
 
-int dm_easy_mesh_ctrl_t::get_sta_config(cJSON *parent, char *key, em_get_sta_list_reason_t reason)
+int dm_easy_mesh_ctrl_t::get_sta_config(cJSON *parent, char *key, em_get_sta_list_reason_t reason, char *data)
 {
     cJSON *net_obj, *dev_list_obj, *dev_obj, *radio_list_obj, *radio_obj, *bss_list_obj;
-    cJSON *bss_obj, *sta_list_obj;
+    cJSON *bss_obj, *sta_list_obj, *link_report_obj;
     int i, j, k;
     char *tmp;
+    dm_device_t *pdev;
+    mac_addr_str_t bss_str, mac_str;
+    dm_bss_t *bss;
+    em_device_info_t *info;
 
     net_obj = cJSON_AddObjectToObject(parent, "Network");
-    dm_network_list_t::get_config(net_obj, key, true);
+
+    if (reason == em_get_sta_list_reason_alarm_report) {
+        dm_network_list_t::get_config(net_obj, key, true);
+        dev_obj = cJSON_AddObjectToObject(net_obj, "Device");
+
+        dm_easy_mesh_t::macbytes_to_string(reinterpret_cast<unsigned char *>(data), mac_str);
+        em_printfout("Searching for Device with MAC: %s", mac_str);
+
+        pdev = get_first_device();
+        while (pdev != NULL) {
+            info = pdev->get_device_info();
+            if (memcmp(info->id.dev_mac, data, sizeof(mac_addr_t)) == 0) {
+                cJSON_AddStringToObject(dev_obj, "ID", mac_str);
+                break;
+            }
+            pdev = get_next_device(pdev);
+        }
+
+        link_report_obj = cJSON_AddArrayToObject(dev_obj, "LinkReport");
+
+        if (pdev == NULL) {
+            em_printfout("Device with MAC not found in device list");
+            return 0;
+        }
+
+        bss = m_data_model_list.get_first_bss(pdev->m_device_info.intf.mac);
+		while (bss != NULL) {
+			// go through all bss
+            em_printfout("Getting STA list for BSS: %s", dm_easy_mesh_t::macbytes_to_string(bss->m_bss_info.id.bssid, bss_str));
+            dm_sta_list_t::get_config(link_report_obj, bss_str, reason);
+			bss = m_data_model_list.get_next_bss(pdev->m_device_info.intf.mac, bss);
+		}
+        return 0;
+    }
 
     dev_list_obj = cJSON_AddArrayToObject(net_obj, "DeviceList");
     dm_device_list_t::get_config(dev_list_obj, key, true);
@@ -1550,6 +1633,8 @@ void dm_easy_mesh_ctrl_t::get_config(em_long_string_t net_id, em_subdoc_info_t *
         get_mld_config(parent, net_id);
     } else if (strncmp(subdoc->name, "WifiReset", strlen(subdoc->name)) == 0) {
         get_wifi_reset_config(parent, net_id);
+    } else {
+        em_printfout("Unknown Subdoc Name: %s\n", subdoc->name);
     }
 
     tmp = cJSON_Print(parent);
@@ -4765,9 +4850,11 @@ int dm_easy_mesh_ctrl_t::init(const char *data_model_path, em_mgr_t *mgr)
 dm_easy_mesh_ctrl_t::dm_easy_mesh_ctrl_t()
 {
     m_initialized = false;
+    m_network_initialized = false;
     m_nb_pipe_rd = 0;
     m_nb_pipe_wr = 0;
     m_nb_evt_id = 0;
+    m_topology = nullptr;
 }
 
 dm_easy_mesh_ctrl_t::~dm_easy_mesh_ctrl_t()

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -490,6 +490,43 @@ dm_bss_t *dm_easy_mesh_list_t::get_bss(const char *key)
 	return dm->find_matching_bss(&id);
 }
 
+dm_bss_t *dm_easy_mesh_list_t::get_first_bss(mac_addr_t al_mac)
+{
+    dm_easy_mesh_t *dm;
+
+    dm = get_data_model(GLOBAL_NET_ID, al_mac);
+    if ((dm != NULL) && (dm->get_num_bss() > 0)) {
+        return &dm->m_bss[0];
+    }
+
+    return NULL;
+}
+
+dm_bss_t *dm_easy_mesh_list_t::get_next_bss(mac_addr_t al_mac, dm_bss_t *bss)
+{
+    dm_easy_mesh_t *dm;
+    unsigned int i;
+    bool found_match = false;
+
+    dm = get_data_model(GLOBAL_NET_ID, al_mac);
+    if ((dm == NULL) || (dm->get_num_bss() == 0)) {
+        return NULL;
+    }
+
+    for (i = 0; i < dm->get_num_bss(); i++) {
+        if (&dm->m_bss[i] == bss) {
+            found_match = true;
+            break;
+        }
+    }
+
+    if ((found_match == true) && (i < (dm->get_num_bss() - 1))) {
+        return &dm->m_bss[i + 1];
+    }
+
+    return NULL;
+}
+
 void dm_easy_mesh_list_t::remove_bss(const char *key)
 {
 	em_bss_id_t id;

--- a/src/dm/dm_network.cpp
+++ b/src/dm/dm_network.cpp
@@ -129,7 +129,11 @@ void dm_network_t::encode(cJSON *obj, bool summary)
 
     dm_easy_mesh_t::macbytes_to_string(m_net_info.colocated_agent_id.mac, mac_str);
     cJSON_AddStringToObject(obj, "CollocatedAgentID", mac_str);
-	
+
+    if (summary == true) {
+        return;
+    }
+
 	if (m_net_info.media == em_media_type_ieee8023ab) {
 		strncpy(str, "Ethernet", strlen("Ethernet") + 1);
 	} else if (m_net_info.media == em_media_type_ieee80211b_24) {

--- a/src/dm/dm_policy.cpp
+++ b/src/dm/dm_policy.cpp
@@ -79,24 +79,24 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
             snprintf(m_policy.managed_sta_marker, sizeof(em_long_string_t), "%s", cJSON_GetStringValue(tmp));
     	}
 	} else if (type == em_policy_id_type_radio_metrics_rep) {
-    	if ((tmp = cJSON_GetObjectItem(obj, "STA RCPI Threshold")) != NULL) {
-			m_policy.rcpi_threshold = static_cast<short unsigned int>(tmp->valuedouble);
-    	}
-    	if ((tmp = cJSON_GetObjectItem(obj, "STA RCPI Hysteresis")) != NULL) {
-			m_policy.rcpi_hysteresis = static_cast<short unsigned int>(tmp->valuedouble);
-    	}
-    	if ((tmp = cJSON_GetObjectItem(obj, "AP Utilization Thresold")) != NULL) {
-			m_policy.util_threshold = static_cast<short unsigned int>(tmp->valuedouble);
-    	}
-    	if ((tmp = cJSON_GetObjectItem(obj, "STA Traffic Stats")) != NULL) {
-       		m_policy.sta_traffic_stats = tmp->valuedouble;
-    	}
-    	if ((tmp = cJSON_GetObjectItem(obj, "STA Link Metrics")) != NULL) {
-       		m_policy.sta_link_metric = tmp->valuedouble;
-    	}
-    	if ((tmp = cJSON_GetObjectItem(obj, "STA Status")) != NULL) {
-			m_policy.sta_status = tmp->valuedouble;
-    	}
+        if ((tmp = cJSON_GetObjectItem(obj, "STA RCPI Threshold")) != NULL) {
+            m_policy.rcpi_threshold = static_cast<short unsigned int>(tmp->valuedouble);
+        }
+        if ((tmp = cJSON_GetObjectItem(obj, "STA RCPI Hysteresis")) != NULL) {
+            m_policy.rcpi_hysteresis = static_cast<short unsigned int>(tmp->valuedouble);
+        }
+        if ((tmp = cJSON_GetObjectItem(obj, "AP Utilization Thresold")) != NULL) {
+            m_policy.util_threshold = static_cast<short unsigned int>(tmp->valuedouble);
+        }
+        if ((tmp = cJSON_GetObjectItem(obj, "STA Traffic Stats")) != NULL) {
+            m_policy.sta_traffic_stats = tmp->valuedouble;
+        }
+        if ((tmp = cJSON_GetObjectItem(obj, "STA Link Metrics")) != NULL) {
+            m_policy.sta_link_metric = tmp->valuedouble;
+        }
+        if ((tmp = cJSON_GetObjectItem(obj, "STA Status")) != NULL) {
+            m_policy.sta_status = tmp->valuedouble;
+        }
 	} else if (type == em_policy_id_type_default_8021q_settings) {
 		if ((tmp = cJSON_GetObjectItem(obj, "Primay VLAN ID")) != NULL) {
 			m_policy.def_8021q_settings.primary_vid = static_cast<unsigned short>(tmp->valuedouble);
@@ -134,10 +134,19 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
     	if ((tmp = cJSON_GetObjectItem(obj, "Report Independent Channel Scans")) != NULL) {
    			m_policy.independent_scan_report = tmp->valuedouble;
     	}
-	} 
+    } else if (type == em_policy_id_type_alarm_threshold) {
+        if ((tmp = cJSON_GetObjectItem(obj, "Collection Start Time")) != NULL) {
+            snprintf(m_policy.link_stats_alarm_cfg.collection_start_time, sizeof(em_long_string_t), "%s", cJSON_GetStringValue(tmp));
+        }
+        if ((tmp = cJSON_GetObjectItem(obj, "Reporting Interval")) != NULL) {
+            m_policy.link_stats_alarm_cfg.reporting_interval = tmp->valuedouble;
+        }
+        if ((tmp = cJSON_GetObjectItem(obj, "Link Quality Threshold")) != NULL) {
+            m_policy.link_stats_alarm_cfg.link_quality_threshold = static_cast<float>(tmp->valuedouble);
+        }
+	}
 	
 	return 0;
-
 }
 
 void dm_policy_t::encode(cJSON *obj, em_policy_id_type_t id)
@@ -202,9 +211,9 @@ void dm_policy_t::encode(cJSON *obj, em_policy_id_type_t id)
 bool dm_policy_t::operator == (const dm_policy_t& obj)
 {
     int ret = 0;
-    
-	ret += (memcmp(&this->m_policy.id.dev_mac, &obj.m_policy.id.dev_mac, sizeof(mac_address_t)) != 0);
-	ret += (memcmp(&this->m_policy.id.radio_mac, &obj.m_policy.id.radio_mac, sizeof(mac_address_t)) != 0);
+
+    ret += (memcmp(&this->m_policy.id.dev_mac, &obj.m_policy.id.dev_mac, sizeof(mac_address_t)) != 0);
+    ret += (memcmp(&this->m_policy.id.radio_mac, &obj.m_policy.id.radio_mac, sizeof(mac_address_t)) != 0);
     ret += !(this->m_policy.interval == obj.m_policy.interval);
     ret += !(this->m_policy.rcpi_threshold == obj.m_policy.rcpi_threshold);
     ret += !(this->m_policy.rcpi_hysteresis == obj.m_policy.rcpi_hysteresis);
@@ -212,19 +221,26 @@ bool dm_policy_t::operator == (const dm_policy_t& obj)
     ret += !(this->m_policy.sta_traffic_stats == obj.m_policy.sta_traffic_stats);
     ret += !(this->m_policy.sta_link_metric == obj.m_policy.sta_link_metric);
     ret += !(this->m_policy.sta_status == obj.m_policy.sta_status);
-	ret += (strncmp(this->m_policy.managed_sta_marker, obj.m_policy.managed_sta_marker, strlen(this->m_policy.managed_sta_marker)) != 0);
+    ret += (strncmp(this->m_policy.managed_sta_marker, obj.m_policy.managed_sta_marker, strlen(this->m_policy.managed_sta_marker)) != 0);
     ret += (memcmp(&this->m_policy.def_8021q_settings, &obj.m_policy.def_8021q_settings, sizeof(em_8021q_settings_policy_t)) != 0);
     ret += (memcmp(&this->m_policy.traffic_separ, &obj.m_policy.traffic_separ, sizeof(em_traffic_separation_policy_t)) != 0);
+    ret += (memcmp(&this->m_policy.link_stats_alarm_cfg, &obj.m_policy.link_stats_alarm_cfg, sizeof(em_link_stats_alarm_cfg_t)) != 0);
 
-	return (ret > 0) ? false:true;
+    return (ret > 0) ? false:true;
 }
 
 void dm_policy_t::operator = (const dm_policy_t& obj)
 {
     if (this == &obj) { return; }
+	memcpy(&this->m_policy.id.net_id, &obj.m_policy.id.net_id, sizeof(mac_address_t));
     memcpy(&this->m_policy.id.dev_mac, &obj.m_policy.id.dev_mac, sizeof(mac_address_t));
     memcpy(&this->m_policy.id.radio_mac, &obj.m_policy.id.radio_mac, sizeof(mac_address_t));
-    this->m_policy.id.type = obj.m_policy.id.type;
+    m_policy.id.type = obj.m_policy.id.type;
+    m_policy.num_sta = obj.m_policy.num_sta;
+    for(int i = 0; i < m_policy.num_sta; i++) {
+        memcpy(this->m_policy.sta_mac[i], obj.m_policy.sta_mac[i], sizeof(mac_address_t));
+    }
+    m_policy.policy = obj.m_policy.policy;
     this->m_policy.interval = obj.m_policy.interval;
     this->m_policy.rcpi_threshold = obj.m_policy.rcpi_threshold;
     this->m_policy.rcpi_hysteresis = obj.m_policy.rcpi_hysteresis;
@@ -240,6 +256,7 @@ void dm_policy_t::operator = (const dm_policy_t& obj)
         this->m_policy.traffic_separ.ssid_info[i].ssid_len = obj.m_policy.traffic_separ.ssid_info[i].ssid_len;
         strncpy(this->m_policy.traffic_separ.ssid_info[i].ssid, obj.m_policy.traffic_separ.ssid_info[i].ssid, MAX_WIFI_SSID_LEN);
     }
+    memcpy(&m_policy.link_stats_alarm_cfg, &obj.m_policy.link_stats_alarm_cfg, sizeof(em_link_stats_alarm_cfg_t));
 }
 
 int dm_policy_t::parse_dev_radio_mac_from_key(const char *key, em_policy_id_t *id)

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -151,6 +151,27 @@ void dm_sta_t::encode(cJSON *obj, em_get_sta_list_reason_t reason)
     mac_addr_str_t  mac_str;
     cJSON *reason_obj, *request_obj;
 
+    if (reason == em_get_sta_list_reason_alarm_report) {
+        dm_easy_mesh_t::macbytes_to_string(m_sta_info.id, mac_str);
+        cJSON_AddStringToObject(obj, "Mac", mac_str);
+        dm_easy_mesh_t::macbytes_to_string(m_sta_info.bssid, mac_str);
+        cJSON_AddStringToObject(obj, "BSSID", mac_str);
+        cJSON_AddStringToObject(obj, "ReportingTime", reinterpret_cast<const char*>(m_sta_info.link_stats_report.reporting_timestamp));
+        cJSON_AddNumberToObject(obj, "Threshold", m_sta_info.link_stats_report.link_quality_threshold);
+        cJSON_AddBoolToObject(obj, "Alarm", m_sta_info.link_stats_report.alarm_triggered);
+        cJSON *samples_obj = cJSON_AddArrayToObject(obj, "Samples");
+        for (unsigned int i = 0; i < m_sta_info.link_stats_report.sample_count; i++) {
+            cJSON *sample = cJSON_CreateObject();
+            cJSON_AddNumberToObject(sample, "Score", m_sta_info.link_stats_report.alarm_sample[i].link_quality_score);
+            cJSON_AddStringToObject(sample, "Time", m_sta_info.link_stats_report.alarm_sample[i].reporting_time);
+            cJSON_AddNumberToObject(sample, "SNR", m_sta_info.link_stats_report.alarm_sample[i].snr);
+            cJSON_AddNumberToObject(sample, "PER", m_sta_info.link_stats_report.alarm_sample[i].per);
+            cJSON_AddNumberToObject(sample, "PHY", m_sta_info.link_stats_report.alarm_sample[i].phy);
+            cJSON_AddItemToArray(samples_obj, sample);
+        }
+        return;
+    }
+
     dm_sta_t::decode_sta_capability(this);
     dm_sta_t::decode_beacon_report(this);
     dm_easy_mesh_t::macbytes_to_string(m_sta_info.id, mac_str);

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -343,19 +343,19 @@ int em_metrics_t::handle_assoc_sta_traffic_stats(unsigned char *buff, bssid_t bs
     em_assoc_sta_traffic_stats_t	*sta_metrics;
     dm_sta_t *sta;
     dm_easy_mesh_t  *dm;
-    mac_addr_str_t sta_str;
 
     dm = get_data_model();
     sta_metrics = reinterpret_cast<em_assoc_sta_traffic_stats_t *> (buff);
 
-    dm_easy_mesh_t::macbytes_to_string(sta_metrics->sta_mac, sta_str);
     sta = dm->find_sta(sta_metrics->sta_mac, bssid);
     if (sta == NULL) {
-        printf("%s:%d: sta not found: %s\n", __func__, __LINE__, sta_str);
+        em_printfout("sta not found: %s for bssid: %s", util::mac_to_string(sta_metrics->sta_mac).c_str(),
+            util::mac_to_string(bssid).c_str());
         return -1;
     }
 
     sta->m_sta_info.bytes_tx        = sta_metrics->tx_bytes;
+    em_printfout("  ===>>> bytes_tx: %d", sta->m_sta_info.bytes_tx);
     sta->m_sta_info.bytes_rx        = sta_metrics->rx_bytes;
     sta->m_sta_info.pkts_tx         = sta_metrics->tx_pkts;
     sta->m_sta_info.pkts_rx         = sta_metrics->rx_pkts;
@@ -366,6 +366,73 @@ int em_metrics_t::handle_assoc_sta_traffic_stats(unsigned char *buff, bssid_t bs
     return 0;
 }
 
+int em_metrics_t::handle_link_stats_alarm_rprt_tlv(unsigned char *buff, short len)
+{
+    em_link_report_t *link_report;
+    em_alarm_samples_t *alarm_samples;
+    dm_sta_t *sta;
+    dm_easy_mesh_t  *dm;
+    mac_addr_str_t sta_str;
+    unsigned char *tmp = buff;
+    size_t sample_sz = 0;
+
+    dm = get_data_model();
+
+    while (link_report != NULL && len > 0) {
+        em_printfout("  length : %d\n", len);
+        link_report = reinterpret_cast<em_link_report_t *> (tmp);
+
+        dm_easy_mesh_t::macbytes_to_string(link_report->sta_mac, sta_str);
+        sta = dm->get_first_sta(link_report->sta_mac);
+        while (sta != NULL) {
+            if (memcmp(sta->m_sta_info.id, link_report->sta_mac, sizeof(mac_address_t)) == 0) {
+                break;
+            }
+            sta = dm->get_next_sta(link_report->sta_mac, sta);
+        }
+
+        if(sta == NULL)
+        {
+            em_printfout("sta[%s] not found\n", sta_str);
+            return -1;
+        }
+
+        em_printfout("sta mac : %s\n", sta_str);
+        memcpy(sta->m_sta_info.link_stats_report.reporting_timestamp, link_report->reporting_timestamp, 31);
+        sta->m_sta_info.link_stats_report.reporting_timestamp[31] = '\0';
+        sta->m_sta_info.link_stats_report.link_quality_threshold = link_report->link_quality_threshold;
+        sta->m_sta_info.link_stats_report.alarm_triggered = link_report->alarm_triggered;
+
+        em_printfout("    ===>>> Link Stats Alarm Report rcvd for STA [%s] <<<===", sta_str);
+        em_printfout("    Reporting Timestamp: %s", sta->m_sta_info.link_stats_report.reporting_timestamp);
+        em_printfout("    Link Quality Threshold: %.2f", sta->m_sta_info.link_stats_report.link_quality_threshold);
+        em_printfout("    Alarm Triggered: %s", sta->m_sta_info.link_stats_report.alarm_triggered ? "True" : "False");
+
+        sta->m_sta_info.link_stats_report.sample_count = link_report->sample_count;
+        em_printfout("    Number of Samples: %d", sta->m_sta_info.link_stats_report.sample_count);
+        for (int i = 0; i < link_report->sample_count; i++) {
+            alarm_samples = &link_report->alarm_sample[i];
+            memcpy(&sta->m_sta_info.link_stats_report.alarm_sample[i], alarm_samples, sizeof(em_alarm_samples_t));
+
+            em_printfout("        Sample %d:", i + 1);
+            em_printfout("            reporting_time: %u", alarm_samples->reporting_time);
+            em_printfout("            Link Quality score: %.2f", alarm_samples->link_quality_score);
+            em_printfout("            SNR: %u dB", alarm_samples->snr);
+            em_printfout("            PER Rate: %u ", alarm_samples->per);
+            em_printfout("            PHY Rate: %u ", alarm_samples->phy);
+        }
+        sample_sz += sizeof(em_alarm_samples_t) * 3;//todo: remove hard-coded during integ
+
+        tmp += sizeof(em_link_report_t);
+        len -= static_cast<unsigned short> (sizeof(em_link_report_t));
+    }
+
+    //form json and send to cli/orchestrator
+    get_mgr()->io_process(em_bus_event_type_link_stats_alarm_report,reinterpret_cast<char*>(dm->get_device_info()->id.dev_mac),
+        sizeof(mac_address_t));
+
+    return 0;
+}
 
 int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int len)
 {
@@ -421,6 +488,7 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
 
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_assoc_sta_traffic_sts) {
+            //todo: bug fix to find sta
             handle_assoc_sta_traffic_stats(tlv->value, bssid);
         }
         tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
@@ -877,10 +945,6 @@ int em_metrics_t::send_ap_metrics_response()
     //AP Metrics Response 17.1.17
     //AP Metrics TLV (17.2.22)
     for (bss_index = 0; bss_index < static_cast<int>(dm->m_num_bss); bss_index++) {
-        if (memcmp(dm->m_bss[bss_index].m_bss_info.ruid.mac,
-            get_current_cmd()->get_param()->u.ap_metrics_params.ruid, sizeof(mac_addr_t)) != 0) {
-            continue;
-        }
 
         tlv = reinterpret_cast<em_tlv_t *> (tmp);
         tlv->type = em_tlv_type_ap_metrics;
@@ -894,15 +958,6 @@ int em_metrics_t::send_ap_metrics_response()
         tlv = reinterpret_cast<em_tlv_t *> (tmp);
         tlv->type = em_tlv_type_ap_ext_metric;
         sz = create_ap_ext_metrics_tlv(tlv->value, dm->m_bss[bss_index]);
-        tlv->len =  htons(static_cast<unsigned short> (sz));
-
-        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-
-        //Radio Metrics TLV (17.2.60)
-        tlv = reinterpret_cast<em_tlv_t *> (tmp);
-        tlv->type = em_tlv_type_radio_metric;
-        sz = create_radio_metrics_tlv(tlv->value);
         tlv->len =  htons(static_cast<unsigned short> (sz));
 
         tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
@@ -964,6 +1019,25 @@ int em_metrics_t::send_ap_metrics_response()
             sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
         }
     }
+
+    for (int i = 0; i < get_current_cmd()->get_param()->u.ap_metrics_params.num_radios; i++) {
+        //Radio Metrics TLV (17.2.60)
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_radio_metric;
+        sz = create_radio_metrics_tlv(tlv->value, i);
+        tlv->len =  htons(static_cast<unsigned short> (sz));
+
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
+
+    //Add Link Stats alarm tlv
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_link_stats_alarm_rprt;
+    sz = create_link_stats_alarm_tlv(tlv->value);
+    tlv->len = htons(static_cast<unsigned short> (sz));
+    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
 
     // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -1251,14 +1325,20 @@ short em_metrics_t::create_beacon_metrics_response_tlv(unsigned char *buff)
 short em_metrics_t::create_ap_metrics_tlv(unsigned char *buff, dm_bss_t &dm_bss)
 {
     size_t len = 0;
-    mac_addr_str_t rad_str, bss_str;
     em_ap_metric_t *ap_metrics = reinterpret_cast<em_ap_metric_t *> (buff);
+    int i = 0;
 
-    dm_easy_mesh_t::macbytes_to_string(dm_bss.m_bss_info.ruid.mac, rad_str);
+ 
+    for(i = 0; i < get_current_cmd()->get_param()->u.ap_metrics_params.num_radios; i++) {
+        if (memcmp(dm_bss.m_bss_info.ruid.mac,
+            get_current_cmd()->get_param()->u.ap_metrics_params.ruid[i], sizeof(mac_addr_t)) == 0) {
+            em_printfout("Creating ap response for radio ruid: %s", util::mac_to_string(dm_bss.m_bss_info.ruid.mac).c_str());
+            break;
+        }
+    }
     if (memcmp(dm_bss.m_bss_info.ruid.mac, 
-        get_current_cmd()->get_param()->u.ap_metrics_params.ruid, sizeof(mac_addr_t)) == 0) {
-        dm_easy_mesh_t::macbytes_to_string(dm_bss.m_bss_info.bssid.mac, bss_str);
-        printf("%s:%d Creating ap response for bssid: %s\n", __func__, __LINE__, bss_str);
+        get_current_cmd()->get_param()->u.ap_metrics_params.ruid[i], sizeof(mac_addr_t)) == 0) {
+        em_printfout("Creating ap response for bssid: %s", util::mac_to_string(dm_bss.m_bss_info.bssid.mac).c_str());
 
         memcpy(ap_metrics->bssid, dm_bss.m_bss_info.bssid.mac, sizeof(mac_address_t));
         len += static_cast<size_t> (sizeof(mac_address_t));
@@ -1284,12 +1364,19 @@ short em_metrics_t::create_ap_metrics_tlv(unsigned char *buff, dm_bss_t &dm_bss)
 short em_metrics_t::create_ap_ext_metrics_tlv(unsigned char *buff, dm_bss_t &dm_bss)
 {
     size_t len = 0;
-    mac_addr_str_t rad_str;
     em_ap_ext_metric_t *ap_ext_metrics = reinterpret_cast<em_ap_ext_metric_t *> (buff);
+    int i = 0;
 
-    dm_easy_mesh_t::macbytes_to_string(dm_bss.m_bss_info.ruid.mac, rad_str);
+    for(i = 0; i < get_current_cmd()->get_param()->u.ap_metrics_params.num_radios; i++) {
+        if (memcmp(dm_bss.m_bss_info.ruid.mac,
+            get_current_cmd()->get_param()->u.ap_metrics_params.ruid[i], sizeof(mac_addr_t)) == 0) {
+            em_printfout("Creating ap response for radio ruid: %s", util::mac_to_string(dm_bss.m_bss_info.ruid.mac).c_str());
+            break;
+        }
+    }
+
     if (memcmp(dm_bss.m_bss_info.ruid.mac,
-        get_current_cmd()->get_param()->u.ap_metrics_params.ruid, sizeof(mac_addr_t)) == 0) {
+        get_current_cmd()->get_param()->u.ap_metrics_params.ruid[i], sizeof(mac_addr_t)) == 0) {
         memcpy(ap_ext_metrics->bssid, dm_bss.m_bss_info.bssid.mac, sizeof(mac_address_t));
     }
 
@@ -1298,14 +1385,14 @@ short em_metrics_t::create_ap_ext_metrics_tlv(unsigned char *buff, dm_bss_t &dm_
     return static_cast<short> (len);
 }
 
-short em_metrics_t::create_radio_metrics_tlv(unsigned char *buff)
+short em_metrics_t::create_radio_metrics_tlv(unsigned char *buff, int index)
 {
     size_t len = 0;
     dm_easy_mesh_t *dm = get_data_model();
     em_radio_metric_t *radio_metric = reinterpret_cast<em_radio_metric_t *> (buff);
     dm_radio_t *radio = NULL;
 
-    radio = dm->get_radio(get_current_cmd()->get_param()->u.ap_metrics_params.ruid);
+    radio = dm->get_radio(get_current_cmd()->get_param()->u.ap_metrics_params.ruid[index]);
     memcpy(radio_metric->ruid, radio->get_radio_info()->intf.mac, sizeof(mac_address_t));
 
     len = static_cast<size_t> (sizeof(em_radio_metric_t));
@@ -1323,6 +1410,10 @@ short em_metrics_t::create_assoc_sta_traffic_stats_tlv(unsigned char *buff, cons
         len += sizeof(response->sta_mac_addr);
 
         response->bytes_sent = sta->m_sta_info.bytes_tx;
+        em_printfout("   ===>>> em_sta_dev_info->bytes_tx %d",sta->m_sta_info.bytes_tx);
+        em_printfout("   ===>>> response->bytes_sent %d",response->bytes_sent);
+
+
         len += sizeof(response->bytes_sent);
 
         response->bytes_recv = sta->m_sta_info.bytes_rx;
@@ -1353,6 +1444,63 @@ short em_metrics_t::create_assoc_wifi6_sta_sta_report_tlv(unsigned char *buff, c
 
     len = static_cast<size_t> (sizeof(em_assoc_wifi6_sta_sts_t));
 
+    return static_cast<short> (len);
+}
+
+short em_metrics_t::create_link_stats_alarm_tlv(unsigned char *buff)
+{
+    size_t len = 0;
+    em_link_report_t *link_stats = reinterpret_cast<em_link_report_t *> (buff);
+    char date_time[EM_DATE_TIME_BUFF_SZ];
+    unsigned char *tmp = buff;
+    dm_sta_t *sta;
+    dm_easy_mesh_t  *dm = get_data_model();
+
+    //add logic to increment above mac value by 1
+    sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
+    while (sta != NULL) {
+        memcpy(link_stats->sta_mac, sta->m_sta_info.id, sizeof(mac_address_t));
+        util::get_date_time_rfc3399(date_time, sizeof(date_time));
+        strncpy(reinterpret_cast<char*>(link_stats->reporting_timestamp), date_time, 32);
+
+        link_stats->link_quality_threshold = 0.1;
+        link_stats->alarm_triggered = 1;
+        link_stats->sample_count = 2;
+
+        em_printfout("   sta mac : %s", util::mac_to_string(link_stats->sta_mac).c_str());
+        em_printfout("   reporting_timestamp : %s", link_stats->reporting_timestamp);
+        em_printfout("   link_quality_threshold : %.2f", link_stats->link_quality_threshold);
+        em_printfout("   alarm_triggered : %d", link_stats->alarm_triggered);
+        em_printfout("create_link_stats_alarm_tlv: sample_count=%d", link_stats->sample_count);
+
+        size_t sample_sz = 0;
+        float score_inc = 0.1;
+        for (int j = 0; j < link_stats->sample_count; j++) {
+            link_stats->alarm_sample[j].link_quality_score = 0.33 + score_inc;
+            strncpy(link_stats->alarm_sample[j].reporting_time, date_time, 32);
+            link_stats->alarm_sample[j].snr = 80 + j;
+            link_stats->alarm_sample[j].per = 70 + j;
+            link_stats->alarm_sample[j].phy = 100 + j;
+
+            em_printfout("   Sample %d:", j + 1);
+            em_printfout("       link_quality_score : %.2f", link_stats->alarm_sample[j].link_quality_score);
+            em_printfout("       reporting_time : %s", link_stats->alarm_sample[j].reporting_time);
+            em_printfout("       snr : %d", link_stats->alarm_sample[j].snr);
+            em_printfout("       per : %d", link_stats->alarm_sample[j].per);
+            em_printfout("       phy : %d", link_stats->alarm_sample[j].phy);
+            sample_sz += sizeof(em_alarm_samples_t);
+        }
+
+        len = static_cast<size_t> (sizeof(em_link_report_t) + sample_sz);
+        tmp += len;
+
+        link_stats = reinterpret_cast<em_link_report_t *>(tmp);
+
+        sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+    }
+
+    len = static_cast<size_t> (sizeof(em_link_report_t));
+    em_printfout("create_link_stats_alarm_tlv done");
     return static_cast<short> (len);
 }
 

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -41,6 +41,8 @@
 #include "em_msg.h"
 #include "em_cmd_exec.h"
 
+static const unsigned char em_vendor_oui[EM_VENDOR_OUI_SIZE] = {0xd8, 0x9c, 0x8e};
+
 short em_policy_cfg_t::create_metrics_rep_policy_tlv(unsigned char *buff)
 {
 	short len = 0;
@@ -75,38 +77,61 @@ short em_policy_cfg_t::create_metrics_rep_policy_tlv(unsigned char *buff)
 	found_match = false;
 	metric->interval = static_cast<unsigned char> (policy->m_policy.interval);
 
+    unsigned int radio_cnt = 0;
+
 	for (i = 0; i < dm->get_num_policy(); i++) {
 		policy = &dm->m_policy[i];
 		if (policy->m_policy.id.type == em_policy_id_type_radio_metrics_rep) {
-			if ((memcmp(policy->m_policy.id.radio_mac, broadcast_mac, sizeof(mac_address_t)) == 0) ||
-					(memcmp(policy->m_policy.id.radio_mac, get_radio_interface_mac(), sizeof(mac_address_t)) == 0)) {
+			if ((memcmp(policy->m_policy.id.radio_mac, broadcast_mac, sizeof(mac_address_t)) == 0)) {
 				found_match = true;
+                //if broadcast, fill all radios
+                em_printfout("  Fill broadcast mac: %s", util::mac_to_string(get_data_model()->get_radio_info(radio_cnt)->id.ruid).c_str());
+                radio_cnt = get_data_model()->get_num_radios();
             	break;	
-			}
+			} else {
+                radio_metric = &metric->radios[radio_cnt];
+                memcpy(radio_metric->ruid, policy->m_policy.id.radio_mac, sizeof(mac_address_t));
+                em_printfout("Radio %d MAC: %s for type %d", radio_cnt, util::mac_to_string(policy->m_policy.id.radio_mac).c_str(), policy->m_policy.id.type);
+
+                radio_metric->rcpi_thres = static_cast<unsigned char> (policy->m_policy.rcpi_threshold);
+                radio_metric->rcpi_hysteresis = static_cast<unsigned char> (policy->m_policy.rcpi_hysteresis);
+                radio_metric->util_thres = static_cast<unsigned char> (policy->m_policy.util_threshold);
+                radio_metric->sta_policy = 0;
+                if (policy->m_policy.sta_traffic_stats == true) {
+                    radio_metric->sta_policy |= (1 << 7);
+                }
+                if (policy->m_policy.sta_link_metric == true) {
+                    radio_metric->sta_policy |= (1 << 6);
+                }
+                if (policy->m_policy.sta_status == true) {
+                    radio_metric->sta_policy |= (1 << 5);
+                }
+                radio_cnt++;
+            }
 		}
 	}
+	em_printfout(" NUM of radios: %d", radio_cnt);
+    metric->radios_num = radio_cnt;
 
-	
-	if (found_match == false) {
-		return 0;
-	}
-
-	metric->radios_num = 1;
-	radio_metric = &metric->radios[0];
-
-	memcpy(radio_metric->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
-	radio_metric->rcpi_thres = static_cast<unsigned char> (policy->m_policy.rcpi_threshold);
-	radio_metric->rcpi_hysteresis = static_cast<unsigned char> (policy->m_policy.rcpi_hysteresis);
-	radio_metric->util_thres = static_cast<unsigned char> (policy->m_policy.util_threshold);
-	radio_metric->sta_policy = 0;
-	if (policy->m_policy.sta_traffic_stats == true) {
-		radio_metric->sta_policy |= (1 << 7);	
-	}
-	if (policy->m_policy.sta_link_metric == true) {
-		radio_metric->sta_policy |= (1 << 6);	
-	}
-	if (policy->m_policy.sta_status == true) {
-		radio_metric->sta_policy |= (1 << 5);	
+    if (found_match == true) {
+        for(i = 0; i < get_data_model()->get_num_radios(); i++) {
+            radio_metric = &metric->radios[i];
+            em_printfout(" Radio %d MAC: %s", i, util::mac_to_string(get_data_model()->get_radio_info(i)->id.ruid).c_str());
+            memcpy(radio_metric->ruid, get_data_model()->get_radio_info(i)->id.ruid, sizeof(mac_address_t));
+            radio_metric->rcpi_thres = static_cast<unsigned char> (policy->m_policy.rcpi_threshold);
+            radio_metric->rcpi_hysteresis = static_cast<unsigned char> (policy->m_policy.rcpi_hysteresis);
+            radio_metric->util_thres = static_cast<unsigned char> (policy->m_policy.util_threshold);
+            radio_metric->sta_policy = 0;
+            if (policy->m_policy.sta_traffic_stats == true) {
+                radio_metric->sta_policy |= (1 << 7);
+            }
+            if (policy->m_policy.sta_link_metric == true) {
+                radio_metric->sta_policy |= (1 << 6);
+            }
+            if (policy->m_policy.sta_status == true) {
+                radio_metric->sta_policy |= (1 << 5);
+            }
+        }
 	}
 
 	tmp += 2*sizeof(unsigned char) + metric->radios_num * sizeof(em_metric_rprt_policy_radio_t);
@@ -315,6 +340,78 @@ short em_policy_cfg_t::create_vendor_policy_cfg_tlv(unsigned char *buff)
     size_t len = 0;
     dm_easy_mesh_t *dm;
     dm_policy_t *policy;
+    unsigned char *tmp = buff;
+    unsigned int i = 0;
+    em_vendor_specific_t *vendor_tlv = reinterpret_cast<em_vendor_specific_t *> (tmp);
+    dm = get_current_cmd()->get_data_model();
+
+    /* Search for both AP Metrics and Alarm Threshold policies before deciding what to append */
+    int idx_ap = -1;
+    int idx_alarm = -1;
+
+    memcpy(reinterpret_cast<char *> (vendor_tlv->vendor_oui), em_vendor_oui, EM_VENDOR_OUI_SIZE);
+    vendor_tlv->m_num = 0;
+    tmp += sizeof(unsigned char) + EM_VENDOR_OUI_SIZE;
+    len += sizeof(unsigned char) + EM_VENDOR_OUI_SIZE;
+
+    for (i = 0; i < dm->get_num_policy(); i++) {
+        if (dm->m_policy[i].m_policy.id.type == em_policy_id_type_ap_metrics_rep) {
+            idx_ap = static_cast<int>(i);
+        } else if (dm->m_policy[i].m_policy.id.type == em_policy_id_type_alarm_threshold) {
+            idx_alarm = static_cast<int>(i);
+        }
+        /* If both found, we can stop scanning early */
+        if ((idx_ap != -1) && (idx_alarm != -1)) {
+            break;
+        }
+    }
+
+    if ((idx_ap == -1) && (idx_alarm == -1)) {
+        return 0;
+    }
+
+    /* If AP metrics policy exists, append its vendor data */
+    if (idx_ap != -1) {
+        policy = &dm->m_policy[idx_ap];
+        em_printfout(" Vendor Policy cfg TLV for metrics report policy ");
+
+        *tmp = static_cast<unsigned char>(vendor_ext_attr_id_policy_sta_marker);
+        tmp += sizeof(unsigned char);
+        len += sizeof(unsigned char);
+
+        strncpy(reinterpret_cast<char *> (tmp), policy->m_policy.managed_sta_marker, strlen(policy->m_policy.managed_sta_marker) + 1);
+        tmp += strlen(policy->m_policy.managed_sta_marker) + 1;
+        len += strlen(policy->m_policy.managed_sta_marker) + 1;
+
+        vendor_tlv->m_num++;
+    }
+
+    if (idx_alarm != -1) {
+        policy = &dm->m_policy[idx_alarm];
+        em_printfout(" Vendor Policy cfg TLV for link stats alarm policy ");
+
+        *tmp = static_cast<unsigned char>(vendor_ext_attr_id_policy_alarm);
+        tmp += sizeof(unsigned char);
+        len += sizeof(unsigned char);
+
+        memcpy(tmp, reinterpret_cast<unsigned char *> (&policy->m_policy.link_stats_alarm_cfg), sizeof(em_link_stats_alarm_cfg_t));
+        tmp += sizeof(em_link_stats_alarm_cfg_t);
+        len += sizeof(em_link_stats_alarm_cfg_t);
+
+        vendor_tlv->m_num++;
+    }
+
+    em_printfout(" Vendor Policy cfg total numbers: %zu ", vendor_tlv->m_num);
+    em_printfout(" Vendor Policy cfg TLV length: %zu ", len);
+
+    return static_cast<short> (len);
+}
+
+short em_policy_cfg_t::create_vendor_policy_cfg_alarm_tlv(unsigned char *buff)
+{
+    size_t len = 0;
+    dm_easy_mesh_t *dm;
+    dm_policy_t *policy;
     bool found_match = false;
     unsigned char *tmp = buff;
     unsigned int i = 0;
@@ -323,7 +420,7 @@ short em_policy_cfg_t::create_vendor_policy_cfg_tlv(unsigned char *buff)
 
     for (i = 0; i < dm->get_num_policy(); i++) {
         policy = &dm->m_policy[i];
-        if (policy->m_policy.id.type == em_policy_id_type_ap_metrics_rep) {
+        if (policy->m_policy.id.type == em_policy_id_type_alarm_threshold) {
             found_match = true;
             break;
         }
@@ -332,10 +429,12 @@ short em_policy_cfg_t::create_vendor_policy_cfg_tlv(unsigned char *buff)
         return 0;
     }
 
-    strncpy(reinterpret_cast<char *> (tmp), policy->m_policy.managed_sta_marker, strlen(policy->m_policy.managed_sta_marker) + 1);
+    em_printfout(" Vendor Policy cfg TLV for link stats alarm policy ");
+    memcpy(tmp, reinterpret_cast<unsigned char *> (&policy->m_policy.link_stats_alarm_cfg), sizeof(em_link_stats_alarm_cfg_t));
+    tmp += sizeof(em_link_stats_alarm_cfg_t);
+    len += sizeof(em_link_stats_alarm_cfg_t);
 
-    tmp += strlen(policy->m_policy.managed_sta_marker);
-    len += strlen(policy->m_policy.managed_sta_marker);
+    em_printfout(" Vendor Policy cfg TLV length: %zu ", len);
 
     return static_cast<short> (len);
 }
@@ -450,9 +549,9 @@ int em_policy_cfg_t::send_policy_cfg_request_msg()
     tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
     len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
 
-    //em_tlv_vendor_plolicy_cfg
+    //em_tlv_type_vendor_policy_cfg_sta_marker
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_vendor_plolicy_cfg;
+    tlv->type = em_tlv_type_vendor_specific;
     sz = create_vendor_policy_cfg_tlv(tlv->value);
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
@@ -568,10 +667,36 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
         } else if (tlv->type == em_tlv_type_unsucc_assoc_policy) {
         } else if (tlv->type == em_tlv_type_backhaul_bss_conf) {
         } else if (tlv->type == em_tlv_type_qos_mgmt_policy){
-        } else if (tlv->type == em_tlv_vendor_plolicy_cfg) {
-            em_vendor_policy_t *vendor = reinterpret_cast<em_vendor_policy_t *> (tlv->value);
-            snprintf(policy.vendor_policy.managed_client_marker, sizeof(em_string_t), "%s", vendor->managed_client_marker);
-            data_len += sizeof(em_vendor_policy_t);
+        } else if (tlv->type == em_tlv_type_vendor_specific) {
+            em_vendor_specific_t *vendor_tlv = reinterpret_cast<em_vendor_specific_t *> (tlv->value);
+            em_printfout("Recvd vendor tlv, m_num: %d and tlv->len:%d", vendor_tlv->m_num, htons(tlv->len));
+            if ((vendor_tlv->m_num <= 0) || (htons(tlv->len) == 0)) {
+                break;
+            }
+
+            unsigned char *tmp = tlv->value;
+            tmp += sizeof(vendor_tlv->m_num) + EM_VENDOR_OUI_SIZE;
+
+            for(int i = 0; i < vendor_tlv->m_num; i++)
+            {
+                em_printfout("vendor attr id is: %d", *tmp);
+                if (*tmp == vendor_ext_attr_id_policy_sta_marker) {
+                    em_vendor_policy_t *vendor = reinterpret_cast<em_vendor_policy_t *> (tmp);
+                    strncpy(policy.vendor_policy.managed_client_marker, vendor->managed_client_marker, strlen(vendor->managed_client_marker) + 1);
+                    tmp += strlen(vendor->managed_client_marker) + sizeof(unsigned char);
+
+                    em_printfout(" Recvd sta marker: %s", policy.vendor_policy.managed_client_marker);
+                } else if (*tmp == vendor_ext_attr_id_policy_alarm) {
+                    em_link_report_alarm_policy_cfg_t *vendor = reinterpret_cast<em_link_report_alarm_policy_cfg_t *> (tmp);
+                    memcpy(&policy.vendor_policy.link_stats_alarm_policy_cfg, vendor, sizeof(em_link_report_alarm_policy_cfg_t));
+
+                    em_printfout(" Recvd link stats alarm cfg, collection_start_time : %s ", policy.vendor_policy.link_stats_alarm_policy_cfg.collection_start_time);
+                    em_printfout(" Recvd link stats alarm cfg, reporting_interval : %d ", policy.vendor_policy.link_stats_alarm_policy_cfg.reporting_interval);
+                    em_printfout(" Recvd link stats alarm cfg, link_quality_threshold : %f ", policy.vendor_policy.link_stats_alarm_policy_cfg.link_quality_threshold);
+
+                    tmp += sizeof(unsigned char) + sizeof(em_link_report_alarm_policy_cfg_t);
+                }
+            }
         }
 
         tlv_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
@@ -579,8 +704,6 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
     }
 
     get_mgr()->io_process(em_bus_event_type_set_policy, reinterpret_cast<unsigned char *> (&policy), sizeof(policy));
-    //send_associated_link_metrics_response(sta);
-    //set_state(em_state_agent_configured);
 
     return 0;
 }

--- a/src/orch/em_orch.cpp
+++ b/src/orch/em_orch.cpp
@@ -245,7 +245,7 @@ bool em_orch_t::eligible_for_active(em_cmd_t *pcmd)
     return eligible;
 }
 
-bool em_orch_t::is_cmd_type_renew_in_progress(em_bus_event_t *evt)
+bool em_orch_t::is_cmd_in_progress_by_radio(em_bus_event_t *evt)
 {
 	em_cmd_stats_t *stats;
 	em_short_string_t key;
@@ -265,7 +265,7 @@ bool em_orch_t::is_cmd_type_renew_in_progress(em_bus_event_t *evt)
 	memcpy(mac, raw->radio, sizeof(mac_address_t));
 	dm_easy_mesh_t::macbytes_to_string(mac, radio_mac);
 	if ((stats = static_cast<em_cmd_stats_t *>(hash_map_get(m_cmd_map, key))) != NULL) {
-	   printf("%s:%d: Command of type: %d actively executing\n", __func__, __LINE__, type);
+	   em_printfout("Command of type: %s and cmd: %s actively executing", em_cmd_t::get_bus_event_type_str(evt->type), em_cmd_t::get_cmd_type_str(type));
 		// Go through the pending queue and check if radio mac match
 		for (i = static_cast<int>(queue_count(m_pending)) - 1; i >= 0; i--) {
 			pcmd = static_cast<em_cmd_t *>(queue_peek(m_pending, static_cast<unsigned int>(i)));
@@ -275,7 +275,8 @@ bool em_orch_t::is_cmd_type_renew_in_progress(em_bus_event_t *evt)
 					dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
 					if (memcmp(mac, em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
 						dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
-						printf("%s:%d: Command of type: %d actively executing for %s\n", __func__, __LINE__, type, mac_str);
+                        em_printfout("Command of type: %s and cmd: %s actively executing for %s",
+                            em_cmd_t::get_bus_event_type_str(evt->type), em_cmd_t::get_cmd_type_str(type), mac_str);
 						return true;
 					}
 				}
@@ -290,7 +291,8 @@ bool em_orch_t::is_cmd_type_renew_in_progress(em_bus_event_t *evt)
 					dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
 					if (memcmp(mac, em->get_radio_interface_mac(), sizeof(mac_addr_t)) == 0) {
 						dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
-						printf("%s:%d: Command of type: %d actively executing for %s\n", __func__, __LINE__, type, mac_str);
+                        em_printfout("Command of type: %d and cmd : %s, actively executing for %s",
+                            em_cmd_t::get_bus_event_type_str(evt->type), em_cmd_t::get_cmd_type_str(type), mac_str);
 						return true;
 					}
 				}
@@ -299,6 +301,44 @@ bool em_orch_t::is_cmd_type_renew_in_progress(em_bus_event_t *evt)
 	}
 
 	return false;
+}
+
+bool em_orch_t::is_cmd_in_progress_by_type(em_bus_event_t *evt)
+{
+    em_cmd_stats_t *stats;
+    em_short_string_t key;
+    em_cmd_type_t		type;
+    em_cmd_t *pcmd;
+    signed int i = 0;
+
+    type = em_cmd_t::bus_2_cmd_type(evt->type);
+    snprintf(key, sizeof(em_short_string_t), "%d", type);
+
+    em_printfout("is_cmd_in_progress_by_type: Checking for command type: %s", em_cmd_t::get_cmd_type_str(type));
+    stats = static_cast<em_cmd_stats_t *>(hash_map_get(m_cmd_map, key));
+    if (stats != NULL) {
+        em_printfout("Command of type: %s and cmd: %s actively executing", em_cmd_t::get_bus_event_type_str(evt->type), em_cmd_t::get_cmd_type_str(type));
+        // Go through the pending queue and check if radio mac match
+        for (i = static_cast<int>(queue_count(m_pending)) - 1; i >= 0; i--) {
+            pcmd = static_cast<em_cmd_t *>(queue_peek(m_pending, static_cast<unsigned int>(i)));
+            if (pcmd->m_type == type) {
+                em_printfout("Command of type: %s and cmd: %s actively executing", em_cmd_t::get_bus_event_type_str(evt->type),
+                    em_cmd_t::get_cmd_type_str(type));
+                return true;
+            }
+        }
+        // go though active queue and check if radio mac match
+        for (i = static_cast<int>(queue_count(m_active)) - 1; i >= 0; i--) {
+            pcmd = static_cast<em_cmd_t *>(queue_peek(m_active, static_cast<unsigned int>(i)));
+            if (pcmd->m_type == type) {
+                em_printfout("Command of type: %d and cmd : %s, actively executing",
+                    em_cmd_t::get_bus_event_type_str(evt->type), em_cmd_t::get_cmd_type_str(type));
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 bool em_orch_t::get_dev_test_status()
@@ -334,10 +374,13 @@ bool em_orch_t::is_cmd_type_in_progress(em_bus_event_t *evt)
 
     if ((type == em_cmd_type_cfg_renew ) ||
         (type == em_cmd_type_ap_metrics_report)) {
-        return is_cmd_type_renew_in_progress(evt);
+        return is_cmd_in_progress_by_radio(evt);
+    } else if ((type == em_cmd_type_em_config) ||
+               (type == em_cmd_type_set_policy)) {
+        return is_cmd_in_progress_by_type(evt);
     }
     if ((stats = static_cast<em_cmd_stats_t *>(hash_map_get(m_cmd_map, key))) != NULL) {
-        //printf("%s:%d: Command of type: %d actively executing\n", __func__, __LINE__, type);
+        //em_printfout("Command of type: %d actively executing", type);
         return true;
     }
 

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -530,6 +530,17 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                 break;
 
 			case em_cmd_type_set_policy:
+                dm = pcmd->get_data_model();
+                //need a radio from a device to send, no need to push all ems
+                if (memcmp(em->get_radio_interface_mac(), dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                    dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+                    em_printfout("em: %s pushed for command: em_cmd_type_set_policy\n", mac_str);
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                    break;
+                }
+                break;
+
 			case em_cmd_type_set_radio:
 				dm = pcmd->get_data_model();
 				for (i = 0; i < dm->get_num_radios(); i++) {


### PR DESCRIPTION
- Policy fixes:
    - Added new custom policy and vendor tlvs to send the custom policy
    - Fixed duplicate policy sending and policy to send per device
    - For AP related policies, updated code to parse policy for all radios if CLI sends radio Mac as ff:ff:ff:ff:ff and controller internally considers it as all radio and formulates radio Mac in the radio metrics reporting accordingly.
    - policy ff:ff:ff:ff:ff fixed so that this parse is to parse for all radios
- AP metrics Report
    - Code is updated to formulate one single report containing all radio tlvs as per the policy - stress testing needed for corner cases
    - comment tests alarms
- Link Stats Alarm Report
    - encode received link stats alarm report
    - receive linkreport of sta, encode a json and publish to orch!