### PR TITLE
RDKBWIFI-362 : Add channel preference support while handling channel preference report

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -174,6 +174,11 @@ extern "C"
 /* Channel Preference Flags*/
 #define EM_CH_PREF_NON_OPERABLE 0x00
 
+/* Flags indicating whether a channel preference entry
+   is considered valid or invalid */
+#define EM_CH_PREF_ENTRY_VALID      0x01
+#define EM_CH_PREF_ENTRY_INVALID    0x00
+
 #define EM_MAX_BANDS    3
 #define EM_MAX_BSSS     EM_MAX_BANDS*8  
 #define EM_MAX_AKMS     10
@@ -2311,6 +2316,8 @@ typedef struct {
     int max_tx_power;
     unsigned int    num_channels;
     unsigned int    channels[EM_MAX_CHANNELS_IN_LIST];
+    unsigned char   channel_pref[EM_MAX_CHANNELS_IN_LIST];
+    bool            pref_valid;
     unsigned short	mins_since_cac_comp;
 	unsigned short	sec_remain_non_occ_dur;
 	unsigned int	countdown_cac_comp;

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -962,7 +962,7 @@ dm_op_class_t *dm_easy_mesh_list_t::get_op_class(const char *key)
 	
     dm = static_cast<dm_easy_mesh_t *> (hash_map_get_first(m_list));
     while (dm != NULL) {
-        if (id.type <= em_op_class_type_capability) {
+        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference) {
 		    for (i = 0; i < dm->get_num_radios(); i++) {
 			    radio = dm->get_radio(i);
 			    if (memcmp(radio->m_radio_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) {
@@ -1078,7 +1078,7 @@ void dm_easy_mesh_list_t::put_op_class(const char *key, const dm_op_class_t *op_
 	// find the dm that has this radio
     dm = static_cast<dm_easy_mesh_t *> (hash_map_get_first(m_list));
     while (dm != NULL) {
-        if (id.type <= em_op_class_type_capability) {
+        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference) {
             for (i = 0; i < dm->get_num_radios(); i++) {
                 radio = dm->get_radio(i);
                 dm_easy_mesh_t::macbytes_to_string(radio->m_radio_info.intf.mac, mac_str);
@@ -1548,12 +1548,12 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
     unsigned int i;
     bool colocated = false;
 	dm_op_class_t	op_class[EM_MAX_PRE_SET_CHANNELS] 	= 	{
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 81}, 81, 0, 0, 0, 1, {6}, 0, 0, 0}), 
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 115}, 115, 0, 0, 0, 1, {36}, 0, 0, 0}), 
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 135}, 135, 0, 0, 0, 1, {1}, 0, 0, 0}),
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 81}, 81, 0, 0, 0, 3, {3, 6, 9}, 0, 0, 0}),
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 115}, 115, 0, 0, 0, 9, {36, 40, 44, 48, 149, 153, 157, 161, 165}, 0, 0, 0}),
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 135}, 135, 0, 0, 0, 1, {1}, 0, 0, 0})
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 81}, 81, 0, 0, 0, 1, {6}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 115}, 115, 0, 0, 0, 1, {36},{0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 135}, 135, 0, 0, 0, 1, {1}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 81}, 81, 0, 0, 0, 3, {3, 6, 9},{0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 115}, 115, 0, 0, 0, 9, {36, 40, 44, 48, 149, 153, 157, 161, 165}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 135}, 135, 0, 0, 0, 1, {1}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0})
 									};
 	dm_policy_t	policy[] = {
 								dm_policy_t(em_policy[0]), dm_policy_t(em_policy[1]), 

--- a/src/dm/dm_op_class.cpp
+++ b/src/dm/dm_op_class.cpp
@@ -153,6 +153,7 @@ bool dm_op_class_t::operator == (const dm_op_class_t& obj)
 						(this->m_op_class_info.id.type == em_op_class_type_scan_param)) {
         ret += !(this->m_op_class_info.num_channels == obj.m_op_class_info.num_channels);
         ret += (memcmp(this->m_op_class_info.channels, obj.m_op_class_info.channels, sizeof(unsigned int) * EM_MAX_CHANNELS_IN_LIST) != 0);
+        ret += (memcmp(this->m_op_class_info.channel_pref, obj.m_op_class_info.channel_pref, sizeof(unsigned char) * EM_MAX_CHANNELS_IN_LIST) != 0);
 	} 
      
     if (ret > 0)
@@ -173,11 +174,11 @@ void dm_op_class_t::operator = (const dm_op_class_t& obj)
     this->m_op_class_info.max_tx_power = obj.m_op_class_info.max_tx_power;
     this->m_op_class_info.num_channels = obj.m_op_class_info.num_channels;
     memcpy(this->m_op_class_info.channels, obj.m_op_class_info.channels, sizeof(unsigned int) * EM_MAX_CHANNELS_IN_LIST);
+    memcpy(this->m_op_class_info.channel_pref, obj.m_op_class_info.channel_pref, sizeof(unsigned char) * EM_MAX_CHANNELS_IN_LIST);
+    this->m_op_class_info.pref_valid = obj.m_op_class_info.pref_valid;
     this->m_op_class_info.mins_since_cac_comp = obj.m_op_class_info.mins_since_cac_comp;
     this->m_op_class_info.sec_remain_non_occ_dur = obj.m_op_class_info.sec_remain_non_occ_dur;
     this->m_op_class_info.countdown_cac_comp = obj.m_op_class_info.countdown_cac_comp;
-    this->m_op_class_info.num_channels = obj.m_op_class_info.num_channels;
-    memcpy(this->m_op_class_info.channels, obj.m_op_class_info.channels, sizeof(unsigned int) * EM_MAX_CHANNELS_IN_LIST);
 }
 
 int dm_op_class_t::parse_op_class_id_from_key(const char *key, em_op_class_id_t *id)

--- a/src/dm/dm_op_class_list.cpp
+++ b/src/dm/dm_op_class_list.cpp
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <unistd.h>
+#include <util.h>
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <linux/filter.h>
@@ -241,6 +242,7 @@ int dm_op_class_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, voi
     mac_addr_str_t mac_str;
     em_long_string_t id;
     em_2xlong_string_t channels_str = {0};
+    em_2xlong_string_t pref_str = {0};
     char tmp[8];
     em_op_class_info_t *info = static_cast<em_op_class_info_t *>(data);
     int ret = 0;
@@ -249,22 +251,33 @@ int dm_op_class_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, voi
     dm_easy_mesh_t::macbytes_to_string(info->id.ruid, mac_str);
     snprintf(id, sizeof(id), "%s@%d@%d", mac_str, info->id.type, info->id.op_class);
     //printf("%s:%d: Operation:%d, id:%s\tClass: %d Channel:%d\n", __func__, __LINE__, op, id, info->op_class, info->channel);
-
+    //Storing channels and its preferences as comma separated string in db.
 	for (i = 0; i < info->num_channels; i++) {
 		snprintf(tmp, sizeof(tmp), "%d,", info->channels[i]);
 		snprintf(channels_str + strlen(channels_str), sizeof(channels_str) - strlen(channels_str), "%s", tmp);
+        if (info->id.type == em_op_class_type_preference) {
+        	snprintf(tmp, sizeof(tmp), "%d,", info->channel_pref[i]);
+        	snprintf(pref_str + strlen(pref_str), sizeof(pref_str) - strlen(pref_str), "%s", tmp);
+        }
 	}
+    if (info->id.type != em_op_class_type_preference) {
+        info->pref_valid = EM_CH_PREF_ENTRY_VALID;
+    }
 	if (strlen(channels_str) > 0) {
 		channels_str[strlen(channels_str) - 1] = 0;
 	}
+
+    if (strlen(pref_str) > 0) {
+        pref_str[strlen(pref_str) - 1] = 0;
+    }
     switch (op) {
         case dm_orch_type_db_insert:
-            ret = insert_row(db_client, id, info->op_class, info->channel, channels_str, info->tx_power, info->max_tx_power,
+            ret = insert_row(db_client, id, info->op_class, info->channel, channels_str, pref_str, info->pref_valid, info->tx_power, info->max_tx_power,
                                            info->mins_since_cac_comp, info->sec_remain_non_occ_dur, info->countdown_cac_comp);
             break;
 
 	    case dm_orch_type_db_update:
-            ret = update_row(db_client, info->op_class, info->channel, channels_str, info->tx_power, info->max_tx_power, 
+            ret = update_row(db_client, info->op_class, info->channel, channels_str, pref_str, info->pref_valid, info->tx_power, info->max_tx_power,
                                        info->mins_since_cac_comp, info->sec_remain_non_occ_dur, info->countdown_cac_comp, id);
             break;
 
@@ -311,25 +324,54 @@ int dm_op_class_list_t::sync_db(db_client_t& db_client, void *ctx)
         dm_op_class_t::parse_op_class_id_from_key(id, &info.id);
         info.op_class = static_cast<short unsigned int>(db_client.get_number(ctx, 2));
         info.channel = static_cast<short unsigned int>(db_client.get_number(ctx, 3));
-        
-		db_client.get_string(ctx, str, 4);
-		for (i = 0; i < EM_MAX_CHANNELS_IN_LIST; i++) {
+
+        db_client.get_string(ctx, str, 4);
+        for (i = 0; i < EM_MAX_CHANNELS_IN_LIST; i++) {
             token_parts[i] = ch_str[i];
         }
 
-		if (*str != 0) {
-			info.num_channels = static_cast<unsigned int>(get_strings_by_token(str, ',', EM_MAX_CHANNELS_IN_LIST, token_parts));
-			for (i = 0; i < info.num_channels; i++) {
-				info.channels[i] = static_cast<unsigned int>(atoi(token_parts[i]));
-			}
-		}
+        if (*str != 0) {
+            info.num_channels = static_cast<unsigned int>(get_strings_by_token(str, ',', EM_MAX_CHANNELS_IN_LIST, token_parts));
+            for (i = 0; i < info.num_channels; i++)
+            {
+                info.channels[i] = static_cast<unsigned int>(atoi(token_parts[i]));
+            }
+        }
 
-        info.tx_power = db_client.get_number(ctx, 5);
-        info.max_tx_power = db_client.get_number(ctx, 6);
+        // Sync DB for preference of each channel in op classs.
+        // This is only applicable for preference type of op class.
+        // For other types, set preference as valid but with 0 preference value.
+        if (info.id.type == em_op_class_type_preference)
+        {
+            db_client.get_string(ctx, str, 5);
+            for (i = 0; i < EM_MAX_CHANNELS_IN_LIST; i++) {
+                token_parts[i] = ch_str[i];
+            }
 
-        info.mins_since_cac_comp = static_cast<short unsigned int>(db_client.get_number(ctx, 7));
-        info.sec_remain_non_occ_dur = static_cast<short unsigned int>(db_client.get_number(ctx, 8));
-        info.countdown_cac_comp = static_cast<unsigned int>(db_client.get_number(ctx, 9));
+            if (*str != 0) {
+                unsigned int num_of_pref = static_cast<unsigned int>(get_strings_by_token(str, ',', EM_MAX_CHANNELS_IN_LIST, token_parts));
+                if (num_of_pref != info.num_channels)
+                {
+                    em_printfout("ERROR: Number of preferences %d does not match number of channels %d for op class %d\n",
+                                 num_of_pref, info.num_channels, info.op_class);
+                }
+                for (i = 0; i < num_of_pref; i++)
+                {
+                    info.channel_pref[i] = static_cast<unsigned char>(atoi(token_parts[i]));
+                }
+            }
+            info.pref_valid = static_cast<short unsigned int>(db_client.get_number(ctx, 6));
+        } else {
+            memset(info.channel_pref, 0, sizeof(info.channel_pref));
+            info.pref_valid = EM_CH_PREF_ENTRY_VALID;
+        }
+
+        info.tx_power = db_client.get_number(ctx, 7);
+        info.max_tx_power = db_client.get_number(ctx, 8);
+
+        info.mins_since_cac_comp = static_cast<short unsigned int>(db_client.get_number(ctx, 9));
+        info.sec_remain_non_occ_dur = static_cast<short unsigned int>(db_client.get_number(ctx, 10));
+        info.countdown_cac_comp = static_cast<unsigned int>(db_client.get_number(ctx, 11));
 
         update_list(dm_op_class_t(&info), dm_orch_type_db_insert);
     }
@@ -345,11 +387,12 @@ void dm_op_class_list_t::init_table()
 void dm_op_class_list_t::init_columns()
 {
     m_num_cols = 0;
-
     m_columns[m_num_cols++] = db_column_t("ID", db_data_type_char, 32);
     m_columns[m_num_cols++] = db_column_t("Class", db_data_type_int, 0);
     m_columns[m_num_cols++] = db_column_t("Channel", db_data_type_int, 0);
-    m_columns[m_num_cols++] = db_column_t("ChannelList", db_data_type_text, sizeof(em_2xlong_string_t));
+    m_columns[m_num_cols++] = db_column_t("ChannelList", db_data_type_varchar, 256);
+    m_columns[m_num_cols++] = db_column_t("ChannelPreferenceList", db_data_type_varchar, 256);
+    m_columns[m_num_cols++] = db_column_t("PrefValidity", db_data_type_int, 0);
     m_columns[m_num_cols++] = db_column_t("TxPower", db_data_type_int, 0);
     m_columns[m_num_cols++] = db_column_t("MaxTxPower", db_data_type_int, 0);
     m_columns[m_num_cols++] = db_column_t("Minutes", db_data_type_int, 0);

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -67,7 +67,7 @@ short em_channel_t::create_channel_pref_tlv_agent(unsigned char *buff, unsigned 
     for (i = 0; i < dm->m_num_opclass; i++) {
 	op_class = &dm->m_op_class[i];
     if (((memcmp(op_class->m_op_class_info.id.ruid, pref->ruid, sizeof(mac_address_t)) == 0) &&
-         (op_class->m_op_class_info.id.type == em_op_class_type_capability)) == false) {
+         (op_class->m_op_class_info.id.type == em_op_class_type_preference)) == false) {
         continue;
     }
 
@@ -219,7 +219,7 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
                     (op_class->m_op_class_info.id.type == em_op_class_type_anticipated)) == false) {
             continue;
         }
-        
+
         pref_op_class->op_class = static_cast<unsigned char> (op_class->m_op_class_info.op_class);
         num_of_channel = op_class->m_op_class_info.num_channels;
         channel_list = &pref_op_class->channels;
@@ -1394,64 +1394,102 @@ int em_channel_t::handle_spatial_reuse_report(unsigned char *buff, unsigned int 
     return 0;
 }
 
-
 int em_channel_t::handle_channel_pref_tlv_ctrl(unsigned char *buff, unsigned int len)
 {
-    em_channel_pref_t   *pref = reinterpret_cast<em_channel_pref_t *> (buff);
-    em_channel_pref_op_class_t *channel_pref;
+    em_channel_pref_t *pref = reinterpret_cast<em_channel_pref_t *>(buff);
     unsigned int i = 0, j = 0;
-	bool match_found = false;
-    em_op_class_info_t      op_class_info[EM_MAX_OP_CLASS];
+    bool match_found = false;
+    em_op_class_info_t op_class_info[EM_MAX_OP_CLASS];
     em_op_class_info_t *pop_class_info;
     dm_easy_mesh_t *dm;
 
     dm = get_data_model();
-    em_device_info_t    *device = dm->get_device_info();
 
-	channel_pref = pref->op_classes;
-	memcpy(op_class_info[i].id.ruid, pref->ruid, sizeof(mac_address_t));
-	for (i = 0; i < pref->op_classes_num; i++) {
-		memset(&op_class_info[i], 0, sizeof(em_op_class_info_t));
-		memcpy(op_class_info[i].id.ruid, device->intf.mac, sizeof(mac_address_t));
-		op_class_info[i].id.type = em_op_class_type_preference;
-		op_class_info[i].op_class = static_cast<unsigned int> (channel_pref->op_class);
-		op_class_info[i].id.op_class = op_class_info[i].op_class;
-		op_class_info[i].num_channels = static_cast<unsigned int> (channel_pref->num);
-		for (j = 0; j < op_class_info[i].num_channels; j++) {
-			op_class_info[i].channels[j] = static_cast<unsigned int > (channel_pref->channels.channel[j]);
-		}
-		channel_pref = reinterpret_cast<em_channel_pref_op_class_t *> (reinterpret_cast<unsigned char *> (channel_pref) + sizeof(em_channel_pref_op_class_t) +
-				op_class_info[i].num_channels + sizeof(unsigned char));
-		//printf("%s:%d op class: %d\tAnticipated Channels: %d\n", __func__, __LINE__, 
-				//op_class_info[i].op_class, op_class_info[i].num_anticipated_channels);
-	}
-	
-	for (i = 0; i < pref->op_classes_num; i++) {
-		for (j = 0; j < dm->get_num_op_class(); j++) {
-			pop_class_info = &dm->m_op_class[j].m_op_class_info;
+    // Parse the received TLV
+    unsigned char *ptr = reinterpret_cast<unsigned char *>(pref->op_classes);
+    for (i = 0; i < pref->op_classes_num && (i < EM_MAX_OP_CLASS); i++) {
+        em_channel_pref_op_class_t *op_class_hdr = reinterpret_cast<em_channel_pref_op_class_t *>(ptr);
+        memset(&op_class_info[i], 0, sizeof(em_op_class_info_t));
+        memcpy(op_class_info[i].id.ruid, pref->ruid, sizeof(mac_address_t));
+        op_class_info[i].id.type = em_op_class_type_preference;
+        op_class_info[i].op_class = static_cast<unsigned int>(op_class_hdr->op_class);
+        op_class_info[i].id.op_class = op_class_info[i].op_class;
+        op_class_info[i].num_channels = static_cast<unsigned int>(op_class_hdr->num);
 
-			if ((memcmp(pop_class_info->id.ruid, op_class_info[i].id.ruid, sizeof(mac_address_t)) == 0) &&
-						(pop_class_info->id.type == op_class_info[i].id.type) &&
-						(pop_class_info->id.op_class == op_class_info[i].id.op_class)) {
-				match_found = true;
-				break;
-			}
-		}
+        unsigned char *chan_ptr = ptr + sizeof(em_channel_pref_op_class_t);
+        unsigned char *pref_bits_ptr = ptr + sizeof(em_channel_pref_op_class_t) + op_class_info[i].num_channels;
 
-		if (match_found == true) {
-			match_found = false;
-			continue;
-		}
-		
-		pop_class_info = &dm->m_op_class[dm->get_num_op_class()].m_op_class_info;
-		memcpy(pop_class_info, &op_class_info[i], sizeof(em_op_class_info_t));
-		dm->set_num_op_class(dm->get_num_op_class() + 1);
-		dm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
-		dm->set_db_cfg_param(db_cfg_type_radio_list_update, "");
-	}
+        for (j = 0; j < op_class_info[i].num_channels; j++) {
+            op_class_info[i].channels[j] = *chan_ptr;
+            op_class_info[i].channel_pref[j] = *pref_bits_ptr;
+            chan_ptr++;
+        }
+
+        op_class_info[i].pref_valid = EM_CH_PREF_ENTRY_VALID;
+        // Advance pointer: header + channels + preference bits
+        ptr = pref_bits_ptr + 1;
+    }
+
+    //Update the parsed data to datamodel
+    for (i = 0; i < pref->op_classes_num; i++) {
+        match_found = false; //Flag if a valid preference entry for the RUID@OPCLASS is found
+        int first_invalid_idx = -1; //Stores the index of the first invalid entry in the datamodel
+
+        //Find the data model entry to update
+        for (j = 0; j < dm->get_num_op_class(); j++) {
+            pop_class_info = &dm->m_op_class[j].m_op_class_info;
+
+            // Check for existing valid entry with same RUID, preference and op class value
+            // then append the channel and preference information parsed.
+            if (pop_class_info->pref_valid == EM_CH_PREF_ENTRY_VALID &&
+                pop_class_info->id.type == op_class_info[i].id.type &&
+                pop_class_info->id.op_class == op_class_info[i].id.op_class &&
+                memcmp(pop_class_info->id.ruid, op_class_info[i].id.ruid, sizeof(mac_address_t)) == 0) {
+
+                unsigned int added_channels_count = 0;
+                for (added_channels_count = 0; (added_channels_count < op_class_info[i].num_channels) &&
+                            ((pop_class_info->num_channels + added_channels_count) < EM_MAX_CHANNELS_IN_LIST); added_channels_count++) {
+                    pop_class_info->channels[pop_class_info->num_channels + added_channels_count] = op_class_info[i].channels[added_channels_count];
+                    pop_class_info->channel_pref[pop_class_info->num_channels + added_channels_count] = op_class_info[i].channel_pref[added_channels_count];
+                }
+
+                // only increment by appended count, if exceeds max channels in list then remaining channels are dropped.
+                pop_class_info->num_channels += added_channels_count;
+                match_found = true;
+
+                break;
+            }
+            else if (first_invalid_idx == -1 && pop_class_info->pref_valid == EM_CH_PREF_ENTRY_INVALID && pop_class_info->id.type == em_op_class_type_preference) {
+                // Store the index of first invalid preference entry in the datamodel
+                first_invalid_idx = j;
+            }
+        }
+        if (!match_found && first_invalid_idx != -1)
+        {
+            // Existing valid entry for the RUID@OPCLASS not found.
+            // Update the first invalid index with new valid data.
+            memcpy(&dm->m_op_class[first_invalid_idx].m_op_class_info, &op_class_info[i], sizeof(em_op_class_info_t));
+            continue;
+        }
+        else if (!match_found)
+        {
+            // Existing valid entry for the RUID@OPCLASS not found. No invalid preference row present
+            // Add new entry to the datamodel
+            if (dm->get_num_op_class() >= EM_MAX_OPCLASS) {
+                em_printfout("Max limit reached for op class entries in datamodel, cannot add more entries\n");
+                break;
+            }
+            pop_class_info = &dm->m_op_class[dm->get_num_op_class()].m_op_class_info;
+            memcpy(pop_class_info, &op_class_info[i], sizeof(em_op_class_info_t));
+            dm->set_num_op_class(dm->get_num_op_class() + 1);
+        }
+    }
+
+    //Update the database with the latest datamodel
+    dm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
+    dm->set_db_cfg_param(db_cfg_type_radio_list_update, "");
 
     return 0;
-
 }
 
 int em_channel_t::handle_eht_operations_tlv_ctrl(unsigned char *buff, unsigned int len)
@@ -1540,6 +1578,27 @@ int em_channel_t::handle_channel_pref_rprt(unsigned char *buff, unsigned int len
 {
     em_tlv_t    *tlv;
     int tlv_len;
+    em_op_class_info_t *pop_class_info;
+    std::vector<em_t*> em_radios;
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    //Invalidate all exisiting preference entries
+    get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
+    for (auto &em : em_radios)
+    {
+        for (unsigned int i = 0; i < dm->get_num_op_class(); i++)
+        {
+            pop_class_info = &dm->m_op_class[i].m_op_class_info;
+            // Check if entry belongs to this ruid and is a preference type
+            if ((memcmp(pop_class_info->id.ruid, em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) &&
+                (pop_class_info->id.type == em_op_class_type_preference))
+            {
+                // Mark as invalid by setting pref_valid to 0 for all radios
+                pop_class_info->pref_valid = EM_CH_PREF_ENTRY_INVALID;
+            }
+        }
+    }
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));


### PR DESCRIPTION
1. Update handling channel preference tlv Added logic to fetch the preference and store in DB Enhance db schema: add channelPreference and ValidEntry columns. Addec changes around the db handling to store and retreive the ChannelPreference and ValidEntry
2. Update Build of channel pref TLV in agent - Addec changes to create channel pref tlv using type em_op_class_type_preference
3. Some formatting fixes and cleanups.

These changes support storing and propagating per channel preference information for opclasses.