### PR TITLE
Issue #654 : Crash in handle_assoc_sta_link_metrics_tlv

### DIFF
--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -190,6 +190,7 @@ class em_metrics_t {
 	 * of an associated station.
 	 *
 	 * @param[in] buff Pointer to the buffer containing the TLV data.
+	 * @param[in] tlv_len Length of the TLV value field.
 	 *
 	 * @returns int Status code indicating success or failure of the operation.
 	 * @retval 0 on success.
@@ -197,8 +198,12 @@ class em_metrics_t {
 	 *
 	 * @note Ensure that the buffer is properly allocated and contains valid TLV data
 	 * before calling this function.
+	 * @note The TLV length must strictly follow: (7 + k × 19), where
+	 * 7 bytes = STA MAC (6) + number of BSSIDs (1),
+	 * and 19 bytes per BSSID metrics entry.
+	 * Invalid or partial TLVs are rejected to prevent out-of-bounds access.
 	 */
-	int handle_assoc_sta_link_metrics_tlv(unsigned char *buff);
+	int handle_assoc_sta_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len);
     
 	/**!
 	 * @brief Handles the association of station external link metrics TLV.

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -47,20 +47,32 @@
 
 static     const unsigned char em_vendor_oui[EM_VENDOR_OUI_SIZE] = {0xd8, 0x9c, 0x8e};
 
-int em_metrics_t::handle_assoc_sta_link_metrics_tlv(unsigned char *buff)
+int em_metrics_t::handle_assoc_sta_link_metrics_tlv(unsigned char *buff,
+                                                    unsigned int tlv_len)
 {
-    em_assoc_sta_link_metrics_t	*sta_metrics;
+    em_assoc_sta_link_metrics_t *sta_metrics;
     em_assoc_link_metrics_t *metrics;
     dm_sta_t *sta;
     unsigned int i;
-    dm_easy_mesh_t  *dm;
+    dm_easy_mesh_t *dm;
+
+    if (buff == NULL || tlv_len == 0 || tlv_len < 7) {
+        return -1;
+    }
 
     dm = get_data_model();
 
-    sta_metrics = reinterpret_cast<em_assoc_sta_link_metrics_t *> (buff);
+    sta_metrics = reinterpret_cast<em_assoc_sta_link_metrics_t *>(buff);
+
+    unsigned int k = sta_metrics->num_bssids;
+    unsigned int expected_len = 7 + (k * sizeof(em_assoc_link_metrics_t));
+
+    if (tlv_len != expected_len) {
+        return -1;
+    }
 
     for (i = 0; i < sta_metrics->num_bssids; i++) {
-        metrics	= &sta_metrics->assoc_link_metrics[i];
+        metrics = &sta_metrics->assoc_link_metrics[i];
         sta = dm->find_sta(sta_metrics->sta_mac, metrics->bssid);
         if (sta == NULL) {
             continue;
@@ -178,10 +190,11 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
 
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_assoc_sta_link_metric) {
-            handle_assoc_sta_link_metrics_tlv(tlv->value);
+            uint16_t tlv_len = ntohs(tlv->len);
+            handle_assoc_sta_link_metrics_tlv(tlv->value, tlv_len);
         }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     tlv = tlv_start;
@@ -520,10 +533,11 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
 
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_assoc_sta_link_metric) {
-            handle_assoc_sta_link_metrics_tlv(tlv->value);
+            uint16_t tlv_len = ntohs(tlv->len);
+            handle_assoc_sta_link_metrics_tlv(tlv->value, tlv_len);
         }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     tlv = tlv_start;


### PR DESCRIPTION
Problem:

    -The function processes the Associated STA Link Metrics TLV without validating the TLV length against the specification.

    -It directly casts the buffer into a structure and accesses fields based on k (number of BSSIDs)
    -If the TLV length is:
       *less than 7 → mandatory fields are missing
       *not equal to (7 + k × 19) → metrics fields are incomplete

-The function crashes when TLV length is not validated against the specification and partial data is parsed.
-As per spec, valid TLV length must be: Length = 7 + (k × 19), where 7 bytes = STA MAC (6) + k (1).
-Valid cases: k=0 → 7, k=1 → 26, k=2 → 45, k=3 → 64, etc.
       *For k=1: any value between 7 + 19 = 26 (i.e., >7 and <26) causes crash due to incomplete metrics.
       *For k=2: any value between 26 and 45 (i.e., >26 and <45) causes crash due to partial second entry.
       *For k=3: any value between 45 and 64 (i.e., >45 and <64) also causes crash; hence only exact lengths are valid.
-This results in out-of-bounds memory access and leads to crashes.
-Therefore, TLV length must strictly match the expected value derived from k to ensure safe parsing.

Steps to reproduce:

    -Construct an Associated STA Link Metrics TLV with k = 1 but an invalid length (e.g., 14 instead of 26 as per spec).
    -Pass this TLV to handle_assoc_sta_link_metrics_tlv(buff, tlv_len).
    -Before the fix, the function directly casts the buffer and accesses metrics fields without validating length, leading to out-of-bounds access and crash.

Fixed:

    -Added Check 1: (buff == NULL || tlv_len == 0 || tlv_len < 7) ensures minimum mandatory fields are present.
    -Added Check 2: (tlv_len == 7 + (k × sizeof(em_assoc_link_metrics_t))) enforces spec-compliant length.
    -Invalid TLVs are now safely rejected with -1, preventing crashes and ensuring safe parsing.