### PR TITLE
RDKBWIFI-354 : Send policy config only if all radios are in policy config pending state

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -571,7 +571,6 @@ public:
 	 * This function processes the M2 transmission event and updates the command array accordingly.
 	 *
 	 * @param[in] evt Pointer to the event structure containing the M2 transmission details.
-	 * @param[in] evt_status Indicates if the same event for this command type is already executing.
 	 * @param[out] cmd Array of command pointers to be updated based on the event analysis.
 	 *
 	 * @returns int Status code indicating success or failure of the analysis.
@@ -580,7 +579,7 @@ public:
 	 *
 	 * @note Ensure that the event and command pointers are valid before calling this function.
 	 */
-	int analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *cmd[], bool evt_status);
+	int analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *cmd[]);
     
 	/**!
 	 * @brief Analyzes the station association event.

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -209,14 +209,13 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     return num;
 }
 
-int dm_easy_mesh_ctrl_t::analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *pcmd[], bool evt_status)
+int dm_easy_mesh_ctrl_t::analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     mac_addr_str_t  radio_str, al_str;
     em_bus_event_type_m2_tx_params_t *params;
     int num = 0;
     dm_easy_mesh_t  dm;
     em_cmd_t *tmp;
-    em_orch_desc_t desc;
 
     if (evt == NULL) {
         printf("%s:%d: NULL event\n", __func__, __LINE__);
@@ -234,22 +233,6 @@ int dm_easy_mesh_ctrl_t::analyze_m2_tx(em_bus_event_t *evt, em_cmd_t *pcmd[], bo
     pcmd[num] = new em_cmd_em_config_t(evt->params, dm);
     tmp = pcmd[num];
     num++;
-
-    em_printfout("type: %s, cmd ip: :%d", em_cmd_t::get_bus_event_type_str(evt->type), evt_status);
-    // If event_status is true, this command type is already in progress.
-    // This event is generated per radio on the device, but for orchestration
-    // types like policy, we should not re-create or re-send the command.
-    // Therefore, if event_status is true, skip policy orchestration and send
-    // the command only once, even if multiple M2 TX events are received.
-    if (evt_status == true) {
-        for (unsigned int i = 0; i < pcmd[num - 1]->m_num_orch_desc; i++) {
-            if (pcmd[num - 1]->m_orch_desc[i].op == dm_orch_type_policy_cfg) {
-                desc.submit = false;
-                pcmd[num - 1]->override_op(i, &desc);
-                break;
-            }
-        }
-    }
 
     while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
         tmp = pcmd[num];

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -232,7 +232,7 @@ void em_ctrl_t::handle_m2_tx(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     int num;
     
-    if ((num = m_data_model.analyze_m2_tx(evt, pcmd, m_orch->is_cmd_type_in_progress(evt))) > 0) {
+    if ((num = m_data_model.analyze_m2_tx(evt, pcmd)) > 0) {
         m_orch->submit_commands(pcmd, static_cast<unsigned int> (num));
     }
 }

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -721,8 +721,61 @@ void em_policy_cfg_t::process_ctrl_state()
 {
     switch (get_state()) {
 		case em_state_ctrl_set_policy_pending:
-        	send_policy_cfg_request_msg();
-			set_state(em_state_ctrl_configured);
+            {
+                em_printfout("Processing set policy pending state for radio %s", util::mac_to_string(get_radio_interface_mac()).c_str());
+                std::vector<em_t *> em_radios;
+                dm_easy_mesh_t *dm = get_data_model();
+
+                get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
+                for (auto &em : em_radios)
+                {
+                    // Check for null em pointer in vector
+                    if (em == NULL) {
+                        em_printfout("Warning: Null em pointer in vector, skipping");
+                        continue;
+                    }
+                    if (em->get_state() != em_state_ctrl_set_policy_pending)
+                    {
+                        em_printfout("radio %s is in state:%s, not in em_state_ctrl_set_policy_pending",
+                                     util::mac_to_string(em->get_radio_interface_mac()).c_str(),  em_t::state_2_str(em->get_state()));
+                        em_radios.clear();
+                        return;
+                    }
+                }
+                // If all radios are in set policy pending state, send policy config request on one of them,
+                // ignore sending policy config request on other radios
+                if (!em_radios.empty() && this == em_radios.front())
+                {
+                    em_printfout("Sending the Policy config request message to agent al_mac:%s on radio: %s",
+                                 util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
+                                 util::mac_to_string(get_radio_interface_mac()).c_str());
+                    em_t *al_em = get_mgr()->get_al_node();
+
+                    // Send policy config request and check for errors
+                    int send_result = send_policy_cfg_request_msg();
+                    if (send_result < 0) {
+                        em_printfout("Error: Failed to send policy config request message");
+                        return;
+                    } else {
+                        em_printfout("Policy config request sent successfully, bytes: %d", send_result);
+                    }
+
+                    // Set state for AL node to configured
+                    al_em->set_state(em_state_ctrl_configured);
+                    em_printfout("Set AL node state to configured");
+                    // Set state for all radios to Configured state
+                    for (auto &em : em_radios)
+                    {
+                        if (em != NULL)
+                        {
+                            em->set_state(em_state_ctrl_configured);
+                            em_printfout("Set radio %s state to configured",
+                                        util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                        }
+                    }
+                }
+                em_radios.clear();
+            }
             break;
 
         default:


### PR DESCRIPTION
Currently, the system sends a policy configuration request as soon as any one radio finishes channel selection. Its better practice to have request sent out after all radios have:
 1. Completed channel selection, and
 2. Moved to the policy_config_pending state.

Changes behaviour:
- The system should wait for all radios to complete channel selection.
- Only when every radio is in the policy_config_pending state should the policy configuration request be sent.