### PR TITLE
RDKBWIFI-380: Updates for Channel Preference TLV processing in Channel selection request on Agent

### DIFF
--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -396,49 +396,123 @@ int dm_easy_mesh_agent_t::analyze_channel_pref_query(em_bus_event_t *evt, em_cmd
 
 int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl)
 {
-	unsigned int i = 0, noofopclass = 0;
-	op_class_channel_sel *channel_sel;
-	em_op_class_info_t *dm_op_class;
-	em_tx_power_limit_t	*tx_power_limit;
-	em_spatial_reuse_req_t *spatial_reuse_req;
-	em_eht_operations_t *eht_ops;
-	bool found_mesh_sta = false;
-	em_bss_info_t *bss_info;
+    unsigned int i = 0, j = 0, noofopclass = 0;
+    op_class_channel_sel *channel_sel;
+    em_op_class_info_t *dm_op_class;
+    em_tx_power_limit_t *tx_power_limit;
+    em_spatial_reuse_req_t *spatial_reuse_req;
+    em_eht_operations_t *eht_ops;
+    bool found_mesh_sta = false;
+    em_bss_info_t *bss_info;
 
 
-	channel_sel = reinterpret_cast<op_class_channel_sel*> (evt->u.raw_buff);
-	printf("%s:%d No of opclass=%d tx=%d\n", __func__, __LINE__,
-        channel_sel->num, channel_sel->tx_power.tx_power_eirp);
-	tx_power_limit =  const_cast<em_tx_power_limit_t*> (&channel_sel->tx_power);
-	spatial_reuse_req =  const_cast<em_spatial_reuse_req_t*> (&channel_sel->spatial_reuse_req);
+    channel_sel = reinterpret_cast<op_class_channel_sel*> (evt->u.raw_buff);
+    em_printfout("No of opclass=%d tx=%d", channel_sel->num, channel_sel->tx_power.tx_power_eirp);
+    tx_power_limit =  const_cast<em_tx_power_limit_t*> (&channel_sel->tx_power);
+    spatial_reuse_req =  const_cast<em_spatial_reuse_req_t*> (&channel_sel->spatial_reuse_req);
     eht_ops =  const_cast<em_eht_operations_t*> (&channel_sel->eht_ops);
 
-	noofopclass = this->get_num_op_class();
+    // Process data from Channel Preference TLVs
+    // Invalidate all old anticipated entries for current RUID in data model
+    noofopclass = this->get_num_op_class();
+    for (i = 0; i < noofopclass; i++) {
+        dm_op_class = this->get_op_class_info(i);
 
-	//TODO Select the right op class and number and configure
-	for (i = 0; i < noofopclass; i++) {
-		dm_op_class = this->get_op_class_info(i);
-		if ((memcmp(&dm_op_class->id.ruid, &channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) && 
-			(dm_op_class->id.type == channel_sel->op_class_info[0].id.type)) {
-			dm_op_class->channel =  channel_sel->op_class_info[0].channels[0];
-			dm_op_class->op_class = channel_sel->op_class_info[0].op_class;
-		break;
-		}
-	}
-	if (i == noofopclass) {
-		dm_op_class = this->get_op_class_info(i);
-		memcpy(dm_op_class, &channel_sel->op_class_info[i], sizeof(em_op_class_info_t));
-		dm_op_class->channel = channel_sel->op_class_info[0].channels[0];
-		dm_op_class->op_class = channel_sel->op_class_info[0].op_class;
-		noofopclass++;
-	}
-	this->set_num_op_class(noofopclass);
-    
-	if(tx_power_limit->tx_power_eirp != 0) {
-		dm_radio_t* radio = this->get_radio(tx_power_limit->ruid);
-		em_radio_info_t* radio_info = radio->get_radio_info();
-		radio_info->transmit_power_limit = tx_power_limit->tx_power_eirp;
-	}
+        // Assumption: recevied channel_sel contains entries for one RUID only
+        if ((dm_op_class->id.type == em_op_class_type_anticipated) &&
+            memcmp(&dm_op_class->id.ruid, &channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) {
+            dm_op_class->pref_valid = false;
+        }
+    }
+
+    if (channel_sel->num == 0) {
+        // UNEXPECTED: Channel Selection Request will have atleast one OPCLASS in Channel Preference TLV
+        em_printfout("Channel Preference TLV contains no op_class entries");
+        return -1;
+    }
+
+    // To store the channel with best preference
+    unsigned char highest_anticipated_preference = 0;
+    unsigned int most_preferred_channel = 0;
+    unsigned int most_preferred_opclass = 0;
+
+    // Process new preferences from channel_sel
+    bool is_anticipated_invalid_entry_present = true;
+    for (i = 0;i < channel_sel->num; i++) {
+
+        // Check for an existing invalid entry with anticipated type
+        if(is_anticipated_invalid_entry_present) {
+            for (j = 0; j < noofopclass; j++) {
+                dm_op_class = this->get_op_class_info(j);
+
+                // Found an entry of anticipated type in DM with invalid flag,
+                // Update DM entry with new entry received in channel selection request
+                if (dm_op_class->id.type == em_op_class_type_anticipated && !dm_op_class->pref_valid) {
+                    // Update existing entry with new preferences
+                    memcpy(dm_op_class, &channel_sel->op_class_info[i], sizeof(em_op_class_info_t));
+                    dm_op_class->pref_valid = true;
+                    break;
+                }
+            }
+
+            // Don't check further for invalid entries of anticipated type
+            if (j == noofopclass)
+                is_anticipated_invalid_entry_present = false;
+        }
+
+        //Add new entry in DM for the opclass/channel received in channel selection request
+        if (!is_anticipated_invalid_entry_present && (noofopclass < EM_MAX_OPCLASS)) {
+            dm_op_class = &this->m_op_class[noofopclass].m_op_class_info;
+            memcpy(dm_op_class, &channel_sel->op_class_info[i], sizeof(em_op_class_info_t));
+            dm_op_class->id.type = em_op_class_type_anticipated;
+            dm_op_class->pref_valid = true;
+            noofopclass++;
+        }
+
+        // Check for all channels in the entry to maintian most preferred channel and opclass
+        for (unsigned int ch_idx = 0;
+             ch_idx < dm_op_class->num_channels && ch_idx < EM_MAX_CHANNELS_IN_LIST;
+             ch_idx++) {
+            if ((dm_op_class->channel_pref[ch_idx] & 0xF0) > (highest_anticipated_preference & 0xF0)) {
+                highest_anticipated_preference = dm_op_class->channel_pref[ch_idx];
+                most_preferred_channel = dm_op_class->channels[ch_idx];
+                most_preferred_opclass = dm_op_class->op_class;
+            }
+        }
+    }
+
+    // Ensure highest preference is non-zero to update current channel
+    if (highest_anticipated_preference > 0) {
+        // Update the most preferred channel/opclass in the datamodel
+        for (i = 0; i < noofopclass; i++) {
+            dm_op_class = this->get_op_class_info(i);
+            if ((memcmp(&dm_op_class->id.ruid, &channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) &&
+                (dm_op_class->id.type == em_op_class_type_current)) {
+                dm_op_class->op_class = most_preferred_opclass;
+                dm_op_class->id.op_class = most_preferred_opclass;
+                dm_op_class->channel = most_preferred_channel;
+                break;
+            }
+        }
+        if (i == noofopclass) {
+            dm_op_class = this->get_op_class_info(i);
+            em_op_class_info_t tmp_op_class_info;
+            memcpy(tmp_op_class_info.id.ruid, channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t));
+            tmp_op_class_info.id.type = em_op_class_type_current;
+            tmp_op_class_info.id.op_class = most_preferred_opclass;
+            tmp_op_class_info.op_class = most_preferred_opclass;
+            tmp_op_class_info.channel = most_preferred_channel;
+            memcpy(dm_op_class, &tmp_op_class_info, sizeof(em_op_class_info_t));
+            noofopclass++;
+        }
+        this->set_num_op_class(noofopclass);
+    }
+
+    if(tx_power_limit->tx_power_eirp != 0) {
+        dm_radio_t* radio = this->get_radio(tx_power_limit->ruid);
+        em_radio_info_t* radio_info = radio->get_radio_info();
+        radio_info->transmit_power_limit = tx_power_limit->tx_power_eirp;
+    }
 
     dm_radio_t* radio = this->get_radio(spatial_reuse_req->ruid);
     em_radio_info_t* radio_info = radio->get_radio_info();
@@ -451,7 +525,7 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     radio_info->srg_obsspd_min_offset = spatial_reuse_req->srg_obsspd_min_offset;
     radio_info->srg_obsspd_max_offset = spatial_reuse_req->srg_obsspd_max_offset;
     memcpy(radio_info->srg_bss_color_bitmap, spatial_reuse_req->srg_bss_color_bitmap, sizeof(radio_info->srg_bss_color_bitmap));
-    memcpy(radio_info->srg_partial_bssid_bitmap, spatial_reuse_req->srg_partial_bssid_bitmap, sizeof(radio_info->srg_partial_bssid_bitmap));   
+    memcpy(radio_info->srg_partial_bssid_bitmap, spatial_reuse_req->srg_partial_bssid_bitmap, sizeof(radio_info->srg_partial_bssid_bitmap));
 
 #ifdef REL_6_FEATURE
     bool found_radio = false;

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -859,6 +859,7 @@ int em_channel_t::send_channel_sel_response_msg(em_chan_sel_resp_code_type_t cod
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
     em_channel_sel_rsp_t *resp;
+    em_spatial_reuse_cfg_rsp_t *spatial_resp;
     unsigned char *tmp = buff;
     dm_easy_mesh_t *dm;
     unsigned short type = htons(ETH_P_1905);
@@ -899,17 +900,17 @@ int em_channel_t::send_channel_sel_response_msg(em_chan_sel_resp_code_type_t cod
     tmp += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
     len += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
     
-	// Zero or more Spatial Reuse Config Response TLVs (see section 17.2.91)
-	tlv = reinterpret_cast<em_tlv_t *> (tmp);
-	tlv->type = em_tlv_type_spatial_reuse_cfg_rsp;
-	tlv->len = htons(sizeof(em_spatial_reuse_cfg_rsp_t));
-	resp = reinterpret_cast<em_channel_sel_rsp_t *> (tlv->value);
-	memcpy(resp->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
-    memcpy(&resp->response_code, reinterpret_cast<unsigned char *> (&code), sizeof(unsigned char));
+    // Zero or more Spatial Reuse Config Response TLVs (see section 17.2.91)
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_spatial_reuse_cfg_rsp;
+    tlv->len = htons(sizeof(em_spatial_reuse_cfg_rsp_t));
+    spatial_resp = reinterpret_cast<em_spatial_reuse_cfg_rsp_t *> (tlv->value);
+    memcpy(spatial_resp->config_resp.ruid, get_radio_interface_mac(), sizeof(mac_address_t));
+    memcpy(&spatial_resp->config_resp.response_code, reinterpret_cast<unsigned char *> (&code), sizeof(unsigned char));
 
 
-    tmp += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
-    len += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
+    tmp += (sizeof(em_tlv_t) + sizeof(em_spatial_reuse_cfg_rsp_t));
+    len += (sizeof(em_tlv_t) + sizeof(em_spatial_reuse_cfg_rsp_t));
 
 	// End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -1774,35 +1775,84 @@ int em_channel_t::handle_channel_pref_tlv(unsigned char *buff, op_class_channel_
 {
     em_channel_pref_t *pref = reinterpret_cast<em_channel_pref_t *> (buff);
     em_channel_pref_op_class_t *channel_pref;
-    unsigned int i = 0, j = 0;
-	em_op_class_info_t op_class_info[EM_MAX_OP_CLASS];
+    unsigned int i = 0, j = 0, k = 0;
+    em_op_class_info_t curr_op_class_info;
+    unsigned char pref_bits;
+    bool entry_found = false;
 
-    channel_pref = pref->op_classes;
     if (pref != NULL) {
-		channel_pref = pref->op_classes;
-		memcpy(op_class_info[i].id.ruid, pref->ruid, sizeof(mac_address_t));
-		for (i = 0; i < pref->op_classes_num; i++) {
-			memcpy(op_class_info[i].id.ruid, pref->ruid, sizeof(mac_address_t));
-			op_class_info[i].id.type = em_op_class_type_current;
-			op_class_info[i].op_class = static_cast<unsigned int> (channel_pref->op_class);
-			op_class_info[i].id.op_class = op_class_info[i].op_class;
-			op_class_info[i].num_channels = static_cast<unsigned int> (channel_pref->num);
-			for (j = 0; j < op_class_info[i].num_channels; j++) {
-					op_class_info[i].channels[j] = static_cast<unsigned int > (channel_pref->channels.channel[j]);
-			}
-			channel_pref = reinterpret_cast<em_channel_pref_op_class_t *> (reinterpret_cast<unsigned char *> (channel_pref) + sizeof(em_op_class_t) + op_class_info[i].num_channels);
-		}
+        channel_pref = pref->op_classes;
+        for (i = 0; i < pref->op_classes_num; i++) {
 
-		op_class->num = 1;
-		for (i = 0; i < pref->op_classes_num; i++) {
-			if (get_band() == (dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int> (op_class_info[i].op_class)))) {
-				memcpy(&op_class->op_class_info[0], &op_class_info[i], sizeof(em_op_class_info_t));
-				//printf("%s:%d Received channel selection request op_class=%d \n",__func__, __LINE__,op_class_info[i].op_class);
-				break;
-			}
-		}
+            // Extract preference bits that follow channel list
+            unsigned char *pref_bits_ptr;
+            pref_bits_ptr = reinterpret_cast<unsigned char *> (channel_pref) + sizeof(em_channel_pref_op_class_t) + channel_pref->num;
+            memcpy(&pref_bits, pref_bits_ptr, sizeof(unsigned char));
+
+            // Skip entries not applicable for the current radio band
+            if (get_band() != (dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int> (channel_pref->op_class)))) {
+                channel_pref = reinterpret_cast<em_channel_pref_op_class_t *> (pref_bits_ptr + sizeof(unsigned char));
+                continue;
+            }
+
+            // Check for any earlier entries with same OPCLASS
+            for (j = 0; j < op_class->num; j++) {
+                if (op_class->op_class_info[j].op_class == static_cast<unsigned int> (channel_pref->op_class)) {
+
+                    // Append the channels and preferences to the existing entry.
+                    unsigned int added_channels_count = 0;
+                    unsigned int existing_channels_count = op_class->op_class_info[j].num_channels;
+                    for (added_channels_count = 0; (added_channels_count < static_cast<unsigned int> (channel_pref->num)) &&
+          ((existing_channels_count + added_channels_count) < EM_MAX_CHANNELS_IN_LIST); added_channels_count++) {
+
+                        op_class->op_class_info[j].channels[existing_channels_count + added_channels_count] =
+              static_cast<unsigned int > (channel_pref->channels.channel[added_channels_count]);
+
+                        op_class->op_class_info[j].channel_pref[existing_channels_count + added_channels_count] = pref_bits;
+                    }
+
+                    // Only increment by appended count
+                    // If count exceeds max channels then remaining channels are dropped.
+                    op_class->op_class_info[j].num_channels += added_channels_count;
+                    entry_found = true;
+                    break;
+                }
+            }
+
+            //Existing row is updated, move to next opclass in the list
+            if (entry_found) {
+                channel_pref = reinterpret_cast<em_channel_pref_op_class_t *> (pref_bits_ptr + sizeof(unsigned char));
+                continue;
+            }
+
+            // Existing row is not found. Add new entry
+            memset(&curr_op_class_info, 0, sizeof(em_op_class_info_t));
+            memcpy(curr_op_class_info.id.ruid, pref->ruid, sizeof(mac_address_t));
+
+            // This function is only called by handle_channel_sel_req. Hence store preferences received from controller as type anticipated
+            curr_op_class_info.id.type = em_op_class_type_anticipated;
+            curr_op_class_info.op_class = static_cast<unsigned int> (channel_pref->op_class);
+            curr_op_class_info.id.op_class = curr_op_class_info.op_class;
+            curr_op_class_info.num_channels = static_cast<unsigned int> (channel_pref->num);
+
+            for (k = 0; k < curr_op_class_info.num_channels; k++) {
+                curr_op_class_info.channels[k] = static_cast<unsigned int > (channel_pref->channels.channel[k]);
+                curr_op_class_info.channel_pref[k] = pref_bits;
+            }
+            curr_op_class_info.pref_valid = EM_CH_PREF_ENTRY_VALID;
+
+            //Add the current opclass entry to the list
+            memcpy(&op_class->op_class_info[op_class->num], &curr_op_class_info, sizeof(em_op_class_info_t));
+            op_class->num++;
+
+            //If MAX entries are added, skip further processing
+            if (op_class->num >= EM_MAX_OP_CLASS)
+                break;
+
+            // Move to next opclass
+            channel_pref = reinterpret_cast<em_channel_pref_op_class_t *> (pref_bits_ptr + sizeof(unsigned char));
+        }
     }
-
     return 0;
 }
 


### PR DESCRIPTION
- Aggregate a list of opclasses and channels from the message TLVs
- Send the list for analysis and activation on the agent DM

Updates in analyze_channel_sel_req to store the message information in DM and activate opclass/channel with best preference
- Invalidate old data if present for the RUID in the DataModel
- Process the aggregated list received from controller and store in the data model
- Select the opclass/channel with best preference in the shared list
- Update/add the best channel to Onewifi Subdoc for further processing and activation

Assumptions:
- A Channel Selection Request contains data for one RUID only
- In case no opclass/channel is present in the message, it shall invalidate existing entries. No update to current channel/onewifi subdoc