### PR TITLE
RDKBWIFI-352: STAMLD, AffiliatedSTA and bSTAMLD for TR-181 added

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -2260,7 +2260,22 @@ public:
 	 * @note The input string must be properly formatted and null-terminated.
 	 */
 	static void string_to_macbytes (char *key, mac_address_t bmac);
-    
+
+	/**!
+	 * @brief Converts a list of MAC addresses to a comma seperated string representation.
+	 *
+	 * This function takes a list of MAC addresses in the form of a `mac_address_t` and converts
+	 * it into a comma seperated, human-readable string format.
+	 *
+	 * @param[in] mac_list The list of MAC addresses to be converted.
+	 * @param[in] mac_count The number of MAC addresses in the list `mac_list`.
+	 * @param[out] string The buffer where the resulting string representation will be stored.
+	 * @param[in] str_len The length of the buffer `string`.
+	 *
+	 * @note Ensure that the `string` buffer is large enough to hold the MAC address string.
+	 */
+	static void maclist_to_string(mac_address_t mac_list[], size_t mac_count, char *string, uint16_t str_len);
+
 	/**!
 	 * @brief Retrieves the MAC address associated with a given interface name.
 	 *

--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -141,6 +141,28 @@ public:
     static bus_error_t affap_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t affap_tget_params(dm_easy_mesh_t *dm, const char *root, em_ap_mld_info_t *ami, bus_data_prop_t **property);
 
+    dm_assoc_sta_mld_t *get_dm_sta_mld(dm_easy_mesh_t *dm, em_ap_mld_info_t *ami, char *instance, bool is_num);
+    bus_error_t stamld_get(char *event_name, raw_data_t *p_data);
+    bus_error_t stamld_tget(char *event_name, raw_data_t *p_data);
+    bus_error_t wifi7caps_get(char *event_name, raw_data_t *p_data);
+    bus_error_t stamldcfg_get(char *event_name, raw_data_t *p_data);
+    static bus_error_t stamld_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t stamld_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t stamld_tget_params(dm_easy_mesh_t *dm, const char *root, em_ap_mld_info_t *ami, bus_data_prop_t **property);
+    static bus_error_t wifi7caps_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t stamldcfg_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
+    bus_error_t affsta_get(char *event_name, raw_data_t *p_data);
+    bus_error_t affsta_tget(char *event_name, raw_data_t *p_data);
+    static bus_error_t affsta_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t affsta_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t affsta_tget_params(dm_easy_mesh_t *dm, const char *root, em_assoc_sta_mld_info_t *smi, bus_data_prop_t **property);
+
+    bus_error_t bstamld_get(char *event_name, raw_data_t *p_data);
+    bus_error_t bstacfg_get(char *event_name, raw_data_t *p_data);
+    static bus_error_t bstamld_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t bstacfg_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
 private:
     db_client_t m_db_client;
     bool	m_initialized;

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -85,6 +85,11 @@ static const yang_to_tr181_map g_yang_map[] = {
 
 #define MAX_INSTANCE_LEN        32
 #define MAX_CAPS_STR_LEN        32
+#define MAX_MACLIST_ITEMS       14
+#define MAX_MACLIST_STRLEN      256
+#define MAX_TIME_STRLEN         24
+#define MAX_ZONE_STRLEN         8
+#define MAX_TIMESTAMP_STRLEN    64
 #define ARRAY_SIZE(a)           (sizeof(a) / sizeof(a[0]))
 
 /* Device.WiFi.DataElements.Network */

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -54,10 +54,28 @@ struct yang_to_tr181_map {
 };
 
 static const yang_to_tr181_map g_yang_map[] = {
+    { "NumberOfDevices", "DeviceNumberOfEntries" },
     { "DeviceList", "Device" },
+    { "NumberOfRadios", "RadioNumberOfEntries" },
+    { "AvailableChannelList", "CACAvailableChannel" },
+    { "NonOccupancyChannelList", "CACNonOccupancyChannel" },
+    { "ActiveChannelList", "CACActiveChannel" },
     { "RadioList", "Radio" },
+    { "NumberOfCurrOpClass", "CurrentOperatingClassProfileNumberOfEntries" },
+    { "NumberOfBSS", "BSSNumberOfEntries" },
+    { "NumberOfUnassocSta", "UnassociatedSTANumberOfEntries" },
+    { "NumberOfOpClass", "CapableOperatingClassProfileNumberOfEntries" },
+    { "OperatingClasses", "CapableOperatingClassProfile" },
+    { "CurrentOperatingClasses", "CurrentOperatingClassProfile" },
     { "BSSList", "BSS" },
+    { "NumberOfSTA", "STANumberOfEntries" },
     { "STAList", "STA" },
+    { "UnassociatedStaList", "UnassociatedSTA" },
+    { "OpClassList", "OpClassChannels" },
+    { "ScanResultList", "ScanResult" },
+    { "OpClassScanList", "OpClassScan" },
+    { "ChannelScanList", "ChannelScan" },
+    { "NeighborList", "NeighborBSS" },
     { "NetworkSSIDList", "SSID" },
 
     { nullptr, nullptr } // Default case
@@ -73,8 +91,8 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_NETWORK_ID           DATAELEMS_NETWORK       "ID"
 #define DE_NETWORK_CTRLID       DATAELEMS_NETWORK       "ControllerID"
 #define DE_NETWORK_COLAGTID     DATAELEMS_NETWORK       "ColocatedAgentID"
-// #define DE_NETWORK_DEVNOE       DATAELEMS_NETWORK       "DeviceNumberOfEntries"NumberOfDevices
-#define DE_NETWORK_DEVNOE       DATAELEMS_NETWORK       "NumberOfDevices"
+#define DE_NETWORK_DEVNOE       DATAELEMS_NETWORK       "DeviceNumberOfEntries"
+#define DE_NETWORK_TIMESTAMP    DATAELEMS_NETWORK       "TimeStamp"
 #define DE_NETWORK_SETSSID      DATAELEMS_NETWORK       "SetSSID()"
 /* Device.WiFi.DataElements.Network.SSID */
 #define DE_NETWORK_SSID         DATAELEMS_NETWORK       "SSID.{i}."
@@ -93,11 +111,9 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_DEVICE_TABLE         DATAELEMS_NETWORK       "Device.{i}"
 #define DE_DEVICE_ID            DE_NETWORK_DEVICE       "ID"
 #define DE_DEVICE_MAPCAP        DE_NETWORK_DEVICE       "MultiAPCapabilities"
-#define DE_DEVICE_NUMRADIO      DE_NETWORK_DEVICE       "NumberOfRadios"
 #define DE_DEVICE_COLLINT       DE_NETWORK_DEVICE       "CollectionInterval"
 #define DE_DEVICE_RUASSOC       DE_NETWORK_DEVICE       "ReportUnsuccessfulAssociations"
 #define DE_DEVICE_MAXRRATE      DE_NETWORK_DEVICE       "MaxReportingRate"
-#define DE_DEVICE_MAPPROF       DE_NETWORK_DEVICE       "MultiAPProfile"
 #define DE_DEVICE_APMERINT      DE_NETWORK_DEVICE       "APMetricsReportingInterval"
 #define DE_DEVICE_MANUFACT      DE_NETWORK_DEVICE       "Manufacturer"
 #define DE_DEVICE_SERIALNO      DE_NETWORK_DEVICE       "SerialNumber"
@@ -107,8 +123,6 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_DEVICE_LSDSTALIST    DE_NETWORK_DEVICE       "LocalSteeringDisallowedSTAList"
 #define DE_DEVICE_BTMSDSTALIST  DE_NETWORK_DEVICE       "BTMSteeringDisallowedSTAList"
 #define DE_DEVICE_MAXVIDS       DE_NETWORK_DEVICE       "MaxVIDs"
-#define DE_DEVICE_BPRIO         DE_NETWORK_DEVICE       "BasicPrioritization"
-#define DE_DEVICE_EPRIO         DE_NETWORK_DEVICE       "EnhancedPrioritization"
 #define DE_DEVICE_DE8021QPVID   DE_NETWORK_DEVICE       "Default8021Q.PrimaryVID"
 #define DE_DEVICE_DE8021QDPCP   DE_NETWORK_DEVICE       "Default8021Q.DefaultPCP"
 #define DE_DEVICE_TSEPPOLI      DE_NETWORK_DEVICE       "TrafficSeparationPolicy"
@@ -120,9 +134,8 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_DEVICE_REPINDSCAN    DE_NETWORK_DEVICE       "ReportIndependentScans"
 #define DE_DEVICE_TRASEPALW     DE_NETWORK_DEVICE       "TrafficSeparationAllowed"
 #define DE_DEVICE_SERPRIOALW    DE_NETWORK_DEVICE       "ServicePrioritizationAllowed"
-#define DE_DEVICE_STASDISALW    DE_NETWORK_DEVICE       "STASteeringDisallowed"
 #define DE_DEVICE_DFSENABLE     DE_NETWORK_DEVICE       "DFSEnable"
-#define DE_DEVICE_MAXUSASSOCREPRATE DE_NETWORK_DEVICE   "MaxUnsuccessfulAssociationReportingRate"
+#define DE_DEVICE_MAXUSASSOCREP DE_NETWORK_DEVICE       "MaxUnsuccessfulAssociationReportingRate"
 #define DE_DEVICE_STASSTATE     DE_NETWORK_DEVICE       "STASteeringState"
 #define DE_DEVICE_COORCACALW    DE_NETWORK_DEVICE       "CoordinatedCACAllowed"
 #define DE_DEVICE_CONOPMODE     DE_NETWORK_DEVICE       "ControllerOperationMode"
@@ -132,11 +145,11 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_DEVICE_TRSEPCAP      DE_NETWORK_DEVICE       "TrafficSeparationCapability"
 #define DE_DEVICE_EASYCCAP      DE_NETWORK_DEVICE       "EasyConnectCapability"
 #define DE_DEVICE_TESTCAP       DE_NETWORK_DEVICE       "TestCapabilities"
-#define DE_DEVICE_BSTAMLDMACLINK    DE_NETWORK_DEVICE   "bSTAMLDMaxLinks"
+#define DE_DEVICE_BSTAMLDMACLNK DE_NETWORK_DEVICE       "bSTAMLDMaxLinks"
 #define DE_DEVICE_MACNUMMLDS    DE_NETWORK_DEVICE       "MaxNumMLDs"
 #define DE_DEVICE_BHALID        DE_NETWORK_DEVICE       "BackhaulALID"
 #define DE_DEVICE_TIDLMAP       DE_NETWORK_DEVICE       "TIDLinkMapping"
-#define DE_DEVICE_ASSOCSTAREPINT    DE_NETWORK_DEVICE   "AssociatedSTAReportingInterval"
+#define DE_DEVICE_ASSOCSTAREP   DE_NETWORK_DEVICE       "AssociatedSTAReportingInterval"
 #define DE_DEVICE_BHMEDIATYPE   DE_NETWORK_DEVICE       "BackhaulMediaType"
 #define DE_DEVICE_RADIONOE      DE_NETWORK_DEVICE       "RadioNumberOfEntries"
 #define DE_DEVICE_CACSTATNOE    DE_NETWORK_DEVICE       "CACStatusNumberOfEntries"
@@ -177,7 +190,6 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_RADIO_TABLE          DE_NETWORK_DEVICE       "Radio.{i}"
 #define DE_RADIO_ID             DE_DEVICE_RADIO         "ID"
 #define DE_RADIO_ENABLED        DE_DEVICE_RADIO         "Enabled"
-#define DE_RADIO_NUMCUROPCLASS  DE_DEVICE_RADIO         "NumberOfCurrOpClass"
 #define DE_RADIO_NOISE          DE_DEVICE_RADIO         "Noise"
 #define DE_RADIO_UTILIZATION    DE_DEVICE_RADIO         "Utilization"
 #define DE_RADIO_TRANSMIT       DE_DEVICE_RADIO         "Transmit"
@@ -185,9 +197,8 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_RADIO_RECEIVEOTHER   DE_DEVICE_RADIO         "ReceiveOther"
 #define DE_RADIO_CHIPVENDOR     DE_DEVICE_RADIO         "ChipsetVendor"
 #define DE_RADIO_CURROPNOE      DE_DEVICE_RADIO         "CurrentOperatingClassProfileNumberOfEntries"
-#define DE_RADIO_BSSNOE         DE_DEVICE_RADIO         "NumberOfBSS"
-#define DE_RADIO_UNASSCSTALIST  DE_DEVICE_RADIO         "UnassociatedStaList"
-#define DE_RADIO_NOUNASSCSTA    DE_DEVICE_RADIO         "NumberOfUnassocSta"
+#define DE_RADIO_BSSNOE         DE_DEVICE_RADIO         "BSSNumberOfEntries"
+#define DE_RADIO_NOUNASSCSTA    DE_DEVICE_RADIO         "UnassociatedSTANumberOfEntries"
 /* Device.WiFi.DataElements.Network.Device.Radio.BackhaulSta */
 #define DE_RADIO_BHSTA          DE_DEVICE_RADIO         "BackhaulSta."
 #define DE_BHSTA_MACADDR        DE_RADIO_BHSTA          "MACAddress"
@@ -202,7 +213,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_RCAPS_SCSTRAFDESC    DE_RADIO_CAPS           "SCSTrafficDescriptionCapability"
 #define DE_RCAPS_CAPOPNOE       DE_RADIO_CAPS           "CapableOperatingClassProfileNumberOfEntries"
 #define DE_RCAPS_AKMFHNOE       DE_RADIO_CAPS           "AKMFrontHaulNumberOfEntries"
-#define DE_RCAPS_AKMBHNOE       DE_RADIO_CAPS           "AKMBackHaulNumberOfEntries"
+#define DE_RCAPS_AKMBHNOE       DE_RADIO_CAPS           "AKMBackhaulNumberOfEntries"
 /* Device.WiFi.DataElements.Network.Device.Radio.Capabilities.WiFi6APRole */
 #define DE_CAPS_WF6AP           DE_RADIO_CAPS           "WiFi6APRole."
 #define DE_WF6AP_HE160          DE_CAPS_WF6AP           "HE160"
@@ -240,8 +251,8 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_WF6BSTA_UL_MUMIMO    DE_CAPS_WF6BSTA         "ULMUMIMO"
 #define DE_WF6BSTA_UL_OFDMA     DE_CAPS_WF6BSTA         "ULOFDMA"
 #define DE_WF6BSTA_DL_OFDMA     DE_CAPS_WF6BSTA         "DLOFDMA"
-#define DE_WF6BSTA_MAX_DL_MUMIMO    DE_CAPS_WF6BSTA     "MaxDLMUMIMO"
-#define DE_WF6BSTA_MAX_UL_MUMIMO    DE_CAPS_WF6BSTA     "MaxULMUMIMO"
+#define DE_WF6BSTA_MAX_DLMUMIMO DE_CAPS_WF6BSTA         "MaxDLMUMIMO"
+#define DE_WF6BSTA_MAX_ULMUMIMO DE_CAPS_WF6BSTA         "MaxULMUMIMO"
 #define DE_WF6BSTA_MAX_DL_OFDMA DE_CAPS_WF6BSTA         "MaxDLOFDMA"
 #define DE_WF6BSTA_MAX_UL_OFDMA DE_CAPS_WF6BSTA         "MaxULOFDMA"
 #define DE_WF6BSTA_RTS          DE_CAPS_WF6BSTA         "RTS"
@@ -250,11 +261,11 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_WF6BSTA_MUEDCA       DE_CAPS_WF6BSTA         "MUEDCA"
 #define DE_WF6BSTA_TWT_REQ      DE_CAPS_WF6BSTA         "TWTRequestor"
 #define DE_WF6BSTA_TWT_RSP      DE_CAPS_WF6BSTA         "TWTResponder"
-#define DE_WF6BSTA_SPATIAL_REUSE    DE_CAPS_WF6BSTA     "SpatialReuse"
-#define DE_WF6BSTA_ANT_CH_USAGE DE_CAPS_WF6BSTA         "AnticipatedChannelUsage"
+#define DE_WF6BSTA_SPAT_REUSE   DE_CAPS_WF6BSTA         "SpatialReuse"
+#define DE_WF6BSTA_ANT_CH_USE   DE_CAPS_WF6BSTA         "AnticipatedChannelUsage"
 /* Device.WiFi.DataElements.Network.Device.Radio.Capabilities.CapableOperatingClassProfile */
-#define DE_CAPS_CAPOP           DE_DEVICE_RADIO         "CapableOperatingClassProfile.{i}."
-#define DE_CAPOP_TABLE          DE_DEVICE_RADIO         "CapableOperatingClassProfile.{i}"
+#define DE_CAPS_CAPOP           DE_RADIO_CAPS           "CapableOperatingClassProfile.{i}."
+#define DE_CAPOP_TABLE          DE_RADIO_CAPS           "CapableOperatingClassProfile.{i}"
 #define DE_CAPOP_CLASS          DE_CAPS_CAPOP           "Class"
 #define DE_CAPOP_MAXTXPOWER     DE_CAPS_CAPOP           "MaxTxPower"
 #define DE_CAPOP_NONOPERABLE    DE_CAPS_CAPOP           "NonOperable"
@@ -262,6 +273,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 /* Device.WiFi.DataElements.Network.Device.Radio.CurrentOperatingClassProfile */
 #define DE_RADIO_CUROP          DE_DEVICE_RADIO         "CurrentOperatingClassProfile.{i}."
 #define DE_CUROP_TABLE          DE_DEVICE_RADIO         "CurrentOperatingClassProfile.{i}"
+#define DE_CUROP_TIMESTAMP      DE_RADIO_CUROP          "TimeStamp"
 #define DE_CUROP_CLASS          DE_RADIO_CUROP          "Class"
 #define DE_CUROP_CHANNEL        DE_RADIO_CUROP          "Channel"
 #define DE_CUROP_TXPOWER        DE_RADIO_CUROP          "TxPower"
@@ -273,16 +285,16 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_WF7AP_NSTR           DE_CAPS_WF7AP           "NSTRSupport"
 #define DE_WF7AP_TID_MAP        DE_CAPS_WF7AP           "TIDLinkMapNegotiation"
 /* Device.WiFi.DataElements.Network.Device.Radio.Capabilities.WiFi7bSTARole */
-#define DE_CAPS_WF7BSTA         DE_DEVICE_RADIO         "WiFi7bSTARole."
+#define DE_CAPS_WF7BSTA         DE_RADIO_CAPS           "WiFi7bSTARole."
 #define DE_WF7BSTA_EMLMR        DE_CAPS_WF7BSTA         "EMLMRSupport"
 #define DE_WF7BSTA_EMLSR        DE_CAPS_WF7BSTA         "EMLSRSupport"
 #define DE_WF7BSTA_STR          DE_CAPS_WF7BSTA         "STRSupport"
 #define DE_WF7BSTA_NSTR         DE_CAPS_WF7BSTA         "NSTRSupport"
 #define DE_WF7BSTA_TID_MAP      DE_CAPS_WF7BSTA         "TIDLinkMapNegotiation"
 /* Device.WiFi.DataElements.Network.Device.Radio.Capabilities.ScanCapability */
-#define DE_CAPS_SCANCAP         DE_DEVICE_RADIO         "ScanCapability."
+#define DE_CAPS_SCANCAP         DE_RADIO_CAPS           "ScanCapability."
 #define DE_SCANCAP_TIMESTAMP    DE_CAPS_SCANCAP         "TimeStamp"
-#define DE_SCANCAP_OPCLSCANSNOE DE_CAPS_SCANCAP         "NumberOfOpClassScans"
+#define DE_SCANCAP_OPCLSCANSNOE DE_CAPS_SCANCAP         "OpClassChannelsNumberOfEntries"
 /* Device.WiFi.DataElements.Network.Device.Radio.BSS */
 #define DE_RADIO_BSS            DE_DEVICE_RADIO         "BSS.{i}."
 #define DE_BSS_TABLE            DE_DEVICE_RADIO         "BSS.{i}"
@@ -290,7 +302,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_BSS_SSID             DE_RADIO_BSS            "SSID"
 #define DE_BSS_ENABLED          DE_RADIO_BSS            "Enabled"
 #define DE_BSS_LASTCHG          DE_RADIO_BSS            "LastChange"
-#define DE_BSS_TS               DE_RADIO_BSS            "TimeStamp"
+#define DE_BSS_TIMESTAMP        DE_RADIO_BSS            "TimeStamp"
 #define DE_BSS_UCAST_TX         DE_RADIO_BSS            "UnicastBytesSent"
 #define DE_BSS_UCAST_RX         DE_RADIO_BSS            "UnicastBytesReceived"
 #define DE_BSS_MCAST_TX         DE_RADIO_BSS            "MulticastBytesSent"
@@ -314,14 +326,15 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_BSS_FHAULAKMS        DE_RADIO_BSS            "FronthaulAKMsAllowed"
 #define DE_BSS_BHAULAKMS        DE_RADIO_BSS            "BackhaulAKMsAllowed"
 #define DE_BSS_QM_DESC          DE_RADIO_BSS            "QMDescriptor"
-#define DE_BSS_NUM_STA          DE_RADIO_BSS            "NumberOfSTA"
 #define DE_BSS_LINK_IMM         DE_RADIO_BSS            "LinkRemovalImminent"
 #define DE_BSS_FH_SUITE         DE_RADIO_BSS            "FronthaulSuiteSelector"
 #define DE_BSS_BH_SUITE         DE_RADIO_BSS            "BackhaulSuiteSelector"
+#define DE_BSS_STANOE           DE_RADIO_BSS            "STANumberOfEntries"
 /* Device.WiFi.DataElements.Network.Device.Radio.BSS.STA */
 #define DE_BSS_STA              DE_RADIO_BSS            "STA.{i}."
 #define DE_STA_TABLE            DE_RADIO_BSS            "STA.{i}"
 #define DE_STA_MACADDR          DE_BSS_STA              "MACAddress"
+#define DE_STA_TIMESTAMP        DE_BSS_STA              "TimeStamp"
 #define DE_STA_HTCAPS           DE_BSS_STA              "HTCapabilities"
 #define DE_STA_VHTCAPS          DE_BSS_STA              "VHTCapabilities"
 #define DE_STA_CLIENTCAPS       DE_BSS_STA              "ClientCapabilities"
@@ -350,6 +363,13 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_STA_WIFI6CAPS        DE_BSS_STA              "WiFi6Capabilities."
 #define DE_STAWF6CAPS_HE160     DE_STA_WIFI6CAPS        "HE160"
 #define DE_STAWF6CAPS_MCSNSS    DE_STA_WIFI6CAPS        "MCSNSS"
+/* Device.WiFi.DataElements.Network.Device.Radio.UnassociatedSTA */
+#define DE_RADIO_UNASSOCSTA     DE_DEVICE_RADIO         "UnassociatedSTA.{i}."
+#define DE_UNASSOCSTA_TABLE     DE_DEVICE_RADIO         "UnassociatedSTA.{i}"
+#define DE_UNASSOCSTA_MACADDR   DE_RADIO_UNASSOCSTA     "MACAddress"
+#define DE_UNASSOCSTA_SGNLSTR   DE_RADIO_UNASSOCSTA     "SignalStrength"
+#define DE_UNASSOCSTA_OPCLASS   DE_RADIO_UNASSOCSTA     "OperatingClass"
+#define DE_UNASSOCSTA_CHANNEL   DE_RADIO_UNASSOCSTA     "Channel"
 /* Device.WiFi.DataElements.Network.Device.APMLD */
 #define DE_DEVICE_APMLD         DE_NETWORK_DEVICE       "APMLD.{i}."
 #define DE_APMLD_TABLE          DE_NETWORK_DEVICE       "APMLD.{i}"
@@ -546,6 +566,20 @@ public:
     static bus_error_t affap_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t affap_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
 
+    //STAMLD
+    static bus_error_t stamld_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t stamld_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t wifi7caps_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t stamldcfg_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
+    //AffiliatedSTA
+    static bus_error_t affsta_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t affsta_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
+    //bSTAMLD
+    static bus_error_t bstamld_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t bstacfg_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+
     //Orchestrator
     static bus_error_t get_network_topology(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t get_node_sync(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
@@ -572,6 +606,7 @@ public:
     void parse_property_constraints(cJSON* schemaNode, data_model_properties_t& props);
     void parse_readwrite(cJSON* schemaNode, data_model_properties_t& props);
     bool schema_has_type(cJSON* schema, const char* want);
+    bool schema_is_deprecated(cJSON* schema);
     void handle_property_node(cJSON* root, const std::string& fullPath, cJSON* propertySchema);
     void traverse_schema(cJSON* root, cJSON* schemaNode, const std::string& basePath);
     bool parse_and_register_schema(const char *filename);

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -2402,6 +2402,46 @@ bus_error_t dm_easy_mesh_ctrl_t::affap_tget(char *event_name, raw_data_t *p_data
     return bus_get_cb_fwd(event_name, p_data, affap_tget_inner);
 }
 
+bus_error_t dm_easy_mesh_ctrl_t::stamld_get(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, stamld_get_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::stamld_tget(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, stamld_tget_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::wifi7caps_get(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, wifi7caps_get_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::stamldcfg_get(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, stamldcfg_get_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::affsta_get(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, affsta_get_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::affsta_tget(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, affsta_tget_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::bstamld_get(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, bstamld_get_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::bstacfg_get(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, bstacfg_get_inner);
+}
+
 const char* dm_easy_mesh_ctrl_t::get_table_instance(const char *src, char *instance, size_t max_len, bool *is_num)
 {
 	char *dst = instance;
@@ -2461,7 +2501,12 @@ bus_error_t dm_easy_mesh_ctrl_t::network_get_inner(char *event_name, raw_data_t 
         dm_network_t *net = dm->get_network();
         dm_easy_mesh_t::macbytes_to_string(net->get_colocated_agent_interface_mac(), str_val);
         rc = dm_ctrl->raw_data_set(p_data, str_val);
-    } else if (strcmp(param, "NumberOfDevices") == 0) {
+    } else if (strcmp(param, "TimeStamp") == 0) {
+        dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
+        dm_network_t *dm_network = dm->get_network();
+        em_network_info_t *ni = dm_network->get_network_info();
+        rc = dm_ctrl->raw_data_set(p_data, ni->timestamp);
+    } else if (strcmp(param, "DeviceNumberOfEntries") == 0) {
         unsigned int dev_cnt = 0;
         dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
         while (dm != NULL) {
@@ -2535,16 +2580,12 @@ bus_error_t dm_easy_mesh_ctrl_t::device_get_inner(char *event_name, raw_data_t *
         rc = dm_ctrl->raw_data_set(p_data, di->intf.mac);
     } else if (strcmp(param, "MultiAPCapabilities") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, di->multi_ap_cap);
-    } else if (strcmp(param, "NumberOfRadios") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, dm->m_num_radios);
     } else if (strcmp(param, "CollectionInterval") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, di->coll_interval);
     } else if (strcmp(param, "ReportUnsuccessfulAssociations") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, di->report_unsuccess_assocs);
     } else if (strcmp(param, "MaxReportingRate") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, di->max_reporting_rate);
-    } else if (strcmp(param, "MultiAPProfile") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, static_cast<int32_t>(di->profile));
     } else if (strcmp(param, "APMetricsReportingInterval") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, di->ap_metrics_reporting_interval);
     } else if (strcmp(param, "Manufacturer") == 0) {
@@ -2563,10 +2604,6 @@ bus_error_t dm_easy_mesh_ctrl_t::device_get_inner(char *event_name, raw_data_t *
         //rc = dm_ctrl->raw_data_set(p_data, );
     } else if (strcmp(param, "MaxVIDs") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, di->max_vids);
-    } else if (strcmp(param, "BasicPrioritization") == 0) {
-        //rc = dm_ctrl->raw_data_set(p_data, );
-    } else if (strcmp(param, "EnhancedPrioritization") == 0) {
-        //rc = dm_ctrl->raw_data_set(p_data, );
     } else if (strcmp(param, "TrafficSeparationPolicy") == 0) {
         //rc = dm_ctrl->raw_data_set(p_data, );
     } else if (strcmp(param, "SSIDtoVIDMapping") == 0) {
@@ -2585,8 +2622,6 @@ bus_error_t dm_easy_mesh_ctrl_t::device_get_inner(char *event_name, raw_data_t *
         rc = dm_ctrl->raw_data_set(p_data, di->traffic_sep_allowed);
     } else if (strcmp(param, "ServicePrioritizationAllowed") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, di->svc_prio_allowed);
-    } else if (strcmp(param, "STASteeringDisallowed") == 0) {
-        //rc = dm_ctrl->raw_data_set(p_data, );
     } else if (strcmp(param, "DFSEnable") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, di->dfs_enable);
     } else if (strcmp(param, "MaxUnsuccessfulAssociationReportingRate") == 0) {
@@ -2770,6 +2805,25 @@ bus_error_t dm_easy_mesh_ctrl_t::device_tget_inner(char *event_name, raw_data_t 
 
         snprintf(path, sizeof(path) - 1, "%s%d.APMLD.", root, idx);
         dm_ctrl->apmld_tget_params(dm, path, &property);
+
+        if (dm->is_bsta_mld_present()) {
+            char maclist_str[256] = { 0 };
+            mac_address_t maclist[16];
+            em_bsta_mld_info_t &bsmi = dm->get_bsta_mld_info();
+            dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.MLDMACAddress", bsmi.mac_addr_valid ? bsmi.mac_addr : ZERO_MAC_ADDR);
+            dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.BSSID", bsmi.ap_mld_mac_addr_valid ? bsmi.ap_mld_mac_addr : ZERO_MAC_ADDR);
+            if (bsmi.num_affiliated_bsta) {
+                for (unsigned int i = 0; i < bsmi.num_affiliated_bsta && i < 16; i++) {
+                    memcpy(maclist[i], bsmi.affiliated_bsta[i].mac_addr, sizeof(mac_address_t));
+                }
+                dm_easy_mesh_t::maclist_to_string(maclist, bsmi.num_affiliated_bsta, maclist_str, sizeof(maclist_str));
+            }
+            dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.AffiliatedbSTAList", maclist_str);
+            dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.bSTAMLDConfig.EMLMREnabled", bsmi.emlmr);
+            dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.bSTAMLDConfig.EMLSREnabled", bsmi.emlsr);
+            dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.bSTAMLDConfig.STREnabled", bsmi.str);
+            dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.bSTAMLDConfig.NSTREnabled", bsmi.nstr);
+        }
     }
 
     if (property) {
@@ -3770,7 +3824,17 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_get_inner(char *event_name, raw_data_t *
     }
     em_op_class_info_t *oci = op_class->get_op_class_info();
 
-    if (strcmp(param, "Class") == 0) {
+    if (strcmp(param, "TimeStamp") == 0) {
+        char time[24];
+        char zone[8];
+        char buffer[64];
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        strftime(time, sizeof(time), "%FT%T", localtime(&ts.tv_sec));
+        strftime(zone, sizeof(zone), "%z", localtime(&ts.tv_sec));
+        snprintf(buffer, sizeof(buffer) - 1, "%s.%06ld%s", time, ts.tv_nsec / 1000, zone);
+        rc = dm_ctrl->raw_data_set(p_data, buffer);
+    } else if (strcmp(param, "Class") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, oci->op_class);
     } else if (strcmp(param, "Channel") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, oci->channel);
@@ -4004,7 +4068,7 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_get_inner(char *event_name, raw_data_t *p_d
         rc = dm_ctrl->raw_data_set(p_data, val_str);
     } else if (strcmp(param, "QMDescriptor") == 0) {
         //rc = dm_ctrl->raw_data_set(p_data, bi->);
-    } else if (strcmp(param, "NumberOfSTA") == 0) {
+    } else if (strcmp(param, "STANumberOfEntries") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, bi->numberofsta);
     } else if (strcmp(param, "LinkRemovalImminent") == 0) {
         //rc = dm_ctrl->raw_data_set(p_data, bi->);
@@ -4177,6 +4241,8 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_d
 
     if (strcmp(param, "MACAddress") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, si->id);
+    } else if (strcmp(param, "TimeStamp") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si->timestamp);
     } else if (strcmp(param, "HTCapabilities") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, si->ht_cap);
     } else if (strcmp(param, "VHTCapabilities") == 0) {
@@ -4495,8 +4561,8 @@ bus_error_t dm_easy_mesh_ctrl_t::apmld_tget_params(dm_easy_mesh_t *dm, const cha
         snprintf(path, sizeof(path) - 1, "%s%d.AffiliatedAP.", root, idx);
         dm_ctrl->affap_tget_params(dm, path, ami, property);
 
-        //snprintf(path, sizeof(path) - 1, "%s%d.STAMLD.", root, idx);
-        //dm_ctrl->stamld_tget_params(dm, path, property);
+        snprintf(path, sizeof(path) - 1, "%s%d.STAMLD.", root, idx);
+        dm_ctrl->stamld_tget_params(dm, path, ami, property);
     }
 
     return rc;
@@ -4709,6 +4775,673 @@ bus_error_t dm_easy_mesh_ctrl_t::affap_tget_params(dm_easy_mesh_t *dm, const cha
         dm_ctrl->property_append_tail(property, root, idx, "MulticastBytesReceived", 0);
         dm_ctrl->property_append_tail(property, root, idx, "BroadcastBytesSent", 0);
         dm_ctrl->property_append_tail(property, root, idx, "BroadcastBytesReceived", 0);
+    }
+
+    return rc;
+}
+
+dm_assoc_sta_mld_t *dm_easy_mesh_ctrl_t::get_dm_sta_mld(dm_easy_mesh_t *dm, em_ap_mld_info_t *ami, char *instance, bool is_num)
+{
+    dm_assoc_sta_mld_t *sta_mld = NULL;
+
+    if (is_num) {
+        unsigned int cnt = 0;
+        unsigned int idx = static_cast<unsigned int>(atoi(instance) - 1);
+        for (unsigned int i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+            dm_assoc_sta_mld_t *sta_mld = &dm->m_assoc_sta_mld[i]; /* no getter? */
+            em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
+            if (memcmp(ami->mac_addr, smi->ap_mld_mac_addr, sizeof(mac_address_t)) != 0) {
+                /* sta_mld does belong to ap_mld */
+                ++cnt;
+                if (cnt == idx) {
+                    return sta_mld;
+                }
+            }
+        }
+    }
+
+    for (unsigned int i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+        char mac_str[18];
+        dm_assoc_sta_mld_t *sta_mld = &dm->m_assoc_sta_mld[i]; /* no getter? */
+        em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
+        dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (smi->mac_addr), mac_str);
+        if (strcmp(instance, mac_str) == 0) {
+            return sta_mld;
+        }
+    }
+
+    return sta_mld;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::stamld_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        return bus_error_invalid_input;
+    }
+    ++param;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+
+    /* Extract ap_mld instance (numeric or alias), find the ap_mld dm object
+     * for that instance, and finally get info struct for ap_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
+    if (ap_mld == NULL) {
+        printf("ap_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
+
+    /* Extract assoc_sta_mld instance (numeric or alias), find the
+     * assoc_sta_mld dm object for that instance, and finally get info struct
+     * for assoc_sta_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
+    if (sta_mld == NULL) {
+        printf("assoc_sta_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
+
+    dm_sta_t *sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
+    em_sta_info_t *si = NULL;
+    while (sta != NULL) {
+        si = sta->get_sta_info();
+        if (si->associated && memcmp(smi->mac_addr, si->id, sizeof(mac_addr_t)) != 0) {
+            break;
+        }
+        sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+        si = NULL;
+    }
+
+    if (strcmp(param, "MLDMACAddress") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->mac_addr);
+    } else if (strcmp(param, "IsbSTA") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, 0);
+    } else if (strcmp(param, "LastConnectTime") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->last_conn_time : 0);
+    } else if (strcmp(param, "BytesSent") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->bytes_tx : 0);
+    } else if (strcmp(param, "BytesReceived") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->bytes_rx : 0);
+    } else if (strcmp(param, "PacketsSent") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->pkts_tx : 0);
+    } else if (strcmp(param, "PacketsReceived") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->pkts_rx : 0);
+    } else if (strcmp(param, "ErrorsSent") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->errors_tx : 0);
+    } else if (strcmp(param, "ErrorsReceived") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->errors_rx : 0);
+    } else if (strcmp(param, "RetransCount") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->retrans_count : 0);
+    } else if (strcmp(param, "AffiliatedSTANumberOfEntries") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->num_affiliated_sta);
+    } else {
+        printf("Invalid param: %s\n", param);
+        rc = bus_error_destination_not_found;
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::stamld_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *root = name;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    bus_data_prop_t *property = NULL;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+    if (*(name + (strlen(name) - 1)) != '.') {
+        /* Only partial paths are valid */
+        return bus_error_invalid_operation;
+    }
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+
+    /* Extract ap_mld instance (numeric or alias), find the ap_mld dm object
+     * for that instance, and finally get info struct for ap_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
+    if (ap_mld == NULL) {
+        printf("ap_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
+
+    rc = dm_ctrl->stamld_tget_params(dm, root, ami, &property);
+    if (rc == bus_error_success && property) {
+        dm_ctrl->raw_data_set(p_data, property);
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::stamld_tget_params(dm_easy_mesh_t *dm, const char *root, em_ap_mld_info_t *ami, bus_data_prop_t **property)
+{
+    char path[512];
+    bus_error_t rc = bus_error_success;
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    unsigned int idx = 0;
+    for (unsigned int cnt = 0; cnt < dm->get_num_assoc_sta_mld(); cnt++) {
+        /* First find assoc_sta_mld for this ap_mld */
+        dm_assoc_sta_mld_t *sta_mld = &dm->m_assoc_sta_mld[cnt]; /* no getter? */
+        em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
+        if (memcmp(ami->mac_addr, smi->ap_mld_mac_addr, sizeof(mac_address_t)) != 0) {
+            /* sta_mld does not belong to this ap_mld, skip */
+            continue;
+        }
+        /* Now find sta for this assoc_sta_mld */
+        dm_sta_t *sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
+        em_sta_info_t *si = NULL;
+        while (sta != NULL) {
+            si = sta->get_sta_info();
+            if (si->associated && memcmp(smi->mac_addr, si->id, sizeof(mac_addr_t)) != 0) {
+                break;
+            }
+            sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+            si = NULL;
+        }
+        ++idx;
+
+        dm_ctrl->property_append_tail(property, root, idx, "MLDMACAddress", smi->mac_addr);
+        dm_ctrl->property_append_tail(property, root, idx, "IsbSTA", 0);
+        dm_ctrl->property_append_tail(property, root, idx, "LastConnectTime", si ? si->last_conn_time : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "BytesReceived", si ? si->bytes_rx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "BytesSent", si ? si->bytes_tx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "PacketsReceived", si ? si->pkts_rx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "PacketsSent", si ? si->pkts_tx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "ErrorsReceived", si ? si->errors_rx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "ErrorsSent", si ? si->errors_tx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "RetransCount", si ? si->retrans_count : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "AffiliatedSTANumberOfEntries", smi->num_affiliated_sta);
+
+        dm_ctrl->property_append_tail(property, root, idx, "STAMLDConfig.EMLMRSupport", smi->emlmr);
+        dm_ctrl->property_append_tail(property, root, idx, "STAMLDConfig.EMLSRSupport", smi->emlsr);
+        dm_ctrl->property_append_tail(property, root, idx, "STAMLDConfig.STRSupport", smi->str);
+        dm_ctrl->property_append_tail(property, root, idx, "STAMLDConfig.NSTRSupport", smi->nstr);
+
+        dm_ctrl->property_append_tail(property, root, idx, "WiFi7Capabilities.EMLMRSupport", smi->emlmr);
+        dm_ctrl->property_append_tail(property, root, idx, "WiFi7Capabilities.EMLSRSupport", smi->emlsr);
+        dm_ctrl->property_append_tail(property, root, idx, "WiFi7Capabilities.STRSupport", smi->str);
+        dm_ctrl->property_append_tail(property, root, idx, "WiFi7Capabilities.NSTRSupport", smi->nstr);
+
+        snprintf(path, sizeof(path) - 1, "%s%d.AffiliatedSTA.", root, idx);
+        dm_ctrl->affsta_tget_params(dm, path, smi, property);
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::wifi7caps_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        return bus_error_invalid_input;
+    }
+    ++param;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+
+    /* Extract ap_mld instance (numeric or alias), find the ap_mld dm object
+     * for that instance, and finally get info struct for ap_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
+    if (ap_mld == NULL) {
+        printf("ap_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
+
+    /* Extract assoc_sta_mld instance (numeric or alias), find the
+     * assoc_sta_mld dm object for that instance, and finally get info struct
+     * for assoc_sta_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
+    if (sta_mld == NULL) {
+        printf("assoc_sta_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
+
+    if (strcmp(param, "EMLMRSupport") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->emlmr);
+    } else if (strcmp(param, "EMLSRSupport") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->emlsr);
+    } else if (strcmp(param, "STRSupport") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->str);
+    } else if (strcmp(param, "NSTRSupport") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->nstr);
+    } else {
+        printf("Invalid param: %s\n", param);
+        rc = bus_error_destination_not_found;
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::stamldcfg_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        return bus_error_invalid_input;
+    }
+    ++param;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+
+    /* Extract ap_mld instance (numeric or alias), find the ap_mld dm object
+     * for that instance, and finally get info struct for ap_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
+    if (ap_mld == NULL) {
+        printf("ap_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
+
+    /* Extract assoc_sta_mld instance (numeric or alias), find the
+     * assoc_sta_mld dm object for that instance, and finally get info struct
+     * for assoc_sta_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
+    if (sta_mld == NULL) {
+        printf("assoc_sta_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
+
+    if (strcmp(param, "EMLMREnabled") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->emlmr);
+    } else if (strcmp(param, "EMLSREnabled") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->emlsr);
+    } else if (strcmp(param, "STREnabled") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->str);
+    } else if (strcmp(param, "NSTREnabled") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, smi->nstr);
+    } else {
+        printf("Invalid param: %s\n", param);
+        rc = bus_error_destination_not_found;
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        return bus_error_invalid_input;
+    }
+    ++param;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+
+    /* Extract ap_mld instance (numeric or alias), find the ap_mld dm object
+     * for that instance, and finally get info struct for ap_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
+    if (ap_mld == NULL) {
+        printf("ap_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
+
+    /* Extract assoc_sta_mld instance (numeric or alias), find the
+     * assoc_sta_mld dm object for that instance, and finally get info struct
+     * for assoc_sta_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
+    if (sta_mld == NULL) {
+        printf("assoc_sta_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
+
+    /* Extract aff_sta instance and get info struct for that aff_sta */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    int idx = atoi(instance);
+    if (!is_num || idx <= 0 || idx > smi->num_affiliated_sta) {
+        printf("aff_sta not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_affiliated_sta_info_t *asi = &smi->affiliated_sta[idx - 1];
+
+    dm_sta_t *sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
+    em_sta_info_t *si = NULL;
+    while (sta != NULL) {
+        si = sta->get_sta_info();
+        if (si->associated && memcmp(asi->mac_addr, si->id, sizeof(mac_addr_t)) != 0) {
+            break;
+        }
+        sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+        si = NULL;
+    }
+
+    if (strcmp(param, "MACAddress") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, asi->mac_addr);
+    } else if (strcmp(param, "BSSID") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, asi->bssid);
+    } else if (strcmp(param, "BytesSent") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->bytes_tx : 0);
+    } else if (strcmp(param, "BytesReceived") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->bytes_rx : 0);
+    } else if (strcmp(param, "PacketsSent") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->pkts_tx : 0);
+    } else if (strcmp(param, "PacketsReceived") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->pkts_rx : 0);
+    } else if (strcmp(param, "ErrorsSent") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->errors_tx : 0);
+    } else if (strcmp(param, "SignalStrength") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->rcpi : 0);
+    } else if (strcmp(param, "EstMACDataRateDownlink") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->est_dl_rate : 0);
+    } else if (strcmp(param, "EstMACDataRateUplink") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, si ? si->est_ul_rate : 0);
+    } else {
+        printf("Invalid param: %s\n", param);
+        rc = bus_error_destination_not_found;
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::affsta_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *root = name;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    bus_data_prop_t *property = NULL;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+    if (*(name + (strlen(name) - 1)) != '.') {
+        /* Only partial paths are valid */
+        return bus_error_invalid_operation;
+    }
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+
+    /* Extract ap_mld instance (numeric or alias), find the ap_mld dm object
+     * for that instance, and finally get info struct for ap_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
+    if (ap_mld == NULL) {
+        printf("ap_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
+
+    /* Extract assoc_sta_mld instance (numeric or alias), find the
+     * assoc_sta_mld dm object for that instance, and finally get info struct
+     * for assoc_sta_mld dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
+    if (sta_mld == NULL) {
+        printf("assoc_sta_mld not found\n");
+        return bus_error_invalid_namespace;
+    }
+    em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
+
+    rc = dm_ctrl->affsta_tget_params(dm, root, smi, &property);
+    if (rc == bus_error_success && property) {
+        dm_ctrl->raw_data_set(p_data, property);
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::affsta_tget_params(dm_easy_mesh_t *dm, const char *root, em_assoc_sta_mld_info_t *smi, bus_data_prop_t **property)
+{
+    bus_error_t rc = bus_error_success;
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    for (unsigned int idx = 1; idx <= smi->num_affiliated_sta; idx++) {
+        em_affiliated_sta_info_t *asi = &smi->affiliated_sta[idx - 1];
+        dm_sta_t *sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
+        em_sta_info_t *si = NULL;
+        while (sta != NULL) {
+            si = sta->get_sta_info();
+            if (si->associated && memcmp(asi->mac_addr, si->id, sizeof(mac_addr_t)) != 0) {
+                break;
+            }
+            sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+            si = NULL;
+        }
+
+        dm_ctrl->property_append_tail(property, root, idx, "MACAddress", asi->mac_addr);
+        dm_ctrl->property_append_tail(property, root, idx, "BSSID", asi->bssid);
+        dm_ctrl->property_append_tail(property, root, idx, "BytesSent", si ? si->bytes_tx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "BytesReceived", si ? si->bytes_rx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "PacketsSent", si ? si->pkts_tx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "PacketsReceived", si ? si->pkts_rx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "ErrorsSent", si ? si->errors_tx : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "SignalStrength", si ? si->rcpi : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "EstMACDataRateDownlink", si ? si->est_dl_rate : 0);
+        dm_ctrl->property_append_tail(property, root, idx, "EstMACDataRateUplink", si ? si->est_ul_rate : 0);
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::bstamld_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        return bus_error_invalid_input;
+    }
+    ++param;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+    if (!dm->is_bsta_mld_present()) {
+        return bus_error_destination_not_found;
+    }
+    em_bsta_mld_info_t &bsmi = dm->get_bsta_mld_info();
+
+    if (strcmp(param, "MLDMACAddress") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, bsmi.mac_addr_valid ? bsmi.mac_addr : ZERO_MAC_ADDR);
+    } else if (strcmp(param, "BSSID") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, bsmi.ap_mld_mac_addr_valid ? bsmi.ap_mld_mac_addr : ZERO_MAC_ADDR);
+    } else if (strcmp(param, "AffiliatedbSTAList") == 0) {
+        char maclist_str[256] = { 0 };
+        mac_address_t maclist[16];
+        if (bsmi.num_affiliated_bsta) {
+            for (unsigned int i = 0; i < bsmi.num_affiliated_bsta && i < 16; i++) {
+                memcpy(maclist[i], bsmi.affiliated_bsta[i].mac_addr, sizeof(mac_address_t));
+            }
+            dm_easy_mesh_t::maclist_to_string(maclist, bsmi.num_affiliated_bsta, maclist_str, sizeof(maclist_str));
+        }
+        rc = dm_ctrl->raw_data_set(p_data, maclist_str);
+    } else {
+        printf("Invalid param: %s\n", param);
+        rc = bus_error_destination_not_found;
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::bstacfg_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        return bus_error_invalid_input;
+    }
+    ++param;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+    if (!dm->is_bsta_mld_present()) {
+        return bus_error_destination_not_found;
+    }
+    em_bsta_mld_info_t &bsmi = dm->get_bsta_mld_info();
+
+    if (strcmp(param, "EMLMREnabled") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, bsmi.emlmr);
+    } else if (strcmp(param, "EMLSREnabled") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, bsmi.emlsr);
+    } else if (strcmp(param, "STREnabled") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, bsmi.str);
+    } else if (strcmp(param, "NSTREnabled") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, bsmi.nstr);
+    } else {
+        printf("Invalid param: %s\n", param);
+        rc = bus_error_destination_not_found;
     }
 
     return rc;

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -2807,13 +2807,13 @@ bus_error_t dm_easy_mesh_ctrl_t::device_tget_inner(char *event_name, raw_data_t 
         dm_ctrl->apmld_tget_params(dm, path, &property);
 
         if (dm->is_bsta_mld_present()) {
-            char maclist_str[256] = { 0 };
-            mac_address_t maclist[16];
+            char maclist_str[MAX_MACLIST_STRLEN] = { 0 };
+            mac_address_t maclist[MAX_MACLIST_ITEMS];
             em_bsta_mld_info_t &bsmi = dm->get_bsta_mld_info();
             dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.MLDMACAddress", bsmi.mac_addr_valid ? bsmi.mac_addr : ZERO_MAC_ADDR);
             dm_ctrl->property_append_tail(&property, root, idx, "bSTAMLD.BSSID", bsmi.ap_mld_mac_addr_valid ? bsmi.ap_mld_mac_addr : ZERO_MAC_ADDR);
             if (bsmi.num_affiliated_bsta) {
-                for (unsigned int i = 0; i < bsmi.num_affiliated_bsta && i < 16; i++) {
+                for (unsigned int i = 0; i < bsmi.num_affiliated_bsta && i < MAX_MACLIST_ITEMS; i++) {
                     memcpy(maclist[i], bsmi.affiliated_bsta[i].mac_addr, sizeof(mac_address_t));
                 }
                 dm_easy_mesh_t::maclist_to_string(maclist, bsmi.num_affiliated_bsta, maclist_str, sizeof(maclist_str));
@@ -3825,9 +3825,9 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_get_inner(char *event_name, raw_data_t *
     em_op_class_info_t *oci = op_class->get_op_class_info();
 
     if (strcmp(param, "TimeStamp") == 0) {
-        char time[24];
-        char zone[8];
-        char buffer[64];
+        char time[MAX_TIME_STRLEN];
+        char zone[MAX_ZONE_STRLEN];
+        char buffer[MAX_TIMESTAMP_STRLEN];
         struct timespec ts;
         clock_gettime(CLOCK_REALTIME, &ts);
         strftime(time, sizeof(time), "%FT%T", localtime(&ts.tv_sec));
@@ -5379,10 +5379,10 @@ bus_error_t dm_easy_mesh_ctrl_t::bstamld_get_inner(char *event_name, raw_data_t 
     } else if (strcmp(param, "BSSID") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, bsmi.ap_mld_mac_addr_valid ? bsmi.ap_mld_mac_addr : ZERO_MAC_ADDR);
     } else if (strcmp(param, "AffiliatedbSTAList") == 0) {
-        char maclist_str[256] = { 0 };
-        mac_address_t maclist[16];
+        char maclist_str[MAX_MACLIST_STRLEN] = { 0 };
+        mac_address_t maclist[MAX_MACLIST_ITEMS];
         if (bsmi.num_affiliated_bsta) {
-            for (unsigned int i = 0; i < bsmi.num_affiliated_bsta && i < 16; i++) {
+            for (unsigned int i = 0; i < bsmi.num_affiliated_bsta && i < MAX_MACLIST_ITEMS; i++) {
                 memcpy(maclist[i], bsmi.affiliated_bsta[i].mac_addr, sizeof(mac_address_t));
             }
             dm_easy_mesh_t::maclist_to_string(maclist, bsmi.num_affiliated_bsta, maclist_str, sizeof(maclist_str));

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -4468,7 +4468,7 @@ bus_error_t dm_easy_mesh_ctrl_t::apmld_get_inner(char *event_name, raw_data_t *p
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -4477,7 +4477,7 @@ bus_error_t dm_easy_mesh_ctrl_t::apmld_get_inner(char *event_name, raw_data_t *p
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -4489,7 +4489,7 @@ bus_error_t dm_easy_mesh_ctrl_t::apmld_get_inner(char *event_name, raw_data_t *p
     } else if (strcmp(param, "STAMLDNumberOfEntries") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, 0);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s", param);
         rc = bus_error_destination_not_found;
     }
 
@@ -4522,7 +4522,7 @@ bus_error_t dm_easy_mesh_ctrl_t::apmld_tget_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -4595,7 +4595,7 @@ bus_error_t dm_easy_mesh_ctrl_t::apmldcfg_get_inner(char *event_name, raw_data_t
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -4604,7 +4604,7 @@ bus_error_t dm_easy_mesh_ctrl_t::apmldcfg_get_inner(char *event_name, raw_data_t
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -4618,7 +4618,7 @@ bus_error_t dm_easy_mesh_ctrl_t::apmldcfg_get_inner(char *event_name, raw_data_t
     } else if (strcmp(param, "NSTREnabled") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, ami->nstr);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s", param);
         rc = bus_error_destination_not_found;
     }
 
@@ -4652,7 +4652,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affap_get_inner(char *event_name, raw_data_t *p
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -4661,7 +4661,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affap_get_inner(char *event_name, raw_data_t *p
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -4670,7 +4670,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affap_get_inner(char *event_name, raw_data_t *p
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     int idx = atoi(instance);
     if (!is_num || idx <= 0 || idx > ami->num_affiliated_ap) {
-        printf("aff_ap not found\n");
+        em_printfout("AffiliatedAP not found");
         return bus_error_invalid_namespace;
     }
     em_affiliated_ap_info_t *aai = &ami->affiliated_ap[idx - 1];
@@ -4700,7 +4700,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affap_get_inner(char *event_name, raw_data_t *p
     } else if (strcmp(param, "BroadcastBytesReceived") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, 0);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s", param);
         rc = bus_error_destination_not_found;
     }
 
@@ -4733,7 +4733,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affap_tget_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -4742,7 +4742,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affap_tget_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -4840,7 +4840,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamld_get_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -4849,7 +4849,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamld_get_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -4860,7 +4860,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamld_get_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
     if (sta_mld == NULL) {
-        printf("assoc_sta_mld not found\n");
+        em_printfout("STAMLD not found");
         return bus_error_invalid_namespace;
     }
     em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
@@ -4899,7 +4899,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamld_get_inner(char *event_name, raw_data_t *
     } else if (strcmp(param, "AffiliatedSTANumberOfEntries") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, smi->num_affiliated_sta);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s", param);
         rc = bus_error_destination_not_found;
     }
 
@@ -4932,7 +4932,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamld_tget_inner(char *event_name, raw_data_t 
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -4941,7 +4941,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamld_tget_inner(char *event_name, raw_data_t 
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -5038,7 +5038,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wifi7caps_get_inner(char *event_name, raw_data_
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -5047,7 +5047,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wifi7caps_get_inner(char *event_name, raw_data_
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -5058,7 +5058,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wifi7caps_get_inner(char *event_name, raw_data_
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
     if (sta_mld == NULL) {
-        printf("assoc_sta_mld not found\n");
+        em_printfout("STAMLD not found");
         return bus_error_invalid_namespace;
     }
     em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
@@ -5072,7 +5072,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wifi7caps_get_inner(char *event_name, raw_data_
     } else if (strcmp(param, "NSTRSupport") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, smi->nstr);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s\n", param);
         rc = bus_error_destination_not_found;
     }
 
@@ -5106,7 +5106,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamldcfg_get_inner(char *event_name, raw_data_
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -5115,7 +5115,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamldcfg_get_inner(char *event_name, raw_data_
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -5126,7 +5126,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamldcfg_get_inner(char *event_name, raw_data_
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
     if (sta_mld == NULL) {
-        printf("assoc_sta_mld not found\n");
+        em_printfout("STAMLD not found");
         return bus_error_invalid_namespace;
     }
     em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
@@ -5140,7 +5140,7 @@ bus_error_t dm_easy_mesh_ctrl_t::stamldcfg_get_inner(char *event_name, raw_data_
     } else if (strcmp(param, "NSTREnabled") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, smi->nstr);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s", param);
         rc = bus_error_destination_not_found;
     }
 
@@ -5174,7 +5174,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -5183,7 +5183,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -5194,7 +5194,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
     if (sta_mld == NULL) {
-        printf("assoc_sta_mld not found\n");
+        em_printfout("STAMLD not found");
         return bus_error_invalid_namespace;
     }
     em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
@@ -5203,7 +5203,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     int idx = atoi(instance);
     if (!is_num || idx <= 0 || idx > smi->num_affiliated_sta) {
-        printf("aff_sta not found\n");
+        em_printfout("AffiliatedSTA not found");
         return bus_error_invalid_namespace;
     }
     em_affiliated_sta_info_t *asi = &smi->affiliated_sta[idx - 1];
@@ -5240,7 +5240,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     } else if (strcmp(param, "EstMACDataRateUplink") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, si ? si->est_ul_rate : 0);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s", param);
         rc = bus_error_destination_not_found;
     }
 
@@ -5273,7 +5273,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_tget_inner(char *event_name, raw_data_t 
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
 
@@ -5282,7 +5282,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_tget_inner(char *event_name, raw_data_t 
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_ap_mld_t *ap_mld = dm_ctrl->get_dm_ap_mld(dm, instance, is_num);
     if (ap_mld == NULL) {
-        printf("ap_mld not found\n");
+        em_printfout("APMLD not found");
         return bus_error_invalid_namespace;
     }
     em_ap_mld_info_t *ami = ap_mld->get_ap_mld_info();
@@ -5293,7 +5293,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_tget_inner(char *event_name, raw_data_t 
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_assoc_sta_mld_t *sta_mld = dm_ctrl->get_dm_sta_mld(dm, ami, instance, is_num);
     if (sta_mld == NULL) {
-        printf("assoc_sta_mld not found\n");
+        em_printfout("STAMLD not found");
         return bus_error_invalid_namespace;
     }
     em_assoc_sta_mld_info_t *smi = sta_mld->get_assoc_sta_mld_info();
@@ -5366,7 +5366,7 @@ bus_error_t dm_easy_mesh_ctrl_t::bstamld_get_inner(char *event_name, raw_data_t 
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
     if (!dm->is_bsta_mld_present()) {
@@ -5389,7 +5389,7 @@ bus_error_t dm_easy_mesh_ctrl_t::bstamld_get_inner(char *event_name, raw_data_t 
         }
         rc = dm_ctrl->raw_data_set(p_data, maclist_str);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s", param);
         rc = bus_error_destination_not_found;
     }
 
@@ -5423,7 +5423,7 @@ bus_error_t dm_easy_mesh_ctrl_t::bstacfg_get_inner(char *event_name, raw_data_t 
     name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
     dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
     if (dm == NULL) {
-        printf("device not found\n");
+        em_printfout("Device not found");
         return bus_error_invalid_namespace;
     }
     if (!dm->is_bsta_mld_present()) {
@@ -5440,7 +5440,7 @@ bus_error_t dm_easy_mesh_ctrl_t::bstacfg_get_inner(char *event_name, raw_data_t 
     } else if (strcmp(param, "NSTREnabled") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, bsmi.nstr);
     } else {
-        printf("Invalid param: %s\n", param);
+        em_printfout("Invalid param: %s", param);
         rc = bus_error_destination_not_found;
     }
 

--- a/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
@@ -1166,7 +1166,10 @@ void tr_181_t::handle_property_node(cJSON* root, const std::string& fullPath, cJ
 
     // 0) If property is deprecated, do not bother
     bool deprecated = schema_is_deprecated(propertySchema);
-    if (deprecated) return;
+    if (deprecated) {
+        em_printfout("Deprecated parameter, skip");
+        return;
+    }
 
     // 1) follow top-level $ref / combiners if present
     cJSON* effective = follow_ref_if_any(root, propertySchema);

--- a/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
@@ -69,6 +69,7 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_NETWORK_CTRLID,        CALLBACK_GETTER(network_get)),
         ELEMENT(DE_NETWORK_COLAGTID,      CALLBACK_GETTER(network_get)),
         ELEMENT(DE_NETWORK_DEVNOE,        CALLBACK_GETTER(network_get)),
+        ELEMENT(DE_NETWORK_TIMESTAMP,     CALLBACK_GETTER(network_get)),
         ELEMENT(DE_SSID_TABLE,            CALLBACK_GETTER(ssid_tget)),
         ELEMENT(DE_SSID_SSID,             CALLBACK_GETTER(ssid_get)),
         ELEMENT(DE_SSID_BAND,             CALLBACK_GETTER(ssid_get)),
@@ -82,11 +83,9 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_DEVICE_TABLE,          CALLBACK_GETTER(device_tget)),
         ELEMENT(DE_DEVICE_ID,                     CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_MAPCAP,                 CALLBACK_GETTER(device_get)),
-        ELEMENT(DE_DEVICE_NUMRADIO,               CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_COLLINT,                CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_RUASSOC,                CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_MAXRRATE,               CALLBACK_GETTER(device_get)),
-        ELEMENT(DE_DEVICE_MAPPROF,                CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_APMERINT,               CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_MANUFACT,               CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_SERIALNO,               CALLBACK_GETTER(device_get)),
@@ -96,8 +95,6 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_DEVICE_LSDSTALIST,             CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_BTMSDSTALIST,           CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_MAXVIDS,                CALLBACK_GETTER(device_get)),
-        ELEMENT(DE_DEVICE_BPRIO,                  CALLBACK_GETTER(device_get)),
-        ELEMENT(DE_DEVICE_EPRIO,                  CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_TSEPPOLI,               CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_STVMAP,                 CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_DSCPM,                  CALLBACK_GETTER(device_get)),
@@ -107,9 +104,8 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_DEVICE_REPINDSCAN,             CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_TRASEPALW,              CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_SERPRIOALW,             CALLBACK_GETTER(device_get)),
-        ELEMENT(DE_DEVICE_STASDISALW,             CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_DFSENABLE,              CALLBACK_GETTER(device_get)),
-        ELEMENT(DE_DEVICE_MAXUSASSOCREPRATE,      CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_MAXUSASSOCREP,          CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_STASSTATE,              CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_COORCACALW,             CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_CONOPMODE,              CALLBACK_GETTER(device_get)),
@@ -119,11 +115,11 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_DEVICE_TRSEPCAP,               CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_EASYCCAP,               CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_TESTCAP,                CALLBACK_GETTER(device_get)),
-        ELEMENT(DE_DEVICE_BSTAMLDMACLINK,         CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_BSTAMLDMACLNK,          CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_MACNUMMLDS,             CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_BHALID,                 CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_TIDLMAP,                CALLBACK_GETTER(device_get)),
-        ELEMENT(DE_DEVICE_ASSOCSTAREPINT,         CALLBACK_GETTER(device_get)),
+        ELEMENT(DE_DEVICE_ASSOCSTAREP,            CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_BHMEDIATYPE,            CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_RADIONOE,               CALLBACK_GETTER(device_get)),
         ELEMENT(DE_DEVICE_CACSTATNOE,             CALLBACK_GETTER(device_get)),
@@ -173,6 +169,7 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_WF7AP_NSTR,             CALLBACK_GETTER(wf7ap_get)),
         ELEMENT(DE_WF7AP_TID_MAP,          CALLBACK_GETTER(wf7ap_get)),
         ELEMENT(DE_CUROP_TABLE,            CALLBACK_GETTER(curops_tget)),
+        ELEMENT(DE_CUROP_TIMESTAMP,        CALLBACK_GETTER(curops_get)),
         ELEMENT(DE_CUROP_CLASS,            CALLBACK_GETTER(curops_get)),
         ELEMENT(DE_CUROP_CHANNEL,          CALLBACK_GETTER(curops_get)),
         ELEMENT(DE_CUROP_TXPOWER,          CALLBACK_GETTER(curops_get)),
@@ -181,7 +178,7 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_BSS_SSID,               CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_ENABLED,            CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_LASTCHG,            CALLBACK_GETTER(bss_get)),
-        ELEMENT(DE_BSS_TS,                 CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_TIMESTAMP,          CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_UCAST_TX,           CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_UCAST_RX,           CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_MCAST_TX,           CALLBACK_GETTER(bss_get)),
@@ -205,12 +202,13 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_BSS_FHAULAKMS,          CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_BHAULAKMS,          CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_QM_DESC,            CALLBACK_GETTER(bss_get)),
-        ELEMENT(DE_BSS_NUM_STA,            CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_LINK_IMM,           CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_FH_SUITE,           CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_BSS_BH_SUITE,           CALLBACK_GETTER(bss_get)),
+        ELEMENT(DE_BSS_STANOE  ,           CALLBACK_GETTER(bss_get)),
         ELEMENT(DE_STA_TABLE,              CALLBACK_GETTER(sta_tget)),
         ELEMENT(DE_STA_MACADDR,            CALLBACK_GETTER(sta_get)),
+        ELEMENT(DE_STA_TIMESTAMP,          CALLBACK_GETTER(sta_get)),
         ELEMENT(DE_STA_HTCAPS,             CALLBACK_GETTER(sta_get)),
         ELEMENT(DE_STA_VHTCAPS,            CALLBACK_GETTER(sta_get)),
         ELEMENT(DE_STA_CLIENTCAPS,         CALLBACK_GETTER(sta_get)),
@@ -256,6 +254,45 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_AFFAP_MCBYTESRCV,       CALLBACK_GETTER(affap_get)),
         ELEMENT(DE_AFFAP_BCBYTESSNT,       CALLBACK_GETTER(affap_get)),
         ELEMENT(DE_AFFAP_BCBYTESRCV,       CALLBACK_GETTER(affap_get)),
+        ELEMENT(DE_STAMLD_TABLE,           CALLBACK_GETTER(stamld_tget)),
+        ELEMENT(DE_STAMLD_MLDMACADDR,      CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_ISBSTA,          CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_LASTCONTME,      CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_BYTESSNT,        CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_BYTESRCV,        CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_PCKTSSNT,        CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_PCKTSRCV,        CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_ERRSSNT,         CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_ERRSRCVD,        CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_RETRANSCNT,      CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_STAMLD_AFFSTANOE,       CALLBACK_GETTER(stamld_get)),
+        ELEMENT(DE_WIFI7CAPS_EMLMR,        CALLBACK_GETTER(wifi7caps_get)),
+        ELEMENT(DE_WIFI7CAPS_EMLSR,        CALLBACK_GETTER(wifi7caps_get)),
+        ELEMENT(DE_WIFI7CAPS_STR,          CALLBACK_GETTER(wifi7caps_get)),
+        ELEMENT(DE_WIFI7CAPS_NSTR,         CALLBACK_GETTER(wifi7caps_get)),
+        ELEMENT(DE_STAMLDCFG_EMLMR,        CALLBACK_GETTER(stamldcfg_get)),
+        ELEMENT(DE_STAMLDCFG_EMLSR,        CALLBACK_GETTER(stamldcfg_get)),
+        ELEMENT(DE_STAMLDCFG_STR,          CALLBACK_GETTER(stamldcfg_get)),
+        ELEMENT(DE_STAMLDCFG_NSTR,         CALLBACK_GETTER(stamldcfg_get)),
+        ELEMENT(DE_AFFSTA_TABLE,           CALLBACK_GETTER(affsta_tget)),
+        ELEMENT(DE_AFFSTA_MACADDR,         CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_BSSID,           CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_BYTESSNT,        CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_BYTESRCV,        CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_PCKTSSNT,        CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_PCKTSRCV,        CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_ERRSSNT,         CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_SIGNALSTR,       CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_ESTMACDRDL,      CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_AFFSTA_ESTMACDRUL,      CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_STAMLD_AFFSTANOE,       CALLBACK_GETTER(affsta_get)),
+        ELEMENT(DE_BSTAMLD_MACADDR,        CALLBACK_GETTER(bstamld_get)),
+        ELEMENT(DE_BSTAMLD_BSSID,          CALLBACK_GETTER(bstamld_get)),
+        ELEMENT(DE_BSTAMLD_AFFBSTAS,       CALLBACK_GETTER(bstamld_get)),
+        ELEMENT(DE_BSTACFG_EMLMR,          CALLBACK_GETTER(bstacfg_get)),
+        ELEMENT(DE_BSTACFG_EMLSR,          CALLBACK_GETTER(bstacfg_get)),
+        ELEMENT(DE_BSTACFG_STR,            CALLBACK_GETTER(bstacfg_get)),
+        ELEMENT(DE_BSTACFG_NSTR,           CALLBACK_GETTER(bstacfg_get)),
 
         ELEMENT(DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY,              CB(NULL, NULL, NULL, NULL, NULL, NULL)),
         ELEMENT(DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC,             CB(.get_handler = get_node_sync, .set_handler = set_node_sync, NULL, NULL, NULL, NULL)),
@@ -280,6 +317,7 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
 
     if (table_found == false) {
         memcpy(cb_table, &bus_default_data_cb.cb_func, sizeof(bus_callback_table_t));
+        return RETURN_ERR;
     }
 
     return RETURN_OK;
@@ -309,6 +347,7 @@ int tr_181_t::wfa_bus_register_namespace(char *full_namespace, bus_element_type_
     bus_error_t rc = get_bus_descriptor()->bus_reg_data_element_fn(&m_bus_handle, &dataElements, num_elements);
     if (rc != bus_error_success) {
         em_printfout("bus: bus_regDataElements failed:%s\n", full_namespace);
+        return RETURN_ERR;
     }
     em_printfout("bus: bus_regDataElements success:%s", full_namespace);
 
@@ -754,6 +793,94 @@ bus_error_t tr_181_t::affap_tget(char *event_name, raw_data_t *p_data, bus_user_
     return bus_error_general;
 }
 
+bus_error_t tr_181_t::stamld_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->stamld_get(event_name, p_data);
+    }
+
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::stamld_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->stamld_tget(event_name, p_data);
+    }
+
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::wifi7caps_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->wifi7caps_get(event_name, p_data);
+    }
+
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::stamldcfg_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->stamldcfg_get(event_name, p_data);
+    }
+
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::affsta_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->affsta_get(event_name, p_data);
+    }
+
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::affsta_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->affsta_tget(event_name, p_data);
+    }
+
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::bstamld_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->bstamld_get(event_name, p_data);
+    }
+
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::bstacfg_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->bstacfg_get(event_name, p_data);
+    }
+
+    return bus_error_general;
+}
+
 bus_error_t tr_181_t::get_network_topology(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     p_data->data_type       = bus_data_type_string;
@@ -1019,6 +1146,13 @@ bool tr_181_t::schema_has_type(cJSON* schema, const char* want)
     return false;
 }
 
+bool tr_181_t::schema_is_deprecated(cJSON* schema)
+{
+    if (!schema) return false;
+
+    return cJSON_IsTrue(cJSON_GetObjectItem(schema, "deprecated"));
+}
+
 // ------------------------------------------------------------
 // Handle ANY property under an object: decide if TABLE or PROPERTY
 // ------------------------------------------------------------
@@ -1029,6 +1163,10 @@ void tr_181_t::handle_property_node(cJSON* root, const std::string& fullPath, cJ
     bus_callback_table_t cbTable = {};
     data_model_properties_t data_model_value;
     memset(&data_model_value, 0, sizeof(data_model_value));
+
+    // 0) If property is deprecated, do not bother
+    bool deprecated = schema_is_deprecated(propertySchema);
+    if (deprecated) return;
 
     // 1) follow top-level $ref / combiners if present
     cJSON* effective = follow_ref_if_any(root, propertySchema);

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -1690,6 +1690,26 @@ void dm_easy_mesh_t::string_to_macbytes(char *key, mac_address_t bmac)
 
 }
 
+void dm_easy_mesh_t::maclist_to_string(mac_address_t mac_list[], size_t mac_count, char *string, uint16_t str_len)
+{
+    uint8_t idx = 0;
+
+    if (mac_list == NULL) {
+        return;
+    }
+
+    while (str_len >= sizeof(mac_addr_str_t) && idx < mac_count) {
+        dm_easy_mesh_t::macbytes_to_string(mac_list[idx], string);
+        string += (sizeof(mac_addr_str_t) - 1);
+        str_len -= sizeof(mac_addr_str_t);
+        if (++idx >= mac_count || str_len == 0) {
+            break;
+        }
+        *string = ',';
+        ++string;
+    }
+}
+
 void dm_easy_mesh_t::securitymode_to_str(unsigned short mode, char *sec_mode_str, size_t len)
 {
     if (mode == EM_AUTH_OPEN)


### PR DESCRIPTION
Reason for change: Getters, setters and methods of WFA datamodel
  parameters are needed for TR-181.
Test Procedure: (RDKB) rbuscli may be used to get parameters
Risks: Low