### PR TITLE
RDKBWIFI-346: vlan id info does not show properly with network topology graph on rdkb cli

### DIFF
--- a/src/ctrl/em_network_topo.cpp
+++ b/src/ctrl/em_network_topo.cpp
@@ -66,6 +66,10 @@ void em_network_topo_t::encode(cJSON *parent)
 							m_data_model->m_radio[i].m_radio_info.id.ruid, sizeof(mac_address_t)) == 0) {
 				bss_obj = cJSON_CreateObject();
 				m_data_model->m_bss[j].encode(bss_obj, true);
+				const em_network_ssid_info_t* network_ssid_info = m_data_model->get_network_ssid_info_by_haul_type(m_data_model->m_bss[j].m_bss_info.id.haul_type);
+				if (network_ssid_info != NULL) {
+				    cJSON_AddNumberToObject(bss_obj, "VlanID", network_ssid_info->vlan_id);
+				}
 				sta_list_obj = cJSON_AddArrayToObject(bss_obj, "STAList");
 				dm_easy_mesh_ctrl_t *dm_ctrl = reinterpret_cast<dm_easy_mesh_ctrl_t *>(em_ctrl_t::get_em_ctrl_instance()->get_data_model(GLOBAL_NET_ID));
 				if (dm_ctrl != NULL) {

--- a/src/dm/dm_bss.cpp
+++ b/src/dm/dm_bss.cpp
@@ -222,7 +222,6 @@ void dm_bss_t::encode(cJSON *obj, bool summary)
     cJSON_AddBoolToObject(obj, "Enabled", m_bss_info.enabled);
     cJSON_AddStringToObject(obj, "TimeStamp", m_bss_info.timestamp);
     cJSON_AddNumberToObject(obj, "VapMode", m_bss_info.vap_mode);
-    cJSON_AddNumberToObject(obj, "VlanID", m_bss_info.vlan_id);
     
 	if (summary == true) {
         return;

--- a/src/rdkb-cli/static/script.js
+++ b/src/rdkb-cli/static/script.js
@@ -2215,7 +2215,7 @@ async handleWebSocketMessage(data) {
         .map(bss => {
           const bandLabel = bss.Band === 0 ? '2.4GHz' :
             bss.Band === 1 ? '5GHz' :
-            bss.Band === 2 ? '6GHz' : 'Unknown';
+            bss.Band === 3 ? '6GHz' : 'Unknown';
 
             if (bss.MLDAddr && bss.MLDAddr !== "") {
               if (!mldMap.has(bss.MLDAddr)) {


### PR DESCRIPTION
Corrected the bsslist encode function to get the vlan from networkssidList
verified the vlan ID showing correctly on network topology graph after the fix.