### PR TITLE
Remove message ID range from service registration response

### DIFF
--- a/inc/al_service_registration_enums.h
+++ b/inc/al_service_registration_enums.h
@@ -19,8 +19,7 @@ enum class ServiceType : uint8_t {
 enum class RegistrationResult : uint8_t {
     UNKNOWN = 0x00,
     SUCCESS = 0x01,
-    NO_RANGES_AVAILABLE = 0x02,
-    SERVICE_NOT_SUPPORTED = 0x03,
+    SERVICE_NOT_SUPPORTED = 0x02,
 };
 
 #endif // AL_SERVICE_REGISTRATION_ENUMS_H

--- a/inc/al_service_registration_response.h
+++ b/inc/al_service_registration_response.h
@@ -3,11 +3,9 @@
 
 #include "al_service_registration_enums.h"
 #include <array>
-#include <utility>
 #include <vector>
 
 using MacAddress = std::array<uint8_t, 6>;
-using MessageIdRange = std::pair<uint16_t, uint16_t>;
 
 // Class used to manage a registration response from the IEEE1905 applicatoin
 class AlServiceRegistrationResponse {
@@ -26,14 +24,13 @@ public:
 	/**!
 	 * @brief Constructor for AlServiceRegistrationResponse class.
 	 *
-	 * This constructor initializes the AlServiceRegistrationResponse object with the given MAC address,
-	 * message ID range, and registration result.
+	 * This constructor initializes the AlServiceRegistrationResponse object with the given MAC address
+	 * and registration result.
 	 *
 	 * @param[in] macAddress The MAC address associated with the service registration.
-	 * @param[in] range The range of message IDs for the service registration.
 	 * @param[in] result The result of the service registration process.
 	 */
-	AlServiceRegistrationResponse(const MacAddress& macAddress, MessageIdRange range, RegistrationResult result);
+	AlServiceRegistrationResponse(const MacAddress& macAddress, RegistrationResult result);
 
     // Setters and getters for local AL MAC address
     
@@ -56,28 +53,6 @@ public:
 	 * @returns A constant reference to the local MAC address.
 	 */
 	const MacAddress& getAlMacAddressLocal() const;
-
-    // Setters and getters for message ID range assigned from the IEEE1905 agent
-    
-	/**!
-	 * @brief Sets the message ID range.
-	 *
-	 * This function assigns a range of message IDs to be used.
-	 *
-	 * @param[in] range The range of message IDs to set.
-	 */
-	void setMessageIdRange(const MessageIdRange& range);
-    
-	/**!
-	 * @brief Retrieves the range of message IDs.
-	 *
-	 * This function returns the range of message IDs that are currently registered.
-	 *
-	 * @returns MessageIdRange The range of message IDs.
-	 *
-	 * @note This function does not modify any member variables.
-	 */
-	MessageIdRange getMessageIdRange() const;
 
     // Setters and getters for registration result
     
@@ -124,7 +99,6 @@ public:
 
 private:
     MacAddress alMacAddressLocal;
-    MessageIdRange messageIdRange;
     RegistrationResult result;
 };
 

--- a/src/al-sap/al_service_registration_response.cpp
+++ b/src/al-sap/al_service_registration_response.cpp
@@ -1,16 +1,16 @@
 #include "al_service_registration_enums.h"
 #include "al_service_registration_response.h"
 #include "al_service_utils.h"
+#include <algorithm>
 #include <stdexcept>
 
 AlServiceRegistrationResponse::AlServiceRegistrationResponse()
-    : alMacAddressLocal{0, 0, 0, 0, 0, 0}, messageIdRange{0, 0}, result(RegistrationResult::UNKNOWN) {}
+    : alMacAddressLocal{0, 0, 0, 0, 0, 0}, result(RegistrationResult::UNKNOWN) {}
 
 AlServiceRegistrationResponse::AlServiceRegistrationResponse(
     const MacAddress& macAddress,
-    MessageIdRange range,
     RegistrationResult result
-) : alMacAddressLocal(macAddress), messageIdRange(range), result(result) {}
+) : alMacAddressLocal(macAddress), result(result) {}
 
 void AlServiceRegistrationResponse::setAlMacAddressLocal(const MacAddress& alMac) {
     alMacAddressLocal = alMac;
@@ -18,14 +18,6 @@ void AlServiceRegistrationResponse::setAlMacAddressLocal(const MacAddress& alMac
 
 const MacAddress& AlServiceRegistrationResponse::getAlMacAddressLocal() const {
     return alMacAddressLocal;
-}
-
-void AlServiceRegistrationResponse::setMessageIdRange(const MessageIdRange& range) {
-    messageIdRange = range;
-}
-
-MessageIdRange AlServiceRegistrationResponse::getMessageIdRange() const {
-    return messageIdRange;
 }
 
 void AlServiceRegistrationResponse::setResult(RegistrationResult result) {
@@ -38,16 +30,10 @@ RegistrationResult AlServiceRegistrationResponse::getResult() const {
 
 std::vector<unsigned char> AlServiceRegistrationResponse::serializeRegistrationResponse() {
     std::vector<unsigned char> data;
-    uint32_t packet_size = alMacAddressLocal.size() + sizeof(MessageIdRange) + sizeof(uint8_t);
+    uint32_t packet_size = alMacAddressLocal.size() + sizeof(uint8_t);
     // Serialize MAC address
     data = convert_u32_into_bytes(packet_size);
     data.insert(data.end(), alMacAddressLocal.begin(), alMacAddressLocal.end());
-
-    // Serialize message ID range
-    data.push_back(static_cast<unsigned char>(messageIdRange.first >> 8));
-    data.push_back(static_cast<unsigned char>(messageIdRange.first & 0xFF));
-    data.push_back(static_cast<unsigned char>(messageIdRange.second >> 8));
-    data.push_back(static_cast<unsigned char>(messageIdRange.second & 0xFF));
 
     // Serialize result
     data.push_back(static_cast<unsigned char>(result));
@@ -56,9 +42,8 @@ std::vector<unsigned char> AlServiceRegistrationResponse::serializeRegistrationR
 }
 
 void AlServiceRegistrationResponse::deserializeRegistrationResponse(const std::vector<unsigned char>& data) {
-    // Ensure data size to be 15.
-    // 4 bytes of frame delimited part + 6 (Macaddress) + 4 (MessageIdRange) + 1 (result)
-    if (data.size() < (sizeof(uint32_t) + sizeof(MacAddress) + sizeof(MessageIdRange) + sizeof(uint8_t))) {
+    // Ensure data size contains length prefix, MAC address, and result.
+    if (data.size() < (sizeof(uint32_t) + sizeof(MacAddress) + sizeof(uint8_t))) {
         throw std::runtime_error("Insufficient data to deserialize AlServiceRegistrationResponse");
     }
     // shadow data variable to limit code changes
@@ -67,10 +52,6 @@ void AlServiceRegistrationResponse::deserializeRegistrationResponse(const std::v
     // Deserialize MAC address
     std::copy(data_raw.begin(), data_raw.begin() + 6, alMacAddressLocal.begin());
 
-    // Deserialize message ID range
-    messageIdRange.first = (data_raw[6] << 8) | data_raw[7];
-    messageIdRange.second = (data_raw[8] << 8) | data_raw[9];
-
     // Deserialize result
-    result = static_cast<RegistrationResult>(data_raw[10]);
+    result = static_cast<RegistrationResult>(data_raw[6]);
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -165,7 +165,6 @@ int main(int argc, char **argv) {
     "AlServiceRegistrationRequest.getSAPActivationStatus_invalidSAPActivation:"
     "AlServiceRegistrationRequest.SetServiceType_Invalid:"
     "AlServiceRegistrationResponseTest.SerializeRegistrationResponseWithInvalidMacAddress:"
-    "AlServiceRegistrationResponseTest.SerializeRegistrationResponseWithEmptyMessageIdRange:"
     "AlServiceRegistrationResponseTest.SerializeRegistrationResponseWithAllNullMacAddress:"
     "dm_radio_t_Test.NullJsonObject:"
     "dm_radio_t_Test.NullParentID:"

--- a/tests/test_l1_al_service_registration_response.cpp
+++ b/tests/test_l1_al_service_registration_response.cpp
@@ -128,7 +128,7 @@ TEST(AlServiceRegistrationResponseTest, RetrieveAlMacAddressLocalWithValidInput)
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call the constructor with macaddress as empty | "00:00:00:00:00:00", range, result | None | Should be initialized |
+ * | 01 | Call the constructor with macaddress as empty | "00:00:00:00:00:00", RegistrationResult::SUCCESS | None | Should be initialized |
  * | 02 | Call the getAlMacAddressLocal function with an empty string as input | input = "" | RETURN_ERR | Should Pass |
  */
 
@@ -264,7 +264,7 @@ TEST(AlServiceRegistrationResponseTest, SerializeValidRegistrationResponse) {
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Initialize the invalid MAC address, valid message range and registration response | invalidMacAddress = "00:00:22:33:34:44", range(0, 65535), RegistrationResult::SUCCESS | None | Should be successful |
+ * | 01 | Initialize the invalid MAC address and registration response result | invalidMacAddress = "00:00:22:33:34:44", RegistrationResult::SUCCESS | None | Should be successful |
  * | 02 | Serialize the registration response | None | serializedData = instance->serializeRegistrationResponse() | Should Pass |
  * | 03 | Verify the serialized data is empty | serializedData.empty() | True | Should Pass |
  */
@@ -292,7 +292,7 @@ TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithInvalid
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Set a valid MAC address, message ID range and failed registration result | "00:11:22:33:44:55", range, RegistrationResult::UNKNOWN | None | Should be successful |
+ * | 01 | Set a valid MAC address and failed registration result | "00:11:22:33:44:55", RegistrationResult::UNKNOWN | None | Should be successful |
  * | 02 | Serialize the registration response | None | serializedData should not be empty | Should Pass |
  */
 TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithFailedResult) {
@@ -320,7 +320,7 @@ TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithFailedR
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Set null MAC address, valid message id range and registration result | "{0, 0, 0, 0, 0, 0}", range(0, 65535), RegistrationResult::SUCCESS |  | Should be successful |
+ * | 01 | Set null MAC address and registration result | "{0, 0, 0, 0, 0, 0}", RegistrationResult::SUCCESS |  | Should be successful |
  * | 02 | Serialize the registration response | instance->serializeRegistrationResponse() | serializedData = empty vector | Should Pass |
  */
 TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithAllNullMacAddress) {
@@ -523,7 +523,7 @@ TEST(AlServiceRegistrationResponseTest, SetAllRegistrationResults) {
 /**
  * @brief Test the AlServiceRegistrationResponse constructor with valid argument values
  *
- * This test verifies that the AlServiceRegistrationResponse constructor correctly initializes the object with a valid MAC address, a valid message ID range, and all possible registration results.
+ * This test verifies that the AlServiceRegistrationResponse constructor correctly initializes the object with a valid MAC address and all possible registration results.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 036@n
@@ -536,12 +536,12 @@ TEST(AlServiceRegistrationResponseTest, SetAllRegistrationResults) {
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data |Expected Result |Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01| Initialize with SUCCESS result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, range = {1000, 2000}, result = SUCCESS | Object should be created with the values | Should Pass |
+ * | 01| Initialize with SUCCESS result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, result = SUCCESS | Object should be created with the values | Should Pass |
  * | 02| Initialize with SERVICE_NOT_SUPPORTED result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, result = SERVICE_NOT_SUPPORTED | Object should be created with the values | Should Pass |
  * | 03| Initialize with UNKNOWN result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, result = UNKNOWN | Object should be created with the values | Should Pass |
  */
-TEST(AlServiceRegistrationResponseTest, ValidMACAddressValidRangeAllResults) {
-    std::cout << "Entering ValidMACAddressValidRangeAllResults" << std::endl;
+TEST(AlServiceRegistrationResponseTest, ValidMACAddressAllResults) {
+    std::cout << "Entering ValidMACAddressAllResults" << std::endl;
     MacAddress macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
     RegistrationResult results[] = {
         RegistrationResult::SUCCESS,
@@ -552,66 +552,13 @@ TEST(AlServiceRegistrationResponseTest, ValidMACAddressValidRangeAllResults) {
         std::cout << "Testing with result: " << static_cast<uint8_t>(result) << std::endl;
         AlServiceRegistrationResponse response(macAddress, result);
     }
-    std::cout << "Exiting ValidMACAddressValidRangeAllResults" << std::endl;
+    std::cout << "Exiting ValidMACAddressAllResults" << std::endl;
 }
 
 /**
- * @brief Test the AlServiceRegistrationResponse constructor with valid argument values
+ * @brief Test the AlServiceRegistrationResponse constructor with all zero MAC address and success result.
  *
- * This test verifies that the AlServiceRegistrationResponse constructor initializes the object with invalid message ID range
- *
- * **Test Group ID:** Basic: 01@n
- * **Test Case ID:** 037@n
- * **Priority:** High@n
- * @n
- * **Dependencies:** None@n
- * **User Interaction:** None@n
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data |Expected Result |Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01| Initialize MAC address, message ID range, and result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, range = {2000, 1000}, result = RegistrationResult::SUCCESS | Object should be created successfully | Should Pass |
- *
- */
-TEST(AlServiceRegistrationResponseTest, ValidMACAddressInvalidRangeSuccessResult) {
-    std::cout << "Entering ValidMACAddressInvalidRangeSuccessResult" << std::endl;
-    MacAddress macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
-    RegistrationResult result = RegistrationResult::SUCCESS;
-    AlServiceRegistrationResponse response(macAddress, result);
-    std::cout << "Exiting ValidMACAddressInvalidRangeSuccessResult" << std::endl;
-}
-
-/**
- * @brief Test the AlServiceRegistrationResponse constructor with zero range.
- *
- * This test verifies that the AlServiceRegistrationResponse object is correctly initialized with a valid MAC address, a zero message ID range, and a success result.
- *
- * **Test Group ID:** Basic: 01@n
- * **Test Case ID:** 038@n
- * **Priority:** High@n
- * @n
- * **Pre-Conditions:** None@n
- * **Dependencies:** None@n
- * **User Interaction:** None@n
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Initialize AlServiceRegistrationResponse with valid MAC address, zero range, and success result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, range = {0, 0}, result = RegistrationResult::SUCCESS | Object should be initialized successfully | Should Pass |
- *
- */
-TEST(AlServiceRegistrationResponseTest, ValidMACAddressZeroRangeSuccessResult) {
-    std::cout << "Entering ValidMACAddressZeroRangeSuccessResult" << std::endl;
-    MacAddress macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
-    RegistrationResult result = RegistrationResult::SUCCESS;
-    AlServiceRegistrationResponse response(macAddress, result);
-    std::cout << "Exiting ValidMACAddressZeroRangeSuccessResult" << std::endl;
-}
-
-/**
- * @brief Test the AlServiceRegistrationResponse constructor with all zero MAC address, valid message ID range, and success result.
- *
- * This test verifies that the AlServiceRegistrationResponse object is correctly initialized when provided with an all-zero MAC address, a valid message ID range, and a success result.@n
+ * This test verifies that the AlServiceRegistrationResponse object is correctly initialized when provided with an all-zero MAC address and a success result.@n
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 039@n
@@ -624,22 +571,22 @@ TEST(AlServiceRegistrationResponseTest, ValidMACAddressZeroRangeSuccessResult) {
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data |Expected Result |Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01| Initialize AlServiceRegistrationResponse with all-zero MAC address, valid message ID range, and success result | macAddress = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, range = {1000, 2000}, result = RegistrationResult::SUCCESS | Object should be initialized successfully | Should Pass |
+ * | 01| Initialize AlServiceRegistrationResponse with all-zero MAC address and success result | macAddress = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, result = RegistrationResult::SUCCESS | Object should be initialized successfully | Should Pass |
  *
  */
-TEST(AlServiceRegistrationResponseTest, AllZeroMACAddressValidRangeSuccessResult) {
-    std::cout << "Entering AllZeroMACAddressValidRangeSuccessResult" << std::endl;
+TEST(AlServiceRegistrationResponseTest, AllZeroMACAddressSuccessResult) {
+    std::cout << "Entering AllZeroMACAddressSuccessResult" << std::endl;
     MacAddress macAddress = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     RegistrationResult result = RegistrationResult::SUCCESS;
     AlServiceRegistrationResponse response(macAddress, result);
-    std::cout << "Exiting AllZeroMACAddressValidRangeSuccessResult" << std::endl;
+    std::cout << "Exiting AllZeroMACAddressSuccessResult" << std::endl;
 }
 
 
 /**
- * @brief Test the AlServiceRegistrationResponse constructor with valid MAC address, message ID range, and success result.
+ * @brief Test the AlServiceRegistrationResponse constructor with all FF MAC address and success result.
  *
- * This test verifies that the AlServiceRegistrationResponse object is correctly initialized with a MAC address of all 0xFF, a valid message ID range, and a success result.
+ * This test verifies that the AlServiceRegistrationResponse object is correctly initialized with a MAC address of all 0xFF and a success result.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 040@n
@@ -652,20 +599,20 @@ TEST(AlServiceRegistrationResponseTest, AllZeroMACAddressValidRangeSuccessResult
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Initialize MAC address, message ID range, and result | macAddress = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, range = {1000, 2000}, result = RegistrationResult::SUCCESS | Object should be initialized successfully | Should be successful |
+ * | 01 | Initialize MAC address and result | macAddress = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, result = RegistrationResult::SUCCESS | Object should be initialized successfully | Should be successful |
  */
-TEST(AlServiceRegistrationResponseTest, AllFFMACAddressValidRangeSuccessResult) {
-    std::cout << "Entering AllFFMACAddressValidRangeSuccessResult" << std::endl;
+TEST(AlServiceRegistrationResponseTest, AllFFMACAddressSuccessResult) {
+    std::cout << "Entering AllFFMACAddressSuccessResult" << std::endl;
     MacAddress macAddress = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     RegistrationResult result = RegistrationResult::SUCCESS;
     AlServiceRegistrationResponse response(macAddress, result);
-    std::cout << "Exiting AllFFMACAddressValidRangeSuccessResult" << std::endl;
+    std::cout << "Exiting AllFFMACAddressSuccessResult" << std::endl;
 }
 
 /**
- * @brief Test the AlServiceRegistrationResponse constructor and getters with valid MAC address, valid range, and invalid result.
+ * @brief Test the AlServiceRegistrationResponse constructor and getters with valid MAC address and invalid result.
  *
- * This test verifies that the AlServiceRegistrationResponse object is correctly constructed when provided with a valid MAC address, a valid message ID range, and an invalid registration result.@n
+ * This test verifies that the AlServiceRegistrationResponse object is correctly constructed when provided with a valid MAC address and an invalid registration result.@n
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 041@n
@@ -678,14 +625,14 @@ TEST(AlServiceRegistrationResponseTest, AllFFMACAddressValidRangeSuccessResult) 
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Construct AlServiceRegistrationResponse object and verify MAC address | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, range = {1000, 2000}, result = 0xFF | response.getAlMacAddressLocal() == macAddress | Should Pass |
+ * | 01 | Construct AlServiceRegistrationResponse object and verify MAC address | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, result = 0xFF | response.getAlMacAddressLocal() == macAddress | Should Pass |
  */
-TEST(AlServiceRegistrationResponseTest, ValidMACAddressValidRangeInvalidResult) {
-    std::cout << "Entering ValidMACAddressValidRangeInvalidResult" << std::endl;
+TEST(AlServiceRegistrationResponseTest, ValidMACAddressInvalidResult) {
+    std::cout << "Entering ValidMACAddressInvalidResult" << std::endl;
     MacAddress macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
     RegistrationResult result = static_cast<RegistrationResult>(0xFF);
     AlServiceRegistrationResponse response(macAddress, result);
-    std::cout << "Exiting ValidMACAddressValidRangeInvalidResult" << std::endl;
+    std::cout << "Exiting ValidMACAddressInvalidResult" << std::endl;
 }
 
 /**

--- a/tests/test_l1_al_service_registration_response.cpp
+++ b/tests/test_l1_al_service_registration_response.cpp
@@ -46,7 +46,6 @@ TEST(AlServiceRegistrationResponseTest, DeserializeWithValidData) {
     std::vector<unsigned char> validData = {
         0xAA, 0xBB, 0xCC, 0xDD,
         0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E,
-        0x12, 0x34, 0x56, 0x78,
         0x01
     };
     std::cout << "Entering DeserializeWithValidData test" << std::endl;
@@ -106,8 +105,7 @@ TEST(AlServiceRegistrationResponseTest, DeserializeWithNullData) {
  */
 TEST(AlServiceRegistrationResponseTest, RetrieveAlMacAddressLocalWithValidInput) {
     std::cout << "Entering RetrieveAlMacAddressLocalWithValidInput test" << std::endl;
-	MessageIdRange range(0, 255);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::SUCCESS);
+	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), RegistrationResult::SUCCESS);
     MacAddress result = instance.getAlMacAddressLocal();
 	std::cout << "The result is " << result << std::endl;
     std::cout << "Exiting RetrieveAlMacAddressLocalWithValidInput test" << std::endl;
@@ -136,97 +134,10 @@ TEST(AlServiceRegistrationResponseTest, RetrieveAlMacAddressLocalWithValidInput)
 
 TEST(AlServiceRegistrationResponseTest, RetrieveAlMacAddressLocalWithEmptyInput) {
     std::cout << "Entering RetrieveAlMacAddressLocalWithEmptyInput test" << std::endl;	 
-	MessageIdRange range(0, 255);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:00:00:00:00:00"), range, RegistrationResult::SUCCESS);
+	AlServiceRegistrationResponse instance(parseMacAddress("00:00:00:00:00:00"), RegistrationResult::SUCCESS);
     const MacAddress result = instance.getAlMacAddressLocal();
     std::cout << "The result is " << result << std::endl;
     std::cout << "Exiting RetrieveAlMacAddressLocalWithEmptyInput test" << std::endl;
-}
-
-/**
- * @brief Test the retrieval of message ID range with valid input
- *
- * This test verifies that the getMessageIdRange function of the AlServiceRegistrationResponse class
- * correctly returns the expected result when provided with valid input.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 006@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call the getMessageIdRange function with valid input | validInput = <valid_value> | RETURN_OK | Should Pass |
- * | 02 | Verify the result using ASSERT_EQ | result = RETURN_OK | Assertion should pass | Should be successful |
- */
-TEST(AlServiceRegistrationResponseTest, RetrieveMessageIdRangeWithValidInput) {
-    std::cout << "Entering RetrieveMessageIdRangeWithValidInput test" << std::endl;	
-	MessageIdRange range(0, 255);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::SUCCESS);
-    MessageIdRange result = instance.getMessageIdRange();
-    std::cout << "The result is " << result << std::endl;
-    std::cout << "Exiting RetrieveMessageIdRangeWithValidInput test" << std::endl;
-}
-
-/**
- * @brief Test to verify the behavior of getMessageIdRange with null input
- *
- * This test checks the behavior of the getMessageIdRange method when a null input is provided. It ensures that the method returns the expected error code when given invalid input.
- *
- * **Test Group ID:** Basic: 01@n
- * **Test Case ID:** 007@n
- * **Priority:** High@n
- * @n
- * **Pre-Conditions:** None@n
- * **Dependencies:** None@n
- * **User Interaction:** None@n
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data |Expected Result |Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01| Call getMessageIdRange with null message range input | range(0,0) | result = RETURN_ERR | Should Pass |
- * | 02| Verify the result using ASSERT_EQ | result = RETURN_ERR | None | Should be successful |
- */
-TEST(AlServiceRegistrationResponseTest, RetrieveMessageIdRangeWithNullInput) {
-    std::cout << "Entering RetrieveMessageIdRangeWithNullInput test" << std::endl;
-    MessageIdRange range(0, 0);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::SUCCESS);
-    MessageIdRange result = instance.getMessageIdRange();
-    std::cout << "The result is " << result << std::endl;
-    std::cout << "Exiting RetrieveMessageIdRangeWithNullInput test" << std::endl;
-}
-
-/**
- * @brief Test the retrieval of message ID range with maximum length input
- *
- * This test verifies that the `getMessageIdRange` function of the `AlServiceRegistrationResponse` class
- * correctly handles the maximum length input and returns the expected result.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 009@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call the getMessageIdRange function with maximum length input | maximumLengthInput = <value> | RETURN_OK | Should Pass |
- * | 02 | Verify the result using ASSERT_EQ | result = RETURN_OK | Assertion should pass | Should be successful |
- */
-TEST(AlServiceRegistrationResponseTest, RetrieveMessageIdRangeWithMaximumLengthInput) {
-    std::cout << "Entering RetrieveMessageIdRangeWithMaximumLengthInput test" << std::endl;
-	MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::SUCCESS);
-    MessageIdRange result = instance.getMessageIdRange();
-	std::cout << "The result is " << result << std::endl;
-    std::cout << "Exiting RetrieveMessageIdRangeWithMaximumLengthInput test" << std::endl;
 }
 
 /**
@@ -250,8 +161,7 @@ TEST(AlServiceRegistrationResponseTest, RetrieveMessageIdRangeWithMaximumLengthI
  */
 TEST(AlServiceRegistrationResponseTest, RetrieveResultWhenUnknown) {
     std::cout << "Entering RetrieveResultWhenUnknown test" << std::endl;
-	MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::UNKNOWN);
+	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), RegistrationResult::UNKNOWN);
     ASSERT_EQ(instance.getResult(), RegistrationResult::UNKNOWN);
     std::cout << "Exiting RetrieveResultWhenUnknown test" << std::endl;
 }
@@ -277,37 +187,9 @@ TEST(AlServiceRegistrationResponseTest, RetrieveResultWhenUnknown) {
  */
 TEST(AlServiceRegistrationResponseTest, RetrieveResultWhenSuccess) {
     std::cout << "Entering RetrieveResultWhenSuccess test" << std::endl;
-	MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::SUCCESS);
+	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), RegistrationResult::SUCCESS);
     ASSERT_EQ(instance.getResult(), RegistrationResult::SUCCESS);
     std::cout << "Exiting RetrieveResultWhenSuccess test" << std::endl;
-}
-
-/**
- * @brief Test to verify the result retrieval when no ranges are available
- *
- * This test checks the functionality of the AlServiceRegistrationResponse class to ensure that it correctly retrieves the result when no ranges are available.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 012@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Set the result to NO_RANGES_AVAILABLE | instance->setResult(RegistrationResult::NO_RANGES_AVAILABLE) | None | Should be successful |
- * | 02 | Retrieve the result and check if it matches NO_RANGES_AVAILABLE | instance->getResult() | RegistrationResult::NO_RANGES_AVAILABLE | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, RetrieveResultWhenNoRangesAvailable) {
-    std::cout << "Entering RetrieveResultWhenNoRangesAvailable test" << std::endl;
-    MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::NO_RANGES_AVAILABLE);
-    ASSERT_EQ(instance.getResult(), RegistrationResult::NO_RANGES_AVAILABLE);
-    std::cout << "Exiting RetrieveResultWhenNoRangesAvailable test" << std::endl;
 }
 
 /**
@@ -333,8 +215,7 @@ TEST(AlServiceRegistrationResponseTest, RetrieveResultWhenNoRangesAvailable) {
  */
 TEST(AlServiceRegistrationResponseTest, RetrieveResultWhenServiceNotSupported) {
     std::cout << "Entering RetrieveResultWhenServiceNotSupported test" << std::endl;
-	MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::SERVICE_NOT_SUPPORTED);
+	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), RegistrationResult::SERVICE_NOT_SUPPORTED);
     ASSERT_EQ(instance.getResult(), RegistrationResult::SERVICE_NOT_SUPPORTED);
     std::cout << "Exiting RetrieveResultWhenServiceNotSupported test" << std::endl;
 }
@@ -355,13 +236,12 @@ TEST(AlServiceRegistrationResponseTest, RetrieveResultWhenServiceNotSupported) {
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Set valid parameters using constructor | "00:1A:2B:3C:4D:5E", range(0, 65535), RegistrationResult::NO_RANGES_AVAILABLE | None | Should be successful |
+ * | 01 | Set valid parameters using constructor | "00:1A:2B:3C:4D:5E", RegistrationResult::SUCCESS | None | Should be successful |
  * | 02 | Serialize the registration response | None | serializedData should not be empty | Should Pass |
  */
 TEST(AlServiceRegistrationResponseTest, SerializeValidRegistrationResponse) {
     std::cout << "Entering SerializeValidRegistrationResponse test" << std::endl;
-    MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), range, RegistrationResult::NO_RANGES_AVAILABLE);
+	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), RegistrationResult::SUCCESS);
     std::vector<unsigned char> serializedData = instance.serializeRegistrationResponse();    
     ASSERT_FALSE(serializedData.empty());
     std::cout << "Exiting SerializeValidRegistrationResponse test" << std::endl;
@@ -390,40 +270,10 @@ TEST(AlServiceRegistrationResponseTest, SerializeValidRegistrationResponse) {
  */
 TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithInvalidMacAddress) {
     std::cout << "Entering SerializeRegistrationResponseWithInvalidMac test" << std::endl;
-	MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:00:22:33:34:44"), range, RegistrationResult::SUCCESS);
+	AlServiceRegistrationResponse instance(parseMacAddress("00:00:22:33:34:44"), RegistrationResult::SUCCESS);
     std::vector<unsigned char> serializedData = instance.serializeRegistrationResponse();    
     ASSERT_TRUE(serializedData.empty());
     std::cout << "Exiting SerializeRegistrationResponseWithInvalidMac test" << std::endl;
-}
-
-/**
- * @brief Test the serialization of a registration response with an empty message ID range.
- *
- * This test verifies that the serialization of a registration response with an empty message ID range results in an empty serialized data vector. This is important to ensure that the system correctly handles cases where no message IDs are provided.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 016@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Set a valid MAC address | validMacAddress = "00:11:22:33:44:55", range = (0,0), RegistrationResult::SUCCESS | None | Should be successful |
- * | 02 | Set a successful registration result | valid vector | None | Should be successful |
- * | 03 | Serialize the registration response | None | serializedData.empty() = true | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithEmptyMessageIdRange) {
-    std::cout << "Entering SerializeRegistrationResponseWithEmptyMessageIdRange test" << std::endl;
-	MessageIdRange range(0, 0);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:11:22:33:44:55"), range, RegistrationResult::SUCCESS);   
-    std::vector<unsigned char> serializedData = instance.serializeRegistrationResponse();    
-    ASSERT_TRUE(serializedData.empty());
-    std::cout << "Exiting SerializeRegistrationResponseWithEmptyMessageIdRange test" << std::endl;
 }
 
 /**
@@ -447,8 +297,7 @@ TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithEmptyMe
  */
 TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithFailedResult) {
     std::cout << "Entering SerializeRegistrationResponseWithFailedResult test" << std::endl;
-    MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(parseMacAddress("00:11:22:33:44:55"), range, RegistrationResult::UNKNOWN);
+	AlServiceRegistrationResponse instance(parseMacAddress("00:11:22:33:44:55"), RegistrationResult::UNKNOWN);
     std::vector<unsigned char> serializedData = instance.serializeRegistrationResponse();    
     ASSERT_FALSE(serializedData.empty());
     std::cout << "Exiting SerializeRegistrationResponseWithFailedResult test" << std::endl;
@@ -477,8 +326,7 @@ TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithFailedR
 TEST(AlServiceRegistrationResponseTest, SerializeRegistrationResponseWithAllNullMacAddress) {
     std::cout << "Entering SerializeRegistrationResponseWithAllNullMacAddress test" << std::endl;
 	MacAddress nullMacAddress = {0, 0, 0, 0, 0, 0};
-    MessageIdRange range(0, 65535);
-	AlServiceRegistrationResponse instance(nullMacAddress, range, RegistrationResult::SUCCESS);
+	AlServiceRegistrationResponse instance(nullMacAddress, RegistrationResult::SUCCESS);
     std::vector<unsigned char> serializedData = instance.serializeRegistrationResponse();    
     ASSERT_TRUE(serializedData.empty());
     std::cout << "Exiting SerializeRegistrationResponseWithAllNullMacAddress test" << std::endl;
@@ -611,271 +459,6 @@ TEST(AlServiceRegistrationResponseTest, SetAlMacAddressLocal_InvalidMacAddress_N
 }
 
 /**
- * @brief Test the setMessageIdRange function with a valid range
- *
- * This test verifies that the setMessageIdRange function correctly handles a valid range of message IDs.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 024@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call setMessageIdRange with valid range | start = 1, end = 100 | None | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_ValidRange) {
-    std::cout << "Entering SetMessageIdRange_ValidRange test" << std::endl;
-    MessageIdRange inputRange = {1, 100};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_ValidRange test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function with start greater than end
- *
- * This test verifies the behavior of the setMessageIdRange function when the start value is greater than the end value.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 025@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call setMessageIdRange with start greater than end | start = 100, end = 1 | None | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_StartGreaterThanEnd) {
-    std::cout << "Entering SetMessageIdRange_StartGreaterThanEnd test" << std::endl;
-    MessageIdRange inputRange = {100, 1};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_StartGreaterThanEnd test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function when start is equal to end
- *
- * This test verifies the behavior of the setMessageIdRange function when the start and end values are equal. 
- * It ensures that the function can handle this edge case without errors.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 026@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call setMessageIdRange with start and end equal | start = 50, end = 50 | None | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_StartEqualToEnd) {
-    std::cout << "Entering SetMessageIdRange_StartEqualToEnd test" << std::endl;
-    MessageIdRange inputRange = {50, 50};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_StartEqualToEnd test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function with a start value of zero.
- *
- * This test verifies that the setMessageIdRange function can handle a start value of zero and a valid end value.
- *
- * **Test Group ID:** Basic: 01@n
- * **Test Case ID:** 027@n
- * **Priority:** High@n
- * @n
- * **Pre-Conditions:** None@n
- * **Dependencies:** None@n
- * **User Interaction:** None@n
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call the SetUp function to initialize the test environment | None | None | Done by Pre-requisite SetUp function |
- * | 02 | Call the setMessageIdRange function with start = 0 and end = 100 | start = 0, end = 100 | None | Should Pass |
- * | 03 | Call the TearDown function to clean up the test environment | None | None | Done by Pre-requisite TearDown function |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_StartZero) {
-    std::cout << "Entering SetMessageIdRange_StartZero test" << std::endl;
-    MessageIdRange inputRange = {0, 100};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_StartZero test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function with end value as zero
- *
- * This test verifies the behavior of the setMessageIdRange function when the end value is set to zero. 
- * It ensures that the function handles this edge case correctly without any errors.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 028@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call the setMessageIdRange function with start value 1 and end value 0 | start = 1, end = 0 | Function should handle the input without errors | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_EndZero) {
-    std::cout << "Entering SetMessageIdRange_EndZero test" << std::endl;
-    MessageIdRange inputRange = {1, 0};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_EndZero test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function with both parameters set to zero.
- *
- * This test verifies the behavior of the setMessageIdRange function when both the start and end message IDs are set to zero. This is a boundary test case to ensure that the function can handle the minimum input values correctly.
- *
- * **Test Group ID:** Basic: 01@n
- * **Test Case ID:** 029@n
- * **Priority:** High@n
- * @n
- * **Pre-Conditions:** None@n
- * **Dependencies:** None@n
- * **User Interaction:** None@n
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call the setMessageIdRange function with both parameters set to zero. | start = 0, end = 0 | Function should execute without errors | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_BothZero) {
-    std::cout << "Entering SetMessageIdRange_BothZero test" << std::endl;
-    MessageIdRange inputRange = {0, 0};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_BothZero test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function with a negative start value
- *
- * This test verifies that the setMessageIdRange function can handle a negative start value correctly.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 030@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call setMessageIdRange with start = -1 and end = 100 | start = -1, end = 100 | None | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_NegativeStart) {
-    std::cout << "Entering SetMessageIdRange_NegativeStart test" << std::endl;
-    MessageIdRange inputRange = {-1, 100};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_NegativeStart test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function with a negative end value
- *
- * This test verifies the behavior of the setMessageIdRange function when provided with a negative end value. 
- * It ensures that the function handles this edge case appropriately.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 031@n
- * **Priority:** High
- * 
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * 
- * **Test Procedure:**
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call the setMessageIdRange function with start = 1 and end = -100 | start = 1, end = -100 | Function should handle the negative end value appropriately | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_NegativeEnd) {
-    std::cout << "Entering SetMessageIdRange_NegativeEnd test" << std::endl;
-    MessageIdRange inputRange = {1, -100};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_NegativeEnd test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function with both negative values
- *
- * This test verifies the behavior of the setMessageIdRange function when both input values are negative.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 032@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call setMessageIdRange with both negative values | startId = -1, endId = -100 | None | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_BothNegative) {
-    std::cout << "Entering SetMessageIdRange_BothNegative test" << std::endl;
-    MessageIdRange inputRange = {-1, -100};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_BothNegative test" << std::endl;
-}
-
-/**
- * @brief Test the setMessageIdRange function with large values
- *
- * This test verifies that the setMessageIdRange function can handle large values for the message ID range without any issues.
- *
- * **Test Group ID:** Basic: 01
- * **Test Case ID:** 033@n
- * **Priority:** High
- * @n
- * **Pre-Conditions:** None
- * **Dependencies:** None
- * **User Interaction:** None
- * @n
- * **Test Procedure:**@n
- * | Variation / Step | Description | Test Data | Expected Result | Notes |
- * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call setMessageIdRange with large values | input1 = 1000000, input2 = 2000000 | None | Should Pass |
- */
-TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_LargeValues) {
-    std::cout << "Entering SetMessageIdRange_LargeValues test" << std::endl;
-    MessageIdRange inputRange = {1000000, 2000000};
-    AlServiceRegistrationResponse instance;
-    instance.setMessageIdRange(inputRange);
-    std::cout << "Exiting SetMessageIdRange_LargeValues test" << std::endl;
-}
-
-/**
  * @brief Test the setResult method of AlServiceRegistrationResponse class to set the result to all possible valid values.
  *
  * This test verifies that the setResult method correctly sets the result to each valid RegistrationResult enum value.
@@ -891,16 +474,15 @@ TEST(AlServiceRegistrationResponseTest, SetMessageIdRange_LargeValues) {
  * **Test Procedure:**@n
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Call the setResult method with each value of RegistrationResult enum | RegistrationResult::UNKNOWN, SUCCESS, NO_RANGES_AVAILABLE, SERVICE_NOT_SUPPORTED | Should set the result to each corresponding value | Iterates through all enum values |
+ * | 01 | Call the setResult method with each value of RegistrationResult enum | RegistrationResult::UNKNOWN, SUCCESS, SERVICE_NOT_SUPPORTED | Should set the result to each corresponding value | Iterates through all enum values |
  */
 TEST(AlServiceRegistrationResponseTest, SetAllRegistrationResults) {
     std::cout << "Entering SetAllRegistrationResults test" << std::endl;
     AlServiceRegistrationResponse instance;
     // Define all enum values in an array
-    const std::array<RegistrationResult, 4> allResults = {
+    const std::array<RegistrationResult, 3> allResults = {
         RegistrationResult::UNKNOWN,
         RegistrationResult::SUCCESS,
-        RegistrationResult::NO_RANGES_AVAILABLE,
         RegistrationResult::SERVICE_NOT_SUPPORTED
     };
 
@@ -955,23 +537,20 @@ TEST(AlServiceRegistrationResponseTest, SetAllRegistrationResults) {
  * | Variation / Step | Description | Test Data |Expected Result |Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01| Initialize with SUCCESS result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, range = {1000, 2000}, result = SUCCESS | Object should be created with the values | Should Pass |
- * | 02| Initialize with NO_RANGES_AVAILABLE result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, range = {1000, 2000}, result = NO_RANGES_AVAILABLE | Object should be created with the values | Should Pass |
- * | 03| Initialize with SERVICE_NOT_SUPPORTED result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, range = {1000, 2000}, result = SERVICE_NOT_SUPPORTED | Object should be created with the values | Should Pass |
- * | 04| Initialize with UNKNOWN result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, range = {1000, 2000}, result = UNKNOWN | Object should be created with the values | Should Pass |
+ * | 02| Initialize with SERVICE_NOT_SUPPORTED result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, result = SERVICE_NOT_SUPPORTED | Object should be created with the values | Should Pass |
+ * | 03| Initialize with UNKNOWN result | macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, result = UNKNOWN | Object should be created with the values | Should Pass |
  */
 TEST(AlServiceRegistrationResponseTest, ValidMACAddressValidRangeAllResults) {
     std::cout << "Entering ValidMACAddressValidRangeAllResults" << std::endl;
     MacAddress macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
-    MessageIdRange range = {1000, 2000};
     RegistrationResult results[] = {
         RegistrationResult::SUCCESS,
-        RegistrationResult::NO_RANGES_AVAILABLE,
         RegistrationResult::SERVICE_NOT_SUPPORTED,
         RegistrationResult::UNKNOWN
     };
     for (const auto& result : results) {
         std::cout << "Testing with result: " << static_cast<uint8_t>(result) << std::endl;
-        AlServiceRegistrationResponse response(macAddress, range, result);
+        AlServiceRegistrationResponse response(macAddress, result);
     }
     std::cout << "Exiting ValidMACAddressValidRangeAllResults" << std::endl;
 }
@@ -997,9 +576,8 @@ TEST(AlServiceRegistrationResponseTest, ValidMACAddressValidRangeAllResults) {
 TEST(AlServiceRegistrationResponseTest, ValidMACAddressInvalidRangeSuccessResult) {
     std::cout << "Entering ValidMACAddressInvalidRangeSuccessResult" << std::endl;
     MacAddress macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
-    MessageIdRange range = {2000, 1000};
     RegistrationResult result = RegistrationResult::SUCCESS;
-    AlServiceRegistrationResponse response(macAddress, range, result);
+    AlServiceRegistrationResponse response(macAddress, result);
     std::cout << "Exiting ValidMACAddressInvalidRangeSuccessResult" << std::endl;
 }
 
@@ -1025,9 +603,8 @@ TEST(AlServiceRegistrationResponseTest, ValidMACAddressInvalidRangeSuccessResult
 TEST(AlServiceRegistrationResponseTest, ValidMACAddressZeroRangeSuccessResult) {
     std::cout << "Entering ValidMACAddressZeroRangeSuccessResult" << std::endl;
     MacAddress macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
-    MessageIdRange range = {0, 0};
     RegistrationResult result = RegistrationResult::SUCCESS;
-    AlServiceRegistrationResponse response(macAddress, range, result);
+    AlServiceRegistrationResponse response(macAddress, result);
     std::cout << "Exiting ValidMACAddressZeroRangeSuccessResult" << std::endl;
 }
 
@@ -1053,9 +630,8 @@ TEST(AlServiceRegistrationResponseTest, ValidMACAddressZeroRangeSuccessResult) {
 TEST(AlServiceRegistrationResponseTest, AllZeroMACAddressValidRangeSuccessResult) {
     std::cout << "Entering AllZeroMACAddressValidRangeSuccessResult" << std::endl;
     MacAddress macAddress = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    MessageIdRange range = {1000, 2000};
     RegistrationResult result = RegistrationResult::SUCCESS;
-    AlServiceRegistrationResponse response(macAddress, range, result);
+    AlServiceRegistrationResponse response(macAddress, result);
     std::cout << "Exiting AllZeroMACAddressValidRangeSuccessResult" << std::endl;
 }
 
@@ -1081,9 +657,8 @@ TEST(AlServiceRegistrationResponseTest, AllZeroMACAddressValidRangeSuccessResult
 TEST(AlServiceRegistrationResponseTest, AllFFMACAddressValidRangeSuccessResult) {
     std::cout << "Entering AllFFMACAddressValidRangeSuccessResult" << std::endl;
     MacAddress macAddress = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    MessageIdRange range = {1000, 2000};
     RegistrationResult result = RegistrationResult::SUCCESS;
-    AlServiceRegistrationResponse response(macAddress, range, result);
+    AlServiceRegistrationResponse response(macAddress, result);
     std::cout << "Exiting AllFFMACAddressValidRangeSuccessResult" << std::endl;
 }
 
@@ -1108,9 +683,8 @@ TEST(AlServiceRegistrationResponseTest, AllFFMACAddressValidRangeSuccessResult) 
 TEST(AlServiceRegistrationResponseTest, ValidMACAddressValidRangeInvalidResult) {
     std::cout << "Entering ValidMACAddressValidRangeInvalidResult" << std::endl;
     MacAddress macAddress = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E};
-    MessageIdRange range = {1000, 2000};
     RegistrationResult result = static_cast<RegistrationResult>(0xFF);
-    AlServiceRegistrationResponse response(macAddress, range, result);
+    AlServiceRegistrationResponse response(macAddress, result);
     std::cout << "Exiting ValidMACAddressValidRangeInvalidResult" << std::endl;
 }
 

--- a/tests/test_l1_utils.cpp
+++ b/tests/test_l1_utils.cpp
@@ -47,11 +47,6 @@ std::ostream& operator<<(std::ostream& os, const MacAddress& mac) {
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const MessageIdRange& range) {
-    os << "[" << range.first << ", " << range.second << "]";
-    return os;
-}
-
 std::ostream& operator<<(std::ostream& os, const SAPActivation& op) {
     switch (op) {
         case SAPActivation::SAP_ENABLE:

--- a/tests/test_l1_utils.h
+++ b/tests/test_l1_utils.h
@@ -26,10 +26,8 @@
 #include "al_service_registration_enums.h"
 
 using MacAddress = std::array<uint8_t, 6>;
-using MessageIdRange = std::pair<uint16_t, uint16_t>;
 
 MacAddress parseMacAddress(const std::string& macStr);
 std::ostream& operator<<(std::ostream& os, const MacAddress& mac);
-std::ostream& operator<<(std::ostream& os, const MessageIdRange& range);
 std::ostream& operator<<(std::ostream& os, const SAPActivation& op);
 std::ostream& operator<<(std::ostream& os, const ServiceType& type);


### PR DESCRIPTION
Remove message ID range from service registration response

#### Summary
- Removed `MessageIdRange` from `AlServiceRegistrationResponse` API and storage.
- Updated registration response serialization/deserialization to include only packet size, local AL MAC address, and result.
- Removed `NO_RANGES_AVAILABLE` registration result and shifted `SERVICE_NOT_SUPPORTED` to `0x02`.
- Cleaned up unit tests and test utilities that referenced message ID ranges.

<img width="1442" height="900" alt="Screenshot from 2026-04-28 19-45-02" src="https://github.com/user-attachments/assets/8c0875a3-4aaa-4033-bdf3-50e27e955653" />

**Related PR:** https://github.com/rdkcentral/ieee1905-rs/pull/348