### PR TITLE
RDKBWIFI-336 : Operating Channel Report is received before the Orchestration executes dm_orch_type_channel_cnf and moves to em_state_ctrl_channel_cnf_pending state

### DIFF
--- a/src/cmd/em_cmd_em_config.cpp
+++ b/src/cmd/em_cmd_em_config.cpp
@@ -42,10 +42,10 @@ em_cmd_em_config_t::em_cmd_em_config_t(em_cmd_params_t param, dm_easy_mesh_t& dm
     m_type = em_cmd_type_em_config;
     memcpy(&m_param, &param, sizeof(em_cmd_params_t));
 
-	memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+    memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
 
     m_orch_op_idx = 0;
-    m_num_orch_desc = 10;
+    m_num_orch_desc = 9;
     m_orch_desc[0].op = dm_orch_type_bss_delete;
     m_orch_desc[0].submit = false;
     m_orch_desc[1].op = dm_orch_type_topo_sync;
@@ -56,16 +56,14 @@ em_cmd_em_config_t::em_cmd_em_config_t(em_cmd_params_t param, dm_easy_mesh_t& dm
     m_orch_desc[3].submit = true;
     m_orch_desc[4].op = dm_orch_type_channel_sel;
     m_orch_desc[4].submit = true;
-    m_orch_desc[5].op = dm_orch_type_channel_cnf;
+    m_orch_desc[5].op = dm_orch_type_policy_cfg;
     m_orch_desc[5].submit = true;
-    m_orch_desc[6].op = dm_orch_type_policy_cfg;
+    m_orch_desc[6].op = dm_orch_type_channel_scan_req;
     m_orch_desc[6].submit = true;
-	m_orch_desc[7].op = dm_orch_type_channel_scan_req;
-    m_orch_desc[7].submit = true;
-	m_orch_desc[8].op = dm_orch_type_topo_update;
-    m_orch_desc[8].submit = false;
-    m_orch_desc[9].op =dm_orch_type_topo_publish;
-    m_orch_desc[9].submit = true;
+    m_orch_desc[7].op = dm_orch_type_topo_update;
+    m_orch_desc[7].submit = false;
+    m_orch_desc[8].op =dm_orch_type_topo_publish;
+    m_orch_desc[8].submit = true;
 
     strncpy(m_name, "em_config", strlen("em_config") + 1);
     m_svc = em_service_type_ctrl;

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -1304,7 +1304,7 @@ int em_channel_t::handle_op_channel_report(unsigned char *buff, unsigned int len
     dm_easy_mesh_t::macbytes_to_string(ruid, ruid_str);
     em_t *radio_em = reinterpret_cast<em_t *>(hash_map_get(get_mgr()->m_em_map, ruid_str));
     if (radio_em) {
-        if(radio_em->get_state() == em_state_ctrl_channel_cnf_pending){
+        if(radio_em->get_state() == em_state_ctrl_channel_selected){
             radio_em->set_state(em_state_ctrl_configured);
             em_printfout("Set em_state_ctrl_configured for radio %s", ruid_str);
         }

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -159,8 +159,6 @@ void em_t::orch_execute(em_cmd_t *pcmd)
                 m_sm.set_state(em_state_ctrl_channel_query_pending);
             } else if ((pcmd->get_orch_op() == dm_orch_type_channel_sel) && (m_sm.get_state() == em_state_ctrl_channel_queried)) {
                 m_sm.set_state(em_state_ctrl_channel_select_pending);
-            } else if ((pcmd->get_orch_op() == dm_orch_type_channel_cnf) && (m_sm.get_state() == em_state_ctrl_channel_selected)) {
-                m_sm.set_state(em_state_ctrl_channel_cnf_pending);
             } else if ((pcmd->get_orch_op() == dm_orch_type_policy_cfg) && (m_sm.get_state() == em_state_ctrl_configured)) {
                 m_sm.set_state(em_state_ctrl_set_policy_pending);
             } else if ((pcmd->get_orch_op() == dm_orch_type_channel_scan_req) && (m_sm.get_state() == em_state_ctrl_configured)) {

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -181,8 +181,6 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
                 return true;
             } else if (em->get_state() == em_state_ctrl_channel_queried) {
                 return true;
-            } else if (em->get_state() == em_state_ctrl_channel_selected) {
-                return true;
             } else if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             } else if (em->get_state() == em_state_ctrl_wsc_m2_sent) {


### PR DESCRIPTION

Changes:
    Removed the separate orchestration type for confirm pending.
    Update the state to configured after operating channel report is received
    and the em state is channel_selected