### PR TITLE
RDKBWIFI-379 : Enable dynamic channel preference assignment in create_channel_pref_tlv

### DIFF
--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -307,10 +307,8 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
                              merged_op.channels[j], merged_op.op_class);
                 continue; // Skip channels non-operable for agent
             }
-            // Note: Temporary hardcoding of preference bits to 0xe0.
-            // Remove hardcoding once Preference value is added to the configuration
-            // pref_bits = merged_op.channel_pref[j];
-            pref_bits = 0xe0;
+            // Assign the preference value for channels
+            pref_bits = merged_op.channel_pref[j];
             channels_per_pref[pref_bits].push_back(merged_op.channels[j]);;
         }
 


### PR DESCRIPTION
- Previously hardcoded pref_bits to 0xe0 because preference settings were not supported by UI
- Now assign pref_bits from merged_op.channel_pref[j] to use actual preference values, as UI support has been added.

Note: This change extends PR #614