### PR TITLE
RDKBWIFI-281: Misconfiguration of SSID on Agent.

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -49,6 +49,8 @@ class dm_easy_mesh_t {
     static std::atomic<int> s_counter;
     int m_instance_num;
     bool m_topo_changed = false;
+    unsigned int ssid_mismatch_check_time = 0;
+    unsigned int last_topo_query_sent_time = 0;
 
 public:
     webconfig_subdoc_data_t *m_wifi_data;
@@ -95,6 +97,10 @@ public:
 	void set_topo_state(bool state) { m_topo_changed = state; }
 	void set_id() { m_instance_num = ++s_counter; }
 	int get_id() const { return m_instance_num; }
+	void set_ssid_mismatch_check_time(unsigned int time) { ssid_mismatch_check_time = time; }
+	unsigned int get_ssid_mismatch_check_time() const { return ssid_mismatch_check_time; }
+	void set_last_topo_query_sent_time(unsigned int time) { last_topo_query_sent_time = time; }
+	unsigned int get_last_topo_query_sent_time() const { return last_topo_query_sent_time; }
 
 	static em_e4_table_t m_e4_table[];
 	
@@ -1128,7 +1134,18 @@ public:
 	 */
 	em_network_ssid_info_t *get_network_ssid_info_by_haul_type(em_haul_type_t haul_type);
 
-	
+	/**!
+     * @brief Checks whether the given SSID matches.
+     *
+     * This function determines whether the specified SSID matches
+     * the SSID associated with this instance.
+     *
+     * @param[in] ssid The SSID to compare against the stored SSID.
+     *
+     * @returns true if the SSIDs match; otherwise, false.
+     */
+    bool is_ssid_match(const ssid_t  &ssid);
+
 	/**!
 	 * @brief Retrieves the operational class information for a given index.
 	 *

--- a/inc/em.h
+++ b/inc/em.h
@@ -71,6 +71,7 @@ class em_t :
     bool dev_test_enable;
 
 	bool m_is_dpp_onboarding = false;
+	bool m_ssid_mismatch = false;
 
 	std::map<std::string, peer_1905_security_status> m_1905_layer_peer_security_statuses;
 
@@ -718,6 +719,24 @@ public:
 	bool get_is_dpp_onboarding() override { return m_is_dpp_onboarding; }
 
 	void set_is_dpp_onboarding(bool is_onboarding) override { m_is_dpp_onboarding = is_onboarding; }
+
+	/**!
+	 *  @brief Retrieves the ssid mismatch bool value.
+	 *
+	 *  This function returns True or False based of ssid mismatch.
+	 *
+	 *  @returns This function returns True or False as bool.
+	 */
+	bool get_ssid_mismatch() { return m_ssid_mismatch; }
+
+	/**!
+	 *  @brief Sets the ssid mismatch bool value.
+     *
+     *  This function sets True or False based of ssid mismatch.
+     *
+     * @returns This function Sets True or False as bool.
+     */
+	void set_ssid_mismatch(bool mismatch) { m_ssid_mismatch = mismatch; }
 
     
 	/**!

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -92,6 +92,7 @@ extern "C"
 #define EM_MAX_CHANNELS_IN_LIST  64
 #define EM_MAX_CMD_GEN_TTL  10
 #define EM_MAX_CMD_EXT_TTL  30
+#define EM_SSID_MISMATCH_TTL  120
 #define EM_MAX_RENEW_TX_THRESH  5
 #define EM_MAX_CAP_QUERY_TX_THRESH  2
 #define EM_MAX_TOPO_QUERY_TX_THRESH  5
@@ -2023,10 +2024,10 @@ typedef enum {
     em_state_ctrl_unconfigured = 0x100,
     em_state_ctrl_wsc_m1_pending,
     em_state_ctrl_wsc_m2_sent,
-    em_state_ctrl_ap_cap_query_pending,
-    em_state_ctrl_ap_cap_report_received,
     em_state_ctrl_topo_sync_pending,
     em_state_ctrl_topo_synchronized,
+    em_state_ctrl_ap_cap_query_pending,
+    em_state_ctrl_ap_cap_report_received,
     em_state_ctrl_channel_query_pending,
 	em_state_ctrl_channel_pref_report_pending,
     em_state_ctrl_channel_queried,

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -2179,7 +2179,6 @@ public:
     unsigned char m_emsk[WPS_EMSK_LEN];
     unsigned int m_renew_tx_cnt;
     unsigned int m_topo_query_tx_cnt;
-
     
 	/**!
 	 * @brief Constructor for em_configuration_t.

--- a/inc/em_orch.h
+++ b/inc/em_orch.h
@@ -196,6 +196,18 @@ public:
 	void destroy_command(em_cmd_t *pcmd);
     
 	/**!
+	 * @brief Cancels a command of the specified type if misconfiguration for specific EMs.
+     *
+     * This function is used to cancel a command that is currently being processed when misconfigure happens.
+     *
+     * @param[in] type The type of command to cancel. This parameter specifies which command
+     * should be canceled based on the em_cmd_type_t enumeration.
+     *
+     * @note Ensure that the command type provided is valid and currently active.
+     */
+    void cancel_command(em_cmd_type_t type, std::vector<em_t*> &em_radios);
+
+	/**!
 	 * @brief Cancels a command of the specified type.
 	 *
 	 * This function is used to cancel a command that is currently being processed or queued.
@@ -206,6 +218,18 @@ public:
 	 * @note Ensure that the command type provided is valid and currently active.
 	 */
 	void cancel_command(em_cmd_type_t type);
+
+	/**!
+	 * @brief Resets the command time for a specific command type.
+	 *
+	 * This function is responsible for resetting the timer associated with a specific command type in the command map.
+	 *
+	 * @param[in] cmd_map Pointer to the command map where the command time should be reset.
+	 * @param[in] type The type of command for which the time should be reset, specified by the em_cmd_type_t enumeration.
+	 *
+	 * @note Ensure that the cmd_map is properly initialized and that the type provided is valid before calling this function.
+	 */
+	void reset_cmd_time(hash_map_t *cmd_map, em_cmd_type_t type);
     
 	/**!
 	 * @brief Pushes statistics to the specified command structure.

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2219,6 +2219,18 @@ void dm_easy_mesh_t::create_client_cap_query_json_cmd(char* src_mac_addr, char* 
     cJSON_Delete(root);
 }
 
+bool dm_easy_mesh_t::is_ssid_match(const ssid_t &ssid)
+{
+    em_network_ssid_info_t *info;
+    for (unsigned int i = 0; i < m_num_net_ssids; i++) {
+        info = &m_network_ssid[i].m_network_ssid_info;
+        if (strncmp(info->ssid, ssid, sizeof(info->ssid)) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 em_network_ssid_info_t *dm_easy_mesh_t::get_network_ssid_info_by_haul_type(em_haul_type_t haul_type)
 {
     em_network_ssid_info_t *info;

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -1998,9 +1998,13 @@ void em_channel_t::process_ctrl_state()
 			}
             break; 
         
-		case em_state_ctrl_channel_scan_pending:
+        case em_state_ctrl_channel_scan_pending:
 			send_channel_scan_request_msg();
-            break; 
+            break;
+
+        case em_state_ctrl_topo_sync_pending:
+            // No channel action required; topology sync handled in configuration state machine.
+            break;
         default:
             em_printfout("unhandled state:%s in channel state machine.", em_t::state_2_str(get_state()));
             break;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1932,6 +1932,7 @@ const char *em_t::get_band_type_str(em_freq_band_t band)
         BAND_TYPE_2S(em_freq_band_24)
         BAND_TYPE_2S(em_freq_band_5)
         BAND_TYPE_2S(em_freq_band_60)
+        BAND_TYPE_2S(em_freq_band_6)
         BAND_TYPE_2S(em_freq_band_unknown)
     }
 


### PR DESCRIPTION
Reason for change: Fix agent-related interoperability errors caused by extended SSID configuration times. 
Test Procedure: Verify whether the agent is being onboarded. 
Risks:low