### PR TITLE
Issue 637: Crash/Memory corruption in handle_bsta_cap_report

### DIFF
--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -1100,8 +1100,8 @@ typedef struct {
 } __attribute__((__packed__)) em_assoc_wifi6_sta_sts_t;
 
 typedef struct {
-    mac_address_t client_mac_addr;
     unsigned char bssid[6];
+    mac_address_t client_mac_addr;
 } __attribute__((__packed__)) em_client_info_t;
 
 typedef struct {

--- a/inc/em_capability.h
+++ b/inc/em_capability.h
@@ -737,26 +737,52 @@ class em_capability_t {
 	 *
 	 * This function processes the capability report received from the Extender.
 	 *
-	 * @param[in] buff Pointer to the buffer containing the notification data.
-	 * @param[in] len Length of the data received.
+	 * @param[in] pkt_buff Pointer to the buffer containing the notification data.
+	 * @param[in] pkt_len Length of the data received.
 	 *
 	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
 	 */
-	int handle_bsta_cap_report(unsigned char *buff, unsigned int len);
+	int handle_bsta_cap_report(unsigned char *pkt_buff, unsigned int pkt_len);
 
 	/**!
 	 * @brief Handles the backhaul sta radio capability TLV
 	 *
 	 * This function processes the backhaul sta radio capability TLV.
 	 *
-	 * @param[in] buff Pointer to the buffer containing the TLV data.
-	 * @param[in] len Length of the data received.
+	 * @param[in] tlv_buff Pointer to the buffer containing the TLV data.
+	 * @param[in] tlv_len Length of the data received.
 	 *
 	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
 	 */
-	int handle_bsta_radio_cap(unsigned char *buff, unsigned int len);
+	int handle_bsta_radio_cap(unsigned char *tlv_buff, unsigned int tlv_len);
+
+	/**!
+	 * @brief Handles the client info TLV
+	 *
+	 * This function processes the client info TLV.
+	 *
+	 * @param[in] tlv_buff Pointer to the buffer containing the TLV data.
+	 * @param[in] tlv_len Length of the data received.
+	 *
+	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
+	 */
+	int handle_client_info(unsigned char *tlv_buff, unsigned int tlv_len);
+
+	/**!
+	 * @brief Processes a 1905 message with the given data and length.
+	 *
+	 * This function takes a pointer to a data buffer containing 1905 message with Ethernet header and its length, then processes the message contained within.
+	 *
+	 * @param[in] pkt_buff Pointer to the data buffer containing the message to be processed.
+	 * @param[in] pkt_len The length of the data buffer.
+	 * @param[in] tlv_type Type of TLV
+	 * @param[in] handler Handler function to process specific TLV
+	 *
+	 * @note Ensure that the data buffer is valid and the length is correctly specified to avoid undefined behavior.
+	 */
+	int process_single_tlv_in_1905_message(unsigned char *pkt_buff, unsigned int pkt_len, em_tlv_type_t tlv_type, int (em_capability_t::*handler)(unsigned char*, unsigned int));
 public:
-    
+
 	/**!
 	 * @brief Processes a message with the given data and length.
 	 *
@@ -768,7 +794,7 @@ public:
 	 * @note Ensure that the data buffer is valid and the length is correctly specified to avoid undefined behavior.
 	 */
 	void    process_msg(unsigned char *data, unsigned int len);
-    
+
 	/**!
 	 * @brief Processes the state of the agent.
 	 *

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -849,89 +849,166 @@ int em_capability_t::handle_bsta_cap_query(unsigned char *buff, unsigned int len
     return 0;
 }
 
-int em_capability_t::handle_bsta_radio_cap(unsigned char *buff, unsigned int len)
+int em_capability_t::handle_bsta_radio_cap(unsigned char *tlv_buff, unsigned int tlv_len)
 {
+    if (!tlv_buff)
+    {
+        return -1;
+    }
+
+    if (!tlv_len || ((tlv_len != sizeof(em_bh_sta_radio_cap_t)) && (tlv_len != offsetof(em_bh_sta_radio_cap_t, bsta_addr))))
+    {
+        em_printfout("Invalid TLV length:%d Must be %d or %d for bsta radio cap TLV",
+		     static_cast<int>(tlv_len),
+                     static_cast<int>(offsetof(em_bh_sta_radio_cap_t, bsta_addr)),
+                     static_cast<int>(sizeof(em_bh_sta_radio_cap_t)));
+        return -1;
+    }
+
+    em_bh_sta_radio_cap_t *bsta_radio_cap = reinterpret_cast<em_bh_sta_radio_cap_t*>(tlv_buff);
+    std::string ruid_str = util::mac_to_string(bsta_radio_cap->ruid);
+    em_printfout("Rcvd BSTA Cap, for radio: %s, mac present: %d",
+            ruid_str.c_str(),
+            bsta_radio_cap->bsta_mac_present);
+
+    if (tlv_len == offsetof(em_bh_sta_radio_cap_t, bsta_addr))
+    {
+        if (bsta_radio_cap->bsta_mac_present)
+        {
+            em_printfout("Error: bsta_mac_present is 1 when tlv_len is %d", static_cast<int>(offsetof(em_bh_sta_radio_cap_t, bsta_addr)));
+            return -1;
+        }
+        return 0;
+    }
+
+    if (!bsta_radio_cap->bsta_mac_present)
+    {
+        em_printfout("Error: bsta_mac_present is 0 when tlv_len is %d", static_cast<int>(sizeof(em_bh_sta_radio_cap_t)));
+        return -1;
+    }
+
     dm_easy_mesh_t *dm = get_data_model();
-    em_bh_sta_radio_cap_t *bsta_radio_cap = reinterpret_cast<em_bh_sta_radio_cap_t*>(buff);
 
-    em_printfout("Rcvd Backhaul STA Radio Capabilities received, sta mac: %s for radio: %s, mac present: %d",
-        util::mac_to_string(bsta_radio_cap->bsta_addr).c_str(),
-        util::mac_to_string(bsta_radio_cap->ruid).c_str(), bsta_radio_cap->bsta_mac_present);
+    if (!dm) {
+        em_printfout("Could not find data model");
+        return -1;
+    }
 
-    //find device based on this radio
     em_device_info_t *dev = dm->get_device_info();
-    if (dev == NULL) {
+    if (!dev)
+    {
         em_printfout("Could not find device in data model");
         return -1;
     }
 
-    em_printfout("Update BSTA Cap for Device id: %s",
-        util::mac_to_string(dev->id.dev_mac).c_str());
-
+    em_printfout("Update BSTA Cap for Device id: %s", util::mac_to_string(dev->id.dev_mac).c_str());
     memcpy(dm->m_device.m_device_info.backhaul_sta, bsta_radio_cap->bsta_addr, sizeof(mac_address_t));
     dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
+    return 0;
+}
+
+int em_capability_t::handle_client_info(unsigned char *tlv_buff, unsigned int tlv_len)
+{
+    if (!tlv_buff) {
+        return -1;
+    }
+
+    if (tlv_len != sizeof(em_client_info_t)) {
+        em_printfout("Invalid TLV length for client info TLV: received %u, expected %d", tlv_len, static_cast<int>(sizeof(em_client_info_t)));
+        return -1;
+    }
+
+    const em_client_info_t *client_info = reinterpret_cast<const em_client_info_t *>(tlv_buff);
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (!dm) {
+        em_printfout("Could not find data model");
+        return -1;
+    }
+
+    if (dm->get_colocated() != true) {
+        memcpy(dm->m_device.m_device_info.backhaul_mac.mac, client_info->client_mac_addr, sizeof(mac_address_t));
+        dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
+    }
 
     return 0;
 }
 
-int em_capability_t::handle_bsta_cap_report(unsigned char *buff, unsigned int len)
+int em_capability_t::process_single_tlv_in_1905_message(unsigned char *pkt_buff, unsigned int pkt_len, em_tlv_type_t tlv_type,
+                                      int (em_capability_t::*handler)(unsigned char*, unsigned int))
 {
-    em_tlv_t *tlv;
-    unsigned int tmp_len;
-    dm_easy_mesh_t *dm;
+    em_tlv_t *tlv = NULL;
+    unsigned int header_len = sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t);
 
-    dm = get_data_model();
-
-    tlv =  reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    tmp_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-
-    em_printfout("Backhaul Sta Capability report message rcvd");
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type != em_tlv_type_bh_sta_radio_cap) {
-            tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-            tlv = reinterpret_cast <em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-            continue;
-        } else {
-            handle_bsta_radio_cap(tlv->value, tlv->len);
-            break;
-        }
-        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    em_device_info_t *dev = dm->get_device_info();
-    if (dev == NULL) {
-        em_printfout("Could not find device in data model");
+    if (!pkt_buff || !pkt_len || !handler) {
         return -1;
     }
 
-    tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    tmp_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_client_info) {
-            if(dm->get_colocated() != true ) {
-                em_printfout("Cap: Update backhaul mac for Device id(non-coloc): %s",
-                    util::mac_to_string(dev->id.dev_mac).c_str());
+    if (pkt_len <= header_len) {
+        return -1;
+    }
 
-                memcpy(dm->m_device.m_device_info.backhaul_mac.mac, tlv->value, sizeof(mac_address_t));
-                dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
-            } else {
-                em_printfout("Device is colocated, not updating backhaul mac for Device id: %s, backhaul mac in dm: %s",
-                    util::mac_to_string(dev->id.dev_mac).c_str(),
-                    util::mac_to_string(dm->m_device.m_device_info.backhaul_mac.mac).c_str());
+    em_tlv_t* tlvs_start = reinterpret_cast<em_tlv_t *>(pkt_buff + header_len);
+    unsigned int tlvs_len = pkt_len - header_len;
+
+    if (tlvs_len < sizeof(em_tlv_t)) {
+            return -1;
+    }
+
+    if (tlvs_start->type == em_tlv_type_eom) {
+            if (ntohs(tlvs_start->len) != 0) {
+                     return -1;
             }
+            return 0;
+    }
+
+    tlv = em_msg_t::get_first_tlv(tlvs_start, tlvs_len);
+
+    if (!tlv) {
+            return -1;
+    }
+
+    while (tlv != NULL) {
+        if (tlv->type == em_tlv_type_eom) {
             break;
         }
 
-        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        if (tlv->type == tlv_type) {
+            uint16_t tlv_len = ntohs(tlv->len);
+            return (this->*handler)(tlv->value, tlv_len);
+        }
+
+        tlv = em_msg_t::get_next_tlv(tlv, tlvs_start, tlvs_len);
     }
 
-    set_state(em_state_ctrl_configured);
-    em_printfout("Cap: Bsta Capability report proceesed, ctrl configured");
-
     return 0;
+}
+
+int em_capability_t::handle_bsta_cap_report(unsigned char *pkt_buff, unsigned int pkt_len)
+{
+    int ret = 0;
+
+    em_printfout("Backhaul Sta Capability report message rcvd");
+
+    ret = process_single_tlv_in_1905_message(pkt_buff, pkt_len,
+            em_tlv_type_bh_sta_radio_cap,
+            &em_capability_t::handle_bsta_radio_cap);
+
+    if (ret < 0)
+        em_printfout("Warning: failed to process bh_sta_radio_cap TLV, continuing");
+
+    ret = process_single_tlv_in_1905_message(pkt_buff, pkt_len,
+            em_tlv_type_client_info,
+            &em_capability_t::handle_client_info);
+
+    if (ret < 0)
+        return ret;
+
+    set_state(em_state_ctrl_configured);
+    em_printfout("Cap: Bsta Capability report processed, ctrl configured");
+
+    return ret;
 }
 
 int em_capability_t::handle_ap_radio_basic_cap(unsigned char *buff, unsigned int len)


### PR DESCRIPTION
Problem/Opportunity

Problem 1: handle_bsta_cap_report does not handle TLVs of invalid lengths causing crashes.
Problem 2: handle_bsta_cap_report writes "dm->m_device.m_device_info.backhaul_sta" with contents of client info TLV, when two TLVs are received. Where first tlv is bsta_radio_cap with bsta_mac_present=0 and second tlv is client info tlv
Problem 3: (Optimisation) handle_bsta_cap_report contains repetitive code for handling TLVs

Fix provided
1. Handle tlv lengths properly in handle_bsta_cap_report
2. Handle bsta_mac_present flag in handle_bsta_radio_cap
3. Introduce process_1905_eth_message() to handle common tlv checks

Testing
 * 52 different combinations of BSTA CAP REPORT packet is tested