### PR TITLE
problem: Crash in get_first_tlv

### DIFF
--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -295,6 +295,11 @@ em_tlv_t *em_msg_t::get_first_tlv(em_tlv_t* tlvs_buff, unsigned int buff_len)
         return NULL;
     }
 
+    if (buff_len < sizeof(em_tlv_t)) {
+        em_printfout("Truncated packet: TLV header requires 3 bytes, received buff_len=%u", buff_len);
+        return NULL;
+    }
+
     em_tlv_t *tlv = tlvs_buff;
     uint16_t tlv_len = ntohs(tlv->len);
 


### PR DESCRIPTION
1.Buffer Underflow: The function crashes when receiving truncated packets because it doesn't verify if buff_len is large enough to contain the len field (2 octets) and type field (1 octet).
2.Unsafe Memory Access: ntohs(tlv->len) is called on potentially invalid memory addresses if buff_len < 3.
3.Stability Issue: Malformed network traffic can trigger a Denial of Service (DoS) by crashing the component.

Steps to reproduce

1.Initialize a Truncated Buffer: Create a raw memory buffer (e.g., uint8_t array) with a size smaller than sizeof(em_tlv_t).
          Example: Define a buffer of only 1 or 2 octets (representing a packet that was cut off mid-header).
2.Invoke the Function: Pass this small buffer and its actual length (e.g., buff_len = 2) into get_first_tlv(). 3.Pointer Dereference (The Failure Point): In the original code, the execution hits the line:
  uint16_t tlv_len = ntohs(tlv->len);
4.Observe the Crash: Because the system attempts to read 2 bytes for the len field from a buffer that may only have 0 or 1 byte remaining at that offset,
  it triggers an Out-of-Bounds Read.

Fix provided:

I added a check to verify that the buffer size is sufficient to hold the TLV header, logging a 'Truncated packet' error and returning NULL if the length is invalid.