### PR TITLE
RDKBWIFI-343 : Asynchronous/unhandled message causes state update which derails the ongoing orchestration

### DIFF
--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -1579,7 +1579,6 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
 		tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
 		tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
     }
-    set_state(em_state_ctrl_configured);
 
 	return 0;
 }

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -341,7 +341,7 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_1905_ack:
             if (m_sm.get_state() == em_state_ctrl_ap_mld_configured) {
                 em_configuration_t::process_msg(data, len);
-            } else {
+            } else if (m_sm.get_state() == em_state_ctrl_sta_steer_pending) {
                 em_steering_t::process_msg(data, len);
             }
             break;


### PR DESCRIPTION
i.e State update Handling of topology notification and ieee1905 ack [Changes]
1. Do not update em state once topology notification is received
2. Handle ieee1905 ACK only when em state is em_state_ctrl_sta_steer_pending