### PR TITLE
RDKBWIFI-411: Fixing memory leaks in uwm

### DIFF
--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -3192,7 +3192,7 @@ int em_configuration_t::compute_keys(unsigned char *remote_pub, unsigned short p
     length[0] = static_cast<size_t> (secret_len);
 
     if (compute_digest(1, addr, length, dhkey) != 1) {
-        free(secret);
+        OPENSSL_free(secret);
         printf("%s:%d: Hash key computation failed\n", __func__, __LINE__);
         return -1;
     }
@@ -3214,7 +3214,7 @@ int em_configuration_t::compute_keys(unsigned char *remote_pub, unsigned short p
     //util::print_hex_dump(length[2], addr[2]);
     
     if (compute_kdk(dhkey, SHA256_MAC_LEN, 3, addr, length, kdk) != 1) {
-        free(secret);
+        OPENSSL_free(secret);
         printf("%s:%d: kdk computation failed\n", __func__, __LINE__);
         return -1;
     }
@@ -3222,7 +3222,7 @@ int em_configuration_t::compute_keys(unsigned char *remote_pub, unsigned short p
     //printf("%s:%d: kdk:\n", __func__, __LINE__);
     //util::print_hex_dump(SHA256_MAC_LEN, kdk);
     if (derive_key(kdk, NULL, 0, str, keys, sizeof(keys)) != 1) {
-        free(secret);
+        OPENSSL_free(secret);
         printf("%s:%d: key derivation failed\n", __func__, __LINE__);
         return -1;
     }
@@ -3234,6 +3234,7 @@ int em_configuration_t::compute_keys(unsigned char *remote_pub, unsigned short p
     //printf("%s:%d: Encrypt/Decrypt Key:\n", __func__, __LINE__);
     //util::print_hex_dump(WPS_EMSK_LEN, m_emsk);
 
+    OPENSSL_free(secret);
     return 1;
 }
 

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -87,7 +87,9 @@ uint8_t em_crypto_t::g_dh1536_g[] = { 0x02 };
 static pthread_once_t init_once = PTHREAD_ONCE_INIT;
 #endif
 
-em_crypto_t::em_crypto_t() {
+em_crypto_t::em_crypto_t()
+    : m_crypto_info{}
+{
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     memset(&m_crypto_info, 0, sizeof(em_crypto_info_t));

--- a/src/em/crypto/em_crypto.cpp
+++ b/src/em/crypto/em_crypto.cpp
@@ -280,14 +280,20 @@ uint8_t em_crypto_t::platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *ke
         return 0;
     }
 
+    int mdlen_int = EVP_MD_size(hashing_algo);
+    if (mdlen_int < 0) {
+        return 0;
+    }
+
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     EVP_MD_CTX   *ctx;
     EVP_PKEY     *pkey;
+    size_t mdlen = static_cast<size_t> (mdlen_int);
 #else
     HMAC_CTX     *ctx;
+    unsigned int mdlen = static_cast<unsigned int> (mdlen_int);
 #endif
     size_t        i;
-    unsigned int mdlen = static_cast<unsigned int> (EVP_MD_size(hashing_algo));
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     ctx = EVP_MD_CTX_new();
@@ -318,7 +324,7 @@ uint8_t em_crypto_t::platform_hmac_hash(const EVP_MD * hashing_algo, uint8_t *ke
         }
     }
 
-    if (EVP_DigestSignFinal(ctx, hmac, reinterpret_cast<size_t*>(&mdlen)) != 1) {
+    if (EVP_DigestSignFinal(ctx, hmac, &mdlen) != 1) {
         goto bail;
     }
 #else


### PR DESCRIPTION
Reason for change:
-  Fix shared secret leak in compute_keys
 compute_secret() allocates the DH shared secret buffer via
OPENSSL_malloc (which wraps malloc). The error paths in compute_keys
already called free(secret) correctly, but the success path fell
through to return 1 without freeing the buffer.
Add free(secret) before the successful return. The secret has already
been hashed into dhkey at that point and is no longer needed.

- Fix memory corruption when address of 32-bit variable is cast to a 64-bit (size_t) pointer and written by openssl.

Test procedure: check onboarding with updated uwm version

Priority: P2
Risk: Low