### PR TITLE
RDKBACCL-1458 : Cleanup onewifi related changes in uwm makefile for RDKB BPI platforms

### DIFF
--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -31,12 +31,7 @@ onewifi_em_agent_CPPFLAGS = \
     -I$(top_srcdir)/inc \
     -I$(top_srcdir)/src/utils \
     -I$(top_srcdir)/src/util \
-    -I$(top_srcdir)/src/util_crypto \
-    -I$(top_srcdir)/OneWifi/lib/log \
-    -I$(top_srcdir)/OneWifi/source/platform/common \
-    -I$(top_srcdir)/OneWifi/source/platform/rdkb \
-    -I$(top_srcdir)/OneWifi/source/ccsp \
-    -I$(top_srcdir)/OneWifi/lib/ds
+    -I$(top_srcdir)/src/util_crypto
 
 onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/em/em.cpp \
@@ -123,10 +118,6 @@ onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/dm/dm_assoc_sta_mld.cpp \
      $(top_srcdir)/src/orch/em_orch.cpp  \
      $(top_srcdir)/src/orch/em_orch_agent.cpp \
-     $(top_srcdir)/OneWifi/source/platform/rdkb/bus.c \
-     $(top_srcdir)/OneWifi/source/platform/common/bus_common.c \
-     $(top_srcdir)/OneWifi/lib/common/util.c \
-     $(top_srcdir)/OneWifi/source/utils/collection.c \
      $(top_srcdir)/src/utils/util.cpp \
      $(top_srcdir)/src/utils/timer.cpp \
      $(top_srcdir)/src/util_crypto/aes_siv.c

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -91,5 +91,4 @@ libemcli_la_SOURCES = \
  $(top_srcdir)/src/utils/util.cpp \
  $(top_srcdir)/src/em/prov/easyconnect/ec_util.cpp \
  $(top_srcdir)/src/em/prov/easyconnect/ec_crypto.cpp \
- $(top_srcdir)/src/util_crypto/aes_siv.c \
- $(top_srcdir)/OneWifi/source/utils/collection.c
+ $(top_srcdir)/src/util_crypto/aes_siv.c

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -31,12 +31,6 @@ onewifi_em_ctrl_CPPFLAGS = \
     -I$(top_srcdir)/src/utils \
     -I$(top_srcdir)/src/util \
     -I$(top_srcdir)/src/util_crypto \
-    -I$(top_srcdir)/OneWifi/include \
-    -I$(top_srcdir)/OneWifi/lib/log  \
-    -I$(top_srcdir)/OneWifi/lib/ds  \
-    -I$(top_srcdir)/OneWifi/source/utils \
-    -I$(top_srcdir)/OneWifi/source/platform/rdkb \
-    -I$(top_srcdir)/OneWifi/source/platform/common \
     -DUNIT_TEST
 
 onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Wconversion -Werror -O2
@@ -145,11 +139,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/orch/em_orch_ctrl.cpp \
      $(top_srcdir)/src/util_crypto/aes_siv.c \
      $(top_srcdir)/src/utils/util.cpp \
-     $(top_srcdir)/src/utils/timer.cpp \
-     $(top_srcdir)/OneWifi/source/utils/collection.c \
-     $(top_srcdir)/OneWifi/lib/common/util.c \
-     $(top_srcdir)/OneWifi/source/platform/rdkb/bus.c \ 
-     $(top_srcdir)/OneWifi/source/platform/common/bus_common.c
+     $(top_srcdir)/src/utils/timer.cpp
  
  
 onewifi_em_ctrl_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lrbus -fsanitize=address -fsanitize=undefined -lmariadb

--- a/src/network_optimiser/Makefile.am
+++ b/src/network_optimiser/Makefile.am
@@ -28,23 +28,12 @@ onewifi_em_network_optimser_CPPFLAGS = \
     -I$(top_srcdir)/src/utils \
     -I$(top_srcdir)/src/util \
     -I$(top_srcdir)/src/util_crypto \
-    -I$(top_srcdir)/OneWifi/include \
-    -I$(top_srcdir)/OneWifi/lib/log  \
-    -I$(top_srcdir)/OneWifi/lib/ds  \
-    -I$(top_srcdir)/OneWifi/source/utils \
-    -I$(top_srcdir)/OneWifi/source/platform/rdkb \
-    -I$(top_srcdir)/OneWifi/source/platform/common \
     -DUNIT_TEST
 
 onewifi_em_network_optimser_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Wconversion -Werror -O2
 
 onewifi_em_network_optimser_SOURCES =  \
-     $(top_srcdir)/src/network_optimiser/test_tr181.cpp \
-     $(top_srcdir)/OneWifi/source/utils/collection.c \
-     $(top_srcdir)/OneWifi/lib/common/util.c \
-     $(top_srcdir)/OneWifi/source/platform/rdkb/bus.c \ 
-     $(top_srcdir)/OneWifi/source/platform/common/bus_common.c
- 
+     $(top_srcdir)/src/network_optimiser/test_tr181.cpp
  
 onewifi_em_network_optimser_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lwifi_bus -lrbus #-lwifi_webconfig
 onewifi_em_network_optimser_LDADD = $(top_builddir)/src/al-sap/libalsap.la

--- a/src/rdkb-cli/Makefile.am
+++ b/src/rdkb-cli/Makefile.am
@@ -95,6 +95,4 @@ libemcli_la_SOURCES = \
  $(top_srcdir)/src/utils/util.cpp \
  $(top_srcdir)/src/em/prov/easyconnect/ec_util.cpp \
  $(top_srcdir)/src/em/prov/easyconnect/ec_crypto.cpp \
- $(top_srcdir)/src/util_crypto/aes_siv.c \
- $(top_srcdir)/OneWifi/source/utils/collection.c
-
+ $(top_srcdir)/src/util_crypto/aes_siv.c


### PR DESCRIPTION
Reason for change: As per current design, uwm builddir holds the onewifi folder structure that needs to be cleaned.
Needed onewifi lib should be linked in uwm recipe instead of this. 
Test Procedure:Build successful and validated the EM functionality 
Risks: Low