### PR TITLE
RDKCOM-5596: RDKBDEV-3424 Issue 644: Crash in get_next_tlv

### DIFF
--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -324,6 +324,11 @@ em_tlv_t *em_msg_t::get_next_tlv(em_tlv_t* tlv, em_tlv_t* tlvs_buff, unsigned in
     size_t offset = static_cast<size_t>(signed_offset);
     EM_ASSERT_MSG_TRUE(offset < buff_len, NULL, "TLV offset exceeds buffer length");
 
+    if (buff_len < sizeof(em_tlv_t)) {
+        em_printfout("Truncated packet: not enough space for TLV length field");
+        return NULL;
+    }
+
     // Calculate the size of the current TLV (header + data)
     uint16_t current_tlv_size = sizeof(em_tlv_t) + ntohs(tlv->len);
     


### PR DESCRIPTION
Problem:

    1.Buffer Underflow: The get_next_tlv function crashes when processing truncated or malformed packets because it lacks a boundary check to verify
      if the remaining buff_len can accommodate the 3-octet TLV header (1-octet Type + 2-octet Length).
    2.Unsafe Memory Access: The code performs ntohs(tlv->len) before validating the buffer size. If buff_len < 3, this results in an out-of-bounds read.
    3.Stability Issue: Malformed network traffic can trigger a Denial of Service (DoS) by crashing the component.

    Steps to reproduce:

    1.Initialize a Truncated Buffer: Create a raw memory buffer with a size smaller than sizeof(em_tlv_t).
      Example: Define a buffer of only 1 or 2 octets (representing a packet that was cut off mid-header).
    2.Invoke the Function: Pass this small buffer and its actual length (e.g., buff_len = 2) into get_next_tlv().
    3.Pointer Dereference (The Failure Point): In the original code, the execution hits the line:
      uint16_t current_tlv_size = sizeof(em_tlv_t) + ntohs(tlv->len);
    4.Observe the Crash: Because the system attempts to read 2 bytes for the len field from a buffer that may only have 0 or 1 byte remaining at that offset, it triggers an Out-of-Bounds Read.

    Fixed:

    I added a check to verify that the buffer size is sufficient to hold the TLV header, logging a 'Truncated packet' error and returning NULL if the length is invalid.