### PR TITLE
[RDKBWIFI-400]Remove optional TLVs Spatial Reuse and EHT Operations from Channel Selection Messages (Channel Selection Req/Resp, Operating Channel Report) as features not supported

### DIFF
--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -412,13 +412,20 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     em_eht_operations_t *eht_ops;
     bool found_mesh_sta = false;
     em_bss_info_t *bss_info;
-
+    dm_radio_t* radio = NULL;
+    em_radio_info_t *radio_info = NULL;
 
     channel_sel = reinterpret_cast<op_class_channel_sel*> (evt->u.raw_buff);
     em_printfout("No of opclass=%d tx=%d", channel_sel->num, channel_sel->tx_power.tx_power_eirp);
     tx_power_limit =  const_cast<em_tx_power_limit_t*> (&channel_sel->tx_power);
     spatial_reuse_req =  const_cast<em_spatial_reuse_req_t*> (&channel_sel->spatial_reuse_req);
     eht_ops =  const_cast<em_eht_operations_t*> (&channel_sel->eht_ops);
+
+    if (channel_sel->num == 0) {
+        // UNEXPECTED: Channel Selection Request will have atleast one OPCLASS in Channel Preference TLV
+        em_printfout("Channel Preference TLV contains no op_class entries");
+        return -1;
+    }
 
     // Process data from Channel Preference TLVs
     // Invalidate all old anticipated entries for current RUID in data model
@@ -431,12 +438,6 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
             memcmp(&dm_op_class->id.ruid, &channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) {
             dm_op_class->pref_valid = false;
         }
-    }
-
-    if (channel_sel->num == 0) {
-        // UNEXPECTED: Channel Selection Request will have atleast one OPCLASS in Channel Preference TLV
-        em_printfout("Channel Preference TLV contains no op_class entries");
-        return -1;
     }
 
     // To store the channel with best preference
@@ -516,24 +517,44 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
         this->set_num_op_class(noofopclass);
     }
 
-    if(tx_power_limit->tx_power_eirp != 0) {
-        dm_radio_t* radio = this->get_radio(tx_power_limit->ruid);
-        em_radio_info_t* radio_info = radio->get_radio_info();
-        radio_info->transmit_power_limit = tx_power_limit->tx_power_eirp;
+    // Fetch radio and radio_info using RUID in Channel Preference TLV
+    // Assumption: One RUID data per Channel Selection Request message
+    radio = this->get_radio(channel_sel->op_class_info[0].id.ruid);
+    if (radio == NULL) {
+        em_printfout("Radio not found for channel_sel op_class_info[0] RUID");
+        return -1;
     }
 
-    dm_radio_t* radio = this->get_radio(spatial_reuse_req->ruid);
-    em_radio_info_t* radio_info = radio->get_radio_info();
-    radio_info->bss_color = spatial_reuse_req->bss_color;
-    radio_info->hesiga_spatial_reuse_value15_allowed = spatial_reuse_req->hesiga_spatial_reuse_value15_allowed;
-    radio_info->srg_information_valid = spatial_reuse_req->srg_info_valid;
-    radio_info->non_srg_offset_valid = spatial_reuse_req->non_srg_offset_valid;
-    radio_info->psr_disallowed = spatial_reuse_req->psr_disallowed;
-    radio_info->non_srg_obsspd_max_offset = spatial_reuse_req->non_srg_obsspd_max_offset;
-    radio_info->srg_obsspd_min_offset = spatial_reuse_req->srg_obsspd_min_offset;
-    radio_info->srg_obsspd_max_offset = spatial_reuse_req->srg_obsspd_max_offset;
-    memcpy(radio_info->srg_bss_color_bitmap, spatial_reuse_req->srg_bss_color_bitmap, sizeof(radio_info->srg_bss_color_bitmap));
-    memcpy(radio_info->srg_partial_bssid_bitmap, spatial_reuse_req->srg_partial_bssid_bitmap, sizeof(radio_info->srg_partial_bssid_bitmap));
+    radio_info = radio->get_radio_info();
+    if (radio_info == NULL) {
+        em_printfout("radio_info is null for channel_sel op_class_info[0]");
+        return -1;
+    }
+
+    // Update tx_power_limit from channel_sel (if present) for the RUID
+    if (tx_power_limit->tx_power_eirp != 0) {
+        if (memcmp(tx_power_limit->ruid, channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) {
+            radio_info->transmit_power_limit = tx_power_limit->tx_power_eirp;
+        } else {
+            em_printfout("Tx power RUID does not match channel_sel RUID, skipping tx_power update");
+        }
+    }
+
+    // Apply spatial_reuse_req fields using the same radio_info
+    if (memcmp(spatial_reuse_req->ruid, channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) {
+        radio_info->bss_color = spatial_reuse_req->bss_color;
+        radio_info->hesiga_spatial_reuse_value15_allowed = spatial_reuse_req->hesiga_spatial_reuse_value15_allowed;
+        radio_info->srg_information_valid = spatial_reuse_req->srg_info_valid;
+        radio_info->non_srg_offset_valid = spatial_reuse_req->non_srg_offset_valid;
+        radio_info->psr_disallowed = spatial_reuse_req->psr_disallowed;
+        radio_info->non_srg_obsspd_max_offset = spatial_reuse_req->non_srg_obsspd_max_offset;
+        radio_info->srg_obsspd_min_offset = spatial_reuse_req->srg_obsspd_min_offset;
+        radio_info->srg_obsspd_max_offset = spatial_reuse_req->srg_obsspd_max_offset;
+        memcpy(radio_info->srg_bss_color_bitmap, spatial_reuse_req->srg_bss_color_bitmap, sizeof(radio_info->srg_bss_color_bitmap));
+        memcpy(radio_info->srg_partial_bssid_bitmap, spatial_reuse_req->srg_partial_bssid_bitmap, sizeof(radio_info->srg_partial_bssid_bitmap));
+    } else {
+        em_printfout("Spatial reuse RUID does not match channel_sel RUID, skipping spatial_reuse update");
+    }
 
 #ifdef REL_6_FEATURE
     bool found_radio = false;

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -806,24 +806,6 @@ int em_channel_t::send_channel_sel_request_msg()
     tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
     len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
 
-    // Zero or more Spatial Reuse Request TLVs (see section 17.2.89).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_spatial_reuse_req;
-    sz = create_spatial_reuse_req_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-    len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-
-    // Zero or one EHT Operations TLV (see section 17.2.103)
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_eht_operations;
-    sz = static_cast<short> (create_eht_operations_tlv(tlv->value));
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-    len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-
     // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_eom;
@@ -859,7 +841,6 @@ int em_channel_t::send_channel_sel_response_msg(em_chan_sel_resp_code_type_t cod
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
     em_channel_sel_rsp_t *resp;
-    em_spatial_reuse_cfg_rsp_t *spatial_resp;
     unsigned char *tmp = buff;
     dm_easy_mesh_t *dm;
     unsigned short type = htons(ETH_P_1905);
@@ -899,20 +880,8 @@ int em_channel_t::send_channel_sel_response_msg(em_chan_sel_resp_code_type_t cod
 
     tmp += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
     len += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
-    
-    // Zero or more Spatial Reuse Config Response TLVs (see section 17.2.91)
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_spatial_reuse_cfg_rsp;
-    tlv->len = htons(sizeof(em_spatial_reuse_cfg_rsp_t));
-    spatial_resp = reinterpret_cast<em_spatial_reuse_cfg_rsp_t *> (tlv->value);
-    memcpy(spatial_resp->config_resp.ruid, get_radio_interface_mac(), sizeof(mac_address_t));
-    memcpy(&spatial_resp->config_resp.response_code, reinterpret_cast<unsigned char *> (&code), sizeof(unsigned char));
 
-
-    tmp += (sizeof(em_tlv_t) + sizeof(em_spatial_reuse_cfg_rsp_t));
-    len += (sizeof(em_tlv_t) + sizeof(em_spatial_reuse_cfg_rsp_t));
-
-	// End of message
+    // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_eom;
     tlv->len = 0;
@@ -1049,24 +1018,6 @@ int em_channel_t::send_operating_channel_report_msg()
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_op_channel_report;
     sz = create_operating_channel_report_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += sizeof(em_tlv_t) + static_cast<short unsigned int> (sz);
-    len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-
-    // Zero or more Spatial Reuse Report TLVs (see section 17.2.90)
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_spatial_reuse_rep;
-    sz = create_spatial_reuse_report_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += sizeof(em_tlv_t) + static_cast<short unsigned int> (sz);
-    len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-
-    // Zero or more EHT Operations TLV (see section 17.2.103)
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_eht_operations;
-    sz = static_cast<short> (create_eht_operations_tlv(tlv->value));
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += sizeof(em_tlv_t) + static_cast<short unsigned int> (sz);
@@ -1932,23 +1883,16 @@ int em_channel_t::handle_channel_sel_req(unsigned char *buff, unsigned int len)
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
 
-    while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
+    while ((tlv->type != em_tlv_type_eom) && (tlv_len > 0)) {
         if (tlv->type == em_tlv_type_channel_pref) {
             handle_channel_pref_tlv(tlv->value, &op_class);
         }
         if (tlv->type == em_tlv_type_tx_power) {
-			memcpy(&op_class.tx_power, tlv->value, sizeof(em_tx_power_limit_t));
-        }
-        if (tlv->type == em_tlv_type_spatial_reuse_req) {
-            memcpy(&op_class.spatial_reuse_req, tlv->value, sizeof(em_spatial_reuse_req_t));
-        }
-        if (tlv->type == em_tlv_eht_operations) {
-            handle_eht_operations_tlv(tlv->value, &op_class.eht_ops);
-            break;
+            memcpy(&op_class.tx_power, tlv->value, sizeof(em_tx_power_limit_t));
         }
 
-        tlv_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tlv_len -= static_cast<int> (sizeof(em_tlv_t) + ntohs(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
 	op_class.freq_band = get_band();
@@ -2009,20 +1953,23 @@ int em_channel_t::handle_operating_channel_rprt(unsigned char *buff, unsigned in
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
 
-    while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
-        if (tlv->type == em_tlv_type_op_channel_report) {
-            handle_op_channel_report(tlv->value, htons(tlv->len));
-        }
-        if (tlv->type == em_tlv_type_spatial_reuse_rep) {
-            handle_spatial_reuse_report(tlv->value, htons(tlv->len));
-        }
-        if (tlv->type == em_tlv_eht_operations) {
-            handle_eht_operations_tlv_ctrl(tlv->value, htons(tlv->len));
+    while ((tlv_len > 0) && (tlv_len >= static_cast<int>(sizeof(em_tlv_t)))) {
+        if (tlv->type == em_tlv_type_eom) {
             break;
         }
 
-        tlv_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        if (tlv->type == em_tlv_type_op_channel_report) {
+            handle_op_channel_report(tlv->value, ntohs(tlv->len));
+        }
+
+        // Ensure we have enough buffer for the complete TLV before advancing
+        int current_tlv_size = sizeof(em_tlv_t) + htons(tlv->len);
+        if (tlv_len < current_tlv_size) {
+            break;
+        }
+
+        tlv_len -= current_tlv_size;
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + current_tlv_size);
     }
     em_printfout("Operating channel report recv\n");
     send_1905_ack_message(ntohs(cmdu->id));


### PR DESCRIPTION
Currently Spatial Reuse and Channel puncturing features are not supported. Thus removing population of Spatial Reuse and EHT  Operations TLV in the Channel Request message.
 
While handling channel selection request on agent, adding proper checks to avoid updates when the above mentioned TLVs are not present