### PR TITLE
RDKBWIFI-356 : Easymesh - Fix topo sync pending issue with latest tip

### DIFF
--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -923,7 +923,7 @@ int em_configuration_t::create_tid_to_link_map_policy_tlv(unsigned char *buff)
 
 int em_configuration_t::send_topology_response_msg(unsigned char *dst, unsigned short msg_id)
 {
-    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char buff[MAX_EM_BUFF_SZ + MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
     unsigned short  msg_type = em_msg_type_topo_resp;
     unsigned int len = 0;


### PR DESCRIPTION
RDKBWIFI-356 : Easymesh - Fix topo sync pending issue with latest tip

Reason for change: Increased buffer size in send_topology_response_msg to prevent buffer overflow. With existing buffer size, buffer over flow happens and packet is being discarded by the ieee1905.  
Test Procedure: Ensure send_topology_response_msg is sent successful from agent to controller.  
Risks: Medium
Priority: P1