### PR TITLE
RDKBWIFI-379 : Update Channel Preference TLV creation in Channel selection request considering the Anticipated entries in DB

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -173,11 +173,15 @@ extern "C"
 
 /* Channel Preference Flags*/
 #define EM_CH_PREF_NON_OPERABLE 0x00
+#define EM_CH_PREF_MAX          0x0F
 
 /* Flags indicating whether a channel preference entry
    is considered valid or invalid */
 #define EM_CH_PREF_ENTRY_VALID      0x01
 #define EM_CH_PREF_ENTRY_INVALID    0x00
+
+/* Global MAC Address */
+static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
 #define EM_MAX_BANDS    3
 #define EM_MAX_BSSS     EM_MAX_BANDS*8  

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -200,7 +200,7 @@ public:
 	 * @note Ensure that the buffer is allocated with sufficient size before calling this function.
 	 */
 	short create_channel_pref_tlv(unsigned char *buff);
-    
+
 	/**!
 	 * @brief Creates an operating channel report TLV.
 	 *
@@ -343,7 +343,8 @@ public:
 	/**!
 	 * @brief Sends a channel selection request message.
 	 *
-	 * This function is responsible for initiating a request to select a specific channel.
+	 * This function is responsible for initiating a request to select a specific or from a list of channels.
+	 * The anticipated list is validated against agent's capability and preference.
 	 *
 	 * @returns int
 	 * @retval 0 on success
@@ -750,6 +751,15 @@ public:
 	 */
 	virtual em_freq_band_t get_band() = 0;
 
+	/**!
+	 * @brief Prepares a list of non-operable channels for the opclass,
+	 * reported by agent in capability and channel preference report.
+	 *
+	 * @param[in] op_class Operational class identifier.
+	 * @param[in] ruid Radio unique identifier (MAC address).
+	 * @returns std::vector<unsigned char> list of non-operable channels. Can be empty.
+	 */
+	std::vector<unsigned char> get_non_operable_channels(unsigned char op_class, const unsigned char *ruid);
     
 	/**!
 	 * @brief Constructor for em_channel_t.

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -962,7 +962,7 @@ dm_op_class_t *dm_easy_mesh_list_t::get_op_class(const char *key)
 	
     dm = static_cast<dm_easy_mesh_t *> (hash_map_get_first(m_list));
     while (dm != NULL) {
-        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference) {
+        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference || id.type == em_op_class_type_anticipated ) {
 		    for (i = 0; i < dm->get_num_radios(); i++) {
 			    radio = dm->get_radio(i);
 			    if (memcmp(radio->m_radio_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) {
@@ -974,11 +974,19 @@ dm_op_class_t *dm_easy_mesh_list_t::get_op_class(const char *key)
 			if (memcmp(dm->m_device.m_device_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) {
             	found_dm = true;
            	}
-		}	
-
-		if (found_dm == true) {
-			break;
 		}
+
+        if (found_dm == true) {
+            break;
+        } else {
+            if (((memcmp(dm->m_device.m_device_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) ||
+                (memcmp(EM_GLOBAL_MAC_ADDRESS, id.ruid, sizeof(mac_address_t)) == 0)) &&
+                (id.type == em_op_class_type_anticipated))
+            {
+                found_dm = true;
+                break;
+            }
+        }
         dm = static_cast<dm_easy_mesh_t *> (hash_map_get_next(m_list, dm));
 	}
 
@@ -1078,7 +1086,7 @@ void dm_easy_mesh_list_t::put_op_class(const char *key, const dm_op_class_t *op_
 	// find the dm that has this radio
     dm = static_cast<dm_easy_mesh_t *> (hash_map_get_first(m_list));
     while (dm != NULL) {
-        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference) {
+        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference || id.type == em_op_class_type_anticipated) {
             for (i = 0; i < dm->get_num_radios(); i++) {
                 radio = dm->get_radio(i);
                 dm_easy_mesh_t::macbytes_to_string(radio->m_radio_info.intf.mac, mac_str);
@@ -1097,6 +1105,9 @@ void dm_easy_mesh_list_t::put_op_class(const char *key, const dm_op_class_t *op_
             break;
         } else {
             if ((memcmp(dm->m_device.m_device_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) && (id.type >= em_op_class_type_cac_available)) {
+                found_dm = true;
+                break;
+            } else if ((memcmp(EM_GLOBAL_MAC_ADDRESS, id.ruid, sizeof(mac_address_t)) == 0) && (id.type == em_op_class_type_anticipated)) {
                 found_dm = true;
                 break;
             }
@@ -1548,9 +1559,9 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
     unsigned int i;
     bool colocated = false;
 	dm_op_class_t	op_class[EM_MAX_PRE_SET_CHANNELS] 	= 	{
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 81}, 81, 0, 0, 0, 1, {6}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 115}, 115, 0, 0, 0, 1, {36},{0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 135}, 135, 0, 0, 0, 1, {1}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 81}, 81, 0, 0, 0, 1, {6}, {0xe0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 115}, 115, 0, 0, 0, 1, {36},{0xe0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 135}, 135, 0, 0, 0, 1, {1}, {0xe0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 81}, 81, 0, 0, 0, 3, {3, 6, 9},{0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 115}, 115, 0, 0, 0, 9, {36, 40, 44, 48, 149, 153, 157, 161, 165}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 135}, 135, 0, 0, 0, 1, {1}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0})

--- a/src/dm/dm_op_class_list.cpp
+++ b/src/dm/dm_op_class_list.cpp
@@ -255,12 +255,12 @@ int dm_op_class_list_t::update_db(db_client_t& db_client, dm_orch_type_t op, voi
 	for (i = 0; i < info->num_channels; i++) {
 		snprintf(tmp, sizeof(tmp), "%d,", info->channels[i]);
 		snprintf(channels_str + strlen(channels_str), sizeof(channels_str) - strlen(channels_str), "%s", tmp);
-        if (info->id.type == em_op_class_type_preference) {
+        if (info->id.type == em_op_class_type_preference || info->id.type == em_op_class_type_anticipated) {
         	snprintf(tmp, sizeof(tmp), "%d,", info->channel_pref[i]);
         	snprintf(pref_str + strlen(pref_str), sizeof(pref_str) - strlen(pref_str), "%s", tmp);
         }
 	}
-    if (info->id.type != em_op_class_type_preference) {
+    if (info->id.type != em_op_class_type_preference && info->id.type != em_op_class_type_anticipated) {
         info->pref_valid = EM_CH_PREF_ENTRY_VALID;
     }
 	if (strlen(channels_str) > 0) {
@@ -339,9 +339,9 @@ int dm_op_class_list_t::sync_db(db_client_t& db_client, void *ctx)
         }
 
         // Sync DB for preference of each channel in op classs.
-        // This is only applicable for preference type of op class.
+        // This is only applicable for preference and anticipated type of op class.
         // For other types, set preference as valid but with 0 preference value.
-        if (info.id.type == em_op_class_type_preference)
+        if (info.id.type == em_op_class_type_preference || info.id.type == em_op_class_type_anticipated)
         {
             db_client.get_string(ctx, str, 5);
             for (i = 0; i < EM_MAX_CHANNELS_IN_LIST; i++) {

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -36,6 +36,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <map>
+#include <vector>
 #include <openssl/rand.h>
 #include "em.h"
 #include "em_msg.h"
@@ -204,52 +206,186 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
 {
     short len = 0;
     unsigned int i, j;
-    em_channel_pref_t       *pref;
-    em_channel_pref_op_class_t      *pref_op_class;
+    em_channel_pref_t *pref;
+    em_channel_pref_op_class_t *pref_op_class;
     dm_easy_mesh_t *dm;
-    dm_op_class_t   *op_class;
+    dm_op_class_t *op_class;
     unsigned char *tmp;
     unsigned char pref_bits = 0xee;
     unsigned int num_of_channel = 0;
     em_channels_list_t *channel_list;
-    em_device_info_t *device ;
+
+    //Stores a merged list of index of Anticipated entries for Global, Device or Radio ID
+    unsigned int merged_anticipated_opclass_idx[EM_MAX_OPCLASS] = {0};
+    bool merged_anticipated_is_ruid_based[EM_MAX_OPCLASS] = {0};
+    unsigned int merged_anticipated_opclass_count = 0;
 
     dm = get_data_model();
     pref = reinterpret_cast<em_channel_pref_t *> (buff);
     memcpy(pref->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
     pref_op_class = pref->op_classes;
     pref->op_classes_num = 0;
-    device = dm->get_device_info();
 
     tmp = reinterpret_cast<unsigned char *> (pref_op_class);
     len += static_cast<short unsigned int> (sizeof(em_channel_pref_t));
 
+    em_printfout("[CHANNEL_SEL] radio %s Creating channel preference TLV\n",
+                 util::mac_to_string(pref->ruid).c_str());
+
     for (i = 0; i < dm->m_num_opclass; i++) {
         op_class = &dm->m_op_class[i];
-        if (((memcmp(op_class->m_op_class_info.id.ruid, device->intf.mac, sizeof(mac_address_t)) == 0)     &&
-                    (op_class->m_op_class_info.id.type == em_op_class_type_anticipated)) == false) {
+
+        // Only handle anticipated entries for RUID, Device or for Global address for the Radio band
+        if (((op_class->m_op_class_info.id.type == em_op_class_type_anticipated) &&
+            ((memcmp(op_class->m_op_class_info.id.ruid, pref->ruid, sizeof(mac_address_t)) == 0) ||
+            (((memcmp(op_class->m_op_class_info.id.ruid, EM_GLOBAL_MAC_ADDRESS, sizeof(mac_address_t)) == 0) ||
+            (memcmp(op_class->m_op_class_info.id.ruid, dm->get_device()->get_dev_interface_mac(), sizeof(mac_address_t)) == 0)) &&
+            get_band() == dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int>(op_class->m_op_class_info.id.op_class))))) == false) {
             continue;
         }
 
-        pref_op_class->op_class = static_cast<unsigned char> (op_class->m_op_class_info.op_class);
-        num_of_channel = op_class->m_op_class_info.num_channels;
-        channel_list = &pref_op_class->channels;
-        len += static_cast<short unsigned int> (sizeof(em_channel_pref_op_class_t));
-        pref_op_class->num = static_cast<unsigned char> (num_of_channel);
-        for (j = 0; j < num_of_channel; j++) {
-            memcpy(channel_list->channel, reinterpret_cast<unsigned char *> (&op_class->m_op_class_info.channels[j]), sizeof(unsigned char));
-            channel_list = reinterpret_cast<em_channels_list_t *> (reinterpret_cast<unsigned char *> (channel_list) + sizeof(unsigned char));
-            len += static_cast<short unsigned int> (sizeof(unsigned char));
+        // Create a merged list of anticipated entries for Global, Device and RUID
+        // Assumes, only one entry for an OPCLASS for Global, Device or RUID
+        // If entry for same OPCLASS exists for both Global, Device and RUID, RUID is stored in the merged list
+        unsigned char class_num = op_class->m_op_class_info.op_class;
+        bool is_current_entry_ruid_based =
+            (memcmp(op_class->m_op_class_info.id.ruid, pref->ruid, sizeof(mac_address_t)) == 0);
+
+        // Find current op_class entry in the merged array
+        int merged_idx = -1;
+        for (j = 0; j < merged_anticipated_opclass_count; j++) {
+            if (dm->m_op_class[merged_anticipated_opclass_idx[j]].m_op_class_info.op_class == class_num) {
+                merged_idx = static_cast<int>(j);
+                break;
+            }
         }
 
-        tmp += sizeof(em_channel_pref_op_class_t) + pref_op_class->num;
-        memcpy(tmp, &pref_bits, sizeof(unsigned char));
-        len += static_cast<short unsigned int> (sizeof(unsigned char));
-        tmp += sizeof(unsigned char);
-        pref_op_class = reinterpret_cast<em_channel_pref_op_class_t *> (tmp);
-        pref->op_classes_num++;
+        if (merged_idx == -1) {
+            // New op-class entry
+            if (merged_anticipated_opclass_count >= EM_MAX_OPCLASS) {
+                em_printfout("Merged op-classes exceeded limit\n");
+                continue;
+            }
+            merged_anticipated_opclass_idx[merged_anticipated_opclass_count] = i;
+            merged_anticipated_is_ruid_based[merged_anticipated_opclass_count] = is_current_entry_ruid_based;
+            merged_anticipated_opclass_count++;
+            em_printfout("Initializing merged new op-class %d (RUID-based: %d)\n",
+                        class_num, is_current_entry_ruid_based);
+        } else {
+            // Op-class already exists
+            bool existing_is_ruid_based = merged_anticipated_is_ruid_based[merged_idx];
+
+            // Existing is Global MAC-based or Device-based, new is RUID-based so REPLACE existing
+            if (!existing_is_ruid_based && is_current_entry_ruid_based) {
+                em_printfout("Op-class %d: Replacing Global MAC-based with RUID-based entry\n",
+                            class_num);
+                merged_anticipated_opclass_idx[merged_idx] = i;
+                merged_anticipated_is_ruid_based[merged_idx] = true;
+                continue;
+            }
+        }
     }
+
+    // Create TLVs from merged anticipated op-classes
+    for (i = 0; i < merged_anticipated_opclass_count; i++) {
+        dm_op_class_t *merged_op_class = &dm->m_op_class[merged_anticipated_opclass_idx[i]];
+        em_op_class_info_t &merged_op = merged_op_class->m_op_class_info;
+
+        // Get list of Non-operable channels for the RUID OPClass
+        std::vector<unsigned char> non_oper_channels = get_non_operable_channels(
+            merged_op.op_class, merged_op.id.ruid);
+
+        // Group operable channels by preference bits, skip non-operable channels for agent
+        std::map<unsigned char, std::vector<unsigned char>> channels_per_pref;
+
+        for (j = 0; j < merged_op.num_channels; j++) {
+            bool is_anticipated_channel_non_operable_by_agent =
+                std::find(non_oper_channels.begin(),non_oper_channels.end(),
+                          merged_op.channels[j]) != non_oper_channels.end();
+            if (is_anticipated_channel_non_operable_by_agent) {
+                em_printfout("Channel %d in Op-Class %d is marked non-operable by agent, skipping this channel\n",
+                             merged_op.channels[j], merged_op.op_class);
+                continue; // Skip channels non-operable for agent
+            }
+            // Note: Temporary hardcoding of preference bits to 0xe0.
+            // Remove hardcoding once Preference value is added to the configuration
+            // pref_bits = merged_op.channel_pref[j];
+            pref_bits = 0xe0;
+            channels_per_pref[pref_bits].push_back(merged_op.channels[j]);;
+        }
+
+        // Create TLV entries for each group of channels with the same preference bits
+        for (auto& pair : channels_per_pref) {
+            pref_bits = pair.first;
+            auto& channels = pair.second;
+            if ((static_cast<unsigned char>(pref_bits) >> 4) >= EM_CH_PREF_MAX) {
+                em_printfout("Preference bits 0x%02x exceed max allowed value, skipping channels in Op-Class %d\n",
+                             pref_bits, merged_op.op_class);
+                continue; // Skip if preference bits exceed max allowed value
+            }
+
+            pref_op_class->op_class = static_cast<unsigned char>(merged_op.op_class);
+            num_of_channel = channels.size();
+            channel_list = &pref_op_class->channels;
+
+            pref_op_class->num = static_cast<unsigned char>(num_of_channel);
+            for (size_t k = 0; k < channels.size(); ++k) {
+                memcpy(channel_list->channel + k, &channels[k], sizeof(unsigned char));
+            }
+            len += static_cast<short unsigned int>(sizeof(em_channel_pref_op_class_t) +
+                                                  num_of_channel * sizeof(unsigned char));
+            tmp += sizeof(em_channel_pref_op_class_t) + num_of_channel * sizeof(unsigned char);
+
+            memcpy(tmp, &pref_bits, sizeof(unsigned char));
+            len += static_cast<short unsigned int>(sizeof(unsigned char));
+            tmp += sizeof(unsigned char);
+
+            pref_op_class = reinterpret_cast<em_channel_pref_op_class_t *>(tmp);
+            pref->op_classes_num++;
+        }
+    }
+
     return len;
+}
+
+std::vector<unsigned char> em_channel_t::get_non_operable_channels(unsigned char op_class, const unsigned char *ruid)
+{
+    std::vector<unsigned char> result;
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (dm == NULL || ruid == NULL) {
+        return result; // return empty vector
+    }
+
+    // Add non-operable channels for RUID in capability and preference list
+    for (unsigned int i = 0; i < dm->m_num_opclass; i++) {
+        dm_op_class_t *dm_op_class = &dm->m_op_class[i];
+        if (dm_op_class->m_op_class_info.op_class != op_class ||
+            memcmp(dm_op_class->m_op_class_info.id.ruid, ruid, sizeof(mac_address_t)) != 0) {
+            continue; // skip unrelated records
+        }
+
+        if (dm_op_class->m_op_class_info.id.type == em_op_class_type_capability) {
+            for (unsigned int j = 0; j < dm_op_class->m_op_class_info.num_channels; j++) {
+                result.push_back(dm_op_class->m_op_class_info.channels[j]);
+            }
+        } else if (dm_op_class->m_op_class_info.id.type == em_op_class_type_preference &&
+                   dm_op_class->m_op_class_info.pref_valid == EM_CH_PREF_ENTRY_VALID) {
+
+            for (unsigned int j = 0; j < dm_op_class->m_op_class_info.num_channels; j++) {
+                unsigned char pref_byte = dm_op_class->m_op_class_info.channel_pref[j];
+
+                //Add non-operable channels
+                if ((pref_byte & 0xF0) == 0x00) {
+                    unsigned int ch = dm_op_class->m_op_class_info.channels[j];
+                    result.push_back(ch);
+                }
+            }
+        }
+        // other types ignored
+    }
+
+    return result;
 }
 
 short em_channel_t::create_transmit_power_limit_tlv(unsigned char *buff)
@@ -695,16 +831,20 @@ int em_channel_t::send_channel_sel_request_msg()
 
     tmp += (sizeof (em_tlv_t));
     len += (sizeof (em_tlv_t));
+
+    // Validate message against IEEE spec compliance
+    em_printfout("Validating Channel Selection Request message (total length: %u bytes)...\n", len);
     if (em_msg_t(em_msg_type_channel_sel_req, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("Channel Selection Request msg failed validation in tnx end\n");
+        em_printfout("Channel Selection Request msg failed validation in txn end\n");
         return -1;
     }
 
     if (send_frame(buff, len)  < 0) {
-        printf("%s:%d: Channel Selection Request msg failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Failed to send Channel Selection Request message (errno: %d)\n", errno);
         return -1;
     }
     m_chan_sel_req_msg_id = ntohs(cmdu->id);
+    em_printfout("Channel Selection Request message sent (msg_id: 0x%04x)\n", m_chan_sel_req_msg_id);
 
     return static_cast<int> (len);
 


### PR DESCRIPTION
1. In DB, for Anticipated type support list of channels and corresponding preference for opclass
2. Support adding a list of channels with preference in Channel Selection Request
3. Merge list of anticipated rows in DB for Global, Device and RUID based configuration. RUID configuration takes precedence over Global/Device configuration.
4. Only include opclass applicable for current band from Global configuration
5. Filter out the channels marked as non-operable by Agent in AP Radio basic Capability and Channel Preference Report
6. Group channels in an opclass by preference for channel preference tlv creation.

Assumptions:
1. The Anticipated rows with RUID are with opclass for the applicable radio band
2. No validation for the channels added for the opclass
3. Channel list in same opclass will not be merged for Global and RUID configuration