### PR TITLE
RDKBACCL-1454: Easymesh - Fix malformed TLV issue in topology response

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -83,8 +83,8 @@ public:
     bool    m_colocated;
     unsigned int    m_num_ap_mld;
     dm_ap_mld_t     m_ap_mld[EM_MAX_AP_MLD];
-    unsigned int    m_num_bsta_mld;
-    dm_bsta_mld_t   m_bsta_mld[EM_MAX_BSTA_MLD];
+    bool    m_bsta_mld_present;
+    dm_bsta_mld_t   m_bsta_mld;
     unsigned int    m_num_assoc_sta_mld;
     dm_assoc_sta_mld_t m_assoc_sta_mld[EM_MAX_ASSOC_STA_MLD];
     dm_tid_to_link_t m_tid_to_link;
@@ -1579,28 +1579,47 @@ public:
 	 */
 	dm_ap_mld_t& get_ap_mld_by_ref(unsigned int index) { return m_ap_mld[index]; }
 
-    
 	/**!
-	 * @brief Retrieves the number of BSTA MLD.
+	 * @brief Checks if BSTA MLD is present.
 	 *
-	 * This function returns the current number of BSTA MLD.
+	 * This function returns a boolean indicating whether the BSTA MLD is currently present.
 	 *
-	 * @returns The number of BSTA MLD.
+	 * @returns True if BSTA MLD is present, false otherwise.
 	 */
-	unsigned int get_num_bsta_mld() { return m_num_bsta_mld; }
-    
+	bool is_bsta_mld_present() { return m_bsta_mld_present; }
+
 	/**!
-	 * @brief Retrieves the number of BSTA MLD.
+	 * @brief Checks if BSTA MLD is present.
 	 *
-	 * This function returns the number of BSTA MLD from the given dm_easy_mesh_t object.
+	 * This function returns a boolean indicating whether the BSTA MLD is present
+	 * from the given dm_easy_mesh_t object.
 	 *
 	 * @param[in] dm Pointer to the dm_easy_mesh_t object.
 	 *
-	 * @returns The number of BSTA MLD.
+	 * @returns True if BSTA MLD is present, false otherwise.
 	 */
-	static unsigned int get_num_bsta_mld(void *dm) { return (static_cast<dm_easy_mesh_t *>(dm))->get_num_bsta_mld(); }
+	static bool is_bsta_mld_present(void *dm) { return (static_cast<dm_easy_mesh_t *>(dm))->is_bsta_mld_present(); }
 
-    
+	/**!
+	 * @brief Retrieves the BSTA MLD information.
+	 *
+	 * This function returns a reference to the BSTA MLD information structure.
+	 *
+	 * @returns Reference to em_bsta_mld_info_t.
+	 */
+	em_bsta_mld_info_t& get_bsta_mld_info() { return m_bsta_mld.m_bsta_mld_info; }
+
+	/**!
+	 * @brief Retrieves the BSTA MLD information.
+	 *
+	 * This function returns the BSTA MLD information from the given dm_easy_mesh_t object.
+	 *
+	 * @param[in] dm Pointer to the dm_easy_mesh_t object.
+	 *
+	 * @returns Reference to em_bsta_mld_info_t.
+	 */
+	static em_bsta_mld_info_t& get_bsta_mld_info(void *dm) { return static_cast<dm_easy_mesh_t *>(dm)->get_bsta_mld_info(); }
+
 	/**!
 	 * @brief Retrieves the number of associated station MLDs.
 	 *

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -181,7 +181,6 @@ extern "C"
 #define EM_MAX_HAUL_TYPES   8
 #define EM_MAX_OPCLASS  64
 #define EM_MAX_AP_MLD   64
-#define EM_MAX_BSTA_MLD   64
 #define EM_MAX_ASSOC_STA_MLD   64
 #define EM_MAX_PRE_SET_CHANNELS   6
 
@@ -2474,7 +2473,7 @@ typedef struct {
     bool  is_bsta_config;
     mac_address_t  mld_mac_addr;
     bool  tid_to_link_map_neg;
-    unsigned char  num_mapping;
+    unsigned short  num_mapping;
     em_tid_to_link_map_info_t  tid_to_link_mapping[EM_MAX_AP_MLD];
 } em_tid_to_link_info_t;
 
@@ -2623,11 +2622,6 @@ typedef struct {
 } __attribute__((__packed__)) em_bsta_mld_t;
 
 typedef struct {
-    unsigned char num_bsta_mld;
-    em_bsta_mld_t bsta_mld[0];
-} __attribute__((__packed__)) em_bsta_mld_config_t;
-
-typedef struct {
     bssid_t bssid;
     mac_addr_t affiliated_sta_mac_addr;
     unsigned char reserved1[19];
@@ -2645,11 +2639,6 @@ typedef struct {
     unsigned char num_affiliated_sta;
     em_affiliated_sta_mld_t affiliated_sta_mld[0];
 } __attribute__((__packed__)) em_assoc_sta_mld_t;
-
-typedef struct {
-    unsigned char num_assoc_sta_mld;
-    em_assoc_sta_mld_t assoc_sta_mld[0];
-} __attribute__((__packed__)) em_assoc_sta_mld_config_report_t;
 
 typedef struct {
     unsigned char reserved4 : 7;
@@ -2674,7 +2663,7 @@ typedef struct {
     unsigned char reserved2 : 7;
     unsigned char tid_to_link_map_negotiation : 1;
     unsigned char reserved3[22];
-    unsigned char num_mapping;
+    unsigned short num_mapping;
     em_tid_to_link_mapping_t tid_to_link_mapping[0];
 } __attribute__((__packed__)) em_tid_to_link_map_policy_t;
 


### PR DESCRIPTION
Reason for change: Updated the TLV creation functions as per spec to fix malformed TLV issue in topology response
Test Procedure: Ensure topology response packet looks fine and functionalities are working fine.
Risks: Medium
Priority: P1