### PR TITLE
RDKBWIFI-278: CLIENT ASSOC CTRL REQUEST

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -2136,7 +2136,7 @@ public:
 	 * @note Ensure that the `info` pointer is valid and points to a properly initialized `em_sta_info_t` structure.
 	 */
 	void put_sta_info(em_sta_info_t *info, em_target_sta_map_t target);
-    
+
 	/**!
 	 * @brief Retrieves the first station information.
 	 *
@@ -2198,7 +2198,28 @@ public:
 	 */
 	static void put_sta_info(void *dm, em_sta_info_t *info, em_target_sta_map_t target) { (static_cast<dm_easy_mesh_t *>(dm))->put_sta_info(info, target); }
 
-    
+	/**!
+	 * @brief Checks whether a station (STA) is currently associated with a given BSSID.
+	 *
+	 * This function determines if the station identified by @p sta_mac is
+	 * presently associated with the basic service set identified by @p bssid
+	 * in the EasyMesh data model.
+	 *
+	 * @param[in] bssid    The BSSID of the access point/BSS to check against.
+	 *                     The association check is performed specifically for
+	 *                     this BSSID and does not search across other BSSIDs.
+	 * @param[in] sta_mac  The MAC address of the station whose association
+	 *                     state is being queried.
+	 *
+	 * @returns true if the station is recorded as associated with the given
+	 *          BSSID, false otherwise.
+	 *
+	 * @note Callers are expected to provide valid, normalized MAC addresses
+	 *       for both @p bssid and @p sta_mac that correspond to entities
+	 *       known to the EasyMesh instance.
+	 */
+	bool is_sta_associated(bssid_t bssid, mac_address_t sta_mac);
+
 	/**!
 	 * @brief Finds a station (STA) based on its MAC address and BSSID.
 	 *

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -640,6 +640,20 @@ public:
 	void handle_onewifi_radio_cb(em_bus_event_t *evt);
     
 	/**!
+	 * @brief Handles the client association control request event.
+	 *
+	 * This function processes the client association control request event received
+	 * through the event bus and applies the necessary blocking/unblocking actions.
+	 *
+	 * @param[in] evt Pointer to the event structure containing the client association
+	 * control request details.
+	 *
+	 * @note Ensure that the event structure is properly initialized before
+	 * calling this function.
+	 */
+	void handle_client_assoc_ctrl_req(em_bus_event_t *evt);
+
+	/**!
 	 * @brief Handles the M2 control configuration event.
 	 *
 	 * This function processes the M2 control configuration event received

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -279,6 +279,10 @@ static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff
 #define WIFI_EM_CHANNEL_SCAN_REQUEST          "Device.WiFi.EM.ChannelScanRequest"
 #endif
 
+#ifndef WIFI_EM_CLIENT_ASSOC_CTRL_REQ
+#define WIFI_EM_CLIENT_ASSOC_CTRL_REQ        "Device.WiFi.EM.ClientAssocCtrlRequest"
+#endif
+
 #ifndef WIFI_EC_SEND_TRIG_STA_SCAN
 #define WIFI_EC_SEND_TRIG_STA_SCAN          "Device.WiFi.EC.TriggerStaScan"
 #endif
@@ -2850,6 +2854,7 @@ typedef enum {
     em_bus_event_type_recv_csa_beacon_frame,
     em_bus_event_type_bsta_cap_req,
     em_bus_event_type_link_quality_report,
+    em_bus_event_type_client_assoc_ctrl_req,
 
     em_bus_event_type_max
 } em_bus_event_type_t;

--- a/inc/em_steering.h
+++ b/inc/em_steering.h
@@ -94,6 +94,8 @@ class em_steering_t {
 	 * @param[in] sta_mac The MAC address of the station to which the acknowledgment
 	 * message will be sent.
 	 * @param[in] msg_id The message ID of the original message being acknowledged.
+	 * @param[in] reason The reason code used in Error Code TLV.
+	 * @param[in] dst Destination AL MAC to use when controller AL MAC is unknown).
 	 *
 	 * @returns int
 	 * @retval 0 on success
@@ -102,7 +104,7 @@ class em_steering_t {
 	 * @note Ensure that the MAC address is valid and the station is reachable
 	 * before calling this function.
 	 */
-	int send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_id);
+	int send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_id, unsigned char reason = 0, unsigned char *dst = nullptr);
     
 	/**!
 	 * @brief Handles the client steering request.
@@ -119,7 +121,23 @@ class em_steering_t {
 	 * @note Ensure that the buffer is properly allocated and the length is correctly specified.
 	 */
 	int handle_client_steering_req(unsigned char *buff, unsigned int len);
-    
+
+	/**!
+	 * @brief Handles the client assoc ctrl request.
+	 *
+	 * This function processes the client assoc ctrl request received from controller.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the request data.
+	 * @param[in] len Length of the data in the buffer.
+	 *
+	 * @returns int Status code indicating success or failure of the operation.
+	 * @retval 0 Success.
+	 * @retval -1 Failure.
+	 *
+	 * @note Ensure that the buffer is properly allocated and the length is correctly specified.
+	 */
+	int handle_client_assoc_ctrl_req(unsigned char *buff, unsigned int len);
+
 	/**!
 	 * @brief Handles the client steering report.
 	 *

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -649,6 +649,42 @@ void em_agent_t::handle_btm_response_action_frame(em_bus_event_t *evt)
     }
 }
 
+void em_agent_t::handle_client_assoc_ctrl_req(em_bus_event_t *evt)
+{
+    wifi_bus_desc_t *desc;
+    raw_data_t raw;
+    client_assoc_ctrl_req_t req_data;
+
+    em_client_assoc_ctrl_req_t *steer_req = reinterpret_cast<em_client_assoc_ctrl_req_t*> (&evt->u.raw_buff);
+
+    if ((desc = get_bus_descriptor()) == NULL) {
+        em_printfout("bus descriptor is null");
+        return;
+    }
+
+    if (steer_req->count != 1) {
+        em_printfout("station count:%d is more than one", steer_req->count);
+        return;
+    }
+    memset(&req_data, 0, sizeof(client_assoc_ctrl_req_t));
+
+    memcpy(req_data.bssid, steer_req->bssid, sizeof(bssid_t));
+    req_data.assoc_control = steer_req->assoc_control;
+    req_data.validity_period = ntohs(steer_req->validity_period);
+    req_data.count = steer_req->count;
+    memcpy(req_data.sta_mac, steer_req->sta_mac, sizeof(mac_address_t));
+
+    memset(&raw, 0, sizeof(raw_data_t));
+    raw.data_type = bus_data_type_bytes;
+    raw.raw_data.bytes = (void *)&req_data;
+    raw.raw_data_len = sizeof(client_assoc_ctrl_req_t);
+
+    if (desc->bus_set_fn(&m_bus_hdl,WIFI_EM_CLIENT_ASSOC_CTRL_REQ, &raw) != 0) {
+        em_printfout("%s:%d Failed to send client assoc ctrl request to bus",__func__, __LINE__);
+    }
+    em_printfout("%s:%d Sent client assoc ctrl request to bus, OneWifi will process the bus event",__func__, __LINE__);
+}
+
 void em_agent_t::handle_channel_scan_result(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -827,7 +863,7 @@ void em_agent_t::handle_link_stats_report(em_bus_event_t *evt)
 
 void em_agent_t::handle_bus_event(em_bus_event_t *evt)
 {   
-    
+
     switch (evt->type) {
         case em_bus_event_type_dev_init:
             handle_dev_init(evt);
@@ -887,6 +923,10 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
 
         case em_bus_event_type_btm_response:
             handle_btm_response_action_frame(evt);
+            break;
+
+        case em_bus_event_type_client_assoc_ctrl_req:
+            handle_client_assoc_ctrl_req(evt);
             break;
 
 		case em_bus_event_type_channel_scan_params:
@@ -1745,6 +1785,17 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 
         case em_msg_type_bh_sta_cap_rprt:
             break;
+
+        case em_msg_type_client_assoc_ctrl_req:
+            em = (em_t *)hash_map_get_first(m_em_map);
+            while (em != NULL) {
+	        if ((em->is_al_interface_em() == true)) {
+	            em_printfout("Rceived client assoc ctrl request from controller");
+	            break;
+	        }
+	        em = (em_t *)hash_map_get_next(m_em_map, em);
+           }
+           break;
 
         default:
             printf("%s:%d: Frame: %d not handled in agent\n", __func__, __LINE__, htons(cmdu->type));

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2593,6 +2593,12 @@ bool dm_easy_mesh_t::has_at_least_one_associated_sta()
     return false;
 }
 
+bool dm_easy_mesh_t::is_sta_associated(bssid_t bssid, mac_address_t sta_mac)
+{
+    dm_sta_t *sta = find_sta(sta_mac, bssid);
+    return (sta != NULL) && sta->m_sta_info.associated;
+}
+
 dm_sta_t *dm_easy_mesh_t::find_sta(mac_address_t sta_mac, bssid_t bssid)
 {
     dm_sta_t *sta;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -335,6 +335,10 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
             break;
         case em_msg_type_client_steering_req:
         case em_msg_type_client_steering_btm_rprt:
+        case em_msg_type_client_assoc_ctrl_req:
+            em_printfout("  proto_process, type rcvd: %d\n", htons(cmdu->type));
+            em_steering_t::process_msg(data, len);
+            break;
         case em_msg_type_1905_ack:
             if (m_sm.get_state() == em_state_ctrl_ap_mld_configured) {
                 em_configuration_t::process_msg(data, len);
@@ -484,8 +488,9 @@ void em_t::handle_ctrl_state()
         case em_cmd_type_set_channel:
             em_capability_t::process_ctrl_state();
             em_configuration_t::process_ctrl_state();
+            em_steering_t::process_ctrl_state();
             em_channel_t::process_ctrl_state();
-			em_policy_cfg_t::process_ctrl_state();
+            em_policy_cfg_t::process_ctrl_state();
             break;
 
 		case em_cmd_type_scan_channel:

--- a/src/em/steering/em_steering.cpp
+++ b/src/em/steering/em_steering.cpp
@@ -44,32 +44,38 @@
 
 int em_steering_t::send_client_assoc_ctrl_req_msg()
 {
-    em_cmd_t *pcmd;
-    em_disassoc_params_t *disassoc_param;
-    unsigned int i, j;
-    unsigned int num = 0;
-    dm_easy_mesh_t *dm;
-    em_client_assoc_ctrl_req_t assoc_ctrl[MAX_EM_BUFF_SZ];
+    em_cmd_t *pcmd = get_current_cmd();
+    dm_easy_mesh_t *dm = get_data_model();
 
-    dm = get_data_model();
+    if (!pcmd || !dm)
+        return -1;
 
-    pcmd = get_current_cmd();
-    for (i = 0; i < pcmd->m_param.u.disassoc_params.num; i++) {
-        disassoc_param = &pcmd->m_param.u.disassoc_params.params[i];
-        for (j = 0; j < dm->m_num_bss; j++) {
+    for (unsigned int i = 0; i < pcmd->m_param.u.disassoc_params.num; i++) {
+        em_disassoc_params_t *disassoc_param = &pcmd->m_param.u.disassoc_params.params[i];
+
+        for (unsigned int j = 0; j < dm->m_num_bss; j++) {
             if ((memcmp(disassoc_param->bssid, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(bssid_t)) == 0) &&
                 (memcmp(dm->m_bss[j].m_bss_info.ruid.mac, get_radio_interface_mac(), sizeof(mac_address_t)) == 0)) {
-                memcpy(assoc_ctrl[num].bssid, disassoc_param->bssid, sizeof(mac_address_t));
-                if (disassoc_param->disassoc_time == 0) {
-                    assoc_ctrl[num].assoc_control = 0x03;
+
+                em_client_assoc_ctrl_req_t assoc_ctrl;
+                memset(&assoc_ctrl, 0, sizeof(assoc_ctrl));
+
+                memcpy(&assoc_ctrl.bssid, &disassoc_param->bssid, sizeof(bssid_t));
+                //Current Implementation for One Sta Per Message
+                assoc_ctrl.count = 1;
+                memcpy(&assoc_ctrl.sta_mac, &disassoc_param->sta_mac, sizeof(mac_address_t));
+
+                if (disassoc_param->disassoc_time > 0) {
+                    // BLOCK
+                    assoc_ctrl.assoc_control  = 0x00;
+                    assoc_ctrl.validity_period = htons(static_cast<uint16_t>(disassoc_param->disassoc_time));
                 } else {
-                    assoc_ctrl[num].assoc_control = 0x02;
-                    assoc_ctrl[num].validity_period = static_cast<short unsigned int> (disassoc_param->disassoc_time);
+                    // UNBLOCK
+                    assoc_ctrl.assoc_control  = 0x01;
+                    assoc_ctrl.validity_period = 0;
                 }
-                assoc_ctrl[num].count = 1;
-                memcpy(assoc_ctrl[num].sta_mac, disassoc_param->sta_mac, sizeof(mac_address_t));
-                send_client_assoc_ctrl_req_msg(&assoc_ctrl[num]);
-                num++;
+
+                send_client_assoc_ctrl_req_msg(&assoc_ctrl);
             }
         }
     }
@@ -117,11 +123,18 @@ int em_steering_t::send_client_assoc_ctrl_req_msg(em_client_assoc_ctrl_req_t *as
 
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_client_assoc_ctrl_req;
-    memcpy(tlv->value, assoc_ctrl, sizeof(em_client_assoc_ctrl_req_t));
-    tlv->len = htons(sizeof(em_client_assoc_ctrl_req_t));
 
-    tmp += (sizeof (em_tlv_t) + sizeof(em_client_assoc_ctrl_req_t));
-    len += (sizeof (em_tlv_t) + sizeof(em_client_assoc_ctrl_req_t));
+    if (assoc_ctrl->count != 1) {
+        em_printfout("assoc_ctrl count=%d unsupported", assoc_ctrl->count);
+        return -1;
+    }
+
+    size_t tlv_value_len = sizeof(em_client_assoc_ctrl_req_t);
+    memcpy(tlv->value, assoc_ctrl, tlv_value_len);
+    tlv->len = htons(tlv_value_len);
+
+    tmp += (sizeof (em_tlv_t) + tlv_value_len);
+    len += (sizeof (em_tlv_t) + tlv_value_len);
 
     // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -285,7 +298,7 @@ int em_steering_t::send_btm_report_msg(mac_address_t sta, bssid_t bss)
     return static_cast<int> (len);
 }
 
-int em_steering_t::send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_id)
+int em_steering_t::send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_id, unsigned char reason, unsigned char *dst)
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
@@ -297,9 +310,16 @@ int em_steering_t::send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_
     short sz = 0;
     unsigned short type = htons(ETH_P_1905);
     dm_easy_mesh_t *dm = get_data_model();
+    mac_address_t zero_mac = {0};
 
-
-    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    if (memcmp(dm->get_ctrl_al_interface_mac(), zero_mac, sizeof(mac_address_t)) != 0) {
+        memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    } else if (dst != nullptr) {
+        memcpy(tmp, const_cast<unsigned char *> (dst), sizeof(mac_address_t));
+    } else {
+        printf("%s:%d: no valid destination MAC address available\n", __func__, __LINE__);
+        return 0;
+    }
     tmp += sizeof(mac_address_t);
     len += sizeof(mac_address_t);
 
@@ -321,14 +341,16 @@ int em_steering_t::send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_
     tmp += sizeof(em_cmdu_t);
     len += sizeof(em_cmdu_t);
 
-    //17.2.36 Error Code TLV format
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_error_code;
-    sz = create_error_code_tlv(tlv->value, 0, sta_mac);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
+    if (reason != 0) {
+        //17.2.36 Error Code TLV format
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_error_code;
+        sz = create_error_code_tlv(tlv->value, reason, sta_mac);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
 
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
 
     // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -485,6 +507,49 @@ int em_steering_t::handle_ack_msg(unsigned char *buff, unsigned int len)
     return 0;
 }
 
+int em_steering_t::handle_client_assoc_ctrl_req(unsigned char *buff, unsigned int len)
+{
+    em_printfout("%s:%d: Received Client Assoc Control Request from Controller", __func__, __LINE__);
+
+    em_tlv_t *tlv;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    em_client_assoc_ctrl_req_t *assoc_ctrl_req;
+
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *> (buff);
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+    unsigned short msg_id = ntohs(cmdu->id);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (em_msg_t(em_msg_type_client_assoc_ctrl_req, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("%s:%d: Client Association Control Request message validation failed", __func__, __LINE__);
+        return -1;
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    assoc_ctrl_req = reinterpret_cast<em_client_assoc_ctrl_req_t *> (&tlv->value);
+
+    if (assoc_ctrl_req->assoc_control == 0x00) {  // Block
+        mac_address_t sta_mac;
+        memcpy(sta_mac, assoc_ctrl_req->sta_mac, sizeof(mac_address_t));
+        // Check for associated STAs if blocking
+        if (dm->is_sta_associated(assoc_ctrl_req->bssid, sta_mac)) {
+            // Send Ack with error
+            em_printfout("%s:%d: Sending ack with Error Code TLV", __func__, __LINE__);
+            send_1905_ack_message(sta_mac, msg_id, 1, hdr->src);
+            return 0;
+        }
+    }
+
+    send_1905_ack_message(assoc_ctrl_req->sta_mac, msg_id, 0, hdr->src);
+
+    // Send the association control request to OneWifi for HAL enforcement
+    uint16_t tlv_len = ntohs(tlv->len);
+    get_mgr()->io_process(em_bus_event_type_client_assoc_ctrl_req,
+        reinterpret_cast<unsigned char *> (assoc_ctrl_req), tlv_len);
+
+    return 0;
+}
+
 void em_steering_t::process_ctrl_state()
 {
     switch (get_state()) {
@@ -524,6 +589,10 @@ void em_steering_t::process_msg(unsigned char *data, unsigned int len)
 
         case em_msg_type_client_steering_btm_rprt:
             handle_client_steering_report(data, len);
+            break;
+
+        case em_msg_type_client_assoc_ctrl_req:
+            handle_client_assoc_ctrl_req(data, len);
             break;
 
         case em_msg_type_1905_ack:


### PR DESCRIPTION
RDKBWIFI-278: CLIENT ASSOC CTRL REQUEST

Implement client association control request handling on a per-station basis.
The agent receives and processes the request, forwarding it from the agent to OneWiFi and then to rdk-wifi-hal to block or unblock clients using the ACL mechanism.

Unit Testing:

Triggered the association control request from the controller using rdkb-cli.
Added a temporary handler in main.go and invoked it via a curl command.
Note: EasyMesh(rdkb-cli) currently supports processing this command only for connected clients.

Test Results:

When the controller sends a request to block a connected client on a specific BSSID for a defined duration, the client is added to the ACL for that BSSID.
If the client disconnects and attempts to reconnect, it is denied access to the same BSSID.
When blocked on the 5GHz BSSID, the client was still able to connect to the 2.4GHz BSSID.
After blocking the client on both 5GHz and 2.4GHz BSSIDs, the client was unable to connect until the validity timer expired.

Signed-off-by: Sundram Patel <Sundram.p@tataelxsi.co.in>