### PR TITLE
TDK-10774: Add changes in configure.ac and Makefile.am files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,8 @@ AC_CONFIG_MACRO_DIR([m4])
  
 # Check for em agent
 AM_CONDITIONAL([EM_EXTENDER], [test x$EM_EXTENDER = xtrue])
-
+# Check for em unittest
+AM_CONDITIONAL([EM_UNITTEST], [test "x$EM_UNITTEST" = "xtrue"])
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -22,7 +22,10 @@ AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
 
 ACLOCAL_AMFLAGS = -I m4
 hardware_platform = i686-linux-gnu
-bin_PROGRAMS = onewifi_em_agent onewifi_em_agent_test
+bin_PROGRAMS = onewifi_em_agent
+if EM_UNITTEST
+bin_PROGRAMS += onewifi_em_agent_test
+endif
 
 onewifi_em_agent_CPPFLAGS = \
     -I$(top_srcdir)/inc \
@@ -130,6 +133,7 @@ onewifi_em_agent_SOURCES =  \
 
 onewifi_em_agent_LDFLAGS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwifi_webconfig -lrbus
 onewifi_em_agent_LDADD = $(top_builddir)/src/al-sap/libalsap.la
+if EM_UNITTEST
 onewifi_em_agent_test_SOURCES = \
 	$(onewifi_em_agent_SOURCES) \
 	$(top_srcdir)/tests/main.cpp \
@@ -182,3 +186,4 @@ onewifi_em_agent_test_CPPFLAGS = $(onewifi_em_agent_CPPFLAGS) \
 onewifi_em_agent_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST
 onewifi_em_agent_test_LDFLAGS = -lcjson -lgtest -lgtest_main -lgmock -lpthread -lssl -lcrypto -lm -luuid -ldl -lwifi_webconfig -lrbus
 onewifi_em_agent_test_LDADD = $(onewifi_em_agent_LDADD)
+endif

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -21,7 +21,10 @@ AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
  
 ACLOCAL_AMFLAGS = -I m4
 hardware_platform = i686-linux-gnu
-bin_PROGRAMS = onewifi_em_ctrl onewifi_em_ctrl_test
+bin_PROGRAMS = onewifi_em_ctrl
+if EM_UNITTEST
+bin_PROGRAMS += onewifi_em_ctrl_test
+endif
  
 onewifi_em_ctrl_CPPFLAGS = \
     -I$(top_srcdir)/inc \
@@ -150,6 +153,7 @@ onewifi_em_ctrl_SOURCES =  \
  
 onewifi_em_ctrl_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lrbus -fsanitize=address -fsanitize=undefined -lmariadb
 onewifi_em_ctrl_LDADD = $(top_builddir)/src/al-sap/libalsap.la
+if EM_UNITTEST
 onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
 	$(top_srcdir)/tests/main.cpp \
 	$(top_srcdir)/tests/test_l1_utils.cpp \
@@ -237,3 +241,4 @@ onewifi_em_ctrl_test_CPPFLAGS = $(onewifi_em_ctrl_CPPFLAGS) \
 onewifi_em_ctrl_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST
 onewifi_em_ctrl_test_LDFLAGS = -lcjson -lgtest -lgtest_main -lgmock -lpthread -lssl -lcrypto -lm -luuid -lssl -lrbus -lmariadb -fsanitize=address -fsanitize=undefined
 onewifi_em_ctrl_test_LDADD = $(top_builddir)/src/al-sap/libalsap.la $(onewifi_em_ctrl_LDADD)
+endif


### PR DESCRIPTION
Add changes in configure.ac, controller and agent Makefile.am files to support the newly added distro Em_Unittest, which supports Easymesh unit test binary generation.