### PR TITLE
Issue 657 : Crash in handle_assoc_sta_ext_link_metrics_tlv

### DIFF
--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -215,9 +215,9 @@ class em_metrics_t {
 	 *
 	 * @note Ensure that the buffer is properly allocated and contains valid TLV data.
          * - Minimum required length is 7 bytes (STA MAC + k).
-         * - Each BSSID entry contains a fixed 22-byte extended metrics block.
-         * - Total TLV length must strictly follow: 
-	 *   tlv_len = 7 + (k * 22)
+         * - Each BSSID entry contains one `em_assoc_ext_link_metrics_t` block
+         * - Total TLV length must strictly follow:
+	 *   tlv_len = 7 + (k * sizeof(em_assoc_ext_link_metrics_t))
          * - Any deviation from expected length results in rejection to prevent
          *   out-of-bounds memory access
 	 */

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -207,14 +207,21 @@ class em_metrics_t {
 	 * station external link metrics TLV.
 	 *
 	 * @param[in] buff Pointer to the buffer containing the TLV data.
-	 *
+	 * @param[in] tlv_len Length of the TLV value field in bytes.
+	 * 
 	 * @returns int
 	 * @retval 0 on success
 	 * @retval -1 on failure
 	 *
 	 * @note Ensure that the buffer is properly allocated and contains valid TLV data.
+         * - Minimum required length is 7 bytes (STA MAC + k).
+         * - Each BSSID entry contains a fixed 22-byte extended metrics block.
+         * - Total TLV length must strictly follow: 
+	 *   tlv_len = 7 + (k * 22)
+         * - Any deviation from expected length results in rejection to prevent
+         *   out-of-bounds memory access
 	 */
-	int handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff);
+	int handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len);
     
 	/**!
 	 * @brief Handles the association of station vendor link metrics TLV.

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -74,7 +74,7 @@ int em_metrics_t::handle_assoc_sta_link_metrics_tlv(unsigned char *buff)
     return 0;
 }
 
-int em_metrics_t::handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff)
+int em_metrics_t::handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len)
 {
     em_assoc_sta_ext_link_metrics_t	*sta_metrics;
     em_assoc_ext_link_metrics_t *metrics;
@@ -82,9 +82,21 @@ int em_metrics_t::handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff)
     unsigned int i;
     dm_easy_mesh_t  *dm;
 
+	if (buff == NULL || tlv_len == 0 || tlv_len < 7) {
+            printf("Invalid input: buff=%p tlv_len=%u\n", buff, tlv_len);
+            return -1;
+	}
+
     dm = get_data_model();
 
     sta_metrics = reinterpret_cast<em_assoc_sta_ext_link_metrics_t *> (buff);
+
+	unsigned int k = sta_metrics->num_bssids;
+	unsigned int expected_len = 7 + (k * sizeof(em_assoc_ext_link_metrics_t));
+
+	if (tlv_len != expected_len) {
+            return -1;
+	}
 
     for (i = 0; i < sta_metrics->num_bssids; i++) {
         metrics	= &sta_metrics->assoc_ext_link_metrics[i];
@@ -192,13 +204,13 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
     tlv = tlv_start;
     tmp_len = base_len;
 
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+    while (((tmp_len > 0) && (tmp_len >= sizeof(em_tlv_t)) && (tlv->type != em_tlv_type_eom))) {
         if (tlv->type == em_tlv_type_assoc_sta_ext_link_metric) {
-            handle_assoc_sta_ext_link_metrics_tlv(tlv->value);
+            handle_assoc_sta_ext_link_metrics_tlv(tlv->value, ntohs(tlv->len));
         }
 
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     tlv = tlv_start;
@@ -517,12 +529,12 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
     tlv = tlv_start;
     tmp_len = base_len;
 
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+    while (((tmp_len > 0) && (tmp_len >= sizeof(em_tlv_t)) && (tlv->type != em_tlv_type_eom))) {
         if (tlv->type == em_tlv_type_assoc_sta_ext_link_metric) {
-            handle_assoc_sta_ext_link_metrics_tlv(tlv->value);
+            handle_assoc_sta_ext_link_metrics_tlv(tlv->value, ntohs(tlv->len));
         }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     tlv = tlv_start;

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -82,21 +82,21 @@ int em_metrics_t::handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff, uns
     unsigned int i;
     dm_easy_mesh_t  *dm;
 
-	if (buff == NULL || tlv_len == 0 || tlv_len < 7) {
-            printf("Invalid input: buff=%p tlv_len=%u\n", buff, tlv_len);
+    if (buff == NULL || tlv_len == 0 || tlv_len < 7) {
+            printf("Invalid input: null buffer or invalid tlv_len=%u\n", tlv_len);
             return -1;
-	}
+    }
 
     dm = get_data_model();
 
     sta_metrics = reinterpret_cast<em_assoc_sta_ext_link_metrics_t *> (buff);
 
-	unsigned int k = sta_metrics->num_bssids;
-	unsigned int expected_len = 7 + (k * sizeof(em_assoc_ext_link_metrics_t));
+    unsigned int k = sta_metrics->num_bssids;
+    unsigned int expected_len = offsetof(em_assoc_sta_ext_link_metrics_t, assoc_ext_link_metrics) + (k * sizeof(em_assoc_ext_link_metrics_t));
 
-	if (tlv_len != expected_len) {
+    if (tlv_len != expected_len) {
             return -1;
-	}
+    }
 
     for (i = 0; i < sta_metrics->num_bssids; i++) {
         metrics	= &sta_metrics->assoc_ext_link_metrics[i];

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -204,7 +204,7 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
     tlv = tlv_start;
     tmp_len = base_len;
 
-    while (((tmp_len > 0) && (tmp_len >= sizeof(em_tlv_t)) && (tlv->type != em_tlv_type_eom))) {
+    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_assoc_sta_ext_link_metric) {
             handle_assoc_sta_ext_link_metrics_tlv(tlv->value, ntohs(tlv->len));
         }
@@ -529,7 +529,7 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
     tlv = tlv_start;
     tmp_len = base_len;
 
-    while (((tmp_len > 0) && (tmp_len >= sizeof(em_tlv_t)) && (tlv->type != em_tlv_type_eom))) {
+    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_assoc_sta_ext_link_metric) {
             handle_assoc_sta_ext_link_metrics_tlv(tlv->value, ntohs(tlv->len));
         }


### PR DESCRIPTION
Problem:

-The function processes the Associated STA Extended Link Metrics TLV without validating the TLV length against the specification. -It directly casts the bffer into a structure and accesses fields based on k (number of BSSIDs) -If the TLV length is:
     *less than 7 → mandatory fields are missing
     *not equal to (7 + k × 22) → metrics fields are incomplete
-The function crashes when TLV length is not validated against the specification and partial data is parsed. -As per spec, valid TLV length must be: Length = 7 + (k × 22), where 7 bytes = STA MAC (6) + k (1). -Valid cases: k=0 → 7, k=1 → 29, k=2 → 51, k=3 → 73, etc.
     *For k=1: any value between 7 + 22 = 29 (i.e., >7 and <29) causes crash due to incomplete metrics.
     *For k=2: any value between 29 and 51 (i.e., >29 and <51) causes crash due to partial second entry.
     *For k=3: any value between 51 and 73 (i.e., >51 and <73) also causes crash; hence only exact lengths are valid.
-This results in out-of-bounds memory access and leads to crashes. Therefore, TLV length must strictly match the expected value derived from k to ensure safe parsing.


Steps to reproduce

*Construct an Associated STA Extended Link Metrics TLV with k = 1 but invalid length (e.g., 20 instead of 29 as per spec)
*Pass this TLV to the handler function
*Before the fix, the function directly casts the buffer and accesses metrics fields without validating length
*This leads to out-of-bounds access and crash

Fixed:
   *Added Check 1: (buff == NULL || tlv_len == 0 || tlv_len < 7) → ensures mandatory fields
   *Added Check 2: (tlv_len == 7 + (k × sizeof(em_assoc_ext_link_metrics_t))) → enforces spec length (22 bytes per block)
-Invalid TLVs are now rejected safely with -1, preventing crashes.