### PR TITLE
RDKBWIFI-364 : Generalizing bus abstraction functions for retrieving and setting bus data property types.

### DIFF
--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -866,7 +866,7 @@ public:
 	 *
 	 * @note Ensure that the `event_name` and `data` are valid before processing.
 	 */
-	static void sta_cb(char *event_name, raw_data_t *data, void *userData);
+	static void sta_cb(char *event_name, bus_data_prop_t *data, void *userData);
     
 	/**!
 	 * @brief Callback function for handling WiFi events.
@@ -881,7 +881,7 @@ public:
 	 * @note Ensure that the data pointer is valid and properly initialized before
 	 * passing it to this function.
 	 */
-	static void onewifi_cb(char *event_name, raw_data_t *data, void *userData);
+	static void onewifi_cb(char *event_name, bus_data_prop_t *data, void *userData);
     
 	/**!
 	 * @brief Callback function for association statistics.
@@ -898,7 +898,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid before calling this function.
 	 */
-	static int assoc_stats_cb(char *event_name, raw_data_t *data, void *userData);
+	static int assoc_stats_cb(char *event_name, bus_data_prop_t *data, void *userData);
     
 	/**!
 	 * @brief Callback function for management action frames.
@@ -915,7 +915,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid and points to the correct data structure.
 	 */
-	static int mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *userData);
+	static int mgmt_action_frame_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**!
 	 * @brief Callback function for management csa beacon frames.
@@ -932,7 +932,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid and points to the correct data structure.
 	 */
-	static int mgmt_csa_beacon_frame_cb(char *event_name, raw_data_t *data, void *userData);
+	static int mgmt_csa_beacon_frame_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**!
 	 * @brief Callback function for channel scanning.
@@ -949,7 +949,7 @@ public:
 	 *
 	 * @note Ensure that the event_name and data are valid before processing.
 	 */
-	static int channel_scan_cb(char *event_name, raw_data_t *data, void *userData);
+	static int channel_scan_cb(char *event_name, bus_data_prop_t *data, void *userData);
     
 	/**!
 	 * @brief Callback function for handling beacon reports.
@@ -966,7 +966,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid before accessing its contents.
 	 */
-	static int beacon_report_cb(char *event_name, raw_data_t *data, void *userData);
+	static int beacon_report_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**
 	 * @brief Callback for association status event
@@ -976,7 +976,7 @@ public:
 	 * @param userData Optional user-provided callback data
 	 * @return int 1 on success, otherwise -1
 	 */
-	static int association_status_cb(char *event_name, raw_data_t *data, void *userData);
+	static int association_status_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**
 	 * @brief Callback for BSS scan events
@@ -986,7 +986,7 @@ public:
 	 * @param userData Optional user-provided callback data
 	 * @return int 1 on success, otherwise -1
 	 */
-	static int bss_info_cb(char *event_name, raw_data_t *data, void *userData);
+	static int bss_info_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**!
 	 * @brief Callback function for handling AP Metrics reports.
@@ -1003,7 +1003,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid before accessing its contents.
 	 */
-	static int report_cb(char *event_name, raw_data_t *data, void *userData);
+	static int report_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**!
 	 * @brief Retrieves the associated data for the given input.

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -655,7 +655,7 @@ public:
 	 * Validates SetSSID input properties, dispatches the request to the EasyMesh
 	 * controller, and optionally populates response properties for the caller.
 	 *
-	 * @param[in] event_name Bus method name (Device.WiFi.DataElements.Network.SetSSID).
+	 * @param[in] method_name Bus method name (Device.WiFi.DataElements.Network.SetSSID).
 	 * @param[in] input_params Linked list of input properties carrying the request payload.
 	 * @param[out] output_params Populated with response properties when provided.
 	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
@@ -666,7 +666,7 @@ public:
 	 *
 	 * @note Input property ownership remains with the caller; this function does not free them.
 	 */
-	static bus_error_t cmd_setssid (const char *event_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+	static bus_error_t cmd_setssid (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
 
 	/**!
 	 *

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -555,7 +555,8 @@ public:
      *
      * @note Ownership of input and output buffers remains with the caller.
      */
-    static bus_error_t setssid_handler(const char *method_name, raw_data_t *input_data, raw_data_t *output_data, void *async_handle);
+    static bus_error_t setssid_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
 
     //Methods helper utilities
 
@@ -641,7 +642,7 @@ public:
      *
      * @note On success, output_data takes ownership of the allocated property.
      */
-    static void tr181_set_status_output(raw_data_t *output_data, const char *status);
+    static void tr181_set_status_output(bus_data_prop_t *output_data, const char *status);
 
     /**!
      * @brief Copy a string property value into a destination buffer.

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1176,32 +1176,32 @@ void em_agent_t::input_listener()
     io(NULL);
 }
 
-int em_agent_t::bss_info_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::bss_info_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     if (data == nullptr) {
         em_printfout("NULL data from OneWifi callback!");
         return -1;
     }
-    g_agent.io_process(em_bus_event_type_bss_info, reinterpret_cast<unsigned char *>(data->raw_data.bytes), data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_bss_info, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     return 1;
 }
 
-int em_agent_t::association_status_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::association_status_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     if (data == nullptr) {
         em_printfout("NULL data from OneWiFi callback!");
         return -1;
     }
-    g_agent.io_process(em_bus_event_type_assoc_status, reinterpret_cast<unsigned char *>(data->raw_data.bytes), data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_assoc_status, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     return 1;
 }
 
-int em_agent_t::channel_scan_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::channel_scan_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
     cJSON *json, *channel_stats_arr;
 
-    json = cJSON_Parse((const char *)data->raw_data.bytes);
+    json = cJSON_Parse((const char *)data->value.raw_data.bytes);
     if (json != NULL) {
         channel_stats_arr = cJSON_GetObjectItem(json, "ChannelScanResponse");
         if ((channel_stats_arr == NULL) && (cJSON_IsObject(channel_stats_arr) == false)) {
@@ -1212,21 +1212,21 @@ int em_agent_t::channel_scan_cb(char *event_name, raw_data_t *data, void *userDa
         }
     }
 
-    g_agent.io_process(em_bus_event_type_scan_result, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_scan_result, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
 
     return 1;
 }
 
-int em_agent_t::report_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::report_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
-    //em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->raw_data.bytes);
+    //em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
     (void)userData;
 
     if (strncmp(event_name, "Device.WiFi.EM.APMetricsReport", sizeof("Device.WiFi.EM.APMetricsReport"))==0) {
-        g_agent.io_process(em_bus_event_type_ap_metrics_report, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_ap_metrics_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
     } else if (strncmp(event_name, WIFI_QUALITY_LINKREPORT, sizeof(WIFI_QUALITY_LINKREPORT))==0) {
-        em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->raw_data.bytes);
-        cJSON *json = cJSON_Parse((const char *)data->raw_data.bytes);
+        em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
+        cJSON *json = cJSON_Parse((const char *)data->value.raw_data.bytes);
         if (json != NULL) {
             cJSON *link_report_arr;
             cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
@@ -1242,32 +1242,32 @@ int em_agent_t::report_cb(char *event_name, raw_data_t *data, void *userData)
                 }
             }
         }
-        g_agent.io_process(em_bus_event_type_link_quality_report, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_link_quality_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
     }
 
     return 0;
 }
 
-int em_agent_t::beacon_report_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::beacon_report_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
-    //printf("%s:%d Received Frame data for event [%s] and data :\n%s\n", __func__, __LINE__, event_name, data->raw_data.bytes);
+    //printf("%s:%d Received Frame data for event [%s] and data :\n%s\n", __func__, __LINE__, event_name, data->value.raw_data.bytes);
     (void)userData;
 
-    g_agent.io_process(em_bus_event_type_beacon_report, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_beacon_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
 
     return 0;
 }
 
-int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::mgmt_action_frame_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
-    em_printfout("Received Frame data for event [%s] and data of len: %d",event_name, data->raw_data_len);
+    em_printfout("Received Frame data for event [%s] and data of len: %d",event_name, data->value.raw_data_len);
 
-    EM_ASSERT_MSG_TRUE(data != NULL && data->raw_data.bytes != NULL && data->raw_data_len > 0, -1,
+    EM_ASSERT_MSG_TRUE(data != NULL && data->value.raw_data.bytes != NULL && data->value.raw_data_len > 0, -1,
                    "Invalid data in mgmt_action_frame_cb");
 
-    uint8_t* mgmt_frame_data = (uint8_t*)data->raw_data.bytes;
-    unsigned int mgmt_hdr_len = data->raw_data_len;
+    uint8_t* mgmt_frame_data = (uint8_t*)data->value.raw_data.bytes;
+    unsigned int mgmt_hdr_len = data->value.raw_data_len;
 
     // The frequency (and other wifi data) is prepended to the action frame data
     mgmt_frame_data += sizeof(wifi_frame_t);
@@ -1277,7 +1277,7 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *u
     
     
 
-    //util::print_hex_dump(data->raw_data_len, (uint8_t*)data->raw_data.bytes);
+    //util::print_hex_dump(data->value.raw_data_len, (uint8_t*)data->value.raw_data.bytes);
 
     //printf("Received Frame data for event %s \n", event_name);
     if (mgmt_frame->u.action.u.bss_tm_resp.action == WLAN_WNM_BTM_RESPONSE) {
@@ -1292,7 +1292,7 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *u
         if (!memcmp(mgmt_frame->u.action.u.vs_public_action.oui, wfa_oui, sizeof(wfa_oui))){
             // Push WFA action frame back to main thread
             // Push all data to pass frequency as well
-            g_agent.io_process(em_bus_event_type_recv_wfa_action_frame, reinterpret_cast<uint8_t*>(data->raw_data.bytes), data->raw_data_len);
+            g_agent.io_process(em_bus_event_type_recv_wfa_action_frame, reinterpret_cast<uint8_t*>(data->value.raw_data.bytes), data->value.raw_data_len);
         }
     }
 
@@ -1305,13 +1305,13 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *u
     return 0;
 }
 
-int em_agent_t::assoc_stats_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::assoc_stats_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
-    //printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, (char *)data->raw_data.bytes);
+    //printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, (char *)data->value.raw_data.bytes);
     cJSON *json, *assoc_stats_arr;
 
-    json = cJSON_Parse((const char *)data->raw_data.bytes);
+    json = cJSON_Parse((const char *)data->value.raw_data.bytes);
     if (json != NULL) {
         cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
         if ((strcmp(subdoc_name->valuestring, "Easymesh STA link metrics") == 0)) {
@@ -1329,27 +1329,27 @@ int em_agent_t::assoc_stats_cb(char *event_name, raw_data_t *data, void *userDat
         }
     }
 
-    g_agent.io_process(em_bus_event_type_sta_link_metrics, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_sta_link_metrics, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
     cJSON_Delete(json);
 
     return 1;
 }
 
-void em_agent_t::sta_cb(char *event_name, raw_data_t *data, void *userData)
+void em_agent_t::sta_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
-    //printf("%s:%d Recv data from onewifi:\r\n%s\r\n", __func__, __LINE__, (char *)data->raw_data.bytes);
-    g_agent.io_process(em_bus_event_type_sta_list, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    //printf("%s:%d Recv data from onewifi:\r\n%s\r\n", __func__, __LINE__, (char *)data->value.raw_data.bytes);
+    g_agent.io_process(em_bus_event_type_sta_list, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
 
 }
 
-void em_agent_t::onewifi_cb(char *event_name, raw_data_t *data, void *userData)
+void em_agent_t::onewifi_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
         (void)userData;
-	const char *json_data = (char *)data->raw_data.bytes;
+	const char *json_data = (char *)data->value.raw_data.bytes;
 	cJSON *json = cJSON_Parse(json_data);
 
-	//printf("%s:%dRecv data from onewifi:\r\n%s\r\n", __func__, __LINE__, (char *)data->raw_data.bytes);
+	//printf("%s:%dRecv data from onewifi:\r\n%s\r\n", __func__, __LINE__, (char *)data->value.raw_data.bytes);
 
 	if (json == NULL) {
 		printf("%s:%d Error parsing JSON\n", __func__, __LINE__);
@@ -1364,17 +1364,17 @@ void em_agent_t::onewifi_cb(char *event_name, raw_data_t *data, void *userData)
     if ((strcmp(subdoc_name->valuestring, "private") == 0) || (strcmp(subdoc_name->valuestring, "Vap_6G") == 0) ||
         (strcmp(subdoc_name->valuestring, "Vap_5G") == 0) || (strcmp(subdoc_name->valuestring, "Vap_2.4G") == 0)) {
         printf("%s:%d Found SubDocName: private\n", __func__, __LINE__);
-        g_agent.io_process(em_bus_event_type_onewifi_private_cb, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_private_cb, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
 
     } else if ((strcmp(subdoc_name->valuestring, "radio") == 0) || (strcmp(subdoc_name->valuestring, "radio_6G") == 0) ||
         (strcmp(subdoc_name->valuestring, "radio_5G") == 0) || (strcmp(subdoc_name->valuestring, "radio_2.4G") == 0)) {
         printf("%s:%d Found SubDocName: radio\n", __func__, __LINE__);
-        g_agent.io_process(em_bus_event_type_onewifi_radio_cb, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_radio_cb, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
 
     } else if ((strcmp(subdoc_name->valuestring, "mesh_sta") == 0) || 
                (strcmp(subdoc_name->valuestring, "mesh backhaul sta") == 0)) {
         printf("%s:%d Found SubDocName: mesh_sta\n", __func__, __LINE__);
-        g_agent.io_process(em_bus_event_type_onewifi_mesh_sta_cb, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_mesh_sta_cb, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
 
     } else {
         em_printfout("SubDocName (%s) not matching private, mesh_sta, or radio", subdoc_name->valuestring);
@@ -1384,11 +1384,11 @@ void em_agent_t::onewifi_cb(char *event_name, raw_data_t *data, void *userData)
 
 }
 
-int em_agent_t::mgmt_csa_beacon_frame_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::mgmt_csa_beacon_frame_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
-    printf("%s:%d Received Frame data for event [%s] and data of len:\n%d\n", __func__, __LINE__, event_name, data->raw_data_len);
+    printf("%s:%d Received Frame data for event [%s] and data of len:\n%d\n", __func__, __LINE__, event_name, data->value.raw_data_len);
 
-    g_agent.io_process(em_bus_event_type_recv_csa_beacon_frame, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_recv_csa_beacon_frame, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
     return 1;
 }
 

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -60,7 +60,7 @@
 
 extern em_network_topo_t *g_network_topology;
 
-bus_error_t em_ctrl_t::cmd_setssid(const char *event_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
 {
     em_subdoc_info_t *subdoc = NULL;
     unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
@@ -74,7 +74,7 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *event_name, const bus_data_prop_t
     char HaulType[TR181_HAULTYPE_MAX_LEN + 1] = {0};
     size_t json_len = 0;
 
-    (void)event_name;
+    (void)method_name;
     (void)async_handle;
 
     if (!input_params) {

--- a/src/ctrl/tr_181/wfa_data_model/tr_181_helper.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181_helper.cpp
@@ -163,14 +163,33 @@ bus_data_prop_t *tr_181_t::tr181_set_status_output_prop(const char *status)
 }
 
 // Populate output_data with a "Status" property containing the given status string.
-void tr_181_t::tr181_set_status_output(raw_data_t *output_data, const char *status)
+void tr_181_t::tr181_set_status_output(bus_data_prop_t *output_data, const char *status)
 {
-    if (!output_data) return;
-    bus_data_prop_t *prop = tr181_set_status_output_prop(status);
-    if (!prop) return;
-    output_data->data_type = bus_data_type_property;
-    output_data->raw_data.bytes = prop;
-    output_data->raw_data_len = sizeof(bus_data_prop_t);
+    if (!output_data || !status) {
+        return;
+    }
+
+    bus_data_prop_t *prop = output_data;
+    memset(prop, 0, sizeof(*prop));
+
+    size_t name_len = strnlen("Status", sizeof(prop->name) - 1U);
+    memcpy(prop->name, "Status", name_len);
+    prop->name[name_len] = '\0';
+    prop->name_len = static_cast<uint32_t>(name_len);
+    prop->is_data_set = true;
+    prop->status = bus_error_success;
+    prop->ref_count = 1;
+
+    size_t value_len = strlen(status);
+    prop->value.data_type = bus_data_type_string;
+    prop->value.raw_data.bytes = malloc(value_len + 1U);
+    if (!prop->value.raw_data.bytes) {
+        prop->is_data_set = false;
+        prop->ref_count = 0;
+        return;
+    }
+    memcpy(prop->value.raw_data.bytes, status, value_len + 1U);
+    prop->value.raw_data_len = static_cast<unsigned int>(value_len + 1U);
 }
 
 // Copy a string property value into a destination buffer, ensuring proper type and null-termination.

--- a/src/ctrl/tr_181/wfa_data_model/tr_181_method.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181_method.cpp
@@ -18,13 +18,11 @@
 #include "em_ctrl.h"
 #include "tr_181.h"
 
-bus_error_t tr_181_t::setssid_handler(const char *method_name, raw_data_t *input_data, raw_data_t *output_data, void *async_handle)
+bus_error_t tr_181_t::setssid_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
 {
-    // Suppress unused parameter warning if async_handle is not used
-    (void)async_handle;
-
     // Standardize input pointer checks
-    if (!input_data || input_data->raw_data_len == 0) {
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
         em_printfout("Invalid input_data or missing input_props");
         if (output_data) {
             tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
@@ -32,10 +30,16 @@ bus_error_t tr_181_t::setssid_handler(const char *method_name, raw_data_t *input
         return bus_error_invalid_input;
     }
 
-    bus_data_prop_t *input_props = static_cast<bus_data_prop_t *>(input_data->raw_data.bytes);
+    bus_data_prop_t *input_props = input_data;
     bus_data_prop_t *output_props = NULL;
 
-    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_data->raw_data_len);
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
     // Log all chained input properties
     for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
         em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
@@ -54,9 +58,14 @@ bus_error_t tr_181_t::setssid_handler(const char *method_name, raw_data_t *input
     bus_error_t rc = ctrl->cmd_setssid(event, input_props, output_data ? &output_props : NULL, async_handle);
 
     if (output_data && output_props) {
-        output_data->data_type = bus_data_type_property;
-        output_data->raw_data.bytes = output_props;
-        output_data->raw_data_len = sizeof(bus_data_prop_t);
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
     }
 
     return rc;


### PR DESCRIPTION
Reason for change : Converted the generic raw_data type to bus_data_prop_t. Risks: Medium
Priority:P0
Test Procedure: Flash the image and verify that all OneWifi-related features work properly.