### PR TITLE
RDKBWIFI-347: Differentiate controller and colocated data models

### DIFF
--- a/inc/dm_device.h
+++ b/inc/dm_device.h
@@ -144,7 +144,7 @@ public:
 	 *
 	 * @note Ensure that the returned pointer is not null before using it.
 	 */
-	em_interface_t *get_al_interface() { return &m_device_info.backhaul_alid; }
+	em_interface_t *get_backhaul_al_interface() { return &m_device_info.backhaul_alid; }
     
 	/**!
 	 * @brief Retrieves the MAC address of the AL interface.
@@ -153,7 +153,7 @@ public:
 	 *
 	 * @note The returned pointer points to the internal MAC address storage and should not be freed by the caller.
 	 */
-	unsigned char *get_al_interface_mac() { return m_device_info.backhaul_alid.mac; }
+	unsigned char *get_backhaul_al_interface_mac() { return m_device_info.backhaul_alid.mac; }
     
 	/**!
 	 * @brief Retrieves the AL interface name.
@@ -164,7 +164,7 @@ public:
 	 *
 	 * @note Ensure that the returned pointer is not null before using it.
 	 */
-	char *get_al_interface_name() { return m_device_info.backhaul_alid.name; }
+	char *get_backhaul_al_interface_name() { return m_device_info.backhaul_alid.name; }
 
     
 	/**!

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -51,6 +51,7 @@ class dm_easy_mesh_t {
     bool m_topo_changed = false;
     unsigned int ssid_mismatch_check_time = 0;
     unsigned int last_topo_query_sent_time = 0;
+    bool m_is_ctlr = false;
 
 public:
     webconfig_subdoc_data_t *m_wifi_data;
@@ -696,24 +697,23 @@ public:
 	/**!
 	 * @brief Retrieves the control AL interface.
 	 *
-	 * This function returns the control AL interface from the network's colocated agent interface.
+	 * This function returns the control AL interface from the dm_network object.
 	 *
 	 * @returns A pointer to the control AL interface.
 	 *
 	 * @note Ensure that the network is properly initialized before calling this function.
 	 */
-	em_interface_t *get_ctrl_al_interface() { return m_network.get_colocated_agent_interface(); }
-    
+	em_interface_t *get_ctrl_al_interface() { return m_network.get_controller_interface(); }
+
 	/**!
 	 * @brief Retrieves the MAC address of the control interface.
 	 *
 	 * This function returns the MAC address associated with the control interface
-	 * of the network's colocated agent.
 	 *
 	 * @returns A pointer to an unsigned char array representing the MAC address.
 	 * @note Ensure that the returned MAC address is valid and properly formatted.
 	 */
-	unsigned char *get_ctrl_al_interface_mac() { return m_network.get_colocated_agent_interface_mac(); }
+	unsigned char *get_ctrl_al_interface_mac() { return m_network.get_controller_interface_mac(); }
     
 	/**!
 	 * @brief Retrieves the control AL interface name.
@@ -724,7 +724,7 @@ public:
 	 *
 	 * @note The returned string is managed internally and should not be freed by the caller.
 	 */
-	char *get_ctrl_al_interface_name() { return m_network.get_colocated_agent_interface_name(); }
+	char *get_ctrl_al_interface_name() { return m_network.get_controller_interface()->name; }
     
 	/**!
 	 * @brief Sets the control AL interface MAC address.
@@ -735,7 +735,7 @@ public:
 	 *
 	 * @note Ensure that the MAC address is valid and properly formatted before calling this function.
 	 */
-	void set_ctrl_al_interface_mac(unsigned char *mac) { m_network.set_colocated_agent_interface_mac(mac); }
+	void set_ctrl_al_interface_mac(unsigned char *mac) { m_network.set_controller_id(mac); }
     
 	/**!
 	 * @brief Sets the control AL interface name.
@@ -746,7 +746,7 @@ public:
 	 *
 	 * @note This function modifies the interface name used by the network control agent.
 	 */
-	void set_ctrl_al_interface_name(char *name) { m_network.set_colocated_agent_interface_name(name); }
+	void set_ctrl_al_interface_name(char *name) { m_network.set_controller_id(reinterpret_cast<unsigned char*>(name)); }
 	
 	/**!
 	 * @brief Sets the controller ID for the network.
@@ -2496,7 +2496,9 @@ public:
 	 * @retval true if colocated, false otherwise.
 	 */
 	bool get_colocated() { return m_colocated; }
-	
+
+	void set_controller(bool controller) { m_is_ctlr = controller; }
+	bool is_controller() { return m_is_ctlr; }
 	/**!
 	 * @brief Sets the list of channels for the specified operating class.
 	 *

--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -106,13 +106,13 @@ public:
     bus_error_t wf6ap_tget(char* event_name, raw_data_t* p_data);
     static bus_error_t wf6ap_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t wf6ap_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
-    static bus_error_t wf6ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, int idx);
+    static bus_error_t wf6ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, unsigned int idx);
 
     bus_error_t wf7ap_get(char* event_name, raw_data_t* p_data);
     bus_error_t wf7ap_tget(char* event_name, raw_data_t* p_data);
     static bus_error_t wf7ap_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t wf7ap_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
-    static bus_error_t wf7ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, int idx);
+    static bus_error_t wf7ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, unsigned int idx);
 
     dm_op_class_t* get_dm_curop(dm_easy_mesh_t *dm, dm_radio_t *radio, int instance);
     bus_error_t curops_get(char* event_name, raw_data_t* p_data);

--- a/inc/dm_easy_mesh_list.h
+++ b/inc/dm_easy_mesh_list.h
@@ -55,19 +55,19 @@ public:
 	 *
 	 * This function initializes and returns a data model object for the specified
 	 * network identifier and interface, with the given profile type. Optionally,
-	 * the data model can be marked as colocated.
+	 * the data model can be marked as that of controller.
 	 *
 	 * @param[in] net_id The network identifier for which the data model is created.
 	 * @param[in] al_intf Pointer to the interface structure used for the data model.
 	 * @param[in] profile The profile type to be used for the data model.
-	 * @param[in] colocated_dm Optional parameter to specify if the data model is colocated.
+	 * @param[in] controller Optional parameter to specify if the data model is of controller.
 	 *
 	 * @returns Pointer to the created data model object.
 	 * @retval NULL if the creation fails.
 	 *
 	 * @note Ensure that the network identifier and interface are valid before calling this function.
 	 */
-	dm_easy_mesh_t *create_data_model(const char *net_id, const em_interface_t *al_intf, em_profile_type_t profile, bool colocated_dm = false);
+	dm_easy_mesh_t *create_data_model(const char *net_id, const em_interface_t *al_intf, em_profile_type_t profile, bool controller = false);
     
 	/**!
 	 * @brief Deletes a data model associated with a given network ID and AL MAC address.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2184,7 +2184,7 @@ typedef struct {
     em_string_t     mscs_disallowed_sta[EM_MSCS_DISALLOWED_STA];
     unsigned char    num_scs_disallowed_sta;
     em_string_t     scs_disallowed_sta[EM_SCS_DISALLOWED_STA];
-    em_interface_t    colocated_agent_id; // Controller and Colocated Agent AL MAC
+    em_interface_t    colocated_agent_id; // Colocated Agent AL MAC
 	em_media_type_t	media;
 } em_network_info_t;
 

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -660,9 +660,8 @@ int dm_easy_mesh_ctrl_t::analyze_set_policy(em_bus_event_t *evt, em_cmd_t *pcmd[
             return 0;
         }
 
-        //TODO: once colocated agent fix is merged, remove this check
-        if(dev_dm->get_colocated() == true) {
-            //em_printfout("Colocated(%s), represent contoller device, so skipping....", mac_str);
+        if(dev_dm->is_controller() == true) {
+            em_printfout("Controller dm(%s), skipping....", mac_str);
             i++;
             continue;
         }
@@ -1536,12 +1535,12 @@ int dm_easy_mesh_ctrl_t::get_wifi_reset_config(cJSON *parent, char *key)
 
     // Prioritize the interface list depending on platform
     if ((intf = dm.get_prioritized_interface(platform)) == NULL) {
-        intf = dm.get_interface_by_index(0);
+        intf = dm.get_interface_by_index(0);//Todo: check why index 0 as it is taking brlan0
     }
 
     dm.set_ctrl_al_interface_mac(intf->mac);
     dm.set_ctrl_al_interface_name(intf->name);
-    dm.set_controller_id(intf->mac);
+    dm.set_controller_id(intf->mac);//Should be set to eth0-virt-peer mac
     dm.set_controller_intf_media(intf->media);
 
     //dm.print_config();
@@ -1665,8 +1664,7 @@ int dm_easy_mesh_ctrl_t::set_config(dm_easy_mesh_t *dm)
 
 dm_easy_mesh_t *dm_easy_mesh_ctrl_t::create_data_model(const char *net_id, const em_interface_t *al_intf, em_profile_type_t profile)
 {
-    
-    return m_data_model_list.create_data_model(net_id, al_intf, profile);
+    return m_data_model_list.create_data_model(net_id, al_intf, profile, true);
 }
 
 void dm_easy_mesh_ctrl_t::handle_dirty_dm()
@@ -2459,7 +2457,9 @@ bus_error_t dm_easy_mesh_ctrl_t::network_get_inner(char *event_name, raw_data_t 
         rc = dm_ctrl->raw_data_set(p_data, str_val);
     } else if (strcmp(param, "ColocatedAgentID") == 0) {
         dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
-        dm_easy_mesh_t::macbytes_to_string(dm->get_ctrl_al_interface_mac(), str_val);
+        //get colocated agent mac address from m_network
+        dm_network_t *net = dm->get_network();
+        dm_easy_mesh_t::macbytes_to_string(net->get_colocated_agent_interface_mac(), str_val);
         rc = dm_ctrl->raw_data_set(p_data, str_val);
     } else if (strcmp(param, "NumberOfDevices") == 0) {
         unsigned int dev_cnt = 0;
@@ -3438,8 +3438,6 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_inner(char *event_name, raw_data_t *
     (void) user_data;
     const char *name = event_name;
     const char *root = name;
-    char path[512];
-    const char *param;
     bus_data_prop_t *property = NULL;
     char instance[MAX_INSTANCE_LEN] = { 0 };
     bool is_num;
@@ -3474,7 +3472,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_inner(char *event_name, raw_data_t *
     }
     em_radio_info_t *ri = radio->get_radio_info();
 
-    rc = dm_ctrl->wf6ap_tget_params(dm, root, ri, &property, radio_instance);
+    rc = dm_ctrl->wf6ap_tget_params(dm, root, ri, &property, static_cast<unsigned int>(radio_instance));
     if (rc == bus_error_success && property) {
         dm_ctrl->raw_data_set(p_data, property);
     }
@@ -3482,7 +3480,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_inner(char *event_name, raw_data_t *
     return rc;
 }
 
-bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, int idx)
+bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, unsigned int idx)
 {
     char mcsnss_str[256] = { 0 };
     bus_error_t rc = bus_error_success;
@@ -3654,7 +3652,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wf7ap_tget_inner(char *event_name, raw_data_t *
     }
     em_radio_info_t *ri = radio->get_radio_info();
 
-    rc = dm_ctrl->wf7ap_tget_params(dm, root, ri, &property, radio_instance);
+    rc = dm_ctrl->wf7ap_tget_params(dm, root, ri, &property, static_cast<unsigned int>(radio_instance));
     if (rc == bus_error_success && property) {
         dm_ctrl->raw_data_set(p_data, property);
     }
@@ -3662,7 +3660,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wf7ap_tget_inner(char *event_name, raw_data_t *
     return rc;
 }
 
-bus_error_t dm_easy_mesh_ctrl_t::wf7ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, int idx)
+bus_error_t dm_easy_mesh_ctrl_t::wf7ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, unsigned int idx)
 {
     bus_error_t rc = bus_error_success;
     unsigned int i;
@@ -4764,7 +4762,7 @@ void dm_easy_mesh_ctrl_t::update_network_topology()
     em_printfout("-----Updating network topology <start>-------");
     dm = get_first_dm();
     while (dm != NULL) {
-        if (dm->get_colocated() == false) {
+        if (dm->is_controller() == false) {
             std::string dev_mac_str = util::mac_to_string(dm->m_device.m_device_info.intf.mac);
             if (g_network_topology->find_topology(dm) == NULL) {
                 em_printfout("New dev_mac:%s num_bss:%d added in topology.",
@@ -4794,7 +4792,7 @@ void dm_easy_mesh_ctrl_t::init_network_topology()
 
     dm = get_first_dm();
     while (dm != NULL) {
-        if (dm->get_colocated() == true) {
+        if (dm->is_controller() == true) {
             m_topology = new em_network_topo_t(dm);
             set_network_initialized();
             dm_easy_mesh_t::macbytes_to_string(dm->m_device.m_device_info.intf.mac, dev_mac_str);

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -86,7 +86,7 @@ void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
             pnet = new_dm.get_network();
             *pnet = *net;
 
-            ref_dm = get_data_model(net->m_net_info.id, net->m_net_info.colocated_agent_id.mac);
+            ref_dm = get_data_model(net->m_net_info.id, net->m_net_info.ctrl_id.mac);
             assert(ref_dm != NULL);
             new_dm.set_num_network_ssid(ref_dm->get_num_network_ssid());
             for (unsigned int i = 0; i < ref_dm->get_num_network_ssid(); i++) {
@@ -670,7 +670,7 @@ void em_ctrl_t::publish_network_topology()
     raw.raw_data.bytes = reinterpret_cast<unsigned char *> (str);
     raw.raw_data_len = static_cast<unsigned int> (strlen(str));
 
-    if (desc->bus_event_publish_fn(m_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY, &raw)== 0) {
+    if (desc->bus_event_publish_fn(m_data_model.get_bus_hdl(), const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY), &raw)== 0) {
         printf("%s:%d Topology published successfull\n",__func__, __LINE__);
     } else {
         printf("%s:%d Topology publish fail\n",__func__, __LINE__);
@@ -1077,16 +1077,16 @@ void em_ctrl_t::start_complete()
 
     //Todo: Revisit placement of data elements registration done for orch
     bus_data_element_t dataElements[] = {
-        { DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY, bus_element_type_method,
+        { const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY), bus_element_type_method,
             { tr_181_t::get_network_topology, NULL , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
             { bus_data_type_string, false, 0, 0, 0, NULL } },
-        { DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC, bus_element_type_method,
+        { const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC), bus_element_type_method,
             { tr_181_t::get_node_sync,  tr_181_t::set_node_sync , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
             { bus_data_type_string, false, 0, 0, 0, NULL } },
-        { DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, bus_element_type_method,
+        { const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY), bus_element_type_method,
             { NULL, tr_181_t::policy_config , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
             { bus_data_type_string, false, 0, 0, 0, NULL } },
-         { DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_LINKSTATS_ALARM, bus_element_type_method,
+         { const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_LINKSTATS_ALARM), bus_element_type_method,
             { NULL, NULL , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
             { bus_data_type_string, false, 0, 0, 0, NULL } },
 	};
@@ -1133,18 +1133,28 @@ void em_ctrl_t::start_complete()
         return;
     }
 
-    intf = m_data_model.get_ctrl_al_interface(const_cast<char*>(GLOBAL_NET_ID));
-    assert(intf != NULL);
+    dm = m_data_model.get_first_dm();
+    while (dm != NULL && dm->is_controller() == false) {
+        dm = m_data_model.get_next_dm(dm);
+    }
 
-    dm_easy_mesh_t::macbytes_to_string(intf->mac, al_mac_str);
-    raw.data_type    = bus_data_type_string;
-    raw.raw_data.bytes   = al_mac_str;
-    raw.raw_data_len = static_cast<unsigned int> (strlen(al_mac_str));
+    if (dm) {
+        intf = dm->get_ctrl_al_interface();
+        assert(intf != NULL);
 
-    if (desc->bus_set_fn(m_data_model.get_bus_hdl(), "Device.WiFi.Ctrl.CollocateAgentID", &raw)== 0) {
-        printf("%s:%d Collocated Agent ID: %s publish successfull\n",__func__, __LINE__, al_mac_str);
+        dm_easy_mesh_t::macbytes_to_string(intf->mac, al_mac_str);
+        raw.data_type    = bus_data_type_string;
+        raw.raw_data.bytes   = al_mac_str;
+        raw.raw_data_len = static_cast<unsigned int> (strlen(al_mac_str));
+
+        if (desc->bus_set_fn(m_data_model.get_bus_hdl(), "Device.WiFi.DataElements.Network.ControllerID", &raw) == 0) {
+            em_printfout("Controller ID: %s publish successful.", al_mac_str);
+        }
+        else {
+            em_printfout("Controller ID: %s publish failed.", al_mac_str);
+        }
     } else {
-        printf("%s:%d Collocated agent ID: %s publish  fail\n",__func__, __LINE__, al_mac_str);
+            em_printfout("Could not find data model with controller role");
     }
 
     if (desc->bus_event_subs_fn(m_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, reinterpret_cast<void *> (&tr_181_t::subs_policy_config), NULL, 0) != 0) {
@@ -1185,7 +1195,6 @@ AlServiceAccessPoint* em_ctrl_t::al_sap_register(const std::string& data_socket_
         uint8_t* al_mac_bytes = g_al_mac_sap.data();
         em_printfout("AL SAP registration successful, AL MAC: %s", util::mac_to_string(al_mac_bytes).c_str());
 
-        m_data_model.set_colocated_agent_interface_mac(al_mac_bytes);
         m_data_model.set_dev_interface_mac(al_mac_bytes);
     } else {
         std::cout << "Registration failed with error: " << static_cast<int>(result) << std::endl;

--- a/src/ctrl/em_network_topo.cpp
+++ b/src/ctrl/em_network_topo.cpp
@@ -142,7 +142,7 @@ em_network_topo_t *em_network_topo_t::find_topology_by_bh_associated(dm_easy_mes
 	// and return that topology object.
 	mac_address_t bss_mac;
 	memcpy(bss_mac, bss->id.bssid, sizeof(mac_address_t));
-	if (dm->get_colocated() == false) {
+	if (dm->is_controller() == false) {
 		// Update the backhaul of the dm object with the bss mac address
 		memcpy(dm->m_device.m_device_info.backhaul_mac.mac, bss_mac, sizeof(mac_address_t));
 		dm->m_device.m_device_info.backhaul_mac.media = em_media_type_ieee80211ac_5;

--- a/src/ctrl/tr_181/tr_181_param.cpp
+++ b/src/ctrl/tr_181/tr_181_param.cpp
@@ -654,7 +654,7 @@ bus_error_t network_get_inner(char *event_name, raw_data_t *p_data, bus_user_dat
         rc = raw_data_set(p_data, str_val);
     } else if (strcmp(param, "ColocatedAgentID") == 0) {
         dm_easy_mesh_t *dm = g_ctrl.get_first_dm();
-        dm_easy_mesh_t::macbytes_to_string(dm->get_ctrl_al_interface_mac(), str_val);
+        dm_easy_mesh_t::macbytes_to_string(dm->get_controller_interface_mac(), str_val);
         //dm_easy_mesh_t::macbytes_to_string(dm->get_network_info()->ctrl_id.mac, str_val);
         rc = raw_data_set(p_data, str_val);
     } else if (strcmp(param, "DeviceNumberOfEntries") == 0) {

--- a/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
@@ -258,7 +258,7 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_AFFAP_BCBYTESRCV,       CALLBACK_GETTER(affap_get)),
 
         ELEMENT(DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY,              CB(NULL, NULL, NULL, NULL, NULL, NULL)),
-        ELEMENT(DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC,             CB(.get_handler = get_node_sync, .set_handler = set_node_sync)),
+        ELEMENT(DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC,             CB(.get_handler = get_node_sync, .set_handler = set_node_sync, NULL, NULL, NULL, NULL)),
         //ELEMENT(DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY,       CB(.set_handler = policy_config))
     };
 

--- a/src/dm/dm_device.cpp
+++ b/src/dm/dm_device.cpp
@@ -144,7 +144,7 @@ int dm_device_t::decode(const cJSON *obj, void *parent_id)
     if ((tmp = cJSON_GetObjectItem(obj, "BackhaulALID")) != NULL) {
         snprintf(mac_str, sizeof(mac_str), "%s", cJSON_GetStringValue(tmp));
         dm_easy_mesh_t::string_to_macbytes(mac_str, m_device_info.backhaul_alid.mac);
-	dm_easy_mesh_t::name_from_mac_address(&m_device_info.backhaul_alid.mac, m_device_info.backhaul_alid.name);
+        dm_easy_mesh_t::name_from_mac_address(&m_device_info.backhaul_alid.mac, m_device_info.backhaul_alid.name);
     }
     if ((tmp = cJSON_GetObjectItem(obj, "TrafficSeparationCapability")) != NULL) {
         m_device_info.traffic_sep_cap = cJSON_IsTrue(tmp);
@@ -412,7 +412,7 @@ dm_device_t::dm_device_t(const dm_device_t& dev)
 
 dm_device_t::dm_device_t()
 {
-
+    memset(&m_device_info, 0, sizeof(em_device_info_t));
 }
 
 dm_device_t::~dm_device_t()

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -3044,6 +3044,7 @@ void dm_easy_mesh_t::reset()
     m_num_ap_mld = 0;
 	m_db_cfg_param.db_cfg_type = db_cfg_type_none;
     m_colocated = false;
+    m_is_ctlr = false;
 
 	memset(&m_network.m_net_info, 0, sizeof(em_network_info_t));
 	memset(&m_device.m_device_info, 0, sizeof(em_device_info_t));
@@ -3073,6 +3074,7 @@ dm_easy_mesh_t::dm_easy_mesh_t()
     m_num_net_ssids = 0;
 	m_db_cfg_param.db_cfg_type = db_cfg_type_none;
     m_colocated = false;
+    m_is_ctlr = false;
 }
 
 dm_easy_mesh_t::~dm_easy_mesh_t()

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -134,11 +134,11 @@ void dm_easy_mesh_list_t::put_network(const char *key, const dm_network_t *net)
     em_network_info_t *net_info;
 
     net_info = &(const_cast<dm_network_t *> (net))->m_net_info;
-    dm_easy_mesh_t::macbytes_to_string(net_info->colocated_agent_id.mac, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(net_info->ctrl_id.mac, mac_str);
 			
     /* try to find any data model with this network, if exists, the colocated dm must be there, otherwise create one */
-    if ((dm = get_data_model(key, net_info->colocated_agent_id.mac)) == NULL) {
-		dm = create_data_model(key, &net_info->colocated_agent_id, em_profile_type_3, true);
+    if ((dm = get_data_model(key, net_info->ctrl_id.mac)) == NULL) {
+		dm = create_data_model(key, &net_info->ctrl_id, em_profile_type_3, true);
 		pnet = dm->get_network();
 		*pnet = *net;	
 		strncpy(m_network_list[m_num_networks], key, strlen(key));
@@ -1473,8 +1473,8 @@ void dm_easy_mesh_list_t::delete_all_data_models()
 		tmp = dm;
         dm = static_cast<dm_easy_mesh_t *> (hash_map_get_next(m_list, dm)); 
 
-        if (tmp->get_colocated() == true) {
-            //printf("%s:%d: Skipping delete as colocated\n", __func__, __LINE__);
+        if (tmp->is_controller() == true) {
+            //printf("%s:%d: Skipping delete of controller data model\n", __func__, __LINE__);
             continue;
         }
 		dev = tmp->get_device();	
@@ -1504,9 +1504,9 @@ void dm_easy_mesh_list_t::delete_data_model(const char *net_id, const unsigned c
     delete dm;
 }
 
-dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const em_interface_t *al_intf, em_profile_type_t profile, bool colocated)
+dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const em_interface_t *al_intf, em_profile_type_t profile, bool controller)
 {
-    dm_easy_mesh_t *dm = NULL, *ref_dm;
+    dm_easy_mesh_t *dm = NULL, *ref_dm, *ctrl_dm;
     mac_addr_str_t mac_str;
     em_short_string_t	key;
     dm_network_t *net, *pnet;
@@ -1546,6 +1546,7 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
 					};
     unsigned int i;
+    bool colocated = false;
 	dm_op_class_t	op_class[EM_MAX_PRE_SET_CHANNELS] 	= 	{
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 81}, 81, 0, 0, 0, 1, {6}, 0, 0, 0}), 
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 115}, 115, 0, 0, 0, 1, {36}, 0, 0, 0}), 
@@ -1566,14 +1567,39 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 
     dm = new dm_easy_mesh_t();
     dm->init();
-    em_printfout("Created data model for net_id: %s mac: %s, coloc:%d", net_id, mac_str, colocated);
-    dm->set_colocated(colocated);
 
+    if (controller == true) {
+        em_printfout("Creating data model as controller ...");
+        dm->set_controller(controller);
+    } else {
+        em_printfout("Creating data model as agent...");
+        //Identify colocated and set colocated here
+        em_interface_name_t name;
+        if (dm_easy_mesh_t::name_from_mac_address(&al_intf->mac, name) == 0) {
+            em_printfout("MAC %s address exists on this device. DM is colocated.", mac_str);
+            colocated = true;
+            dm->set_colocated(colocated);
+
+            if ((net = get_network(net_id)) != NULL) {
+                ctrl_dm = get_data_model(GLOBAL_NET_ID, net->m_net_info.ctrl_id.mac);
+                assert(ctrl_dm != NULL);
+                pnet = ctrl_dm->get_network();
+                *pnet = *net;
+                //if colocated, set the agent interface mac address in controller's dm
+                ctrl_dm->m_network.set_colocated_agent_interface_mac(const_cast<unsigned char *>(al_intf->mac));
+                em_printfout("Set colocated agent interface mac %s in controller dm",
+                    util::mac_to_string(ctrl_dm->m_network.get_colocated_agent_interface_mac()).c_str());
+                //also trigger db update of networklist for colocated agent id
+                ctrl_dm->set_db_cfg_param(db_cfg_type_network_list_update, "");
+            }
+        }
+    }
+    em_printfout("Created data model for net_id: %s mac: %s, is_colocated:%d is_controller:%d", net_id, mac_str, colocated, controller);
 
     dev = dm->get_device();
     memcpy(dev->m_device_info.intf.mac, al_intf->mac, sizeof(mac_address_t));
     strncpy(dev->m_device_info.id.net_id, net_id, strlen(net_id) + 1);
-	if (colocated == true) {
+	if (controller == true) {
 		dev->m_device_info.id.media = dm->m_network.m_net_info.media;
 		//TODO: Monitor Checks
 		//memcpy(dev->m_device_info.backhaul_mac.mac, al_intf->mac, sizeof(mac_address_t));
@@ -1581,8 +1607,8 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 		em_printfout("Backhaul mac updated to :%s device media:%d backhaul media:%d",
 			util::mac_to_string(dev->m_device_info.backhaul_mac.mac).c_str(),
 			dev->m_device_info.id.media, dev->m_device_info.backhaul_mac.media);
-		//Update the easymesh configuration file
-		dev->update_easymesh_json_cfg(colocated);
+		//Update the easymesh configuration file to specify colocated agent as true.
+		dev->update_easymesh_json_cfg(true);
 	} else {
         dm->set_id();
         em_printfout("dm->get_id():%d", dm->get_id());
@@ -1601,14 +1627,18 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
         pnet = dm->get_network();
         *pnet = *net;
 
-        ref_dm = get_data_model(net->m_net_info.id, net->m_net_info.colocated_agent_id.mac);
-        assert(ref_dm != NULL);
-        dm->set_num_network_ssid(ref_dm->get_num_network_ssid());
-        //printf("%s:%d: Number of network ssid in reference data model: %d\n", __func__, __LINE__, ref_dm->get_num_network_ssid());
-        for (i = 0; i < ref_dm->get_num_network_ssid(); i++) {
-            pnet_ssid = dm->get_network_ssid(i);
-            net_ssid = ref_dm->get_network_ssid(i);
-            *pnet_ssid = *net_ssid;
+        ref_dm = get_data_model(net->m_net_info.id, net->m_net_info.ctrl_id.mac);
+        if(ref_dm != NULL) {
+            dm->set_num_network_ssid(ref_dm->get_num_network_ssid());
+            //printf("%s:%d: Number of network ssid in reference data model: %d\n", __func__, __LINE__, ref_dm->get_num_network_ssid());
+            for (i = 0; i < ref_dm->get_num_network_ssid(); i++) {
+                pnet_ssid = dm->get_network_ssid(i);
+                net_ssid = ref_dm->get_network_ssid(i);
+                *pnet_ssid = *net_ssid;
+            }
+        } else {
+            em_printfout("Reference data model not found for network: %s and ctrl AL mac: %s",
+                net->m_net_info.id, util::mac_to_string(net->m_net_info.ctrl_id.mac).c_str());
         }
     }
     em_printfout("Putting data model at key: %s", key);

--- a/src/dm/dm_network_list.cpp
+++ b/src/dm/dm_network_list.cpp
@@ -118,9 +118,6 @@ dm_orch_type_t dm_network_list_t::get_dm_orch_type(db_client_t& db_client, const
 void dm_network_list_t::update_list(const dm_network_t& net, dm_orch_type_t op)
 {
     dm_network_t *pnet;
-    mac_addr_str_t  mac_str;
-
-    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (net.m_net_info.colocated_agent_id.mac), mac_str);
 
     switch (op) {
         case dm_orch_type_db_insert:
@@ -267,5 +264,5 @@ em_interface_t *dm_network_list_t::get_ctrl_al_interface(em_long_string_t net_id
 	return NULL;
     }
 	
-    return net->get_colocated_agent_interface();	
+    return net->get_controller_interface();
 }

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -854,7 +854,7 @@ int em_capability_t::handle_bsta_radio_cap(unsigned char *buff, unsigned int len
     dm_easy_mesh_t *dm = get_data_model();
     em_bh_sta_radio_cap_t *bsta_radio_cap = reinterpret_cast<em_bh_sta_radio_cap_t*>(buff);
 
-    em_printfout("Rcvd Backhaul STA Radio Capabilities received, sta mac: %s for radio: %s, mac present?: %d",
+    em_printfout("Rcvd Backhaul STA Radio Capabilities received, sta mac: %s for radio: %s, mac present: %d",
         util::mac_to_string(bsta_radio_cap->bsta_addr).c_str(),
         util::mac_to_string(bsta_radio_cap->ruid).c_str(), bsta_radio_cap->bsta_mac_present);
 
@@ -910,22 +910,16 @@ int em_capability_t::handle_bsta_cap_report(unsigned char *buff, unsigned int le
     tmp_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_client_info) {
-            if( dm->get_colocated() == true ) {
-                //Trigger event to request backhaul cap report, as this would handle the initial onboarding scenario, use the al em for this
-                //check if its the same device
-                if ( (memcmp(dev->id.dev_mac, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t)) != 0) ) {
-                    em_printfout("Cap: Update backhaul mac for Device id: %s",
-                        util::mac_to_string(dev->id.dev_mac).c_str());
-
-                    memcpy(dm->m_device.m_device_info.backhaul_mac.mac, tlv->value, sizeof(mac_address_t));
-                    dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
-                }
-            } else {
+            if(dm->get_colocated() != true ) {
                 em_printfout("Cap: Update backhaul mac for Device id(non-coloc): %s",
                     util::mac_to_string(dev->id.dev_mac).c_str());
 
                 memcpy(dm->m_device.m_device_info.backhaul_mac.mac, tlv->value, sizeof(mac_address_t));
                 dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
+            } else {
+                em_printfout("Device is colocated, not updating backhaul mac for Device id: %s, backhaul mac in dm: %s",
+                    util::mac_to_string(dev->id.dev_mac).c_str(),
+                    util::mac_to_string(dm->m_device.m_device_info.backhaul_mac.mac).c_str());
             }
             break;
         }

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -1024,7 +1024,6 @@ int em_metrics_t::send_ap_metrics_response()
     short sz = 0;
     unsigned short type = htons(ETH_P_1905);
     dm_easy_mesh_t *dm = get_data_model();
-    mac_addr_str_t mac_str;
     dm_sta_t *sta;
     int bss_index = 0;
 
@@ -1148,16 +1147,15 @@ int em_metrics_t::send_ap_metrics_response()
     len += (sizeof(em_tlv_t));
 
     if (em_msg_t(em_msg_type_ap_metrics_rsp, em_profile_type_2, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        printf("%s:%d: AP Metrics Response validation failed for %s\n", __func__, __LINE__, mac_str);
+        em_printfout("AP Metrics Response validation failed for agent:%s, still sending",
+            util::mac_to_string(dm->get_agent_al_interface_mac()).c_str());
         //return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: AP Metrics Response send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("AP Metrics Response send failed, error:%d\n", errno);
         return -1;
     }
-
-    printf("%s:%d: AP Metrics Response send success\n", __func__, __LINE__);
 
     set_state(em_state_agent_configured);
 

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -352,7 +352,7 @@ short em_policy_cfg_t::create_vendor_policy_cfg_tlv(unsigned char *buff)
     }
 
     if ((idx_ap == -1) && (idx_alarm == -1) && (idx_filter == -1)) {
-        return 0;
+        return static_cast<short> (len);
     }
 
     /* If AP metrics policy exists, append its vendor data */
@@ -561,6 +561,7 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    em_printfout("Handling Policy Cfg Request Msg len=%d, tlv_len=%d", len, tlv_len);
 
     while ((tlv->type != em_tlv_type_eom) && (tlv_len > 0)) {
         if (tlv->type == em_tlv_type_steering_policy) {

--- a/src/rdkb-cli/main.go
+++ b/src/rdkb-cli/main.go
@@ -3373,7 +3373,7 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
     switch r.Method {
         case http.MethodGet:
             log.Println("Received GET request for wifireset")
-            collocatedValue := getTreeValue(resetTree, "CollocatedAgentID")
+            controllerValue := getTreeValue(resetTree, "ControllerID")
 
             // Interface MACs
             interfacesList := C.get_network_tree_by_key(resetTree, C.CString("List"))
@@ -3390,7 +3390,7 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
 
             response := MacResponse{
                 Options:        macOptions,
-                SelectedOption: collocatedValue,
+                SelectedOption: controllerValue,
                 SSIDHaulConfig: ssidHaulConfig,
             }
 
@@ -3410,8 +3410,8 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
             if payload.SelectedMac != "" {
                 selectedMac := strings.Split(payload.SelectedMac, " ")[0]
 
-                // update the CollocatedAgentID in reset tree
-                if err := updateCollocatedAgentID(resetTree, selectedMac); err != nil {
+                // update the ControllerID in reset tree
+                if err := updateControllerID(resetTree, selectedMac); err != nil {
                     msg := fmt.Sprintf("Update failed for AL_MAC Interface: %v", err)
                     errorsList = append(errorsList, msg)
                 }
@@ -3529,26 +3529,26 @@ func getConfiguredHauls(tree *C.em_network_node_t) []HaulConfig {
     return haulConfigs
 }
 
-/* func: updateCollocatedAgentID
+/* func: updateControllerID
  * Description:
- * updates the CollocatedAgentID value in the given reset configuration tree
+ * updates the ControllerID value in the given reset configuration tree
  * based on the selected or manually entered MAC address, validates its format,
  * and executes the reset command to apply the updated configuration.
  * Return: true or false
  */
-func updateCollocatedAgentID(resetTree *C.em_network_node_t, selectedMac string) error {
+func updateControllerID(resetTree *C.em_network_node_t, selectedMac string) error {
     if !isValidMac(selectedMac) {
         return fmt.Errorf("invalid MAC address: %s", selectedMac)
     }
 
     cMac := C.CString(selectedMac)
-    cKey := C.CString("CollocatedAgentID")
+    cKey := C.CString("ControllerID")
     defer C.free(unsafe.Pointer(cMac))
     defer C.free(unsafe.Pointer(cKey))
 
     node := C.get_network_tree_by_key(resetTree, cKey)
     if node == nil {
-        return fmt.Errorf("CollocatedAgentID node not found in reset tree")
+        return fmt.Errorf("ControllerID node not found in reset tree")
     }
 
     buf := (*[256]byte)(unsafe.Pointer(&node.value_str[0]))


### PR DESCRIPTION
There was no proper way to differentiate controller and colocated data model causing some discrepancies in backhaul details. This commit addresses that to provide clear differentaion in datamodel between controller and colocated.

Co-authored by: Nikita Hakai <nikita_hakai@comcast.com>