### PR TITLE
RDKBWIFI-410: Rework channel selection flow to delegate decision to platform ACS

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -195,6 +195,14 @@ public:
 	static em_freq_band_t get_freq_band_by_op_class(int op_class);
 
 	/**!
+	 * @brief Returns all op_class numbers for the given frequency band.
+	 *
+	 * @param[in] band Frequency band to filter by.
+	 * @returns Vector of op_class numbers belonging to that band.
+	 */
+	static std::vector<int> get_op_classes_by_band(em_freq_band_t band);
+
+	/**!
 	 * @brief Retrieves the list of channel associated with a given operating class.
 	 *
 	 * This function takes an operating class as input and returns the corresponding

--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -189,6 +189,27 @@ public:
 	 */
 	int analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl);
 
+	/**!
+	 * @brief Builds and sends the ACS exclude-channel list to OneWifi.
+	 *
+	 * Constructs a JSON document containing the channels that ACS must not select,
+	 * derived from the Channel Selection Request TLV and hardware/regulatory capability
+	 * constraints. Publishes the document to OneWifi via the StartACS rbus interface,
+	 * delegating the final channel decision to the platform ACS.
+	 *
+	 * @param[in] desc Pointer to the WiFi bus descriptor to be updated.
+	 * @param[in] bus_hdl Handle to the bus where the event is processed.
+	 * @param[in] channel_sel Pointer to the parsed channel selection request data.
+	 * @param[in] radio_name Radio identifier string (e.g. "radio1") published as RadioName
+	 *                      in the ACS subdoc so OneWifi/vendor ACS can resolve the target radio.
+	 *
+	 * @returns int Status code indicating success or failure of the operation.
+	 * @retval 0 on success.
+	 * @retval Non-zero error code on failure.
+	 */
+	int send_acs_subdoc(wifi_bus_desc_t *desc, bus_handle_t *bus_hdl, op_class_channel_sel *channel_sel,
+	                    const char *radio_name);
+
     /**!
 	 * @brief Analyzes the csa beacon frame received.
 	 *

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -19,11 +19,13 @@
 #ifndef EM_CHANNEL_H
 #define EM_CHANNEL_H
 
+#include <vector>
 #include "em_base.h"
 
 #define ACK_FROM_AGENT 0
 #define ACK_FROM_CTRL  1
 
+class em_t;
 class em_cmd_t;
 class em_channel_t {
 
@@ -202,7 +204,7 @@ public:
 	 *
 	 * @note Ensure that the buffer is allocated with sufficient size before calling this function.
 	 */
-	short create_channel_pref_tlv(unsigned char *buff);
+	short create_channel_pref_tlv(unsigned char *buff, em_t *target = NULL);
 
 	/**!
 	 * @brief Updates map with non-operable and unsupported channels as per
@@ -333,7 +335,7 @@ public:
 	 *
 	 * @note Ensure the buffer is large enough to hold the TLV.
 	 */
-	short create_transmit_power_limit_tlv(unsigned char *buff);
+	short create_transmit_power_limit_tlv(unsigned char *buff, em_t *target = NULL);
     
 	/**!
 	 * @brief Creates a spatial reuse request TLV.
@@ -403,7 +405,7 @@ public:
 	 *
 	 * @note Ensure that the channel is available before sending the request.
 	 */
-	int send_channel_sel_request_msg();
+	int send_channel_sel_request_msg(const std::vector<em_t *> *targets = NULL);
     
 	/**!
 	 * @brief Sends a channel selection response message.
@@ -637,7 +639,7 @@ public:
 	 *
 	 * @note Ensure the buffer is properly initialized before calling this function.
 	 */
-	int handle_channel_pref_tlv(unsigned char *buff, op_class_channel_sel *op_class);
+	int handle_channel_pref_tlv(unsigned char *buff, op_class_channel_sel *op_class, em_freq_band_t ruid_band);
     
 	/**!
 	 * @brief Handles the channel preference TLV control.

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -36,6 +36,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <unordered_map>
+#include <map>
+#include <set>
 #include <string>
 #include "em_cmd_dev_init.h"
 #include "dm_easy_mesh_agent.h"
@@ -392,7 +394,6 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
     webconfig_subdoc_type_t type;
     int num = 0;
     mac_addr_str_t  mac_str;
-    unsigned int index = 0;
     dm_easy_mesh_agent_t  dm;
     em_cmd_t *tmp;
     em_commit_target_t cm_config;
@@ -417,19 +418,30 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
         em_printfout("Radio subdoc decode fail");
     }
 
-	dm_easy_mesh_t::macbytes_to_string(dm.get_radio(index)->get_radio_info()->intf.mac, mac_str);
-	cm_config.type = em_commit_target_radio;
-	snprintf(reinterpret_cast<char *> (cm_config.params), sizeof(cm_config.params), "%s", mac_str);
-	commit_config(dm, cm_config);
-	pcmd[num] = new em_cmd_op_channel_report_t(evt->params, dm);
-	tmp = pcmd[num];
-	num++;
+    // Commit each radio returned in the subdoc and spawn a per-radio
+    // op_channel_report command, tagging each pcmd's ctx.arr_index so the
+    // orchestrator's build_candidates can match the right EM per radio.
+    unsigned int num_radios = dm.get_num_radios();
+    for (unsigned int i = 0; i < num_radios; i++) {
+        dm_easy_mesh_t::macbytes_to_string(dm.get_radio(i)->get_radio_info()->intf.mac, mac_str);
+        cm_config.type = em_commit_target_radio;
+        snprintf(reinterpret_cast<char *> (cm_config.params), sizeof(cm_config.params), "%s", mac_str);
+        commit_config(dm, cm_config);
 
-	while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
-		tmp = pcmd[num];
-		num++;
-	}
-	return num;
+        pcmd[num] = new em_cmd_op_channel_report_t(evt->params, dm);
+        em_cmd_ctx_t *ctx = pcmd[num]->get_data_model()->get_cmd_ctx();
+        ctx->arr_index = i;
+        tmp = pcmd[num];
+        num++;
+
+        while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
+            em_cmd_ctx_t *clone_ctx = pcmd[num]->get_data_model()->get_cmd_ctx();
+            clone_ctx->arr_index = i;
+            tmp = pcmd[num];
+            num++;
+        }
+    }
+    return num;
 }
         
 int dm_easy_mesh_agent_t::analyze_channel_pref_query(em_bus_event_t *evt, em_cmd_t *pcmd[])
@@ -446,6 +458,111 @@ int dm_easy_mesh_agent_t::analyze_channel_pref_query(em_bus_event_t *evt, em_cmd
     return num;
 }
 
+int dm_easy_mesh_agent_t::send_acs_subdoc(wifi_bus_desc_t *desc, bus_handle_t *bus_hdl,
+                                           op_class_channel_sel *channel_sel,
+                                           const char *radio_name)
+{
+    if (radio_name == NULL || radio_name[0] == '\0') {
+        em_printfout("ACS subdoc: radio_name is empty");
+        return -1;
+    }
+
+    // The controller now sends every channel in the band with its preference,
+    // so the exclude list is simply the channels marked non-operable (pref == 0)
+    // in the Channel Preference TLV, grouped per op_class. The platform ACS
+    // picks the channel from whatever remains.
+    std::map<int, std::set<unsigned int>> exclude_per_opclass;
+
+    for (unsigned int i = 0; i < channel_sel->num; i++) {
+        const em_op_class_info_t &info = channel_sel->op_class_info[i];
+        int op_class = static_cast<int>(info.op_class);
+
+        // Ensure an entry exists for every op_class present in the TLV, even
+        // if it has no excluded channels (all operable -> empty exclude list).
+        exclude_per_opclass[op_class];
+
+        for (unsigned int ch_idx = 0; ch_idx < info.num_channels && ch_idx < EM_MAX_CHANNELS_IN_LIST; ch_idx++) {
+            if ((info.channel_pref[ch_idx] & 0xF0) == 0) {
+                exclude_per_opclass[op_class].insert(info.channels[ch_idx]);
+            }
+        }
+    }
+
+    // Build ACS subdoc JSON
+    cJSON *root = cJSON_CreateObject();
+    if (root == NULL) {
+        em_printfout("ACS subdoc: failed to create root JSON object");
+        return -1;
+    }
+    cJSON_AddStringToObject(root, "Version", "1.0");
+    cJSON_AddStringToObject(root, "SubDocName", "Acs");
+    cJSON_AddStringToObject(root, "RadioName", radio_name);
+
+    em_printfout("ACS subdoc: Radio name: %s", radio_name);
+
+    cJSON *acs_list = cJSON_AddArrayToObject(root, "AcsList");
+    if (acs_list == NULL) {
+        em_printfout("ACS subdoc: failed to create AcsList array");
+        cJSON_Delete(root);
+        return -1;
+    }
+
+    em_printfout("ACS subdoc: band=%d num_opclass=%zu",
+                 channel_sel->freq_band, exclude_per_opclass.size());
+
+    for (const auto &oc_pair : exclude_per_opclass) {
+        int op_class = oc_pair.first;
+        const std::set<unsigned int> &exclude_channels = oc_pair.second;
+
+        /* Skip opclasses with no excluded channels (decoder rejects length 0). */
+        if (exclude_channels.empty()) {
+            continue;
+        }
+
+        cJSON *op_class_obj = cJSON_CreateObject();
+        if (op_class_obj == NULL) {
+            continue;
+        }
+        cJSON_AddNumberToObject(op_class_obj, "opclass", op_class);
+        cJSON_AddNumberToObject(op_class_obj, "exclude_channels_length", static_cast<double>(exclude_channels.size()));
+        cJSON *ch_arr = cJSON_AddArrayToObject(op_class_obj, "exclude_channels");
+        if (ch_arr != NULL) {
+            for (unsigned int ex_ch : exclude_channels) {
+                cJSON_AddItemToArray(ch_arr, cJSON_CreateNumber(static_cast<double>(ex_ch)));
+            }
+        }
+        cJSON_AddItemToArray(acs_list, op_class_obj);
+    }
+
+    char *json_str = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+
+    if (json_str == NULL) {
+        em_printfout("ACS subdoc: JSON serialization failed");
+        return -1;
+    }
+
+    em_printfout("ACS subdoc: %s", json_str);
+
+    raw_data_t bus_data;
+    memset(&bus_data, 0, sizeof(raw_data_t));
+    bus_data.data_type      = bus_data_type_string;
+    bus_data.raw_data.bytes = json_str;
+    bus_data.raw_data_len   = strlen(json_str);
+
+    int ret = 0;
+    // TODO: Replace with OneWiFi macro once Device.WiFi.X_RDKCENTRAL-COM_StartACS is added there
+    if (desc->bus_set_fn(bus_hdl, "Device.WiFi.X_RDKCENTRAL-COM_StartACS", &bus_data) == 0) {
+        em_printfout("ACS subdoc send success");
+    } else {
+        em_printfout("ACS subdoc send failed");
+        ret = -1;
+    }
+
+    free(json_str);
+    return ret;
+}
+
 int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl)
 {
     unsigned int i = 0, j = 0, noofopclass = 0;
@@ -453,8 +570,6 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     em_op_class_info_t *dm_op_class = nullptr;
     em_tx_power_limit_t *tx_power_limit;
     em_spatial_reuse_req_t *spatial_reuse_req;
-    bool found_mesh_sta = false;
-    em_bss_info_t *bss_info;
     dm_radio_t* radio = NULL;
     em_radio_info_t *radio_info = NULL;
 
@@ -478,43 +593,32 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     for (i = 0; i < noofopclass; i++) {
         dm_op_class = this->get_op_class_info(i);
 
-        // Assumption: recevied channel_sel contains entries for one RUID only
+        // Assumption: received channel_sel contains entries for one RUID only
         if ((dm_op_class->id.type == em_op_class_type_anticipated) &&
             memcmp(&dm_op_class->id.ruid, &channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) {
             dm_op_class->pref_valid = false;
         }
     }
 
-    // To store the channel with best preference
-    unsigned char highest_anticipated_preference = 0;
-    unsigned int most_preferred_channel = 0;
-    unsigned int most_preferred_opclass = 0;
-
-    // Process new preferences from channel_sel
+    // Update DM with new anticipated entries from Channel Selection Request
     bool is_anticipated_invalid_entry_present = true;
-    for (i = 0;i < channel_sel->num; i++) {
+    for (i = 0; i < channel_sel->num; i++) {
 
-        // Check for an existing invalid entry with anticipated type
-        if(is_anticipated_invalid_entry_present) {
+        if (is_anticipated_invalid_entry_present) {
             for (j = 0; j < noofopclass; j++) {
                 dm_op_class = this->get_op_class_info(j);
 
-                // Found an entry of anticipated type in DM with invalid flag,
-                // Update DM entry with new entry received in channel selection request
                 if (dm_op_class->id.type == em_op_class_type_anticipated && !dm_op_class->pref_valid) {
-                    // Update existing entry with new preferences
                     memcpy(dm_op_class, &channel_sel->op_class_info[i], sizeof(em_op_class_info_t));
                     dm_op_class->pref_valid = true;
                     break;
                 }
             }
 
-            // Don't check further for invalid entries of anticipated type
             if (j == noofopclass)
                 is_anticipated_invalid_entry_present = false;
         }
 
-        //Add new entry in DM for the opclass/channel received in channel selection request
         if (!is_anticipated_invalid_entry_present && (noofopclass < EM_MAX_OPCLASS)) {
             dm_op_class = &this->m_op_class[noofopclass].m_op_class_info;
             memcpy(dm_op_class, &channel_sel->op_class_info[i], sizeof(em_op_class_info_t));
@@ -522,47 +626,8 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
             dm_op_class->pref_valid = true;
             noofopclass++;
         }
-
-        // Check for all channels in the entry to maintian most preferred channel and opclass
-        for (unsigned int ch_idx = 0;
-             ch_idx < dm_op_class->num_channels && ch_idx < EM_MAX_CHANNELS_IN_LIST;
-             ch_idx++) {
-            if ((dm_op_class->channel_pref[ch_idx] & 0xF0) > (highest_anticipated_preference & 0xF0)) {
-                highest_anticipated_preference = dm_op_class->channel_pref[ch_idx];
-                most_preferred_channel = dm_op_class->channels[ch_idx];
-                most_preferred_opclass = dm_op_class->op_class;
-            }
-        }
     }
-
-    // Ensure highest preference is non-zero to update current channel
-    if (highest_anticipated_preference > 0) {
-	//Get beacon channel for the preferred opclass/channel
-        most_preferred_channel = static_cast<unsigned int>(dm_easy_mesh_t::get_beaconchannel_by_opclass(static_cast<int>(most_preferred_opclass), static_cast<int>(most_preferred_channel)));
-        // Update the most preferred channel/opclass in the datamodel
-        for (i = 0; i < noofopclass; i++) {
-            dm_op_class = this->get_op_class_info(i);
-            if ((memcmp(&dm_op_class->id.ruid, &channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t)) == 0) &&
-                (dm_op_class->id.type == em_op_class_type_current)) {
-                dm_op_class->op_class = most_preferred_opclass;
-                dm_op_class->id.op_class = most_preferred_opclass;
-                dm_op_class->channel = most_preferred_channel;
-                break;
-            }
-        }
-        if (i == noofopclass) {
-            dm_op_class = this->get_op_class_info(i);
-            em_op_class_info_t tmp_op_class_info;
-            memcpy(tmp_op_class_info.id.ruid, channel_sel->op_class_info[0].id.ruid, sizeof(mac_address_t));
-            tmp_op_class_info.id.type = em_op_class_type_current;
-            tmp_op_class_info.id.op_class = most_preferred_opclass;
-            tmp_op_class_info.op_class = most_preferred_opclass;
-            tmp_op_class_info.channel = most_preferred_channel;
-            memcpy(dm_op_class, &tmp_op_class_info, sizeof(em_op_class_info_t));
-            noofopclass++;
-        }
-        this->set_num_op_class(noofopclass);
-    }
+    this->set_num_op_class(noofopclass);
 
     // Fetch radio and radio_info using RUID in Channel Preference TLV
     // Assumption: One RUID data per Channel Selection Request message
@@ -636,28 +701,30 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     }
 #endif
 
-    for (i = 0; i < this->m_num_bss; i++) {
-        bss_info = this->get_bss(i)->get_bss_info();
-        if (bss_info == NULL) {
-            printf("%s:%d: Cannot find bss info for index %d\n", __func__, __LINE__, i);
-            continue;
-        }
-        if (memcmp(tx_power_limit->ruid, bss_info->ruid.mac, sizeof(mac_address_t)) == 0 &&
-            strncmp(bss_info->bssid.name, "mesh_sta", strlen("mesh_sta")) == 0 &&
-            bss_info->connect_status) {
-            found_mesh_sta = true;
+    // Resolve the 0-based DM radio index for this request's RUID and build the
+    // "radioN" identifier expected by OneWifi/vendor ACS (1-based, per vendor doc).
+    unsigned int radio_idx = 0;
+    bool radio_idx_found = false;
+    for (unsigned int k = 0; k < this->get_num_radios(); k++) {
+        if (memcmp(this->get_radio_by_ref(k).get_radio_interface_mac(),
+                   channel_sel->op_class_info[0].id.ruid,
+                   sizeof(mac_address_t)) == 0) {
+            radio_idx = k;
+            radio_idx_found = true;
             break;
         }
     }
-
-    if(radio_info->init_cfg_done && found_mesh_sta) {
-        printf("%s:%d channel change trigger is based on CSA since mesh sta present\n", __func__, __LINE__);
-        return 1;
-    } else {
-        radio_info->init_cfg_done = true;
-        return refresh_onewifi_subdoc(desc, bus_hdl, "Radio", get_subdoc_radio_type_for_freq(channel_sel->freq_band));
+    if (!radio_idx_found) {
+        em_printfout("Radio index not found for channel_sel op_class_info[0] RUID");
+        return -1;
     }
+    char radio_name[16];
+    snprintf(radio_name, sizeof(radio_name), "radio%u", radio_idx + 1);
 
+    // Delegate channel selection entirely to OneWifi via ACS subdoc.
+    // Current opclass/channel will be updated when OneWifi sends back a radio
+    // subdoc update through em_bus_event_type_onewifi_radio_cb.
+    return send_acs_subdoc(desc, bus_hdl, channel_sel, radio_name);
 }
 
 int dm_easy_mesh_agent_t::analyze_csa_beacon_frame(em_bus_event_t *evt, wifi_bus_desc_t *desc, bus_handle_t *bus_hdl)

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2502,6 +2502,18 @@ int dm_easy_mesh_t::get_beaconchannel_by_opclass(int op_class, int channel)
     return channel;
 }
 
+std::vector<int> dm_easy_mesh_t::get_op_classes_by_band(em_freq_band_t band)
+{
+    std::vector<int> result;
+    size_t count = sizeof(m_e4_table) / sizeof(m_e4_table[0]);
+    for (size_t i = 0; i < count; ++i) {
+        if (m_e4_table[i].band == band) {
+            result.push_back(m_e4_table[i].op_class);
+        }
+    }
+    return result;
+}
+
 // Function to get frequency band by operating class
 em_freq_band_t  dm_easy_mesh_t::get_freq_band_by_op_class(int op_class)
 {

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -38,6 +38,8 @@
 #include <pthread.h>
 #include <map>
 #include <vector>
+#include <set>
+#include <string>
 #include <openssl/rand.h>
 #include "em.h"
 #include "em_msg.h"
@@ -224,7 +226,7 @@ short em_channel_t::create_channel_scan_req_tlv(unsigned char *buff)
 	return len;
 }
 
-short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
+short em_channel_t::create_channel_pref_tlv(unsigned char *buff, em_t *target)
 {
     short len = 0;
     em_channel_pref_t *pref;
@@ -234,8 +236,14 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
     unsigned int num_of_channel = 0;
     em_channels_list_t *channel_list;
 
+    // When no explicit target is passed, default to "this" - preserves the
+    // per-EM call site semantics the single radio flow relied on.
+    const unsigned char *target_ruid = (target != NULL) ? target->get_radio_interface_mac()
+                                                        : get_radio_interface_mac();
+    em_freq_band_t target_band = (target != NULL) ? target->get_band() : get_band();
+
     pref = reinterpret_cast<em_channel_pref_t *> (buff);
-    memcpy(pref->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
+    memcpy(pref->ruid, target_ruid, sizeof(mac_address_t));
     pref_op_class = pref->op_classes;
     pref->op_classes_num = 0;
 
@@ -273,7 +281,7 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
     for (const auto &oc_pair : opclass_channel_prefs) {
         unsigned char opclass = oc_pair.first;
         em_freq_band_t oc_band = dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int>(opclass));
-        if (oc_band != get_band())
+        if (oc_band != target_band)
             continue;
 
         /* Group channels by preference */
@@ -385,14 +393,16 @@ void em_channel_t::update_map_with_agent_capability_preference(const unsigned ch
         }
     }
 
-    // Remove unsupported opclasses from the map
-    for (auto& oc_pair : opclass_channel_prefs) {
-        unsigned int opclass = oc_pair.first;
-        if (supported_opclasses.find(opclass) == supported_opclasses.end()) {
-            // Opclass not present in AP Capability Report.
-            opclass_channel_prefs.erase(opclass);
-            break;
+    // Drop opclasses not in the AP Capability Report. Collect keys first, then
+    // erase, to remove all of them without invalidating the iterator mid-loop.
+    std::vector<unsigned char> unsupported_opclasses;
+    for (const auto& oc_pair : opclass_channel_prefs) {
+        if (supported_opclasses.find(oc_pair.first) == supported_opclasses.end()) {
+            unsupported_opclasses.push_back(oc_pair.first);
         }
+    }
+    for (unsigned char opclass : unsupported_opclasses) {
+        opclass_channel_prefs.erase(opclass);
     }
 }
 
@@ -543,15 +553,20 @@ std::vector<unsigned char> em_channel_t::get_non_operable_channels(unsigned char
     return result;
 }
 
-short em_channel_t::create_transmit_power_limit_tlv(unsigned char *buff)
+short em_channel_t::create_transmit_power_limit_tlv(unsigned char *buff, em_t *target)
 {
     short len = 0;
     em_tx_power_limit_t	*tx_power_limit;
 
+    // When no explicit target is passed, default to "this" - preserves the
+    // per-EM call site semantics the single radio flow relied on.
+    const unsigned char *target_ruid = (target != NULL) ? target->get_radio_interface_mac()
+                                                        : get_radio_interface_mac();
+
     tx_power_limit = reinterpret_cast<em_tx_power_limit_t *> (buff);
-    memcpy(tx_power_limit->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
-    
-    dm_radio_t* radio = get_data_model()->get_radio(get_radio_interface_mac());
+    memcpy(tx_power_limit->ruid, target_ruid, sizeof(mac_address_t));
+
+    dm_radio_t* radio = get_data_model()->get_radio(target_ruid);
     em_radio_info_t* radio_info = radio->get_radio_info();
     tx_power_limit->tx_power_eirp = static_cast<unsigned char> (radio_info->transmit_power_limit);
 
@@ -922,7 +937,7 @@ short em_channel_t::create_spatial_reuse_req_tlv(unsigned char *buff)
     return len;
 }
 
-int em_channel_t::send_channel_sel_request_msg()
+int em_channel_t::send_channel_sel_request_msg(const std::vector<em_t *> *targets)
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
@@ -936,6 +951,15 @@ int em_channel_t::send_channel_sel_request_msg()
     dm_easy_mesh_t *dm;
 
     dm = get_data_model();
+
+    // Build the target list. When caller passes no targets, fall back to
+    // the single radio behaviour of emitting TLVs for "this" EM - same
+    // bytes on the wire as the pre-bundling code path.
+    std::vector<em_t *> default_targets;
+    if (targets == NULL || targets->empty()) {
+        default_targets.push_back(static_cast<em_t *>(this));
+        targets = &default_targets;
+    }
 
     memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
@@ -960,23 +984,28 @@ int em_channel_t::send_channel_sel_request_msg()
     tmp += sizeof(em_cmdu_t);
     len += sizeof(em_cmdu_t);
 
-    // Zero or more Channel Preference TLVs (see section 17.2.13).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_channel_pref;
-    sz = create_channel_pref_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
+    // Emit one Channel Preference TLV + one Transmit Power Limit TLV per
+    // target radio, all bundled in a single Channel Selection Request
+    // message (IEEE 1905 / EasyMesh 8.2 permits multiple such TLVs).
+    for (em_t *target : *targets) {
+        // Channel Preference TLV (see section 17.2.13)
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_channel_pref;
+        sz = create_channel_pref_tlv(tlv->value, target);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
 
-    tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-    len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
+        len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
 
-	// Zero or more Transmit Power Limit TLVs (see section 17.2.15)
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_tx_power;
-    sz = create_transmit_power_limit_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
+        // Transmit Power Limit TLV (see section 17.2.15)
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_tx_power;
+        sz = create_transmit_power_limit_tlv(tlv->value, target);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
 
-    tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-    len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
+        len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
+    }
 
     // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -987,7 +1016,8 @@ int em_channel_t::send_channel_sel_request_msg()
     len += (sizeof (em_tlv_t));
 
     // Validate message against IEEE spec compliance
-    em_printfout("Validating Channel Selection Request message (total length: %u bytes)...\n", len);
+    em_printfout("Validating Channel Selection Request message (total length: %u bytes, %zu radio(s))...\n",
+                 len, targets->size());
     if (em_msg_t(em_msg_type_channel_sel_req, em_profile_type_3, buff, len).validate(errors) == 0) {
         em_printfout("Channel Selection Request msg failed validation in txn end\n");
         return -1;
@@ -997,8 +1027,16 @@ int em_channel_t::send_channel_sel_request_msg()
         em_printfout("Failed to send Channel Selection Request message (errno: %d)\n", errno);
         return -1;
     }
-    m_chan_req_msg_id = ntohs(cmdu->id);
-    em_printfout("Channel Selection Request message sent (msg_id: 0x%04x)\n", m_chan_req_msg_id);
+
+    // All targeted EMs share the same msg_id so each can match its own
+    // Channel Selection Response TLV when the single bundled response arrives.
+    unsigned short msg_id = ntohs(cmdu->id);
+    for (em_t *target : *targets) {
+        static_cast<em_channel_t *>(target)->m_chan_req_msg_id = msg_id;
+    }
+    m_chan_req_msg_id = msg_id;
+    em_printfout("Channel Selection Request message sent (msg_id: 0x%04x, radios: %zu)\n",
+                 msg_id, targets->size());
 
     return static_cast<int> (len);
 
@@ -1042,16 +1080,40 @@ int em_channel_t::send_channel_sel_response_msg(em_chan_sel_resp_code_type_t cod
     tmp += sizeof(em_cmdu_t);
     len += sizeof(em_cmdu_t);
 
-    // one or more Channel selection Response TLVs (see section 17.2.16).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_channel_sel_resp;
-    tlv->len = htons(sizeof(em_channel_sel_rsp_t));
-    resp = reinterpret_cast<em_channel_sel_rsp_t *> (tlv->value);
-    memcpy(resp->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
-    memcpy(&resp->response_code, reinterpret_cast<unsigned char *> (&code), sizeof(unsigned char));
+    // When the incoming request bundled TLVs for multiple radios we need
+    // to acknowledge every one of them. Collect every per-radio EM that
+    // currently holds this msg_id (set by handle_channel_sel_req) and
+    // emit one Channel Selection Response TLV for each.
+    std::vector<em_t *> em_radios;
+    std::vector<em_t *> ack_targets;
+    get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
+    for (auto &em : em_radios) {
+        if (em->is_al_interface_em()) {
+            continue;
+        }
+        em_channel_t *chan = static_cast<em_channel_t *>(em);
+        if (chan->m_chan_req_msg_id == msg_id &&
+            em->get_state() == em_state_agent_channel_select_configuration_pending) {
+            ack_targets.push_back(em);
+        }
+    }
+    em_radios.clear();
+    if (ack_targets.empty()) {
+        ack_targets.push_back(static_cast<em_t *>(this));
+    }
 
-    tmp += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
-    len += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
+    // one or more Channel selection Response TLVs (see section 17.2.16).
+    for (em_t *ack : ack_targets) {
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_channel_sel_resp;
+        tlv->len = htons(sizeof(em_channel_sel_rsp_t));
+        resp = reinterpret_cast<em_channel_sel_rsp_t *> (tlv->value);
+        memcpy(resp->ruid, ack->get_radio_interface_mac(), sizeof(mac_address_t));
+        memcpy(&resp->response_code, reinterpret_cast<unsigned char *> (&code), sizeof(unsigned char));
+
+        tmp += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
+        len += (sizeof(em_tlv_t) + sizeof(em_channel_sel_rsp_t));
+    }
 
     // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -1814,7 +1876,7 @@ int em_channel_t::handle_channel_pref_rprt(unsigned char *buff, unsigned int len
 	return 0;
 }
 
-int em_channel_t::handle_channel_pref_tlv(unsigned char *buff, op_class_channel_sel *op_class)
+int em_channel_t::handle_channel_pref_tlv(unsigned char *buff, op_class_channel_sel *op_class, em_freq_band_t ruid_band)
 {
     em_channel_pref_t *pref = reinterpret_cast<em_channel_pref_t *> (buff);
     em_channel_pref_op_class_t *channel_pref;
@@ -1832,8 +1894,10 @@ int em_channel_t::handle_channel_pref_tlv(unsigned char *buff, op_class_channel_
             pref_bits_ptr = reinterpret_cast<unsigned char *> (channel_pref) + sizeof(em_channel_pref_op_class_t) + channel_pref->num;
             memcpy(&pref_bits, pref_bits_ptr, sizeof(unsigned char));
 
-            // Skip entries not applicable for the current radio band
-            if (get_band() != (dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int> (channel_pref->op_class)))) {
+            // Skip entries not applicable for this TLV's target radio band.
+            // In a bundled request the TLVs may span multiple radios, so we
+            // filter against the RUID's band rather than the dispatching EM.
+            if (ruid_band != (dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int> (channel_pref->op_class)))) {
                 channel_pref = reinterpret_cast<em_channel_pref_op_class_t *> (pref_bits_ptr + sizeof(unsigned char));
                 continue;
             }
@@ -1917,30 +1981,74 @@ int em_channel_t::handle_channel_sel_req(unsigned char *buff, unsigned int len)
     em_tlv_t    *tlv;
     int tlv_len;
 
-    op_class_channel_sel op_class;
+    dm_easy_mesh_t *dm = get_data_model();
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+    unsigned short req_msg_id = ntohs(cmdu->id);
 
-    memset(&op_class, 0, sizeof(op_class_channel_sel));
+    // The request may carry TLVs for multiple radios bundled into a single
+    // 1905 message. Group TLVs by RUID so each target radio gets its own
+    // op_class_channel_sel event with the correct freq_band.
+    std::map<std::string, op_class_channel_sel> per_ruid;
+
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
 
     while ((tlv->type != em_tlv_type_eom) && (tlv_len > 0)) {
         if (tlv->type == em_tlv_type_channel_pref) {
-            handle_channel_pref_tlv(tlv->value, &op_class);
+            em_channel_pref_t *pref = reinterpret_cast<em_channel_pref_t *>(tlv->value);
+            mac_addr_str_t ruid_key;
+            dm_easy_mesh_t::macbytes_to_string(pref->ruid, ruid_key);
+
+            op_class_channel_sel &entry = per_ruid[std::string(ruid_key)];
+            if (entry.num == 0) {
+                memset(&entry, 0, sizeof(op_class_channel_sel));
+                dm_radio_t *target_radio = dm->get_radio(pref->ruid);
+                entry.freq_band = (target_radio != NULL)
+                                      ? target_radio->get_radio_info()->band
+                                      : get_band();
+            }
+            handle_channel_pref_tlv(tlv->value, &entry, entry.freq_band);
         }
         if (tlv->type == em_tlv_type_tx_power) {
-            memcpy(&op_class.tx_power, tlv->value, sizeof(em_tx_power_limit_t));
+            em_tx_power_limit_t *tx = reinterpret_cast<em_tx_power_limit_t *>(tlv->value);
+            mac_addr_str_t ruid_key;
+            dm_easy_mesh_t::macbytes_to_string(tx->ruid, ruid_key);
+            op_class_channel_sel &entry = per_ruid[std::string(ruid_key)];
+            memcpy(&entry.tx_power, tx, sizeof(em_tx_power_limit_t));
         }
 
         tlv_len -= static_cast<int> (sizeof(em_tlv_t) + ntohs(tlv->len));
         tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
-	op_class.freq_band = get_band();
-   
-	get_mgr()->io_process(em_bus_event_type_channel_sel_req, reinterpret_cast<unsigned char *> (&op_class), sizeof(op_class_channel_sel));
-    
-	printf("%s:%d Received channel selection request \n",__func__, __LINE__);
-	set_state(em_state_agent_channel_select_configuration_pending);
+    // Dispatch one event per RUID so analyze_channel_sel_req processes each
+    // radio independently and each corresponding EM reaches the
+    // channel_select_configuration_pending state used by the message gate.
+    for (auto &kv : per_ruid) {
+        op_class_channel_sel &entry = kv.second;
+        if (entry.num == 0) {
+            continue;
+        }
+        get_mgr()->io_process(em_bus_event_type_channel_sel_req,
+                              reinterpret_cast<unsigned char *>(&entry),
+                              sizeof(op_class_channel_sel));
+
+        // Flip the matching per-radio EM into configuration-pending so
+        // subsequent gate checks behave the same for every bundled radio,
+        // not just the one 1905 dispatch happened to land on. Remember the
+        // request msg_id too. send_channel_sel_response_msg uses it to pick
+        // every EM that needs a Channel Selection Response TLV in the reply.
+        em_t *radio_em = reinterpret_cast<em_t *>(
+            hash_map_get(get_mgr()->m_em_map, const_cast<char *>(kv.first.c_str())));
+        if (radio_em != NULL) {
+            em_channel_t *chan = static_cast<em_channel_t *>(radio_em);
+            chan->set_state(em_state_agent_channel_select_configuration_pending);
+            chan->m_chan_req_msg_id = req_msg_id;
+        }
+    }
+
+    em_printfout("%s:%d Received channel selection request (radios=%zu)",
+           __func__, __LINE__, per_ruid.size());
     return 0;
 }
 
@@ -2394,12 +2502,37 @@ void em_channel_t::process_ctrl_state()
             break;
 
         case em_state_ctrl_channel_select_pending:
+            if (get_service_type() == em_service_type_ctrl) {
+                // Collect every EM that is currently pending a channel selection and
+                // bundle their TLVs into a single 1905 Channel Selection Request.
+                // Only the first pending EM emits the message; the rest fall through
+                // this case as no-ops since the message (and their state) has already
+                // been handled.
+                std::vector<em_t *> em_radios;
+                std::vector<em_t *> pending;
+                get_mgr()->get_all_em_for_al_mac(get_data_model()->get_agent_al_interface_mac(), em_radios);
+                for (auto &em : em_radios) {
+                    if (em->is_al_interface_em()) {
+                        continue;
+                    }
+                    if (em->get_state() == em_state_ctrl_channel_select_pending) {
+                        pending.push_back(em);
+                    }
+                }
+                em_radios.clear();
+
+                if (!pending.empty() && this == static_cast<em_channel_t *>(pending.front())) {
+                    send_channel_sel_request_msg(&pending);
+                }
+            }
+            break;
+
         case em_state_ctrl_avail_spectrum_inquiry_pending:
-			if(get_service_type() == em_service_type_ctrl) {
-				send_channel_sel_request_msg();
-			}
-            break; 
-        
+            if (get_service_type() == em_service_type_ctrl) {
+                send_channel_sel_request_msg();
+            }
+            break;
+
         case em_state_ctrl_channel_scan_pending:
 			send_channel_scan_request_msg();
             break;

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -460,9 +460,9 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
 				break;
             case em_cmd_type_op_channel_report:
                 if (!(em->is_al_interface_em())) {
-                    radio = pcmd->m_data_model.get_radio(static_cast<unsigned int> (0));
+                    radio = pcmd->m_data_model.get_radio(ctx->arr_index);
                     if (radio == NULL) {
-                        printf("%s:%d channel sel radio cannot be found.\n", __func__, __LINE__);
+                        printf("%s:%d channel sel radio cannot be found for arr_index=%u.\n", __func__, __LINE__, ctx->arr_index);
                         break;
                     }
                     if ((memcmp(radio->get_radio_interface_mac(),em->get_radio_interface_mac(),sizeof(mac_address_t)) == 0) && (em->get_state() == em_state_agent_channel_select_configuration_pending)) {

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -143,6 +143,16 @@ void em_orch_ctrl_t::orch_transient(em_cmd_t *pcmd, em_t *em)
             break;
         }
 
+        case em_cmd_type_set_channel:
+            // Platform ACS scan/convergence (and DFS CAC) take longer than the
+            // generic TTL; use the extended window to avoid cancelling mid-ACS.
+            if (stats->time > (EM_MAX_CMD_GEN_TTL + EM_MAX_CMD_EXT_TTL))
+            {
+                em_printfout("Canceling cmd: %s because time limit exceeded",pcmd->get_cmd_name());
+                cancel_command(pcmd->get_type());
+            }
+            break;
+
         default:
         if (stats->time > EM_MAX_CMD_GEN_TTL)
         {


### PR DESCRIPTION
Channel selection is delegated to the platform ACS. The EasyMesh Controller
and Agent no longer pick a channel; they only constrain the set of channels
the platform ACS is allowed to use.

CLI/UI -> Controller(all channels + prefs) -> Agent(exclude list) -> OneWifi(route subdoc) -> Platform ACS(pick channel)

This aligns with FTRS EasyMesh+ CORE_AIR_0013 and CORE_AIR_0014: width and opclass
decisions belong to the platform; the Agent's exclude list only reflects the
channels the ACS daemon may not use.

Controller:
The Channel Preference TLV carries every channel in the radio's band with its
preference byte: operable channels keep a non-zero preference, non-operable
channels are encoded with pref_bits = EM_CH_PREF_NON_OPERABLE. This preserves
the agent capability/preference and the CLI anticipated preferences end to end.
create_channel_pref_tlv and create_transmit_power_limit_tlv take an optional
target EM so a single Channel Selection Request can bundle one TLV pair per radio.

Agent:
analyze_channel_sel_req no longer runs any local channel-picking logic.
It now builds an ACS subdoc and publishes it over rbus via
WIFI_WEBCONFIG_START_ACS (Device.WiFi.X_RDKCENTRAL-COM_StartACS).
The exclude list is taken directly from the channels marked non-operable
(pref == 0) in the Channel Preference TLV, grouped per opclass. No separate
capability merge is needed: the controller already encodes capability
non-operable channels as pref == 0 and the CLI anticipated preferences cannot
override them, so the TLV is the single source of truth.

{
  "Version": "1.0",
  "SubDocName": "Acs",
  "RadioName": "radio1",
  "AcsList": [
    { "opclass": 81, "exclude_channels_length": 2, "exclude_channels": [12,13] }
  ]
}

RadioName is lowercase radio<N>, N = DM index + 1, matches how OneWifi parses it
in convert_radio_name_to_index().

Multi-radio orchestration:
A single CLI POST can target multiple radios. send_channel_sel_request_msg
bundles a Channel Preference + Transmit Power Limit TLV per pending radio into
one 1905 message with a shared msg_id; handle_channel_sel_req splits the
bundled TLVs back per RUID and dispatches one event per radio. The radio
callback iterates all radios in the decoded subdoc and spawns one
em_cmd_op_channel_report_t per radio, tagged with ctx->arr_index so the
orchestrator can match each command to the correct EM. send_channel_sel_response_msg
acknowledges every radio that shares the request msg_id.

Note: Requires corresponding changes in OneWifi for full functionality.