### PR TITLE
RDKBWIFI-357: For MultiAP Policy Config Request and Channel Scan Request RDK agent is not sending 1905 ACK.

### DIFF
--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -21,6 +21,9 @@
 
 #include "em_base.h"
 
+#define ACK_FROM_AGENT 0
+#define ACK_FROM_CTRL  1
+
 class em_cmd_t;
 class em_channel_t {
 
@@ -54,7 +57,7 @@ class em_channel_t {
 	 * @retval 0 on failure
 	 *
 	 */
-	int send_1905_ack_message(unsigned short msg_id);
+	int send_1905_ack_message(unsigned short msg_id, bool ack_from);
 	/**!
 	 * @brief Pushes an event to the event manager.
 	 *
@@ -442,6 +445,22 @@ public:
 	 * @note Ensure the buffer is properly initialized before calling this function.
 	 */
 	int handle_channel_scan_req(unsigned char *buff, unsigned int len);
+
+	/**!
+	 * @brief Handles a 1905 acknowledgment message for channel operations.
+	 *
+	 * This function processes 1905 ack message received in response to channel scan requests.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the 1905 ACK message data.
+	 * @param[in] len Length of the message data in the buffer.
+	 *
+	 * @returns int Status code indicating success or failure.
+	 * @retval 0 on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note This function is called when a 1905 ACK message is received
+	 */
+	int handle_1905_ack(unsigned char *buff, unsigned int len);
     
 	/**!
 	 * @brief Handles the channel scan report.
@@ -742,7 +761,8 @@ public:
 
     unsigned int m_channel_pref_query_tx_cnt;
     unsigned int m_channel_sel_req_tx_cnt;
-    unsigned short m_chan_sel_req_msg_id;
+    //stores Channel request msg_id
+    unsigned short m_chan_req_msg_id = 0;
 	
 	/**!
 	 * @brief Retrieves the frequency band.

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -70,6 +70,8 @@ public:
     static em_ctrl_t *get_em_ctrl_instance();
 
 	dm_easy_mesh_ctrl_t *get_dm_ctrl() { return &m_data_model; }
+
+	em_orch_t *get_orch() override { return m_orch; }
     
 	/**!
 	 * @brief Listens for input events and processes them accordingly.

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -82,6 +82,13 @@ public:
 	 */
 	virtual bool    is_data_model_initialized() = 0;
 
+	/**!
+	 * @brief Get the orchestration engine for this manager.
+	 *
+	 * @returns Pointer to the orchestration object(controller or agent), or nullptr if not available.
+	 */
+	virtual em_orch_t *get_orch() { return nullptr; }
+
     
 	/**!
 	 * @brief Pushes an event to the queue.

--- a/inc/em_orch.h
+++ b/inc/em_orch.h
@@ -220,6 +220,16 @@ public:
 	void cancel_command(em_cmd_type_t type);
 
 	/**!
+	 * @brief Removes em_config command for the EM with radio mac.
+	 *
+	 * This function is used to remove cmd_type_em_config currently active and queued for the EM with the radio mac.
+	 *
+	 * @param[in] radio_mac Radio MAC of the EM for which the command should be removed.
+	 *
+	 */
+	void remove_em_config_cmd_for_em(unsigned char *radio_mac);
+
+	/**!
 	 * @brief Resets the command time for a specific command type.
 	 *
 	 * This function is responsible for resetting the timer associated with a specific command type in the command map.

--- a/inc/em_policy_cfg.h
+++ b/inc/em_policy_cfg.h
@@ -272,6 +272,19 @@ public:
 	 */
 	int send_policy_cfg_request_msg();
 
+	/**!
+	 * @brief Sends a 1905 acknowledgment message.
+	 *
+	 * This function is responsible for sending an acknowledgment message
+	 *
+	 * @param[in] msg_id The message ID of the original message being acknowledged.
+	 *
+	 * @returns int
+	 * @retval length of buffer on success
+	 * @retval 0 on failure
+	 *
+	 */
+	int send_1905_ack_message(unsigned short msg_id);
     
 	/**!
 	 * @brief Handles the policy configuration request.
@@ -289,6 +302,21 @@ public:
 	 */
 	int handle_policy_cfg_req(unsigned char *buff, unsigned int len);
 
+	/**!
+	 * @brief Handles a 1905 acknowledgment message for policy configuration operations.
+	 *
+	 * This function processes 1905 ack messages received in response to policy configuration requests.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the 1905 ACK message data.
+	 * @param[in] len Length of the message data in the buffer.
+	 *
+	 * @returns int Status code indicating success or failure.
+	 * @retval 0 on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note This function is called when a 1905 ACK message is received and handles acknowledgments for policy configuration.
+	 */
+	int handle_1905_ack(unsigned char *buff, unsigned int len);
     
 	/**!
 	 * @brief Processes a message with the given data and length.
@@ -339,6 +367,9 @@ public:
 	 * @note This is a virtual destructor, allowing for proper cleanup of derived classes.
 	 */
 	virtual ~em_policy_cfg_t();
+
+	//stores MultiAP Policy config req msg_id
+	unsigned short m_policy_req_msg_id = 0;
 };
 
 #endif

--- a/src/cmd/em_cmd_em_config.cpp
+++ b/src/cmd/em_cmd_em_config.cpp
@@ -54,9 +54,10 @@ em_cmd_em_config_t::em_cmd_em_config_t(em_cmd_params_t param, dm_easy_mesh_t& dm
     m_orch_desc[2].submit = true;
     m_orch_desc[3].op = dm_orch_type_channel_pref;
     m_orch_desc[3].submit = true;
-    m_orch_desc[4].op = dm_orch_type_channel_sel;
+    //sending policy_cfg req before channel selection, since policy_cfg is per device
+    m_orch_desc[4].op = dm_orch_type_policy_cfg;
     m_orch_desc[4].submit = true;
-    m_orch_desc[5].op = dm_orch_type_policy_cfg;
+    m_orch_desc[5].op = dm_orch_type_channel_sel;
     m_orch_desc[5].submit = true;
     m_orch_desc[6].op = dm_orch_type_channel_scan_req;
     m_orch_desc[6].submit = true;

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -95,9 +95,9 @@ short em_channel_t::create_channel_pref_tlv_agent(unsigned char *buff, unsigned 
     return len;
 }
 
-int em_channel_t::send_1905_ack_message(unsigned short msg_id)
+int em_channel_t::send_1905_ack_message(unsigned short msg_id, bool ack_from)
 {
-    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char buff[MAX_EM_BUFF_SZ] = {0};
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
     unsigned short  msg_type = em_msg_type_1905_ack;
     size_t len = 0;
@@ -107,17 +107,31 @@ int em_channel_t::send_1905_ack_message(unsigned short msg_id)
     unsigned short type = htons(ETH_P_1905);
     dm_easy_mesh_t *dm = get_data_model();
 
-    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
-    tmp += sizeof(mac_address_t);
-    len += sizeof(mac_address_t);
+    if (ack_from == ACK_FROM_CTRL) {
+	    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+	    tmp += sizeof(mac_address_t);
+	    len += sizeof(mac_address_t);
+            
+	    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+	    tmp += sizeof(mac_address_t);
+	    len += sizeof(mac_address_t);
 
-    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
-    tmp += sizeof(mac_address_t);
-    len += sizeof(mac_address_t);
+	    memcpy(tmp, reinterpret_cast<unsigned char *> (&type), sizeof(unsigned short));
+	    tmp += sizeof(unsigned short);
+	    len += sizeof(unsigned short);
+    } else {
+	    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+	    tmp += sizeof(mac_address_t);
+	    len += static_cast<unsigned int> (sizeof(mac_address_t));
+            
+	    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+	    tmp += sizeof(mac_address_t);
+	    len += static_cast<unsigned int> (sizeof(mac_address_t));
 
-    memcpy(tmp, reinterpret_cast<unsigned char *> (&type), sizeof(unsigned short));
-    tmp += sizeof(unsigned short);
-    len += sizeof(unsigned short);
+	    memcpy(tmp, reinterpret_cast<unsigned char *> (&type), sizeof(unsigned short));
+	    tmp += sizeof(unsigned short);
+	    len += static_cast<unsigned int> (sizeof(unsigned short));
+    }
 
     cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
     memset(tmp, 0, sizeof(em_cmdu_t));
@@ -146,6 +160,7 @@ int em_channel_t::send_1905_ack_message(unsigned short msg_id)
         return 0;
     }
     em_printfout("1905 ACK send success\n");
+
     return static_cast<int> (len);
 }
 
@@ -467,7 +482,8 @@ int em_channel_t::send_channel_scan_request_msg()
         return -1;
     }
 
-	set_state(em_state_ctrl_configured);
+    m_chan_req_msg_id = ntohs(cmdu->id);
+    em_printfout("Channel Scan Request message sent (msg_id: 0x%04x)\n", m_chan_req_msg_id);
 
     return  static_cast<int> (len);
 
@@ -823,8 +839,8 @@ int em_channel_t::send_channel_sel_request_msg()
         em_printfout("Failed to send Channel Selection Request message (errno: %d)\n", errno);
         return -1;
     }
-    m_chan_sel_req_msg_id = ntohs(cmdu->id);
-    em_printfout("Channel Selection Request message sent (msg_id: 0x%04x)\n", m_chan_sel_req_msg_id);
+    m_chan_req_msg_id = ntohs(cmdu->id);
+    em_printfout("Channel Selection Request message sent (msg_id: 0x%04x)\n", m_chan_req_msg_id);
 
     return static_cast<int> (len);
 
@@ -1924,9 +1940,9 @@ int em_channel_t::handle_channel_sel_rsp(unsigned char *buff, unsigned int len)
             dm_easy_mesh_t::macbytes_to_string(ruid, mac_str);
             em_t *radio_em = reinterpret_cast<em_t *>(hash_map_get(get_mgr()->m_em_map, mac_str));
             if (radio_em) {
-                if((radio_em->get_state() == em_state_ctrl_channel_select_pending) && (response_msg_id == radio_em->m_chan_sel_req_msg_id)) {
+                if((radio_em->get_state() == em_state_ctrl_channel_select_pending) && (response_msg_id == radio_em->m_chan_req_msg_id)) {
                     radio_em->set_state(em_state_ctrl_channel_selected);
-                    radio_em->m_chan_sel_req_msg_id = 0;
+                    radio_em->m_chan_req_msg_id = 0;
                     em_printfout("Set em_state_ctrl_channel_selected for radio %s", mac_str);
                 }
             } else {
@@ -1970,7 +1986,33 @@ int em_channel_t::handle_operating_channel_rprt(unsigned char *buff, unsigned in
         tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + current_tlv_size);
     }
     em_printfout("Operating channel report recv\n");
-    send_1905_ack_message(ntohs(cmdu->id));
+    send_1905_ack_message(ntohs(cmdu->id), ACK_FROM_CTRL);
+    return 0;
+}
+
+int em_channel_t::handle_1905_ack(unsigned char *buff, unsigned int len)
+{
+    std::vector<em_t *> em_radios;
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+    unsigned short response_msg_id = ntohs(cmdu->id);
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+    get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
+
+    for (auto &em : em_radios)
+    {
+        //check for null em pointer in vector
+        if (em == NULL) {
+            em_printfout("Warning: Null em pointer in vector, skipping");
+            continue;
+        }
+
+        if((em->get_state() == em_state_ctrl_channel_scan_pending) && (response_msg_id == em->m_chan_req_msg_id)) {
+            em->set_state(em_state_ctrl_configured);
+            em->m_chan_req_msg_id = 0;
+            em_printfout("Channel scan ACK handled for radio %s", util::mac_to_string(em->get_radio_interface_mac()).c_str());
+        }
+    }
+    em_radios.clear();
     return 0;
 }
 
@@ -1984,6 +2026,7 @@ int em_channel_t::handle_channel_scan_req(unsigned char *buff, unsigned int len)
 	unsigned int i;
 
 	memset(&params, 0, sizeof(em_scan_params_t));
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
@@ -2014,6 +2057,7 @@ int em_channel_t::handle_channel_scan_req(unsigned char *buff, unsigned int len)
 		get_mgr()->io_process(em_bus_event_type_channel_scan_params,  reinterpret_cast<unsigned char *> (&params), sizeof(em_scan_params_t));
 	}
 
+	send_1905_ack_message(ntohs(cmdu->id), ACK_FROM_AGENT);
 	return 0;
 }
 
@@ -2210,6 +2254,10 @@ void em_channel_t::process_msg(unsigned char *data, unsigned int len)
            		handle_channel_scan_rprt(data, len);
 			}
             break;
+
+	        case em_msg_type_1905_ack:
+	    		handle_1905_ack(data, len);
+			break;     
 
         default:
             break;

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -5074,6 +5074,12 @@ int em_configuration_t::handle_autoconfig_wsc_m1(unsigned char *buff, unsigned i
         printf("%s:%d: autoconfig wsc m2 send failed, error:%d\n", __func__, __LINE__, errno);
         return -1;
     }
+
+    em_printfout("%s:%d: Removing previous em_config command for radio " MACSTRFMT "\n", __func__, __LINE__, MAC2STR(get_radio_interface_mac()));
+    if (em_orch_t *orch = get_mgr()->get_orch()) {
+	 orch->remove_em_config_cmd_for_em(get_radio_interface_mac());
+    }
+
 	set_state(em_state_ctrl_wsc_m2_sent);
 	printf("%s:%d: autoconfig wsc m2 send, len:%d\n", __func__, __LINE__, sz);
     memcpy(raw.al, const_cast<unsigned char *> (get_peer_mac()), sizeof(mac_address_t));

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -157,10 +157,10 @@ void em_t::orch_execute(em_cmd_t *pcmd)
                 m_sm.set_state(em_state_ctrl_ap_cap_query_pending);
             } else if ((pcmd->get_orch_op() == dm_orch_type_channel_pref) && (m_sm.get_state() == em_state_ctrl_ap_cap_report_received)) {
                 m_sm.set_state(em_state_ctrl_channel_query_pending);
-            } else if ((pcmd->get_orch_op() == dm_orch_type_channel_sel) && (m_sm.get_state() == em_state_ctrl_channel_queried)) {
-                m_sm.set_state(em_state_ctrl_channel_select_pending);
-            } else if ((pcmd->get_orch_op() == dm_orch_type_policy_cfg) && (m_sm.get_state() == em_state_ctrl_configured)) {
+            } else if ((pcmd->get_orch_op() == dm_orch_type_policy_cfg) && (m_sm.get_state() == em_state_ctrl_channel_queried)) {
                 m_sm.set_state(em_state_ctrl_set_policy_pending);
+            } else if ((pcmd->get_orch_op() == dm_orch_type_channel_sel) && (m_sm.get_state() == em_state_ctrl_configured)) {
+                m_sm.set_state(em_state_ctrl_channel_select_pending);
             } else if ((pcmd->get_orch_op() == dm_orch_type_channel_scan_req) && (m_sm.get_state() == em_state_ctrl_configured)) {
                 m_sm.set_state(em_state_ctrl_channel_scan_pending);
             } else if ((pcmd->get_orch_op() == dm_orch_type_topo_publish) && (m_sm.get_state() == em_state_ctrl_configured)) {
@@ -340,6 +340,9 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
                 em_configuration_t::process_msg(data, len);
             } else if (m_sm.get_state() == em_state_ctrl_sta_steer_pending) {
                 em_steering_t::process_msg(data, len);
+            } else {
+                em_policy_cfg_t::process_msg(data, len);
+                em_channel_t::process_msg(data, len);
             }
             break;
 

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -556,6 +556,8 @@ int em_policy_cfg_t::send_policy_cfg_request_msg()
 
 	printf("%s:%d: Policy Cfg Request Msg Send Success\n", __func__, __LINE__);
 
+    m_policy_req_msg_id = ntohs(cmdu->id);
+
     return static_cast<int> (len);
 
 }
@@ -570,7 +572,8 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
     unsigned char *cursor = NULL;
     em_vendor_data_t *data = NULL;
 
-    memset(&policy, 0, sizeof(em_policy_cfg_t));
+    memset(&policy, 0, sizeof(policy));
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
@@ -693,7 +696,103 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
     }
 
     get_mgr()->io_process(em_bus_event_type_set_policy, reinterpret_cast<unsigned char *> (&policy), sizeof(policy));
+    send_1905_ack_message(ntohs(cmdu->id));
 
+    return 0;
+}
+
+int em_policy_cfg_t::send_1905_ack_message(unsigned short msg_id)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ] = {0};
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned short  msg_type = em_msg_type_1905_ack;
+    unsigned int len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    mac_addr_str_t ctrl_mac_str;
+    dm_easy_mesh_t::macbytes_to_string(dm->get_ctrl_al_interface_mac(), ctrl_mac_str);
+
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int> (sizeof(mac_address_t));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    mac_addr_str_t agent_mac_str;
+    dm_easy_mesh_t::macbytes_to_string(dm->get_agent_al_interface_mac(), agent_mac_str);
+
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int> (sizeof(mac_address_t));
+
+    memcpy(tmp, reinterpret_cast<unsigned char *> (&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
+
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    // End of message
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += (sizeof (em_tlv_t));
+    len += static_cast<unsigned int> (sizeof (em_tlv_t));
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("1905 ACK validation failed\n");
+        return 0;
+    }
+
+    if (send_frame(buff, len)  < 0) {
+        em_printfout("1905 ACK send failed, error:%d\n", errno);
+        return 0;
+    }
+    em_printfout("1905 ACK send success\n");
+
+    return static_cast<int> (len);
+}
+
+int em_policy_cfg_t::handle_1905_ack(unsigned char *buff, unsigned int len)
+{
+    std::vector<em_t *> em_radios;
+    bool match_found = false;
+
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+    unsigned short response_msg_id = ntohs(cmdu->id);
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+    // Access the source MAC address (as a byte array)
+    mac_address_t src_mac;
+    memcpy(src_mac, hdr->src, sizeof(mac_address_t));
+    get_mgr()->get_all_em_for_al_mac(src_mac, em_radios);
+
+    for (auto &em : em_radios)
+    {
+	    if (em->get_state() == em_state_ctrl_set_policy_pending && response_msg_id == em->m_policy_req_msg_id) {
+		    match_found = true;
+		    em->m_policy_req_msg_id = 0;
+		    break;
+	    }
+    }
+    
+    if (match_found) {
+	    for (auto &em : em_radios) {
+		    em->set_state(em_state_ctrl_configured);
+	    }
+    } else {
+	    em_printfout("No radio waiting for policy config ack for given msg_id\n");
+    }
+    em_radios.clear();
     return 0;
 }
 
@@ -704,6 +803,9 @@ void em_policy_cfg_t::process_msg(unsigned char *data, unsigned int len)
     switch (htons(cmdu->type)) {
 		case em_msg_type_map_policy_config_req:
 			handle_policy_cfg_req(data, len);
+			break;
+		case em_msg_type_1905_ack:
+			handle_1905_ack(data, len);
 			break;
         default:
             break;
@@ -725,6 +827,8 @@ void em_policy_cfg_t::process_ctrl_state()
                 em_printfout("Processing set policy pending state for radio %s", util::mac_to_string(get_radio_interface_mac()).c_str());
                 std::vector<em_t *> em_radios;
                 dm_easy_mesh_t *dm = get_data_model();
+                mac_address_t current_ruid;
+                memcpy(current_ruid, get_radio_interface_mac(), sizeof(mac_address_t));
 
                 get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
                 for (auto &em : em_radios)
@@ -747,35 +851,26 @@ void em_policy_cfg_t::process_ctrl_state()
                 }
                 // If all radios or some radios in set policy pending state, send policy config request on one of them,
                 // ignore sending policy config request on other radios
-                if (!em_radios.empty())
+                if (!em_radios.empty() && em_radios.front() == this)
                 {
-                    em_printfout("Sending the Policy config request message to agent al_mac:%s on radio: %s",
+                    // Check if current radio's RUID matches the first radio's RUID in the vector
+                    if (memcmp(current_ruid, em_radios.front()->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
+                         em_printfout("Sending the Policy config request message to agent al_mac:%s on radio: %s",
                                  util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
                                  util::mac_to_string(get_radio_interface_mac()).c_str());
-                    em_t *al_em = get_mgr()->get_al_node();
-
-                    // Send policy config request and check for errors
-                    int send_result = send_policy_cfg_request_msg();
-                    if (send_result < 0) {
-                        em_printfout("Error: Failed to send policy config request message");
-                        return;
-                    } else {
-                        em_printfout("Policy config request sent successfully, bytes: %d", send_result);
+                         // Send policy config request and check for errors
+                         int send_result = send_policy_cfg_request_msg();
+                         if (send_result < 0) {
+                             em_printfout("Error: Failed to send policy config request message");
+                             return;
+                         } else {
+                             em_printfout("Policy config request sent successfully, bytes: %d", send_result);
+                         }
                     }
-
-                    // Set state for AL node to configured
-                    al_em->set_state(em_state_ctrl_configured);
-                    em_printfout("Set AL node state to configured");
-                    // Set state for all radios to Configured state
-                    for (auto &em : em_radios)
-                    {
-                        if (em != NULL)
-                        {
-                            em->set_state(em_state_ctrl_configured);
-                            em_printfout("Set radio %s state to configured",
-                                        util::mac_to_string(em->get_radio_interface_mac()).c_str());
-                        }
-                    }
+                } else if (!em_radios.empty() && em_radios.front() != this) {
+                    em_printfout("Policy config request message already sent by radio %s, not sending again from radio %s",
+                              util::mac_to_string(em_radios.front()->get_radio_interface_mac()).c_str(),
+                              util::mac_to_string(get_radio_interface_mac()).c_str());
                 }
                 em_radios.clear();
             }

--- a/src/orch/em_orch.cpp
+++ b/src/orch/em_orch.cpp
@@ -207,8 +207,56 @@ void em_orch_t::cancel_command(em_cmd_type_t type, std::vector<em_t*> &em_radios
         }
     }
 
-    // reset the elapsed time for the command type to avoid triggering timeouts for cancelled commands.
     reset_cmd_time(m_cmd_map, type);
+}
+
+void em_orch_t::remove_em_config_cmd_for_em(unsigned char *radio_mac)
+{
+    em_cmd_t       *pcmd = NULL;
+    em_t           *em = NULL;
+    mac_addr_str_t  mac_str;
+
+    for (int i = static_cast<int>(queue_count(m_pending)) - 1; i >= 0; i--) {
+        pcmd = static_cast<em_cmd_t *>(queue_peek(m_pending, static_cast<unsigned int>(i)));
+        if (pcmd->m_type == em_cmd_type_em_config) {
+            for (int j = static_cast<int>(queue_count(pcmd->m_em_candidates)) - 1; j >= 0; j--) {
+                em = static_cast<em_t *>(queue_peek(pcmd->m_em_candidates, static_cast<unsigned int>(j)));
+                if (memcmp(radio_mac, em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
+                    dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+                    printf("%s:%d: Removing em:%s from command type:%s\n", __func__, __LINE__, mac_str, em_cmd_t::get_cmd_type_str(em_cmd_type_em_config));
+                    queue_remove(pcmd->m_em_candidates, static_cast<unsigned int>(j));
+                    break;
+                }
+            }
+            if (queue_count(pcmd->m_em_candidates) == 0) {
+                queue_remove(m_pending, static_cast<unsigned int>(i));
+                pop_stats(pcmd);
+                destroy_command(pcmd);
+            }
+        }
+    }
+
+    for (int i = static_cast<int>(queue_count(m_active)) - 1; i >= 0; i--) {
+        pcmd = static_cast<em_cmd_t *>(queue_peek(m_active, static_cast<unsigned int>(i)));
+        if (pcmd->m_type == em_cmd_type_em_config) {
+            for (int j = static_cast<int>(queue_count(pcmd->m_em_candidates)) - 1; j >= 0; j--) {
+                em = static_cast<em_t *>(queue_peek(pcmd->m_em_candidates, static_cast<unsigned int>(j)));
+                if (memcmp(radio_mac, em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
+                    dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+                    em_printfout("Setting em:%s State set to cancel", mac_str);
+                    // pre_process_cancel(pcmd, em);
+                    em->set_state(em_state_ctrl_unconfigured);
+                    em->set_topo_query_tx_count(0);
+                    em->set_channel_pref_query_tx_count(0);
+                    em->set_cap_query_tx_count(0);
+                    em->set_orch_state(em_orch_state_cancel);
+                }
+            }
+        }
+    }
+
+    // reset the elapsed time for the command type to avoid triggering timeouts for cancelled commands.
+    reset_cmd_time(m_cmd_map, em_cmd_type_em_config);
 }
 
 void em_orch_t::cancel_command(em_cmd_type_t type) 


### PR DESCRIPTION
- Send ACK message for both MultiAP Policy Config Request and Channel Scan Request
- Added message ID validation to ensure ACKs are sent for the correct request messages
- Enhanced orchestration logic to handle repeated EM config commands properly
- Updated state machine to wait and transition appropriately after ACK processing