### PR TITLE
RDKBWIFI-391 : RDKBCLI - Channel Selection - Controller orchestration…

### DIFF
--- a/src/cmd/em_cmd_set_channel.cpp
+++ b/src/cmd/em_cmd_set_channel.cpp
@@ -45,11 +45,9 @@ em_cmd_set_channel_t::em_cmd_set_channel_t(em_cmd_params_t param, dm_easy_mesh_t
     memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
 
     m_orch_op_idx = 0;
-    m_num_orch_desc = 2;
+    m_num_orch_desc = 1;
     m_orch_desc[0].op = dm_orch_type_channel_sel;
     m_orch_desc[0].submit = true;
-    m_orch_desc[1].op = dm_orch_type_channel_cnf;
-    m_orch_desc[1].submit = true;
 
     strncpy(m_name, "set_channel", strlen("set_channel") + 1);
     m_svc = em_service_type_ctrl;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -198,11 +198,9 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             break;
 
         case em_cmd_type_set_channel:
-	    if (pcmd->get_orch_op() == dm_orch_type_channel_sel) {
-            	m_sm.set_state(em_state_ctrl_channel_select_pending);
-	    } else if ((pcmd->get_orch_op() == dm_orch_type_channel_cnf) && (m_sm.get_state() == em_state_ctrl_channel_selected)) {
-		 m_sm.set_state(em_state_ctrl_channel_cnf_pending);
-	    }
+            if (pcmd->get_orch_op() == dm_orch_type_channel_sel) {
+                m_sm.set_state(em_state_ctrl_channel_select_pending);
+            }
             break;
 
         case em_cmd_type_scan_channel:

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -198,10 +198,8 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             break;
         
         case em_cmd_type_set_channel:
-	    if (em->get_state() == em_state_ctrl_channel_selected) {
+            if (em->get_state() == em_state_ctrl_configured) {
                 return true;
-            } else if (em->get_state() == em_state_ctrl_configured) {
-		return true;
             }
 	    break;
         case em_cmd_type_scan_channel:
@@ -370,6 +368,15 @@ void em_orch_ctrl_t::pre_process_cancel(em_cmd_t *pcmd, em_t *em)
            	em->set_state(em_state_ctrl_misconfigured);
             em->set_renew_tx_count(0);
 			break;
+
+        case em_cmd_type_set_channel:
+            em_printfout("Cancel received for Set Channel command, transitioning to configured state radio: %s",
+                util::mac_to_string(em->get_radio_interface_mac()).c_str());
+            em->set_state(em_state_ctrl_configured);
+            // Reset the count of active channel selection requests
+            // Currently this counter is not used, reset for future use of this counter
+            em->set_channel_sel_req_tx_count(0);
+            break;
 
         default:
             break;


### PR DESCRIPTION
… state machine not updated/cleaned correctly during channel change

Description:
    History: The issue of handling OCR (Operating Channel Report) during configuration was fixed in #593. While testing onboarding of third-party agents,
             it was observed that OCR was being received before the dm_orch_type_channel_cnf orchestration state became active.
             Due to this, the orchestration command was updated to handle channel selection in a single orchestration to ensure proper state management and cleanup during channel changes.
    
    This fix was not applied for channel selection request when triggered from GUI/any other way apart from em_config.