### PR TITLE
RDKBWIFI-402: Implement IEEE 1905.1 Backhaul Steering

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -529,7 +529,7 @@ public:
 	 * @note Ensure that the event and command array are properly initialized before calling this function.
 	 */
 	int analyze_command_steer(em_bus_event_t *evt, em_cmd_t *cmd[]);
-    
+
 	/**!
 	 * @brief Analyzes the disassociation command.
 	 *
@@ -777,6 +777,16 @@ public:
          *       EasyMesh specification.
          */
          int analyze_unassoc_sta_metrics_query(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
+	/**!
+	 * @brief Analyzes the backhaul steering command.
+	 *
+	 * @param[in] evt Pointer to the event structure containing the backhaul steering command.
+	 * @param[in] cmd Array of command structures to be populated.
+	 *
+	 * @returns int Number of commands created, 0 if no change needed.
+	 */
+	int analyze_backhaul_steer(em_bus_event_t *evt, em_cmd_t *cmd[]);
 
 	/**!
 	 * @brief Resets the configuration to its default state.

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -181,7 +181,7 @@ class em_agent_t : public em_mgr_t {
 	 * @note Ensure that the event structure is properly initialized before calling this function.
 	 */
 	void handle_btm_request_action_frame(em_bus_event_t *evt);
-    
+
 	/**!
 	 * @brief Handles the reception of WFA action frames.
 	 *
@@ -359,6 +359,16 @@ class em_agent_t : public em_mgr_t {
         * @retval Non-zero error code on failure.
         */
        static int unassoc_sta_link_metrics_cb(char *event_name, bus_data_prop_t  *data, void *userData);
+
+	/**!
+	 * @brief Handles a backhaul steering request from the controller.
+	 *
+	 * Forwards the steering parameters to OneWifi so the backhaul
+	 * STA can connect to the target BSSID.
+	 *
+	 * @param[in] evt Pointer to the bus event carrying em_bh_steering_req_t data.
+	 */
+	void handle_backhaul_steer(em_bus_event_t *evt);
 
 	/**
 	 * @brief Send an action frame

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -323,6 +323,10 @@ static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff
 #define WIFI_SET_DISCONN_SCAN_NONE_STATE      "Device.WiFi.EM.SetDisconnScanNoneState"
 #endif
 
+#ifndef WIFI_EM_BACKHAUL_STEER
+#define WIFI_EM_BACKHAUL_STEER                "Device.WiFi.EM.BackhaulSteer"
+#endif
+
 // Beacon CSA parsing
 #define CSA_TAG_ID                   37
 #define CSA_IE_MIN_LENGTH            3
@@ -846,6 +850,16 @@ typedef enum {
 
     em_tlv_type_max
 } em_tlv_type_t;
+
+// Error Code TLV Reason_Code values
+typedef enum {
+    em_error_code_sta_associated_with_bss           = 0x01,
+    em_error_code_sta_not_associated_with_bss       = 0x02,
+    em_error_code_client_cap_report_failure         = 0x03,
+    em_error_code_bh_steer_rejected_channel         = 0x04,
+    em_error_code_bh_steer_signal_weak_or_not_found = 0x05,
+    em_error_code_bh_steer_rejected_by_target_bss   = 0x06,
+} em_error_code_reason_t;
 
 typedef enum {
     em_tlv_type_radio_capability = 0x0013,
@@ -2273,6 +2287,7 @@ typedef enum {
     em_state_agent_client_cap_report,
     em_state_agent_sta_link_metrics_pending,
     em_state_agent_steer_btm_res_pending,
+    em_state_agent_bh_steer_pending,
     em_state_agent_beacon_report_pending,
     em_state_agent_link_quality_report_pending,
 
@@ -2307,7 +2322,9 @@ typedef enum {
     em_state_ctrl_avail_spectrum_inquiry_pending,
     em_state_ctrl_bsta_cap_pending,
     em_state_ctrl_topo_publish_pending,
-    em_state_ctrl_unassoc_sta_link_metrics_pending, 
+    em_state_ctrl_unassoc_sta_link_metrics_pending,
+    em_state_ctrl_bh_steer_pending,
+    em_state_ctrl_bh_steer_req_ack_rcvd,
 
     em_state_max,
 } em_state_t;
@@ -2362,6 +2379,7 @@ typedef enum {
     em_cmd_type_get_link_quality_report,
     em_cmd_type_unassoc_sta_query,
     em_cmd_type_unassoc_sta_result,
+    em_cmd_type_backhaul_steer,
 
     em_cmd_type_max,
 } em_cmd_type_t;
@@ -3063,6 +3081,7 @@ typedef enum {
     em_bus_event_type_unassoc_sta_query,
     em_bus_event_type_unassoc_sta_link_metrics_query,
     em_bus_event_type_unassoc_sta_result,
+    em_bus_event_type_backhaul_steer,
 
     em_bus_event_type_max
 } em_bus_event_type_t;
@@ -3155,7 +3174,7 @@ typedef enum {
     dm_orch_type_link_quality_report,
     dm_orch_type_unassoc_sta_link_req_query,
     dm_orch_type_unassoc_sta_result,
-    
+    dm_orch_type_backhaul_steer
 } dm_orch_type_t;
 
 typedef struct {
@@ -3273,6 +3292,14 @@ typedef struct {
 } em_cmd_steer_params_t;
 
 typedef struct {
+    mac_address_t al_mac;
+    mac_address_t sta_mac;
+    bssid_t       target_bssid;
+    unsigned int  op_class;
+    unsigned int  channel;
+} em_cmd_backhaul_steer_params_t;
+
+typedef struct {
     bssid_t	source;
     mac_address_t	sta_mac;
     unsigned char status_code;
@@ -3340,6 +3367,7 @@ typedef struct {
     union {
         em_cmd_args_t	args;
         em_cmd_steer_params_t	steer_params;
+        em_cmd_backhaul_steer_params_t backhaul_steer_params;
         em_cmd_btm_report_params_t  btm_report_params;
         em_cmd_disassoc_params_t	disassoc_params;
 		em_cmd_scan_params_t	scan_params;

--- a/inc/em_cmd_backhaul_steer.h
+++ b/inc/em_cmd_backhaul_steer.h
@@ -1,0 +1,20 @@
+#ifndef EM_CMD_BACKHAUL_STEER_H
+#define EM_CMD_BACKHAUL_STEER_H
+
+#include "em_cmd.h"
+
+class em_cmd_backhaul_steer_t : public em_cmd_t {
+
+public:
+
+    /**!
+     * @brief Constructs a backhaul steering command.
+     *
+     * @param[in] params The backhaul steering parameters (al_mac, sta_mac, target_bssid, op_class, channel).
+     * @param[in] svc    Service type (controller or agent). Defaults to controller.
+     */
+    em_cmd_backhaul_steer_t(em_cmd_backhaul_steer_params_t params,
+                            em_service_type_t svc = em_service_type_ctrl);
+};
+
+#endif

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -220,7 +220,7 @@ public:
 	 * @note Ensure that the event structure is properly initialized before calling this function.
 	 */
 	void handle_client_steer(em_bus_event_t *evt);
-    
+
 	/**!
 	 * @brief Handles the disassociation of a client.
 	 *
@@ -484,6 +484,13 @@ public:
          *       before calling this function.
          */
         void handle_unassoc_sta_metrics_query(em_bus_event_t *evt);
+
+	/**!
+	 * @brief Handles the backhaul steering request event.
+	 *
+	 * @param[in] evt Pointer to the bus event containing backhaul steering parameters.
+	 */
+	void handle_backhaul_steer(em_bus_event_t *evt);
 
 	/**!
 	 * @brief 

--- a/inc/em_steering.h
+++ b/inc/em_steering.h
@@ -23,10 +23,13 @@
 
 class em_steering_t {
 
-    unsigned int m_client_steering_req_tx_cnt;
-    unsigned int m_client_assoc_ctrl_req_tx_cnt;
+	unsigned int m_client_steering_req_tx_cnt;
+	unsigned int m_client_assoc_ctrl_req_tx_cnt;
 
-    
+	// BH Steering pending context. Saved on request receipt, used by timeout/result handlers.
+	mac_address_t m_bh_steer_pending_sta_mac;
+	bssid_t       m_bh_steer_pending_bssid;
+
 	/**!
 	 * @brief Sends a client steering request message.
 	 *
@@ -39,7 +42,59 @@ class em_steering_t {
 	 * @note Ensure that the client is ready to receive the steering request before calling this function.
 	 */
 	int send_client_steering_req_msg();
-    
+
+	/**!
+	 * @brief Sends a 1905 Backhaul Steering Request message.
+	 *
+	 * @returns int bytes sent on success, -1 on failure.
+	 */
+	int send_bh_steering_req_msg();
+
+	/**!
+	 * @brief Sends a 1905 Backhaul Steering Response message (agent side).
+	 *
+	 * @param[in] sta_mac      Backhaul STA MAC address.
+	 * @param[in] target_bssid Target BSSID from the steering request.
+	 * @param[in] result_code  0x00 = success, 0x01 = failure.
+	 * @param[in] error_reason Error Code TLV Reason_Code per 17.2.36
+	 *                         (0x04/0x05/0x06). Only used when result_code == 0x01.
+	 *
+	 * @returns int bytes sent on success, -1 on failure.
+	 */
+	int send_bh_steering_rsp_msg(mac_address_t sta_mac, unsigned char *target_bssid,
+		unsigned char result_code, unsigned char error_reason = 0x00);
+
+	/**!
+	 * @brief Handles a received Backhaul Steering Request (agent side).
+	 *
+	 * @param[in] buff Buffer containing the raw message.
+	 * @param[in] len Length of the message.
+	 *
+	 * @returns int 0 on success, -1 on failure.
+	 */
+	int handle_bh_steering_req(unsigned char *buff, unsigned int len);
+
+	/**!
+	 * @brief Handles a received Backhaul Steering Response.
+	 *
+	 * @param[in] buff Buffer containing the raw message.
+	 * @param[in] len Length of the message.
+	 *
+	 * @returns int 0 on success, -1 on failure.
+	 */
+	int handle_bh_steering_rsp(unsigned char *buff, unsigned int len);
+
+	/**!
+	 * @brief Sends a 1905 ACK message from the controller to the agent.
+	 *
+	 * Used after the controller receives a Backhaul Steering Response
+	 *
+	 * @param[in] msg_id CMDU message ID of the Response being acknowledged.
+	 *
+	 * @returns int bytes sent on success, -1 on failure.
+	 */
+	int send_1905_ack_to_agent(unsigned short msg_id);
+
 	/**!
 	 * @brief Sends a client association control request message.
 	 *
@@ -216,7 +271,7 @@ class em_steering_t {
 	short create_btm_request_tlv(unsigned char *buff);
 
 public:
-	
+
 	/**!
 	 * @brief Retrieves the manager instance.
 	 *
@@ -297,6 +352,28 @@ public:
 
 public:
 
+	/**!
+	 * @brief Delivers a BH Steering result received from OneWifi via AssociationStatus.
+	 *
+	 * Called when an AssociationStatus event arrives while BH Steering is in flight.
+	 * Cancels the 10-second timeout and sends the actual BH Steering Response based on
+	 * the connection outcome.
+	 *
+	 * @param[in] connected_bssid BSSID that the backhaul STA connected to (or attempted).
+	 * @param[in] connect_status  Raw wifi_connection_status_t value from OneWifi.
+	 *
+	 * @returns true  if this node had a pending BH steer and handled the result.
+	 * @returns false if no BH steer is in flight on this node (caller should try next node).
+	 */
+	bool handle_bh_steer_result(const bssid_t connected_bssid, int connect_status);
+
+	/**!
+	 * @brief Handles BH Steering orchestration timeout.
+	 *
+	 * Sends a failure BH Steering Response when the orchestration timer expires
+	 * without receiving a result from OneWifi.
+	 */
+	void handle_bh_steer_timeout();
     
 	/**!
 	 * @brief Retrieves the client steering request transmission count.

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -94,6 +94,7 @@ onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_topo_sync.cpp \
      $(top_srcdir)/src/cmd/em_cmd_scan_result.cpp \
      $(top_srcdir)/src/cmd/em_cmd_btm_report.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_backhaul_steer.cpp \
      $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
      $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
      $(top_srcdir)/src/cmd/em_cmd_beacon_report.cpp \

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -38,6 +38,7 @@
 #include "ieee80211.h"
 #include "em_cmd_agent.h"
 #include "em_orch_agent.h"
+#include "em_cmd_backhaul_steer.h"
 #include "ec_util.h"
 #include "util.h"
 
@@ -460,6 +461,17 @@ void em_agent_t::handle_recv_assoc_status(em_bus_event_t *event)
         return;
     }
     rdk_sta_data_t *sta_data = reinterpret_cast<rdk_sta_data_t *>(event->u.raw_buff);
+
+    // Deliver the result to any EM node that has a BH Steering operation in flight.
+    // This cancels the 10-second timeout and sends the actual BH Steering Response.
+    em_t *em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+    while (em != nullptr) {
+        if (em->handle_bh_steer_result(sta_data->bss_info.bssid,
+                                        static_cast<int>(sta_data->stats.connect_status))) {
+            break;  // Found the pending node, stop iterating
+        }
+        em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
+    }
 
     // Only the `ec_manager_t` (which belongs only to the AL node) needs to get live association status at this time
     em_t *al_node = get_al_node();
@@ -1189,6 +1201,46 @@ void em_agent_t::handle_link_stats_report(em_bus_event_t *evt)
     }
 }
 
+void em_agent_t::handle_backhaul_steer(em_bus_event_t *evt)
+{
+    wifi_bus_desc_t *desc = get_bus_descriptor();
+    if (desc == NULL) {
+        em_printfout("Bus descriptor is null, cannot forward BH Steer request");
+        return;
+    }
+
+    raw_data_t l_bus_data;
+    memset(&l_bus_data, 0, sizeof(raw_data_t));
+    l_bus_data.data_type = bus_data_type_bytes;
+    l_bus_data.raw_data.bytes = (void *)evt->u.raw_buff;
+    l_bus_data.raw_data_len = sizeof(em_bh_steering_req_t);
+
+    int bus_rc = desc->bus_set_fn(&m_bus_hdl, WIFI_EM_BACKHAUL_STEER, &l_bus_data);
+    if (bus_rc != 0) {
+        // Forward to OneWifi failed: fail now instead of waiting for the timeout.
+        em_printfout("bus_set_fn failed for path " WIFI_EM_BACKHAUL_STEER " rc=%d; failing BH steer immediately", bus_rc);
+        em_t *al_node = get_al_node();
+        if (al_node != nullptr) {
+            al_node->handle_bh_steer_timeout();
+        }
+        return;
+    }
+
+    // Submit orchestration command to track timeout for the pending BH steer.
+    em_bh_steering_req_t *bh_req = reinterpret_cast<em_bh_steering_req_t *>(evt->u.raw_buff);
+    em_cmd_backhaul_steer_params_t params{};
+    memcpy(params.sta_mac, bh_req->bh_sta_mac_addr, sizeof(mac_address_t));
+    memcpy(params.target_bssid, bh_req->target_bssid, sizeof(bssid_t));
+    params.op_class = bh_req->op_class;
+    params.channel = bh_req->channel_numb;
+
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    pcmd[0] = new em_cmd_backhaul_steer_t(params, em_service_type_agent);
+    if (m_orch->submit_commands(pcmd, 1) > 0) {
+        em_printfout("Submitted BH steer command for agent-side orchestration");
+    }
+}
+
 void em_agent_t::handle_bus_event(em_bus_event_t *evt)
 {   
 
@@ -1306,6 +1358,10 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
 
         case em_bus_event_type_unassoc_sta_result:
             handle_unassoc_sta_result(evt);
+            break;
+
+        case em_bus_event_type_backhaul_steer:
+            handle_backhaul_steer(evt);
             break;
 
         default:
@@ -2247,6 +2303,11 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case em_msg_type_unassoc_sta_link_metrics_rsp:
            printf("%s:%d: Sending Unassoc STA Link Metrics response\n", __func__, __LINE__);
            break;
+
+        case em_msg_type_bh_steering_req:
+        case em_msg_type_bh_steering_rsp:
+            em = al_em;
+            break;
 
         default:
             printf("%s:%d: Frame: %d not handled in agent\n", __func__, __LINE__, htons(cmdu->type));

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -471,6 +471,11 @@ void em_cmd_t::init()
             m_svc = em_service_type_ctrl;
             break;
 
+        case em_cmd_type_backhaul_steer:
+            strncpy(m_name, "steer_backhaul", strlen("steer_backhaul") + 1);
+            m_svc = em_service_type_ctrl;
+            break;
+
         default:
             snprintf(m_name, sizeof(m_name), "%s", "unknown");
             m_svc = em_service_type_none;
@@ -523,7 +528,8 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_query)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_link_metrics_query)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_result)
-       
+        BUS_EVENT_TYPE_2S(em_bus_event_type_backhaul_steer)
+
         default:
            break;
     }
@@ -602,6 +608,7 @@ const char *em_cmd_t::get_orch_op_str(dm_orch_type_t type)
         ORCH_TYPE_2S(dm_orch_type_topo_publish)
         ORCH_TYPE_2S(dm_orch_type_unassoc_sta_link_req_query)
 	ORCH_TYPE_2S(dm_orch_type_unassoc_sta_result)
+        ORCH_TYPE_2S(dm_orch_type_backhaul_steer)
 
         default:
            break;
@@ -660,6 +667,7 @@ const char *em_cmd_t::get_cmd_type_str(em_cmd_type_t type)
         CMD_TYPE_2S(em_cmd_type_get_link_quality_report)
         CMD_TYPE_2S(em_cmd_type_unassoc_sta_query)
 	CMD_TYPE_2S(em_cmd_type_unassoc_sta_result)
+        CMD_TYPE_2S(em_cmd_type_backhaul_steer)
 
         default:
            break;
@@ -818,6 +826,10 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
             type = em_cmd_type_set_channel;
             break;
 
+        case em_bus_event_type_backhaul_steer:
+            type = em_cmd_type_backhaul_steer;
+            break;
+
         default:
             break;
     }
@@ -876,6 +888,10 @@ em_bus_event_type_t em_cmd_t::cmd_2_bus_event_type(em_cmd_type_t ctype)
 
         case em_cmd_type_unassoc_sta_result:
             type = em_bus_event_type_unassoc_sta_result;
+            break;
+
+        case em_cmd_type_backhaul_steer:
+            type = em_bus_event_type_backhaul_steer;
             break;
 
         default:

--- a/src/cmd/em_cmd_backhaul_steer.cpp
+++ b/src/cmd/em_cmd_backhaul_steer.cpp
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "em_cmd_backhaul_steer.h"
+
+em_cmd_backhaul_steer_t::em_cmd_backhaul_steer_t(em_cmd_backhaul_steer_params_t params,
+                                                 em_service_type_t svc)
+{
+    em_cmd_ctx_t ctx;
+    dm_easy_mesh_t dm;
+
+    m_type = em_cmd_type_backhaul_steer;
+    memcpy(&m_param.u.backhaul_steer_params, &params, sizeof(em_cmd_backhaul_steer_params_t));
+
+    memset(reinterpret_cast<unsigned char *>(&m_orch_desc[0]), 0, EM_MAX_CMD * sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+    m_num_orch_desc = 1;
+    m_orch_desc[0].op = dm_orch_type_backhaul_steer;
+    m_orch_desc[0].submit = true;
+
+    strncpy(m_name, "steer_backhaul", strlen("steer_backhaul") + 1);
+    m_svc = svc;
+    init(dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+    ctx.type = m_orch_desc[0].op;
+    m_data_model.set_cmd_ctx(&ctx);
+}

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -96,6 +96,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
      $(top_srcdir)/src/cmd/em_cmd_bsta_cap.cpp \
      $(top_srcdir)/src/cmd/em_cmd_unassoc_sta_query.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_backhaul_steer.cpp \
      $(top_srcdir)/src/ctrl/dm_easy_mesh_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_cmd_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_ctrl.cpp \
@@ -237,7 +238,8 @@ onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
 	$(top_srcdir)/tests/test_l1_ec_manager.cpp \
 	$(top_srcdir)/src/al-sap/al_service_registration_response.cpp \
 	$(top_srcdir)/tests/test_l1_em_ctrl.cpp \
-	$(top_srcdir)/tests/test_l1_dm_easy_mesh_list.cpp
+	$(top_srcdir)/tests/test_l1_dm_easy_mesh_list.cpp \
+	$(top_srcdir)/tests/test_l1_em_cmd_backhaul_steer.cpp
 
 onewifi_em_ctrl_test_CPPFLAGS = $(onewifi_em_ctrl_CPPFLAGS) \
                                 -I$(PKG_CONFIG_SYSROOT_DIR)$(includedir)/gtest \

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -60,6 +60,7 @@
 #include "em_cmd_mld_reconfig.h"
 #include "em_cmd_bsta_cap.h"
 #include "em_cmd_unassoc_sta_query.h"
+#include "em_cmd_backhaul_steer.h"
 
 extern em_network_topo_t *g_network_topology;
 
@@ -2535,6 +2536,111 @@ int dm_easy_mesh_ctrl_t::analyze_command_steer(em_bus_event_t *evt, em_cmd_t *cm
         }
     }
     cJSON_free(obj);
+
+    return num;
+}
+
+int dm_easy_mesh_ctrl_t::analyze_backhaul_steer(em_bus_event_t *evt, em_cmd_t *cmd[])
+{
+    cJSON *obj, *wfa_obj;
+    cJSON *al_mac_obj, *sta_mac_obj, *bssid_obj, *op_class_obj, *channel_obj;
+    int num = 0;
+    em_subdoc_info_t *subdoc;
+    em_long_string_t wfa;
+    em_cmd_backhaul_steer_params_t bsteer_param;
+
+    subdoc = &evt->u.subdoc;
+    obj = cJSON_Parse(subdoc->buff);
+    if (obj == NULL) {
+        em_printfout("%s:%d: Failed to parse: %s", __func__, __LINE__, subdoc->buff);
+        return 0;
+    }
+
+    snprintf(wfa, sizeof(wfa), "wfa-dataelements:BackhaulSteering");
+
+    if ((wfa_obj = cJSON_GetObjectItem(obj, wfa)) == NULL) {
+        em_printfout("%s:%d: Failed to get BackhaulSteering object", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    memset(&bsteer_param, 0, sizeof(em_cmd_backhaul_steer_params_t));
+
+    if ((al_mac_obj = cJSON_GetObjectItem(wfa_obj, "AlMac")) == NULL) {
+        em_printfout("%s:%d: Failed to get AlMac", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    const char *al_mac_str = cJSON_GetStringValue(al_mac_obj);
+    if (al_mac_str == NULL) {
+        em_printfout("%s:%d: AlMac is not a string", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    dm_easy_mesh_t::string_to_macbytes(const_cast<char *> (al_mac_str), bsteer_param.al_mac);
+
+    if ((sta_mac_obj = cJSON_GetObjectItem(wfa_obj, "StaMac")) == NULL) {
+        em_printfout("%s:%d: Failed to get StaMac", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    const char *sta_mac_str = cJSON_GetStringValue(sta_mac_obj);
+    if (sta_mac_str == NULL) {
+        em_printfout("%s:%d: StaMac is not a string", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    dm_easy_mesh_t::string_to_macbytes(const_cast<char *> (sta_mac_str), bsteer_param.sta_mac);
+
+    if ((bssid_obj = cJSON_GetObjectItem(wfa_obj, "Bssid")) == NULL) {
+        em_printfout("%s:%d: Failed to get Bssid", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    const char *bssid_str = cJSON_GetStringValue(bssid_obj);
+    if (bssid_str == NULL) {
+        em_printfout("%s:%d: Bssid is not a string", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    dm_easy_mesh_t::string_to_macbytes(const_cast<char *> (bssid_str), bsteer_param.target_bssid);
+
+    // OpClass and Channel are encoded as single octets in the 1905 TLV,
+    // so reject out-of-range values instead of silently truncating them.
+    if ((op_class_obj = cJSON_GetObjectItem(wfa_obj, "OpClass")) != NULL) {
+        if (!cJSON_IsNumber(op_class_obj)) {
+            em_printfout("%s:%d: OpClass is not a number", __func__, __LINE__);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        double op_class_val = cJSON_GetNumberValue(op_class_obj);
+        if (op_class_val < 0 || op_class_val > 255) {
+            em_printfout("%s:%d: OpClass %f out of range 0-255", __func__, __LINE__, op_class_val);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        bsteer_param.op_class = static_cast<unsigned int>(op_class_val);
+    }
+
+    if ((channel_obj = cJSON_GetObjectItem(wfa_obj, "Channel")) != NULL) {
+        if (!cJSON_IsNumber(channel_obj)) {
+            em_printfout("%s:%d: Channel is not a number", __func__, __LINE__);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        double channel_val = cJSON_GetNumberValue(channel_obj);
+        if (channel_val < 0 || channel_val > 255) {
+            em_printfout("%s:%d: Channel %f out of range 0-255", __func__, __LINE__, channel_val);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        bsteer_param.channel = static_cast<unsigned int>(channel_val);
+    }
+
+    cJSON_Delete(obj);
+
+    cmd[num] = new em_cmd_backhaul_steer_t(bsteer_param);
+    num++;
 
     return num;
 }

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -498,6 +498,22 @@ void em_ctrl_t::handle_link_stats_alarm_report(em_bus_event_t *evt)
     cJSON_Delete(parent);
 }
 
+void em_ctrl_t::handle_backhaul_steer(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    int num;
+
+    if (m_orch->is_cmd_type_in_progress(evt) == true) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
+    } else if ((num = m_data_model.analyze_backhaul_steer(evt, pcmd)) == 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int>(num)) > 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_success);
+    } else {
+        m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+    }
+}
+
 void em_ctrl_t::handle_dirty_dm()
 {
 	m_data_model.handle_dirty_dm();
@@ -669,6 +685,10 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
 	case em_bus_event_type_unassoc_sta_query:
            handle_unassoc_sta_metrics_query(evt);
            break;
+
+        case em_bus_event_type_backhaul_steer:
+            handle_backhaul_steer(evt);
+            break;
 
         default:
             break;
@@ -1108,8 +1128,23 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
 	case em_msg_type_unassoc_sta_link_metrics_rsp:
             em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
-                if ((em->is_al_interface_em() == false) && 
+                if ((em->is_al_interface_em() == false) &&
 	          (memcmp(em->get_data_model()->get_agent_al_interface_mac(), hdr->src, sizeof(mac_address_t)) == 0)) {
+                    break;
+                }
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
+            }
+            break;
+
+        case em_msg_type_bh_steering_req:
+            break; // outgoing from ctrl, not received
+
+        case em_msg_type_bh_steering_rsp:
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+            while (em != NULL) {
+                if (em->is_al_interface_em() == false &&
+                    memcmp(em->get_data_model()->get_agent_al_interface_mac(),
+                           hdr->src, sizeof(mac_address_t)) == 0) {
                     break;
                 }
                 em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -215,6 +215,14 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_ctrl_sta_steer_pending);
             break;
 
+        case em_cmd_type_backhaul_steer:
+            if (m_service_type == em_service_type_agent) {
+                m_sm.set_state(em_state_agent_bh_steer_pending);
+            } else {
+                m_sm.set_state(em_state_ctrl_bh_steer_pending);
+            }
+            break;
+
         case em_cmd_type_btm_report:
             m_sm.set_state(em_state_agent_steer_btm_res_pending);
             break;
@@ -357,7 +365,8 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_1905_ack:
             if (m_sm.get_state() == em_state_ctrl_ap_mld_configured) {
                 em_configuration_t::process_msg(data, len);
-            } else if (m_sm.get_state() == em_state_ctrl_sta_steer_pending) {
+            } else if (m_sm.get_state() == em_state_ctrl_sta_steer_pending ||
+                       m_sm.get_state() == em_state_ctrl_bh_steer_pending) {
                 em_steering_t::process_msg(data, len);
             } else if (m_sm.get_state() == em_state_ctrl_unassoc_sta_link_metrics_pending) {
                 em_metrics_t::process_msg(data, len);		    
@@ -375,6 +384,11 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_bh_sta_cap_rprt:
             em_printfout("  proto_process, type rcvd: %d", htons(cmdu->type));
             em_capability_t::process_msg(data, len);
+            break;
+
+        case em_msg_type_bh_steering_req:
+        case em_msg_type_bh_steering_rsp:
+            em_steering_t::process_msg(data, len);
             break;
 
         default:
@@ -474,6 +488,12 @@ void em_t::handle_agent_state()
             }
             break;
 
+        case em_cmd_type_backhaul_steer:
+            if (m_sm.get_state() == em_state_agent_bh_steer_pending) {
+                em_steering_t::process_agent_state();
+            }
+            break;
+
 		case em_cmd_type_scan_result:
 			if (m_sm.get_state() == em_state_agent_channel_scan_result_pending) {
 				em_channel_t::process_state();
@@ -556,6 +576,10 @@ void em_t::handle_ctrl_state()
             break;
 
         case em_cmd_type_sta_disassoc:
+            em_steering_t::process_ctrl_state();
+            break;
+
+        case em_cmd_type_backhaul_steer:
             em_steering_t::process_ctrl_state();
             break;
 
@@ -2875,6 +2899,8 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_ctrl_bsta_cap_pending)
         EM_STATE_2S(em_state_ctrl_topo_publish_pending)
 	EM_STATE_2S(em_state_ctrl_unassoc_sta_link_metrics_pending)
+        EM_STATE_2S(em_state_ctrl_bh_steer_pending)
+        EM_STATE_2S(em_state_ctrl_bh_steer_req_ack_rcvd)
         EM_STATE_2S(em_state_agent_unconfigured)
         EM_STATE_2S(em_state_agent_autoconfig_rsp_pending)
         EM_STATE_2S(em_state_agent_wsc_m2_pending)
@@ -2895,6 +2921,7 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_agent_beacon_report_pending)
         EM_STATE_2S(em_state_agent_channel_select_configuration_pending)
 	EM_STATE_2S(em_state_agent_unassoc_sta_metrics_report_pending)
+        EM_STATE_2S(em_state_agent_bh_steer_pending)
         EM_STATE_2S(em_state_max)
         default: break;
     }

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -1026,17 +1026,6 @@ em_msg_t::em_msg_t(em_msg_type_t type, em_profile_type_t profile, unsigned char 
             higher_layer_data();
             break;
 
-
-        case em_msg_type_bh_steering_req:
-            bh_steering_req();
-            break;
-
-
-        case em_msg_type_bh_steering_rsp:
-            bh_steering_rsp();
-            break;
-
-
         case em_msg_type_client_cap_rprt:
             client_cap_rprt();
             break;
@@ -1203,6 +1192,14 @@ em_msg_t::em_msg_t(em_msg_type_t type, em_profile_type_t profile, unsigned char 
 
         case em_msg_type_1905_ack:
             i1905_ack();
+            break;
+
+        case em_msg_type_bh_steering_req:
+            bh_steering_req();
+            break;
+
+        case em_msg_type_bh_steering_rsp:
+            bh_steering_rsp();
             break;
 
         default: 

--- a/src/em/steering/em_steering.cpp
+++ b/src/em/steering/em_steering.cpp
@@ -160,6 +160,287 @@ int em_steering_t::send_client_assoc_ctrl_req_msg(em_client_assoc_ctrl_req_t *as
     return static_cast<int> (len);
 }
 
+int em_steering_t::send_bh_steering_req_msg()
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned short msg_type = em_msg_type_bh_steering_req;
+    size_t len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm;
+    em_bh_steering_req_t *bh_req;
+    em_cmd_backhaul_steer_params_t *params;
+    mac_addr_str_t sta_str, bssid_str, al_str;
+
+    dm = get_data_model();
+    params = &get_current_cmd()->m_param.u.backhaul_steer_params;
+
+    dm_easy_mesh_t::macbytes_to_string(params->sta_mac, sta_str);
+    dm_easy_mesh_t::macbytes_to_string(params->target_bssid, bssid_str);
+    dm_easy_mesh_t::macbytes_to_string(params->al_mac, al_str);
+    em_printfout("Sending BH Steering Request: dst_al=%s sta=%s target_bssid=%s op_class=%d channel=%d",
+        al_str, sta_str, bssid_str, params->op_class, params->channel);
+
+    memcpy(tmp, params->al_mac, sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    cmdu->last_frag_ind = 1;
+    cmdu->relay_ind = 0;
+
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_bh_steering_req;
+    bh_req = reinterpret_cast<em_bh_steering_req_t *>(tlv->value);
+    memcpy(bh_req->bh_sta_mac_addr, params->sta_mac, sizeof(mac_address_t));
+    memcpy(bh_req->target_bssid, params->target_bssid, sizeof(bssid_t));
+    bh_req->op_class = static_cast<unsigned char>(params->op_class);
+    bh_req->channel_numb = static_cast<unsigned char>(params->channel);
+    tlv->len = htons(sizeof(em_bh_steering_req_t));
+
+    tmp += (sizeof(em_tlv_t) + sizeof(em_bh_steering_req_t));
+    len += (sizeof(em_tlv_t) + sizeof(em_bh_steering_req_t));
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_bh_steering_req, em_profile_type_2, buff, static_cast<unsigned int>(len)).validate(errors) == 0) {
+        em_printfout("BH Steering Request msg validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, static_cast<unsigned int>(len)) < 0) {
+        em_printfout("BH Steering Request send failed: errno=%d", errno);
+        return -1;
+    }
+
+    return static_cast<int>(len);
+}
+
+int em_steering_t::handle_bh_steering_rsp(unsigned char *buff, unsigned int len)
+{
+    em_tlv_t *tlv;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    em_bh_steering_resp_t *bh_rsp;
+    mac_addr_str_t mac_str;
+
+    if (em_msg_t(em_msg_type_bh_steering_rsp, em_profile_type_2, buff, len).validate(errors) == 0) {
+        em_printfout("BH Steering Response validation failed");
+        return -1;
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    bh_rsp = reinterpret_cast<em_bh_steering_resp_t *>(tlv->value);
+
+    mac_addr_str_t bssid_str;
+    dm_easy_mesh_t::macbytes_to_string(bh_rsp->bh_sta_mac_addr, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(bh_rsp->target_bssid, bssid_str);
+    em_printfout("BH Steering Response received: sta=%s target_bssid=%s result=%d",
+        mac_str, bssid_str, bh_rsp->result_code);
+
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+    send_1905_ack_to_agent(ntohs(cmdu->id));
+
+    set_state(em_state_ctrl_configured);
+    return 0;
+}
+
+int em_steering_t::send_1905_ack_to_agent(unsigned short msg_id)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned short msg_type = em_msg_type_1905_ack;
+    size_t len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id   = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len  = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_3, buff, static_cast<unsigned int>(len)).validate(errors) == 0) {
+        em_printfout("ACK (ctrl -> agent) validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, static_cast<unsigned int>(len)) < 0) {
+        em_printfout("ACK (ctrl -> agent) send failed: errno=%d", errno);
+        return -1;
+    }
+
+    em_printfout("ACK sent to agent (msg_id=0x%04x)", msg_id);
+    return static_cast<int>(len);
+}
+
+int em_steering_t::handle_bh_steering_req(unsigned char *buff, unsigned int len)
+{
+    em_tlv_t *tlv;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    em_bh_steering_req_t *bh_req;
+    em_cmdu_t *cmdu;
+    mac_addr_str_t mac_str, bssid_str;
+
+    if (em_msg_t(em_msg_type_bh_steering_req, em_profile_type_2, buff, len).validate(errors) == 0) {
+        em_printfout("BH Steering Request validation failed");
+        return -1;
+    }
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+    tlv  = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    bh_req = reinterpret_cast<em_bh_steering_req_t *>(tlv->value);
+
+    dm_easy_mesh_t::macbytes_to_string(bh_req->bh_sta_mac_addr, mac_str);
+    dm_easy_mesh_t::macbytes_to_string(bh_req->target_bssid, bssid_str);
+    em_printfout("BH Steering Request received: sta=%s target_bssid=%s op_class=%d channel=%d",
+        mac_str, bssid_str, bh_req->op_class, bh_req->channel_numb);
+
+    send_1905_ack_message(bh_req->bh_sta_mac_addr, ntohs(cmdu->id));
+
+    get_mgr()->io_process(em_bus_event_type_backhaul_steer,
+                          reinterpret_cast<unsigned char *>(bh_req),
+                          sizeof(em_bh_steering_req_t));
+
+    // Save context for the timeout callback.
+    memcpy(m_bh_steer_pending_sta_mac, bh_req->bh_sta_mac_addr, sizeof(mac_address_t));
+    memcpy(m_bh_steer_pending_bssid,   bh_req->target_bssid,    sizeof(bssid_t));
+
+    // Orchestration timeout (EM_MAX_CMD_GEN_TTL) will send the failure response
+    // if no result arrives from OneWifi. See em_orch_agent_t::pre_process_cancel().
+    set_state(em_state_agent_bh_steer_pending);
+
+    return 0;
+}
+
+int em_steering_t::send_bh_steering_rsp_msg(mac_address_t sta_mac, unsigned char *target_bssid,
+                                             unsigned char result_code, unsigned char error_reason)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned short msg_type = em_msg_type_bh_steering_rsp;
+    size_t len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm;
+    em_bh_steering_resp_t *bh_rsp;
+    mac_addr_str_t sta_str, bssid_str;
+
+    dm = get_data_model();
+    dm_easy_mesh_t::macbytes_to_string(sta_mac, sta_str);
+    dm_easy_mesh_t::macbytes_to_string(target_bssid, bssid_str);
+    em_printfout("Sending BH Steering Response: sta=%s target_bssid=%s result=0x%02x",
+        sta_str, bssid_str, result_code);
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    cmdu->last_frag_ind = 1;
+    cmdu->relay_ind = 0;
+
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_bh_steering_rsp;
+    bh_rsp = reinterpret_cast<em_bh_steering_resp_t *>(tlv->value);
+    memcpy(bh_rsp->bh_sta_mac_addr, sta_mac, sizeof(mac_address_t));
+    memcpy(bh_rsp->target_bssid, target_bssid, sizeof(bssid_t));
+    bh_rsp->result_code = result_code;
+    tlv->len = htons(sizeof(em_bh_steering_resp_t));
+
+    tmp += (sizeof(em_tlv_t) + sizeof(em_bh_steering_resp_t));
+    len += (sizeof(em_tlv_t) + sizeof(em_bh_steering_resp_t));
+
+    // Include Error Code TLV on failure.
+    if (result_code == 0x01) {
+        short err_sz;
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_error_code;
+        err_sz = create_error_code_tlv(tlv->value, static_cast<int>(error_reason), sta_mac);
+        tlv->len = htons(static_cast<unsigned short>(err_sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t>(err_sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t>(err_sz));
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_bh_steering_rsp, em_profile_type_2, buff, static_cast<unsigned int>(len)).validate(errors) == 0) {
+        em_printfout("BH Steering Response msg validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, static_cast<unsigned int>(len)) < 0) {
+        em_printfout("BH Steering Response send failed: errno=%d", errno);
+        return -1;
+    }
+
+    return static_cast<int>(len);
+}
+
 int em_steering_t::send_client_steering_req_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
@@ -503,7 +784,11 @@ int em_steering_t::handle_client_steering_report(unsigned char *buff, unsigned i
 
 int em_steering_t::handle_ack_msg(unsigned char *buff, unsigned int len)
 {
-    set_state(em_state_ctrl_steer_btm_req_ack_rcvd);
+    if (get_state() == em_state_ctrl_bh_steer_pending) {
+        set_state(em_state_ctrl_bh_steer_req_ack_rcvd);
+    } else {
+        set_state(em_state_ctrl_steer_btm_req_ack_rcvd);
+    }
     return 0;
 }
 
@@ -561,6 +846,10 @@ void em_steering_t::process_ctrl_state()
             send_client_assoc_ctrl_req_msg();
             break;
 
+        case em_state_ctrl_bh_steer_pending:
+            send_bh_steering_req_msg();
+            break;
+
         default:
             break;
     }
@@ -571,6 +860,11 @@ void em_steering_t::process_agent_state()
     switch (get_state()) {
         case em_state_agent_steer_btm_res_pending:
             send_btm_report_msg(get_radio_interface_mac(), get_radio_interface_mac());
+            break;
+
+        case em_state_agent_bh_steer_pending:
+            // Waiting for OneWifi result (AssociationStatus callback).
+            // Orchestration timeout handles the failure case.
             break;
 
         default:
@@ -595,6 +889,14 @@ void em_steering_t::process_msg(unsigned char *data, unsigned int len)
             handle_client_assoc_ctrl_req(data, len);
             break;
 
+        case em_msg_type_bh_steering_req:
+            handle_bh_steering_req(data, len);
+            break;
+
+        case em_msg_type_bh_steering_rsp:
+            handle_bh_steering_rsp(data, len);
+            break;
+
         case em_msg_type_1905_ack:
             handle_ack_msg(data, len);
 
@@ -603,13 +905,59 @@ void em_steering_t::process_msg(unsigned char *data, unsigned int len)
     }
 }
 
+bool em_steering_t::handle_bh_steer_result(const bssid_t connected_bssid, int connect_status)
+{
+    if (get_state() != em_state_agent_bh_steer_pending) {
+        return false;
+    }
+
+    mac_addr_str_t sta_str, bssid_str;
+    dm_easy_mesh_t::macbytes_to_string(m_bh_steer_pending_sta_mac, sta_str);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<uint8_t *> (connected_bssid), bssid_str);
+
+    bool is_target_bssid = (memcmp(connected_bssid, m_bh_steer_pending_bssid, sizeof(bssid_t)) == 0);
+
+    if (connect_status == wifi_connection_status_connected && is_target_bssid) {
+        em_printfout("BH Steering result: STA %s connected to target %s - sending success response",
+                     sta_str, bssid_str);
+        send_bh_steering_rsp_msg(m_bh_steer_pending_sta_mac, m_bh_steer_pending_bssid, 0x00);
+    } else if (connect_status != wifi_connection_status_connected && !is_target_bssid) {
+        // Old connection dropping during steer, ignore and keep waiting for target result
+        em_printfout("BH Steering: ignoring disconnect from old BSS %s (status=%d), waiting for target",
+                     bssid_str, connect_status);
+        return false;
+    } else {
+        unsigned char reason = (connect_status == wifi_connection_status_ap_not_found)
+                               ? em_error_code_bh_steer_signal_weak_or_not_found
+                               : em_error_code_bh_steer_rejected_by_target_bss;
+        em_printfout("BH Steering result: STA %s failed (connect_status=%d bssid=%s) - sending failure response (reason=0x%02x)",
+                     sta_str, connect_status, bssid_str, reason);
+        send_bh_steering_rsp_msg(m_bh_steer_pending_sta_mac, m_bh_steer_pending_bssid, 0x01, reason);
+    }
+
+    set_state(em_state_agent_configured);
+    return true;
+}
+
+void em_steering_t::handle_bh_steer_timeout()
+{
+    if (get_state() != em_state_agent_bh_steer_pending) {
+        return;
+    }
+    em_printfout("BH Steering: orchestration timeout expired, sending failure response");
+    send_bh_steering_rsp_msg(m_bh_steer_pending_sta_mac, m_bh_steer_pending_bssid,
+                             0x01, em_error_code_bh_steer_signal_weak_or_not_found);
+    set_state(em_state_agent_configured);
+}
+
 em_steering_t::em_steering_t()
 {
     m_client_steering_req_tx_cnt = 0;
     m_client_assoc_ctrl_req_tx_cnt = 0;
+    memset(m_bh_steer_pending_sta_mac, 0, sizeof(m_bh_steer_pending_sta_mac));
+    memset(m_bh_steer_pending_bssid,   0, sizeof(m_bh_steer_pending_bssid));
 }
 
 em_steering_t::~em_steering_t()
 {
-
 }

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -64,7 +64,10 @@ void em_orch_agent_t::orch_transient(em_cmd_t *pcmd, em_t *em)
     if (stats->time > EM_MAX_CMD_GEN_TTL) {
         em_printfout("Canceling cmd: %s because time limit exceeded\n", pcmd->get_cmd_name());
         cancel_command(pcmd->get_type());
-    	if (em->get_state() < em_state_agent_topo_synchronized) {
+        if (pcmd->get_type() == em_cmd_type_backhaul_steer) {
+            // BH steer timeout: failure response already sent by pre_process_cancel.
+            em->set_state(em_state_agent_configured);
+        } else if (em->get_state() < em_state_agent_topo_synchronized) {
 	    	em->set_state(em_state_agent_unconfigured);
 		} else {
 	    	em->set_state(em_state_agent_topo_synchronized);
@@ -116,6 +119,12 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             break;
 
         case em_cmd_type_btm_report:
+            if (em->get_state() == em_state_agent_configured) {
+                return true;
+            }
+            break;
+
+        case em_cmd_type_backhaul_steer:
             if (em->get_state() == em_state_agent_configured) {
                 return true;
             }
@@ -203,6 +212,10 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
             ((em->get_state() ==em_state_agent_unassoc_sta_metrics_report_pending))) {
             return true;
         }
+    } else if (pcmd->m_type == em_cmd_type_backhaul_steer) {
+        if (em->get_state() == em_state_agent_bh_steer_pending) {
+            return true;
+        }
     }
 
     return false;
@@ -211,7 +224,9 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
 
 void em_orch_agent_t::pre_process_cancel(em_cmd_t *pcmd, em_t *em)
 {
-
+    if (pcmd->get_type() == em_cmd_type_backhaul_steer) {
+        em->handle_bh_steer_timeout();
+    }
 }
 
 bool em_orch_agent_t::pre_process_orch_op(em_cmd_t *pcmd)
@@ -334,6 +349,7 @@ bool em_orch_agent_t::pre_process_orch_op(em_cmd_t *pcmd)
         case dm_orch_type_channel_pref:
         case dm_orch_type_op_channel_report:
         case dm_orch_type_beacon_report:
+        case dm_orch_type_backhaul_steer:
             break;
 
         case dm_orch_type_sta_link_metrics:
@@ -517,8 +533,15 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
             case em_cmd_type_unassoc_sta_result:
                 // Unassociated STA metrics response is processed only once.
                 // Select the first non-AL EM instance as the candidate and
-                // avoid queuing additional EMs for the same response.		
+                // avoid queuing additional EMs for the same response.
                 if (!(em->is_al_interface_em()) && (count == 0)) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+                break;
+
+            case em_cmd_type_backhaul_steer:
+                if (em->get_state() == em_state_agent_bh_steer_pending) {
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
                 }

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -241,6 +241,12 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
+        case em_cmd_type_backhaul_steer:
+            if (em->get_state() == em_state_ctrl_configured) {
+                return true;
+            }
+            break;
+
         case em_cmd_type_sta_disassoc:
             if (em->get_client_assoc_ctrl_req_tx_count() >= EM_MAX_CLIENT_ASSOC_CTRL_REQ_TX_THRESH) {
                 em->set_client_assoc_ctrl_req_tx_count(0);
@@ -306,6 +312,7 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_set_radio:
         case em_cmd_type_mld_reconfig:
         case em_cmd_type_start_dpp:
+        case em_cmd_type_backhaul_steer:
             return true;
 
         case em_cmd_type_em_config:
@@ -401,6 +408,12 @@ void em_orch_ctrl_t::pre_process_cancel(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_set_policy:
             em_printfout("Cancel received for Set Policy command, transitioning to configured state radio: %s",
                 util::mac_to_string(em->get_radio_interface_mac()).c_str());
+            em->set_state(em_state_ctrl_configured);
+            break;
+
+        case em_cmd_type_backhaul_steer:
+            // Timed out waiting for the agent's response; reset so the EM is not stuck.
+            em_printfout("Cancel received for Backhaul Steering command, transitioning to configured state");
             em->set_state(em_state_ctrl_configured);
             break;
 
@@ -696,6 +709,23 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
 
             case em_cmd_type_sta_steer:
                 if (em->find_sta(pcmd->m_param.u.steer_params.sta_mac, pcmd->m_param.u.steer_params.source) != NULL) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+                break;
+
+            case em_cmd_type_backhaul_steer:
+                /**
+                 * Send to the first radio level em_t that belongs to the target agent.
+                 * AL interface em_t instances are skipped because remote agents are only
+                 * represented in the em_map via their radio em_t instances.
+                 * count == 0 ensures we enqueue exactly one candidate (all radios share
+                 * the same AL MAC and in AL-SAP mode routing is by AL MAC anyway).
+                 */
+                if (count == 0 &&
+                    em->is_al_interface_em() == false &&
+                    memcmp(em->get_data_model()->get_agent_al_interface_mac(),
+                           pcmd->m_param.u.backhaul_steer_params.al_mac, sizeof(mac_address_t)) == 0) {
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
                 }

--- a/src/rdkb-cli/Makefile.am
+++ b/src/rdkb-cli/Makefile.am
@@ -73,6 +73,7 @@ libemcli_la_SOURCES = \
  $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
  $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
  $(top_srcdir)/src/cmd/em_cmd_unassoc_sta_query.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_backhaul_steer.cpp \
  $(top_srcdir)/src/dm/dm_device.cpp \
  $(top_srcdir)/src/dm/dm_ieee_1905_security.cpp \
  $(top_srcdir)/src/dm/dm_easy_mesh.cpp  \

--- a/src/rdkb-cli/em_cmd_cli.cpp
+++ b/src/rdkb-cli/em_cmd_cli.cpp
@@ -70,6 +70,7 @@ em_cmd_params_t spec_params[] = {
     {.u = {.args = {2, {"", "", "", "", ""}, "MLDReconfig"}}},
     {.u = {.args = {2, {"", "", "", "", ""}, "WifiReset"}}},
     {.u = {.args = {2, {"", "", "", "", ""}, "UnassocSTAQuery.json"}}},
+    {.u = {.args = {2, {"", "", "", "", ""}, "BackhaulSteer.json"}}},
 	{.u = {.args = {0, {"", "", "", "", ""}, "max"}}},
 };
 
@@ -105,7 +106,8 @@ em_cmd_t em_cmd_cli_t::m_client_cmd_spec[] = {
     em_cmd_t(em_cmd_type_mld_reconfig, spec_params[27]),
     em_cmd_t(em_cmd_type_get_reset, spec_params[28]),
     em_cmd_t(em_cmd_type_unassoc_sta_query, spec_params[29]),
-    em_cmd_t(em_cmd_type_max, spec_params[30]),
+    em_cmd_t(em_cmd_type_backhaul_steer, spec_params[30]),
+    em_cmd_t(em_cmd_type_max, spec_params[31]),
 };
 
 int em_cmd_cli_t::get_edited_node(em_network_node_t *node, const char *header, char *buff)
@@ -469,7 +471,19 @@ int em_cmd_cli_t::execute(char *result)
                return -1;
            }
            break;
-	   
+
+        case em_cmd_type_backhaul_steer:
+            bevt->type = em_bus_event_type_backhaul_steer;
+            info = &bevt->u.subdoc;
+            strncpy(info->name, param->u.args.fixed_args, sizeof(info->name) - 1);
+            info->name[sizeof(info->name) - 1] = '\0';
+            if ((bevt->data_len = get_edited_node(m_cmd.m_param.net_node, "BackhaulSteering", info->buff)) < 0) {
+                printf("%s:%d: failed to get backhaul steer node\n", __func__, __LINE__);
+                return -1;
+            }
+            break;
+
+
         default:
             break;
     }

--- a/src/rdkb-cli/main.go
+++ b/src/rdkb-cli/main.go
@@ -111,6 +111,16 @@ type Backhaul struct {
     Child      []NetworkDevice `json:"child"`
 }
 
+// Holds the parameters for a 1905 Backhaul Steering Request.
+// Field names match the keys expected by the C JSON parser.
+type backhaulSteeringRequest struct {
+    AlMac   string `json:"AlMac"`
+    StaMac  string `json:"StaMac"`
+    Bssid   string `json:"Bssid"`
+    OpClass int    `json:"OpClass"`
+    Channel int    `json:"Channel"`
+}
+
 type Radio struct {
     Band     int      `json:"band"`
     Channel  int      `json:"channel"`
@@ -2905,8 +2915,11 @@ func main() {
 	//system setting Wifi Reset
 	api.HandleFunc("/wifireset", WifiResetHandler).Methods("GET", "POST")
 
-	// Unassoc STA 
+	// Unassoc STA
 	api.HandleFunc("/unassoc_sta_query", unassocStaQueryHandler).Methods("POST")
+
+	// 1905 Backhaul Steering
+	api.HandleFunc("/backhaul_steer", backhaulSteerHandler).Methods("POST")
 
 	// Enable CORS
 	router.Use(corsMiddleware)
@@ -3519,7 +3532,6 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
     }
 }
 
-
 /*
  * func: unassocStaQueryHandler()
  *
@@ -3534,7 +3546,7 @@ func unassocStaQueryHandler(w http.ResponseWriter, r *http.Request) {
     }
 
     defer r.Body.Close()
-    
+
     const maxRequestSize = 64 * 1024 // 64 KB
     r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 
@@ -3613,9 +3625,90 @@ func unassocStaQueryHandler(w http.ResponseWriter, r *http.Request) {
 
     if err := json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "message": "Unassoc STA Query sent",}); err != nil {
         log.Printf("[ERROR][HTTP] Failed to encode response: %v", err)
-    }    
+    }
 }
 
+/* func: backhaulSteerHandler()
+ * Description:
+ * Handles POST /backhaul_steer requests. Parses the backhaulSteeringRequest payload
+ * and triggers a 1905 Backhaul Steering Request.
+ */
+func backhaulSteerHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method != http.MethodPost {
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+        return
+    }
+
+    defer r.Body.Close()
+
+    const maxRequestSize = 64 * 1024 // 64 KB
+    r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
+
+    var req backhaulSteeringRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "Invalid request payload", http.StatusBadRequest)
+        return
+    }
+
+    if req.AlMac == "" || req.StaMac == "" || req.Bssid == "" {
+        http.Error(w, "AlMac, StaMac and Bssid are required", http.StatusBadRequest)
+        return
+    }
+
+    for _, m := range []struct{ name, val string }{{"AlMac", req.AlMac}, {"StaMac", req.StaMac}, {"Bssid", req.Bssid}} {
+        if hw, err := net.ParseMAC(m.val); err != nil || len(hw) != 6 {
+            http.Error(w, m.name+" is not a valid MAC address", http.StatusBadRequest)
+            return
+        }
+    }
+
+    // OpClass and Channel are encoded as single octets in the 1905 TLV.
+    if req.OpClass < 0 || req.OpClass > 255 {
+        http.Error(w, "OpClass must be in range 0-255", http.StatusBadRequest)
+        return
+    }
+    if req.Channel < 0 || req.Channel > 255 {
+        http.Error(w, "Channel must be in range 0-255", http.StatusBadRequest)
+        return
+    }
+
+    jsonBytes, err := json.Marshal(req)
+    if err != nil {
+        http.Error(w, "Failed to serialize backhaul steer parameters", http.StatusInternalServerError)
+        return
+    }
+
+    cJsonStr := C.CString(string(jsonBytes))
+    defer C.free(unsafe.Pointer(cJsonStr))
+
+    node := C.get_network_tree(cJsonStr)
+    if node == nil {
+        http.Error(w, "Failed to create network tree for backhaul steer request", http.StatusInternalServerError)
+        return
+    }
+    defer C.free_network_tree(node)
+
+    cmd := C.CString("steer_backhaul OneWifiMesh")
+    defer C.free(unsafe.Pointer(cmd))
+
+    result := C.exec(cmd, C.strlen(cmd), node)
+    if result == nil {
+        http.Error(w, "Backhaul steering command failed", http.StatusInternalServerError)
+        return
+    }
+    defer C.free_network_tree(result)
+
+    log.Printf("Backhaul steering request sent: almac=%s stamac=%s bssid=%s opclass=%d channel=%d",
+        req.AlMac, req.StaMac, req.Bssid, req.OpClass, req.Channel)
+
+    w.Header().Set("Content-Type", "application/json")
+    if err := json.NewEncoder(w).Encode(map[string]interface{}{
+        "success": true,
+        "message": "Backhaul steering request sent",
+    }); err != nil {
+        log.Printf("[ERROR][HTTP] Failed to encode response: %v", err)
+    }
+}
 
 //------------------------------------------------------------
 //                    Helper Functions

--- a/tests/test_l1_em_cmd_backhaul_steer.cpp
+++ b/tests/test_l1_em_cmd_backhaul_steer.cpp
@@ -1,0 +1,189 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <stdio.h>
+#include <cstring>
+#include <iostream>
+#include "em_cmd_backhaul_steer.h"
+
+// Helper: parse a colon separated MAC string into a 6-byte array.
+static void parse_mac(const char *str, unsigned char out[6])
+{
+    unsigned int b[6];
+    if (sscanf(str, "%02X:%02X:%02X:%02X:%02X:%02X",
+               &b[0], &b[1], &b[2], &b[3], &b[4], &b[5]) != 6) {
+        memset(out, 0, 6);
+        return;
+    }
+    for (int i = 0; i < 6; i++)
+        out[i] = static_cast<unsigned char>(b[i]);
+}
+
+/**
+ * @brief Tests the creation of an em_cmd_backhaul_steer_t instance with valid standard parameters.
+ *
+ * Verifies that the constructor properly initializes type, name, orchestration
+ * descriptor, and copies all MAC/BSSID/channel parameters without throwing.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 001@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None
+ * **Dependencies:** None
+ * **User Interaction:** None
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description | Test Data | Expected Result | Notes |
+ * | :----: | --------- | ---------- |-------------- | ----- |
+ * | 01 | Initialize em_cmd_backhaul_steer_params_t with valid values. | al_mac="AA:BB:CC:DD:EE:FF", sta_mac="00:11:22:33:44:55", target_bssid="66:77:88:99:AA:BB", op_class=81, channel=6 | Structure correctly initialized. | Should be successful |
+ * | 02 | Invoke the em_cmd_backhaul_steer_t constructor. | params as above | Instance created without exception; m_type, m_name, m_orch_desc, and params match. | Should Pass |
+ */
+TEST(em_cmd_backhaul_steer_t, em_cmd_backhaul_steer_t_valid_standard_parameters)
+{
+    std::cout << "Entering em_cmd_backhaul_steer_t_valid_standard_parameters test" << std::endl;
+
+    em_cmd_backhaul_steer_params_t params{};
+    const char *al_mac_str     = "AA:BB:CC:DD:EE:FF";
+    const char *sta_mac_str    = "00:11:22:33:44:55";
+    const char *bssid_str      = "66:77:88:99:AA:BB";
+
+    unsigned char al_mac_bytes[6], sta_mac_bytes[6], bssid_bytes[6];
+    parse_mac(al_mac_str,  al_mac_bytes);
+    parse_mac(sta_mac_str, sta_mac_bytes);
+    parse_mac(bssid_str,   bssid_bytes);
+
+    memcpy(params.al_mac,       al_mac_bytes,  6);
+    memcpy(params.sta_mac,      sta_mac_bytes, 6);
+    memcpy(params.target_bssid, bssid_bytes,   6);
+    params.op_class = 81;
+    params.channel  = 6;
+
+    std::cout << "al_mac: "       << al_mac_str  << std::endl;
+    std::cout << "sta_mac: "      << sta_mac_str << std::endl;
+    std::cout << "target_bssid: " << bssid_str   << std::endl;
+    std::cout << "op_class: "     << params.op_class << std::endl;
+    std::cout << "channel: "      << params.channel  << std::endl;
+
+    EXPECT_NO_THROW({
+        em_cmd_backhaul_steer_t obj(params);
+        std::cout << "Instance created successfully." << std::endl;
+
+        EXPECT_EQ(obj.m_type, em_cmd_type_backhaul_steer);
+        EXPECT_STREQ(obj.m_name, "steer_backhaul");
+        EXPECT_EQ(obj.m_orch_op_idx, 0);
+        EXPECT_EQ(obj.m_num_orch_desc, 1u);
+        EXPECT_EQ(obj.m_orch_desc[0].op, dm_orch_type_backhaul_steer);
+        EXPECT_EQ(obj.m_orch_desc[0].submit, true);
+        EXPECT_EQ(obj.m_svc, em_service_type_ctrl);
+
+        EXPECT_EQ(memcmp(obj.m_param.u.backhaul_steer_params.al_mac,       al_mac_bytes,  6), 0);
+        EXPECT_EQ(memcmp(obj.m_param.u.backhaul_steer_params.sta_mac,      sta_mac_bytes, 6), 0);
+        EXPECT_EQ(memcmp(obj.m_param.u.backhaul_steer_params.target_bssid, bssid_bytes,   6), 0);
+        EXPECT_EQ(obj.m_param.u.backhaul_steer_params.op_class, 81u);
+        EXPECT_EQ(obj.m_param.u.backhaul_steer_params.channel,  6u);
+
+        obj.deinit();
+    });
+
+    std::cout << "Exiting em_cmd_backhaul_steer_t_valid_standard_parameters test" << std::endl;
+}
+
+/**
+ * @brief Tests the creation of an em_cmd_backhaul_steer_t instance with all-zero parameters.
+ *
+ * Verifies that the constructor succeeds with zeroed MAC addresses and channel fields,
+ * representing a minimal/default initialization scenario.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 002@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description | Test Data | Expected Result | Notes |
+ * | :----: | --------- | ---------- |-------------- | ----- |
+ * | 01 | Zero-initialize em_cmd_backhaul_steer_params_t. | all fields = 0 | Structure zeroed. | Should be successful |
+ * | 02 | Invoke the constructor with zeroed params. | params{} | Instance created without exception; type and name correct. | Should Pass |
+ */
+TEST(em_cmd_backhaul_steer_t, em_cmd_backhaul_steer_t_valid_zero_parameters)
+{
+    std::cout << "Entering em_cmd_backhaul_steer_t_valid_zero_parameters test" << std::endl;
+
+    em_cmd_backhaul_steer_params_t params{};
+    memset(&params, 0, sizeof(params));
+
+    EXPECT_NO_THROW({
+        em_cmd_backhaul_steer_t obj(params);
+        std::cout << "Instance created successfully." << std::endl;
+
+        EXPECT_EQ(obj.m_type, em_cmd_type_backhaul_steer);
+        EXPECT_STREQ(obj.m_name, "steer_backhaul");
+        EXPECT_EQ(obj.m_orch_op_idx, 0);
+        EXPECT_EQ(obj.m_num_orch_desc, 1u);
+        EXPECT_EQ(obj.m_orch_desc[0].op, dm_orch_type_backhaul_steer);
+        EXPECT_EQ(obj.m_orch_desc[0].submit, true);
+        EXPECT_EQ(obj.m_svc, em_service_type_ctrl);
+        EXPECT_EQ(obj.m_param.u.backhaul_steer_params.op_class, 0u);
+        EXPECT_EQ(obj.m_param.u.backhaul_steer_params.channel,  0u);
+
+        obj.deinit();
+    });
+
+    std::cout << "Exiting em_cmd_backhaul_steer_t_valid_zero_parameters test" << std::endl;
+}
+
+/**
+ * @brief Tests the creation of an em_cmd_backhaul_steer_t instance with maximum boundary values.
+ *
+ * Verifies that the constructor correctly handles maximum uint8 (0xFF) values for all
+ * MAC/BSSID bytes, op_class, and channel fields.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 003@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description | Test Data | Expected Result | Notes |
+ * | :----: | --------- | ---------- |-------------- | ----- |
+ * | 01 | Initialize params with broadcast MACs and max uint values. | all MACs="FF:FF:FF:FF:FF:FF", op_class=255, channel=255 | Structure correctly initialized. | Should be successful |
+ * | 02 | Invoke the constructor. | params as above | Instance created without exception; params stored correctly. | Should Pass |
+ */
+TEST(em_cmd_backhaul_steer_t, em_cmd_backhaul_steer_t_valid_max_boundary_values)
+{
+    std::cout << "Entering em_cmd_backhaul_steer_t_valid_max_boundary_values test" << std::endl;
+
+    em_cmd_backhaul_steer_params_t params{};
+    const char *mac_ff = "FF:FF:FF:FF:FF:FF";
+    unsigned char ff_bytes[6];
+    parse_mac(mac_ff, ff_bytes);
+
+    memcpy(params.al_mac,       ff_bytes, 6);
+    memcpy(params.sta_mac,      ff_bytes, 6);
+    memcpy(params.target_bssid, ff_bytes, 6);
+    params.op_class = 255;
+    params.channel  = 255;
+
+    EXPECT_NO_THROW({
+        em_cmd_backhaul_steer_t obj(params);
+        std::cout << "Instance created successfully." << std::endl;
+
+        EXPECT_EQ(obj.m_type, em_cmd_type_backhaul_steer);
+        EXPECT_STREQ(obj.m_name, "steer_backhaul");
+        EXPECT_EQ(memcmp(obj.m_param.u.backhaul_steer_params.al_mac,       ff_bytes, 6), 0);
+        EXPECT_EQ(memcmp(obj.m_param.u.backhaul_steer_params.sta_mac,      ff_bytes, 6), 0);
+        EXPECT_EQ(memcmp(obj.m_param.u.backhaul_steer_params.target_bssid, ff_bytes, 6), 0);
+        EXPECT_EQ(obj.m_param.u.backhaul_steer_params.op_class, 255u);
+        EXPECT_EQ(obj.m_param.u.backhaul_steer_params.channel,  255u);
+
+        obj.deinit();
+    });
+
+    std::cout << "Exiting em_cmd_backhaul_steer_t_valid_max_boundary_values test" << std::endl;
+}


### PR DESCRIPTION
Add end to end backhaul steering support across the controller and agent stack. The controller builds and sends the BH Steering Request CMDU to the target agent via the CLI. The agent receives the request, forwards it to OneWifi via rbus, and sends back a BH Steering Response.