### PR TITLE
RDKBWIFI-378: Redesign of rdkb cli channel change to support channel update per radio and set preference.

### DIFF
--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -1703,6 +1703,12 @@ int dm_easy_mesh_ctrl_t::get_channel_config(cJSON *parent, char *key, em_get_cha
         for (j = 0; j < cJSON_GetArraySize(radio_list_obj); j++) {
             radio_obj = cJSON_GetArrayItem(radio_list_obj, j);
             tmp = cJSON_GetStringValue(cJSON_GetObjectItem(radio_obj, "ID"));
+            // Radio specific AnticipatedChannelPreference
+            if (reason == em_get_channel_list_reason_set_anticipated) {
+                channel_list_obj = cJSON_AddArrayToObject(radio_obj, "AnticipatedChannelPreference");
+                snprintf(op_key, sizeof(op_key), "%s@%d@%d", tmp, em_op_class_type_anticipated, 0);
+                dm_op_class_list_t::get_config(op_class_list_obj, op_key);
+            }
             op_class_list_obj = cJSON_AddArrayToObject(radio_obj, "CurrentOperatingClasses");
             snprintf(op_key, sizeof(op_key), "%s@%d@%d", tmp, em_op_class_type_current, 0);
             dm_op_class_list_t::get_config(op_class_list_obj, op_key);

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -1122,7 +1122,7 @@ int dm_easy_mesh_t::decode_config_set_policy(em_subdoc_info_t *subdoc, const cha
 int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const char *key, unsigned int index, unsigned int *num)
 {
     cJSON *parent_obj, *net_obj, *net_obj_id; 
-	cJSON *target_arr_obj, *target_obj, *channel_arr_obj;
+    cJSON *target_arr_obj, *target_obj, *channel_arr_obj, *channel_pref_arry_obj;
     int i, j, arr_size;
     char *net_id;
 	em_long_string_t	target_key;	
@@ -1194,13 +1194,19 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
         	return -1;
 		}
 
+		if ((channel_pref_arry_obj = cJSON_GetObjectItem(target_obj, "ChannelPrefList")) == NULL) {
+			cJSON_Delete(parent_obj);
+			em_printfout("Error: %s not present\n", target_key);
+			return -1;
+		}
+
 		m_op_class[m_num_opclass].m_op_class_info.num_channels = 0;
 
 		for (j = 0; j < cJSON_GetArraySize(channel_arr_obj); j++) {
 			m_op_class[m_num_opclass].m_op_class_info.channels[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_arr_obj, j)));
+			m_op_class[m_num_opclass].m_op_class_info.channel_pref[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_pref_arry_obj, j)));
 			m_op_class[m_num_opclass].m_op_class_info.num_channels++;
-		}	
-
+		}
 		m_num_opclass++;
 	}	
 	

--- a/src/dm/dm_op_class_list.cpp
+++ b/src/dm/dm_op_class_list.cpp
@@ -99,7 +99,7 @@ int dm_op_class_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
 void dm_op_class_list_t::get_config(cJSON *obj_arr, em_op_class_type_t type)
 {
 	dm_op_class_t *op_class;
-	cJSON *obj, *channel_arr;
+	cJSON *obj, *channel_arr, *channel_pref_arr;
 	unsigned int i;
 
 	// only anticipated is implemented now
@@ -115,8 +115,10 @@ void dm_op_class_list_t::get_config(cJSON *obj_arr, em_op_class_type_t type)
 
 		cJSON_AddNumberToObject(obj, "Class", op_class->m_op_class_info.op_class);
 		channel_arr = cJSON_AddArrayToObject(obj, "ChannelList");
+		channel_pref_arr = cJSON_AddArrayToObject(obj, "ChannelPrefList");
 		for (i = 0; i < op_class->m_op_class_info.num_channels; i++) {
            	cJSON_AddItemToArray(channel_arr, cJSON_CreateNumber(op_class->m_op_class_info.channels[i]));
+           	cJSON_AddItemToArray(channel_pref_arr, cJSON_CreateNumber(op_class->m_op_class_info.channel_pref[i]));
        	}
 
 		cJSON_AddItemToArray(obj_arr, obj);

--- a/src/rdkb-cli/main.go
+++ b/src/rdkb-cli/main.go
@@ -53,6 +53,7 @@ import (
 )
 
 const remoteCtrl_Addr_path = "/nvram/remoteCtrl.json"
+var nonHex = regexp.MustCompile(`[^a-fA-F0-9]`)
 var timerCount = 0
 
 // ===== SIMPLIFIED DATA MODELS =====
@@ -413,11 +414,12 @@ type ClassInfo struct {
 
 // channelConfig struct to store previous configuration
 type channelConfig struct {
+	DeviceID    string `json:"device_id,omitempty"`
 	RadioID    string  `json:"radio_id"`
 	RadioIndex int     `json:"radio_index"`
 	Class      int     `json:"class"`
 	Channels   []int   `json:"channels"`
-	Preference []int   `json:"preference"`
+	Preferences []int  `json:"preferences"`
 }
 
 type AdvancedWirelessSettings struct {
@@ -1964,7 +1966,7 @@ func getRadioConfigsHandler(w http.ResponseWriter, r *http.Request) {
                 return
             }
 
-           applyChannelConfig(wifiChannelUpdateTree)
+            applyChannelConfig(wifiChannelUpdateTree)
 
            // Return success response
             w.Header().Set("Content-Type", "application/json")
@@ -3453,7 +3455,6 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
                 }
             }
 
-			dumpNetNode(resetTree);
             if applyResetConfig(resetTree) != true {
                 msg := fmt.Sprintf("Failed to apply wifi reset config")
                 errorsList = append(errorsList, msg)
@@ -4850,20 +4851,82 @@ func getConfiguredChannels(tree *C.em_network_node_t) []WifiChannelConfig {
         return result
     }
 
+    // ---------- Build GLOBAL entry ----------
+    {
+        var globalCfgs []channelConfig
+        // Iterate through the global AnticipatedChannelPreference
+        for idx := 0; idx < int(configuredChannelPrefNode.num_children); idx++ {
+            var bandIndex int
+            cfgNode := configuredChannelPrefNode.child[idx]
+            if cfgNode == nil {
+               continue
+            }
+
+            if idx == 2 {
+                // bandIndex of 6Ghz is 3
+                bandIndex = idx + 1
+            } else {
+                bandIndex = idx
+            }
+
+            // Read Class
+            ConfigClass := getKeyIntValue(cfgNode, "Class")
+
+            // Read ChannelList
+            chListKey := C.CString("ChannelList")
+            chListNode := C.get_network_tree_by_key(cfgNode, chListKey)
+            C.free(unsafe.Pointer(chListKey))
+
+            var configChannels []int
+            if chListNode != nil {
+                for k := 0; k < int(chListNode.num_children); k++ {
+                    configChannels = append(configChannels, int(chListNode.child[k].value_int))
+                }
+            }
+
+            // Read ChannelPrefList
+            prefListKey := C.CString("ChannelPrefList")
+            prefListNode := C.get_network_tree_by_key(cfgNode, prefListKey)
+            C.free(unsafe.Pointer(prefListKey))
+
+            var configChannelsPref []int
+            if prefListNode != nil {
+                for k := 0; k < int(prefListNode.num_children); k++ {
+                    configChannelsPref = append(configChannelsPref, int(prefListNode.child[k].value_int))
+                }
+            }
+
+            // RadioID left empty for global.
+            globalCfgs = append(globalCfgs, channelConfig{
+                RadioID:     "",
+                RadioIndex:  bandIndex,
+                Class:       ConfigClass,
+                Channels:    configChannels,
+                Preferences: configChannelsPref,
+            })
+        }
+
+        result = append(result, WifiChannelConfig{
+            DeviceID:       "FF:FF:FF:FF:FF:FF", // GLOBAL sentinel
+            SupportedClass: nil,                 // can be filled from capability later
+            SelectedConfig: globalCfgs,
+        })
+    }
+
+    // ---------- Build per-device entries ----------
     for i := 0; i < int(deviceListNode.num_children); i++ {
         deviceNode := deviceListNode.child[i]
+        if deviceNode == nil {
+            continue
+        }
+
         deviceID := getTreeValue(deviceNode, "ID")
 
         keyRadioList := C.CString("RadioList")
         defer C.free(unsafe.Pointer(keyRadioList))
-        RadioListNode := C.get_network_tree_by_key(tree, keyRadioList)
-        if RadioListNode == nil {
-            log.Printf("Failed to get previous channel configuration")
-            result = append(result, WifiChannelConfig{
-                DeviceID:       deviceID,
-                SupportedClass: nil,
-                SelectedConfig: nil,
-            })
+        RadioListNode := C.get_network_tree_by_key(deviceNode, keyRadioList)
+        if RadioListNode == nil || int(RadioListNode.num_children) == 0 {
+            log.Printf("Radio List is empty for device %s. moving to next device\n", deviceID)
             continue
         }
 
@@ -4871,32 +4934,70 @@ func getConfiguredChannels(tree *C.em_network_node_t) []WifiChannelConfig {
         var cfgs []channelConfig
         for j := 0; j < int(RadioListNode.num_children); j++ {
             radioNode := RadioListNode.child[j]
+            if radioNode == nil {
+                continue
+            }
+
             radioID := getTreeValue(radioNode, "ID")
             bandIndex := getKeyIntValue(radioNode, "Band")
-            //TODO: remote or modify later after supporting per radio channel update.
-            anticipatedChannelIndex := bandIndex
-            if bandIndex == 0 ||  bandIndex == 1 {
-                anticipatedChannelIndex = bandIndex
-            } else if bandIndex == 3 {
-                anticipatedChannelIndex = 2
+
+            // Keep empty config item to reflect that radio exists
+            cfgs = append(cfgs, channelConfig{
+                RadioID:     radioID,
+                RadioIndex:  bandIndex,
+                Class:       0,
+                Channels:    nil,
+                Preferences: nil,
+            })
+
+            //configuredChannel := configuredChannelPrefNode.child[anticipatedChannelIndex]
+            radioChannelNode := C.get_network_tree_by_key(radioNode, keyACP)
+            if radioChannelNode == nil {
+                continue
             }
-            configuredChannel := configuredChannelPrefNode.child[anticipatedChannelIndex]
-            ConfigClass := getKeyIntValue(configuredChannel, "Class")
-            configChannelList := C.get_network_tree_by_key(configuredChannel, C.CString("ChannelList"))
-            var configChannels []int
-            if configChannelList != nil {
-                for j := 0; j < int(configChannelList.num_children); j++ {
-                    configChannels = append(configChannels, int(configChannelList.child[j].value_int))
+
+            for idx := 0; idx < int(radioChannelNode.num_children); idx++ {
+                cfgNode := radioChannelNode.child[idx]
+                if cfgNode == nil {
+                    continue
                 }
-            }
+
+                // Read Class
+                ConfigClass := getKeyIntValue(cfgNode, "Class")
+
+                // Read ChannelList
+                chListKey := C.CString("ChannelList")
+                chListNode := C.get_network_tree_by_key(cfgNode, chListKey)
+                C.free(unsafe.Pointer(chListKey))
+
+                var configChannels []int
+                if chListNode != nil {
+                    for k := 0; k < int(chListNode.num_children); k++ {
+                        configChannels = append(configChannels, int(chListNode.child[k].value_int))
+                    }
+                }
+
+                // Read ChannelPrefList
+                prefListKey := C.CString("ChannelPrefList")
+                prefListNode := C.get_network_tree_by_key(cfgNode, prefListKey)
+                C.free(unsafe.Pointer(prefListKey))
+
+                var configChannelsPref []int
+                if prefListNode != nil {
+                    for k := 0; k < int(prefListNode.num_children); k++ {
+                        configChannelsPref = append(configChannelsPref, int(prefListNode.child[k].value_int))
+                    }
+                }
 
             cfgs  = append(cfgs , channelConfig{
                 RadioID: radioID,
                 RadioIndex: bandIndex,
                 Class:      ConfigClass,
                 Channels:   configChannels,
+                Preferences: configChannelsPref,
             })
         }
+    }
 
         result = append(result, WifiChannelConfig{
             DeviceID:       deviceID,
@@ -4922,25 +5023,120 @@ func updateAnticipatedChannelPreference(tree *C.em_network_node_t, updatedChanne
         return fmt.Errorf("updateAnticipatedChannelPreference: updated channel array is nil")
     }
 
-    channelPrefTree_cmd := C.CString("AnticipatedChannelPreference")
-    classNode_cmd := C.CString("Class")
-    defer C.free(unsafe.Pointer(channelPrefTree_cmd))
-    defer C.free(unsafe.Pointer(classNode_cmd))
-    channelPrefTree := C.get_network_tree_by_key(tree, channelPrefTree_cmd)
+    // --------- C keys ----------
+    keyACP              := C.CString("AnticipatedChannelPreference")
+    keyClass            := C.CString("Class")
+    keyChannelList      := C.CString("ChannelList")
+    keyChannelPrefList  := C.CString("ChannelPrefList")
+    keyDeviceList       := C.CString("DeviceList")
+    keyRadioList        := C.CString("RadioList")
+
+    // Free at the end of the function
+    defer func() {
+        C.free(unsafe.Pointer(keyACP))
+        C.free(unsafe.Pointer(keyClass))
+        C.free(unsafe.Pointer(keyChannelList))
+        C.free(unsafe.Pointer(keyChannelPrefList))
+        C.free(unsafe.Pointer(keyDeviceList))
+        C.free(unsafe.Pointer(keyRadioList))
+    }()
+
+    channelPrefTree := C.get_network_tree_by_key(tree, keyACP)
     if channelPrefTree == nil {
         return fmt.Errorf("updateAnticipatedChannelPreference: missing 'AnticipatedChannelPreference' node")
     }
 
     for _, cfg := range updatedChannelArray {
-        channelPrefNode := channelPrefTree.child[cfg.RadioIndex]
-        classNode := C.get_network_tree_by_key(channelPrefNode, classNode_cmd)
-        if classNode != nil {
-            classNode.value_int = C.uint(cfg.Class)
+        if IsAllFF(cfg.DeviceID) {
+            // update global config
+            channelPrefNode := channelPrefTree.child[cfg.RadioIndex]
+            classNode := C.get_network_tree_by_key(channelPrefNode, keyClass)
+            if classNode != nil {
+                classNode.value_int = C.uint(cfg.Class)
+            }
+            channelListNode := C.get_network_tree_by_key(channelPrefNode, keyChannelList)
+            C.set_node_type(channelListNode, C.em_network_node_data_type_array_num)
+            channelListNode.num_children = 0
+            C.set_node_array_value(channelListNode, C.CString(mapchannelsToSlice(cfg.Channels)))
+
+            //update channel preference list
+            channelPrefListNode := C.get_network_tree_by_key(channelPrefNode, keyChannelPrefList)
+            if channelPrefListNode != nil {
+               C.set_node_type(channelPrefListNode, C.em_network_node_data_type_array_num)
+               channelPrefListNode.num_children = 0
+               C.set_node_array_value(channelPrefListNode, C.CString(mapchannelsToSlice(cfg.Preferences)))
+           }
+        } else {
+            // update for specific radio
+            isRadioIdFound := false
+            deviceListNode := C.get_network_tree_by_key(tree, keyDeviceList)
+            if deviceListNode == nil {
+                return fmt.Errorf("updateAnticipatedChannelPreference: Failed to get the device list\n")
+            }
+
+            for i := 0; i < int(deviceListNode.num_children); i++ {
+                deviceNode := deviceListNode.child[i]
+                if deviceNode == nil {
+                    return fmt.Errorf("updateAnticipatedChannelPreference: Failed to parse device list\n")
+                }
+
+                deviceID := getTreeValue(deviceNode, "ID")
+
+                if deviceID == cfg.DeviceID {
+                    RadioListNode := C.get_network_tree_by_key(deviceNode, keyRadioList)
+                    if RadioListNode == nil || int(RadioListNode.num_children) == 0 {
+                        log.Printf("Radio List is empty for device %s\n", deviceID)
+                        return fmt.Errorf("updateAnticipatedChannelPreference: Failed to parse Radio list\n")
+                    }
+                    for j := 0; j < int(RadioListNode.num_children); j++ {
+                        radioNode := RadioListNode.child[j]
+                        if radioNode == nil {
+                            return fmt.Errorf("updateAnticipatedChannelPreference: Failed to parse Radio ID\n")
+                        }
+                        radioID := getTreeValue(radioNode, "ID")
+                        if radioID == cfg.RadioID {
+                            isRadioIdFound = true
+                            log.Printf("Updating the channel config for RUID %s\n", cfg.RadioID)
+                            radioChannelNode := C.get_network_tree_by_key(radioNode, keyACP)
+                            if radioChannelNode == nil {
+                                return fmt.Errorf("updateAnticipatedChannelPreference: Failed to parse updateAnticipatedChannelPreference for Radio ID %s\n", cfg.RadioID)
+                            }
+                            if (radioChannelNode.num_children < 1) {
+                                cloneTree := C.clone_network_tree_for_display(channelPrefTree, nil, 0xffff, false)
+                                if cloneTree == nil || cloneTree.num_children == 0 || cloneTree.child[0] == nil {
+                                    log.Printf("clone failed at i=%d; aborting grow..!", i)
+                                    return fmt.Errorf("updateAnticipatedChannelPreference: clone failed for Radio ID %s\n", cfg.RadioID)
+                                }
+                                radioChannelNode.child[0] = cloneTree.child[cfg.RadioIndex]
+                                radioChannelNode.num_children = 1
+							}
+							channelPrefNode := radioChannelNode.child[0]
+							classNode := C.get_network_tree_by_key(channelPrefNode, keyClass)
+							if classNode != nil {
+							    classNode.value_int = C.uint(cfg.Class)
+                            }
+                            channelListNode := C.get_network_tree_by_key(channelPrefNode, keyChannelList)
+                            C.set_node_type(channelListNode, C.em_network_node_data_type_array_num)
+                            channelListNode.num_children = 0
+                            C.set_node_array_value(channelListNode, C.CString(mapchannelsToSlice(cfg.Channels)))
+
+                            //update channel preference list
+                            channelPrefListNode := C.get_network_tree_by_key(channelPrefNode, keyChannelPrefList)
+                            if channelPrefListNode != nil {
+                                C.set_node_type(channelPrefListNode, C.em_network_node_data_type_array_num)
+                                channelPrefListNode.num_children = 0
+                                C.set_node_array_value(channelPrefListNode, C.CString(mapchannelsToSlice(cfg.Preferences)))
+                            }
+                            break
+                        }
+                    }
+                }
+                if isRadioIdFound == true {
+                    //Radio id is found hence breaking the loop for devic id.
+                    break
+                }
+            }
         }
-        channelListNode := C.get_network_tree_by_key(channelPrefNode, C.CString("ChannelList"))
-        C.set_node_type(channelListNode, C.em_network_node_data_type_array_num)
-        channelListNode.num_children = 0
-        C.set_node_array_value(channelListNode, C.CString(mapchannelsToSlice(cfg.Channels)))
     }
     return nil
 }
@@ -4999,6 +5195,23 @@ func mapchannelsToSlice(channels []int) string {
     return "[" + strings.Join(strKeys, ", ") + "]"
 }
 
+/* func: IsAllFF()
+ * Description:
+ * check if mac address is FF:FF:FF:FF:FF:FF
+ * returns: true if mac is all ff else flase
+ */
+func IsAllFF(mac string) bool {
+    hex := nonHex.ReplaceAllString(strings.TrimSpace(mac), "")
+    if len(hex) != 10 && len(hex) != 12 {
+        return false
+    }
+    for _, ch := range hex {
+        if ch != 'F' && ch != 'f' {
+            return false
+        }
+    }
+    return true
+}
 /* func: dumpNetNode()
  * Description:
  * Print the tree for debug purpose

--- a/src/rdkb-cli/static/wireless-settings.js
+++ b/src/rdkb-cli/static/wireless-settings.js
@@ -455,6 +455,13 @@ class WirelessSettings {
     const UNSET_PREF = 15;
 
     // ---------- Small helpers ----------
+    const isAllFF = (mac) => {
+      const hex = String(mac || '').replace(/[^a-fA-F0-9]/g, '');
+      return hex.length === 10 || hex.length === 12
+        ? /^[Ff]+$/.test(hex)
+        : false;
+    };
+
     const getEl = (id) => document.getElementById(id);
 
     const normalizeBandKey = (bandLabel) =>
@@ -475,6 +482,17 @@ class WirelessSettings {
       val === UNSET_PREF ? '—' : (val === 0 ? '0 (Non operable)' : (val === 14 ? '14 (Most preferable)' : String(val)));
     const prefTitle = (val) =>
       val === UNSET_PREF ? 'Not set (defaults to 15)' : (val === 0 ? '0 — Non operable' : (val === 14 ? '14 — Most preferable' : String(val)));
+
+    const encodePref = (guiVal) => (Number.isFinite(guiVal) ? (Number(guiVal) << 4) : (UNSET_PREF << 4));
+    const decodePref = (storedVal) => {
+      return (storedVal == null) ? UNSET_PREF : (Number(storedVal) >> 4);
+    };
+
+    const importIncomingPref = (n) => {
+      const num = Number(n);
+      if (!Number.isFinite(num)) return encodePref(UNSET_PREF);
+      return (num >= 16) ? num : encodePref(num);
+    };
 
     const getChannelsFromClassObj = (clsObj) => {
       if (!clsObj) return [];
@@ -512,14 +530,35 @@ class WirelessSettings {
       }
 
       const implicit = String(bandConfig?.selected_wifi_config?.device_id ?? bandConfig?.device_id ?? bandConfig?.deviceId ?? '').trim();
-      return implicit ? [{ device_id: implicit, supported_class: bandSupported, selected_config: bandSelected }] : [];
+      if (implicit) {
+        return [{ device_id: implicit, supported_class: bandSupported, selected_config: bandSelected }];
+      }
+      if (bandSupported.length) {
+        return [{
+          device_id: 'all',
+          supported_class: bandSupported,
+          selected_config: bandSelected
+        }];
+      }
+      return [];
     };
 
     const coerceSelected = (selected_config) => {
-      if (!selected_config) return { cls: '', channels: [] };
-      const one = (o) => ({ cls: String(o?.class ?? o?.Class ?? '').trim(), channels: Array.isArray(o?.channels) ? o.channels : [] });
+      if (!selected_config) {
+        return { cls: '', channels: [], prefsArr: [], radio_id: '', radio_index: undefined };
+      }
+
+      const one = (o) => ({
+        cls: String(o?.class ?? o?.Class ?? '').trim(),
+        channels: Array.isArray(o?.channels) ? o.channels : [],
+        //preferences will be an array aligned by index to `channels`
+        prefsArr: Array.isArray(o?.preferences) ? o.preferences : [],
+        radio_id: String(o?.radio_id ?? o?.radioId ?? '').trim(),
+        radio_index: Number.isFinite(Number(o?.radio_index)) ? Number(o.radio_index) : undefined,
+      });
       return Array.isArray(selected_config) ? one(selected_config[0] || {}) : one(selected_config);
     };
+
 
     const ensureBucket = (bandIndex) => {
       if (!ctx.updateChannelConfig) ctx.updateChannelConfig = {};
@@ -545,7 +584,7 @@ class WirelessSettings {
     const debounce = (fn, ms = 120) => { let t; return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); }; };
 
     // ---------- Rendering: channels (with badge + inline preference dropdown) ----------
-    const renderChannels = (bandKey, bandIndex, device, classValue, carryPrevChannels = []) => {
+    const renderChannels = (bandKey, bandIndex, device, classValue, carryPrevChannels = [], carryPrevPrefsArr = []) => {
       const listBody = getEl(`list-${bandKey}`);
       const chkAll   = getEl(`checkAll-${bandKey}`);
       const searchEl = getEl(`search-${bandKey}`);
@@ -561,14 +600,43 @@ class WirelessSettings {
       const channels = q ? allChannels.filter(ch => String(ch).includes(q)) : allChannels;
 
       const bucket = ensureBucket(bandIndex);
-      bucket.device_id   = String(device.device_id);
+      // Preserve a virtual "all" device_id if that's the current selection.
+      // Otherwise, track the concrete device ID we are rendering for.
+      {
+        const incomingDeviceId = String(device.device_id);
+        bucket.device_id = (bucket.device_id === 'all') ? 'all' : incomingDeviceId;
+      }
+      if (!bucket.radio_id && bucket.device_id !== 'all') {
+        const { radio_id: rid, radio_index: rix } = coerceSelected(device?.selected_config);
+        if (rid) bucket.radio_id = rid;
+        if (Number.isFinite(rix)) bucket.radio_index = rix;
+      }
+
       bucket.radio_index = bandIndex;
       bucket.class       = parseInt(classValue, 10) || 0;
 
       // Seed previous selection only once
       if (Array.isArray(carryPrevChannels) && carryPrevChannels.length && bucket.channels.length === 0) {
-        bucket.channels = [...new Set(carryPrevChannels.map(Number))];
-        for (const c of bucket.channels) if (bucket.preferences[String(c)] == null) bucket.preferences[String(c)] = UNSET_PREF;
+        // Keep original order so index mapping to prefsArr stays correct
+        const uniq = [];
+        const seen = new Set();
+        for (const ch of carryPrevChannels) {
+          const n = Number(ch);
+          if (!seen.has(n)) { seen.add(n); uniq.push(n); }
+        }
+        bucket.channels = uniq;
+        // Map channel[i] => prefsArr[i] if available; else set UNSET (shifted)
+        for (let i = 0; i < uniq.length; i++) {
+          const ch = uniq[i];
+          const key = String(ch);
+          if (bucket.preferences[key] == null) {
+            if (Array.isArray(carryPrevPrefsArr) && i < carryPrevPrefsArr.length) {
+              bucket.preferences[key] = importIncomingPref(carryPrevPrefsArr[i]);
+            } else {
+              bucket.preferences[key] = encodePref(UNSET_PREF);
+            }
+          }
+        }
       }
 
       listBody.dataset.bandKey = bandKey;
@@ -586,7 +654,8 @@ class WirelessSettings {
       listBody.innerHTML = channels.map(ch => {
         const chNum = Number(ch);
         const isSelected = selSet.has(chNum);
-        const prefVal = (bucket.preferences[String(chNum)] != null) ? bucket.preferences[String(chNum)] : UNSET_PREF;
+        const stored = bucket.preferences[String(chNum)];
+        const prefVal = decodePref(stored);
         return `
           <div class="list-row" data-channel="${chNum}">
             <div><input type="checkbox" class="ch-check" ${isSelected ? 'checked' : ''} aria-label="Select channel ${chNum}"></div>
@@ -605,11 +674,24 @@ class WirelessSettings {
                 ${isSelected ? '' : 'disabled'}
                 hidden
                 aria-label="Preference for channel ${chNum}">
-                ${Array.from({length: PREF_MAX - PREF_MIN + 1}, (_,i) => i + PREF_MIN).map(v => `
-                  <option value="${v}" ${(bucket.preferences[String(chNum)] !== undefined && v === Number(bucket.preferences[String(chNum)])) ? 'selected' : ''}>
-                    ${v===0 ? '0 (Non operable)' : (v===14 ? '14 (Most preferable)' : v)}
-                  </option>
-                `).join('')}
+                ${(() => {
+                  const cur = decodePref(bucket.preferences[String(chNum)]);
+                  const items = [];
+                  // Placeholder: "Select preference" - represents UNSET (15)
+                  items.push(`
+                    <option value="${UNSET_PREF}" ${cur == null || Number(cur) === UNSET_PREF ? 'selected' : ''}>
+                      Select preference
+                    </option>
+                  `);
+                  for (let v = PREF_MIN; v <= PREF_MAX; v++) {
+                    items.push(`
+                      <option value="${v}" ${(cur != null && Number(cur) === v) ? 'selected' : ''}>
+                        ${v === 0 ? '0 (Non operable)' : (v === 14 ? '14 (Most preferable)' : v)}
+                      </option>
+                    `);
+                  }
+                  return items.join('');
+                })()}
               </select>
             </div>
           </div>`;
@@ -627,7 +709,7 @@ class WirelessSettings {
             if (chkAll.checked) {
               for (const c of channels.map(Number)) {
                 if (!bucket.channels.includes(c)) bucket.channels.push(c);
-                if (bucket.preferences[String(c)] == null) bucket.preferences[String(c)] = UNSET_PREF;
+                if (bucket.preferences[String(c)] == null) bucket.preferences[String(c)] = encodePref(UNSET_PREF);
               }
             } else {
               const rm = new Set(channels.map(Number));
@@ -670,9 +752,9 @@ class WirelessSettings {
           if (e.target.classList.contains('ch-check')) {
             if (chk.checked) {
               if (!bucket.channels.includes(chNum)) bucket.channels.push(chNum);
-              if (bucket.preferences[String(chNum)] == null) bucket.preferences[String(chNum)] = UNSET_PREF;
+              if (bucket.preferences[String(chNum)] == null) bucket.preferences[String(chNum)] = encodePref(UNSET_PREF);
 
-              const v = bucket.preferences[String(chNum)];
+              const v = decodePref(bucket.preferences[String(chNum)]);
               btn.disabled = false; dd.disabled = false;
               badge.textContent = prefText(v);
               badge.title = prefTitle(v);
@@ -702,15 +784,16 @@ class WirelessSettings {
 
           // Preference change
           if (e.target.classList.contains('pref-inline-dd')) {
-            const val = Math.max(PREF_MIN, Math.min(PREF_MAX, Math.round(Number(e.target.value))));
-            bucket.preferences[String(chNum)] = val;
+            const guiVal = Math.max(PREF_MIN, Math.min(PREF_MAX, Math.round(Number(e.target.value))));
+            bucket.preferences[String(chNum)] = encodePref(guiVal);
+
             if (!bucket.channels.includes(chNum)) bucket.channels.push(chNum);
             chk.checked = true; btn.disabled = false; dd.disabled = false;
 
-            badge.textContent = prefText(val);
-            badge.title = prefTitle(val);
-            badge.style.background = prefColor(val);
-            badge.classList.toggle('muted', val === UNSET_PREF);
+            badge.textContent = prefText(guiVal);
+            badge.title = prefTitle(guiVal);
+            badge.style.background = prefColor(guiVal);
+            badge.classList.toggle('muted', guiVal === UNSET_PREF);
 
             dd.hidden = true;
             btn.setAttribute('aria-expanded','false');
@@ -738,11 +821,11 @@ class WirelessSettings {
       }
 
       const supported = Array.isArray(device?.supported_class) ? device.supported_class : [];
-      const { cls, channels } = coerceSelected(device?.selected_config);
+      const { cls, channels, prefsArr, radio_id, radio_index } = coerceSelected(device?.selected_config);
 
       if (!supported.length) {
         classSel.innerHTML = `<option value="" disabled selected>No classes available</option>`;
-        renderChannels(bandKey, bandIndex, device, '', []);
+        renderChannels(bandKey, bandIndex, device, '', [], []);
         return;
       }
 
@@ -753,14 +836,47 @@ class WirelessSettings {
         })
         .join('');
 
-      const initial = (cls || classSel.options[0]?.value || '').trim();
-      classSel.value = initial;
+      // ---- Determine if selected_config is actually present for this device ----
+      const hasSelectedConfig = (() => {
+        const sc = device?.selected_config;
+        if (sc == null) return false;
+        if (Array.isArray(sc)) return sc.length > 0;
+        if (typeof sc === 'object') return Object.keys(sc).length > 0;
+        return false;
+      })();
+
+      let initial = '';
+      if (!hasSelectedConfig) {
+        // Requirement: If selected_config is NOT present, select the FIRST class.
+        if (classSel.options.length) classSel.selectedIndex = 0;
+        initial = classSel.value;
+      } else {
+        // selected_config exists: honor it if valid; otherwise fallback to first.
+        const supportedValues = supported
+          .map(sc => String(sc?.class ?? '').trim())
+          .filter(Boolean);
+        const clsStr = String(cls ?? '').trim();
+        if (clsStr && supportedValues.includes(clsStr)) {
+          initial = clsStr;
+          classSel.value = initial;
+        } else {
+          if (clsStr && !supportedValues.includes(clsStr)) {
+            console.warn(
+              `[${bandKey}] Selected class (${clsStr}) not in supported: ${supportedValues.join(', ')}`
+            );
+          }
+          if (classSel.options.length) classSel.selectedIndex = 0;
+          initial = classSel.value;
+        }
+      }
 
       const b = ensureBucket(bandIndex);
       b.device_id = device.device_id;
-      b.class = parseInt(initial, 10) || 0;
+      b.radio_id = (b.device_id === 'all') ? '' : (radio_id || '');
+      b.radio_index = Number.isFinite(radio_index) ? radio_index : bandIndex;
+      b.class = Number.isFinite(Number(initial)) ? Number(initial) : initial;
 
-      renderChannels(bandKey, bandIndex, device, initial, carryPrev ? channels : []);
+      renderChannels(bandKey, bandIndex, device, initial, carryPrev ? channels : [], carryPrev ? (prefsArr || []) : []);
 
       if (!classSel.__wired) {
         classSel.addEventListener('change', () => {
@@ -775,7 +891,7 @@ class WirelessSettings {
           }
 
           const newClass = String(classSel.value).trim();
-          b.class = parseInt(newClass, 10) || Number.isFinite(Number(newClass)) ? Number(newClass) : newClass;
+          b.class = Number.isFinite(Number(newClass)) ? Number(newClass) : newClass;
           const saved = b.perClass[String(newClass)];
           if (saved && Array.isArray(saved.channels)) {
             b.channels = saved.channels.slice();
@@ -784,7 +900,7 @@ class WirelessSettings {
             b.channels = [];
             b.preferences = {};
           }
-          renderChannels(bandKey, bandIndex, device, classSel.value, saved?.channels || []);
+          renderChannels(bandKey, bandIndex, device, classSel.value, saved?.channels || [], []);
         });
         classSel.__wired = true;
       }
@@ -811,46 +927,38 @@ class WirelessSettings {
 
       const devices = getDevicesForBand(bandConfig).filter(d => d.device_id);
 
-      //TODO: For now fixing the device list to ALL Station, later it will be modified based on RUID
-      deviceSel.innerHTML = `<option value="all" selected>ALL station</option>`;
-      deviceSel.disabled = true;
-
-      //TODO enable later to Populate device select
-      /*deviceSel.innerHTML = devices.length
-        ? devices.map((d,i) => `<option value="${d.device_id}" ${i===0?'selected':''}>${d.device_id}</option>`).join('')
-        : `<option value="" disabled selected>No devices</option>`;
-      */
-      if (!devices.length) {
+      // Populate device dropdown: "ALL station" for global config, or all device IDs/ruid specific.
+      if (devices.length) {
+        const options = devices.map(d => {
+          const { radio_id } = coerceSelected(d.selected_config);
+          const label = (d.device_id === 'all')? 'ALL station': (isAllFF(d.device_id) ? 'ALL station' : d.device_id);
+          return `<option value="${d.device_id}">${label}</option>`;
+        }).join('');
+        deviceSel.innerHTML = options;
+        deviceSel.disabled = false;
+      } else {
+        deviceSel.innerHTML = `<option value="" disabled selected>No devices</option>`;
         classSel.innerHTML = `<option value="" disabled selected>No classes available</option>`;
         listBody.innerHTML = '<div class="empty">No devices for this band.</div>';
         return;
       }
 
-      //TODO: For now fixing the device list to ALL Station, later it will be modified based on RUID
-      //--------------------------------------
-      // Use the first real device only for UI rendering
+      // Initial selection:
+      // - If bucket already has device_id and it's still valid, honor it.
+      // - Otherwise default to "all".
       const firstDevice = devices[0];
+      const b = ensureBucket(bandIndex);
+      const knownIds = new Set(devices.map(d => String(d.device_id)));
+      if (!b.device_id || !knownIds.has(String(b.device_id))) {
+        b.device_id = String(firstDevice.device_id);
+      }
+      deviceSel.value = String(b.device_id);
 
-      const bucket = ensureBucket(bandIndex);
-      bucket.device_id = "all";  // Important! For future apply logic.
+      const currentDevice = () => {
+        return devices.find(d => String(d.device_id) === deviceSel.value) || firstDevice;
+      };
 
-      // Render using the first device's classes/channels
-      renderClasses(bandKey, bandIndex, firstDevice, true);
-      //--------------------------------------
-
-      //TODO To be enabled later for device selection from GUI
-      // Prefer device that has previous selection
-      /*const idxWithSel = devices.findIndex(d => {
-        const sc = d.selected_config;
-        if (!sc) return false;
-        if (Array.isArray(sc)) return sc.length > 0;
-        return Boolean(sc?.class || (Array.isArray(sc?.channels) && sc.channels.length > 0));
-      });
-      deviceSel.value = (idxWithSel >= 0 ? devices[idxWithSel] : devices[0]).device_id;
-
-      const currentDevice = () => devices.find(d => d.device_id === deviceSel.value) || devices[0];
-
-      ensureBucket(bandIndex).device_id = deviceSel.value;
+      // Render with the chosen (or representative) device
       renderClasses(bandKey, bandIndex, currentDevice(), true);
 
       if (!deviceSel.__wired) {
@@ -862,7 +970,7 @@ class WirelessSettings {
           renderClasses(bandKey, bandIndex, currentDevice(), true);
         });
         deviceSel.__wired = true;
-      }*/
+      }
     };
 
     // ---------- Initialize all bands ----------
@@ -1263,6 +1371,9 @@ class WirelessSettings {
       saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
     }
 
+    // Keep this in sync with your UI constant
+    const UNSET_PREF = 15;
+
     try {
       const settings = this.updateChannelConfig;
       const channelConfigs = Object.values(settings).map(cfg => {
@@ -1271,6 +1382,10 @@ class WirelessSettings {
 
         const classVal = typeof cfg.class === 'string'
           ? parseInt(cfg.class, 10) : cfg.class;
+
+        // --- radio_id as MAC string
+        const rawRadioId = (cfg && typeof cfg.radio_id === 'string') ? cfg.radio_id.trim() : '';
+        const deviceId   = (typeof cfg.device_id === 'string') ? cfg.device_id.trim() : '';
 
         // Ensure channels is an array of integers
         const channels = Array.isArray(cfg.channels) ? (
@@ -1283,10 +1398,24 @@ class WirelessSettings {
           ).sort((a, b) => a - b)
         ) : [];
 
+        const prefsMap = (cfg.preferences && typeof cfg.preferences === 'object') ? cfg.preferences : {};
+
+        const preferences = channels.map(ch => {
+          const key = String(ch);
+          const raw = prefsMap[key];
+          const prefInt = (typeof raw === 'string') ? parseInt(raw, 10) : raw;
+
+           // If pref is a valid integer, use it; otherwise default UNSET_PREF
+           return Number.isInteger(prefInt) ? prefInt : UNSET_PREF;
+        });
+
         return {
+          device_id: deviceId,
+          radio_id: rawRadioId,
           radio_index: Number.isInteger(radioIndex) ? radioIndex : 0,
           class: Number.isInteger(classVal) ? classVal : 0,
           channels,
+          preferences,
         };
       });
 


### PR DESCRIPTION
The changes include.
  a) Rdkb cli support change channel for global and specific radio.
       for example, 
       if user select 2.4 and device id from drop down the channel change will be applicable for 2.4Ghz radio id of selected device. 
       if user select "ALL Station" the channel config will be global and applicable for all radio ID
b) Option to select the preference for each selected channel.
     - if channel is selected and preference not set, the default preference will be set as 15 else the selected preference from 0 to 14 will be set.


This Changes does not include handling ruid based channel change handling and db update from ctrl side, this need to be handled separately. 