### PR TITLE
Changes for Wifi Radio Capability data to be populated in OneWifi

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -1670,6 +1670,11 @@ public:
 	void update_assoc_sta_mld_info(em_assoc_sta_mld_info_t *assoc_sta_mld_info);
 	static void update_assoc_sta_mld_info(void *dm, em_assoc_sta_mld_info_t *assoc_sta_mld_info) { (static_cast<dm_easy_mesh_t *>(dm))->update_assoc_sta_mld_info(assoc_sta_mld_info); }
 
+	static void *get_radio_cap(void *dm, int index) { 
+	    dm_radio_cap_t *cap = (static_cast<dm_easy_mesh_t *>(dm))->get_radio_cap(index);
+            return cap ? cap->get_radio_cap_info() : nullptr;
+	}
+
 	/**!
 	 * @brief Retrieves the Data Model DPP object.
 	 *
@@ -1845,6 +1850,7 @@ public:
 	 * @note Ensure that the MAC address provided is valid and registered in the system.
 	 */
 	dm_radio_cap_t *get_radio_cap(mac_address_t mac);
+	dm_radio_cap_t *get_radio_cap(int index);
 
     
 	/**!

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -3166,6 +3166,7 @@ typedef enum {
     em_commit_target_agent,
     em_commit_target_sta_hash_map,
     em_commit_target_radio,
+    em_commit_target_radio_cap,
     em_commit_target_bss,
 } em_commit_target_type_t;
 

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -210,7 +210,7 @@ void dm_easy_mesh_agent_t::translate_onewifi_dml_data (char *str)
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
             get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
-            update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
+            update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid, get_radio_cap);
     
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -272,7 +272,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, 
             get_op_class_info, get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac,
-            update_scan_results, update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
+            update_scan_results, update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid, get_radio_cap);
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
     if (webconfig_init(&config) != webconfig_error_none) {
@@ -347,7 +347,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
             get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info, 
             get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
-            update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
+            update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid, get_radio_cap);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -938,7 +938,7 @@ void dm_easy_mesh_agent_t::translate_and_decode_onewifi_subdoc(char *str, webcon
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
         get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
         get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
-        update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
+        update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid, get_radio_cap);
 
     config.initializer = webconfig_initializer_onewifi;
     config.apply_data =  webconfig_dummy_apply;
@@ -963,7 +963,7 @@ int dm_easy_mesh_agent_t::refresh_onewifi_subdoc(wifi_bus_desc_t *desc, bus_hand
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
         get_device_info, get_network_info, get_radio_info, get_ieee_1905_security_info, get_bss_info, get_op_class_info,
         get_first_sta_info, get_next_sta_info, get_sta_info, put_sta_info, get_bss_info_with_mac, update_scan_results,
-        update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid);
+        update_ap_mld_info, update_bsta_mld_info, update_assoc_sta_mld_info, get_ap_mld_frm_bssid, get_radio_cap);
 
     webconfig_t config;
     config.initializer = webconfig_initializer_onewifi;

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -67,6 +67,10 @@ dm_easy_mesh_t& dm_easy_mesh_t::operator = (dm_easy_mesh_t const& obj)
         m_radio[i] = obj.m_radio[i];
     }
 
+    for(unsigned int i = 0; i < EM_MAX_BANDS; i++) {
+        m_radio_cap[i] = obj.m_radio_cap[i];
+    }
+
     this->m_num_bss = obj.m_num_bss;
     for (unsigned int i = 0; i < EM_MAX_BSSS; i++) {
         m_bss[i] = obj.m_bss[i];
@@ -115,6 +119,7 @@ int dm_easy_mesh_t::commit_config(dm_easy_mesh_t& dm, em_commit_target_t target)
 {
     unsigned int i, j = 0, found = 0;
     dm_radio_t *radio;
+    dm_radio_cap_t *radio_cap;
     mac_address_t mac;
     mac_addr_str_t mac_str;
 
@@ -135,6 +140,10 @@ int dm_easy_mesh_t::commit_config(dm_easy_mesh_t& dm, em_commit_target_t target)
             }
             if (i == m_num_radios) { //New Radio
                 m_radio[m_num_radios] = *(radio);
+
+		radio_cap = dm.get_radio_cap(m_num_radios);
+		m_radio_cap[m_num_radios] = *(radio_cap);
+
                 m_num_radios = m_num_radios + 1;
                 printf("%s:%d New Radio %s configuration created no of radios=%d\n", __func__, __LINE__,target.params,m_num_radios);
             }
@@ -1953,6 +1962,11 @@ dm_radio_cap_t *dm_easy_mesh_t::get_radio_cap(mac_address_t mac)
         }
     }
     return NULL;
+}
+
+dm_radio_cap_t *dm_easy_mesh_t::get_radio_cap(int index)
+{
+    return &m_radio_cap[index];
 }
 
 dm_radio_t *dm_easy_mesh_t::find_matching_radio(dm_radio_t *radio)


### PR DESCRIPTION
Reason for change: The OneWifi/Easymesh needs Radio Capabilities data which is missing. Hence implemented the method to pull the caps from Driver(Hostap) to Easymesh.