### PR TITLE
RDKBWIFI-385: [Easymesh] Disable ASAN by default for em_ctrl and alig…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,11 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_CONDITIONAL([EM_EXTENDER], [test x$EM_EXTENDER = xtrue])
 # Check for em unittest
 AM_CONDITIONAL([EM_UNITTEST], [test "x$EM_UNITTEST" = "xtrue"])
+# Check for ASAN in em_ctrl
+AM_CONDITIONAL([EM_ASAN_CTRL], [test "x$EM_ASAN_CTRL" = "xtrue"])
+# Check for ASAN in em_agent
+AM_CONDITIONAL([EM_ASAN_AGENT], [test "x$EM_ASAN_AGENT" = "xtrue"])
+
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -33,6 +33,11 @@ onewifi_em_agent_CPPFLAGS = \
     -I$(top_srcdir)/src/util \
     -I$(top_srcdir)/src/util_crypto
 
+onewifi_em_agent_CXXFLAGS = $(INCLUDEDIRS) -g -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fno-omit-frame-pointer #-Wconversion -Werror -O2
+if EM_ASAN_AGENT
+onewifi_em_agent_CXXFLAGS += -fsanitize=address -fsanitize=undefined
+endif
+
 onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/em/em.cpp \
      $(top_srcdir)/src/em/em_mgr.cpp \
@@ -124,6 +129,10 @@ onewifi_em_agent_SOURCES =  \
 
 
 onewifi_em_agent_LDFLAGS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwifi_webconfig -lrbus
+if EM_ASAN_AGENT
+onewifi_em_agent_LDFLAGS += -fsanitize=address -fsanitize=undefined
+endif
+
 onewifi_em_agent_LDADD = $(top_builddir)/src/al-sap/libalsap.la
 if EM_UNITTEST
 onewifi_em_agent_test_SOURCES = \
@@ -171,14 +180,17 @@ onewifi_em_agent_test_SOURCES = \
 	$(top_srcdir)/tests/test_l1_util.cpp \
 	$(top_srcdir)/tests/test_l1_ec_1905_encrypt_layer.cpp \
 	$(top_srcdir)/tests/test_l1_ec_enrollee.cpp \
-        $(top_srcdir)/tests/test_l1_ec_util.cpp \
+	$(top_srcdir)/tests/test_l1_ec_util.cpp \
 	$(top_srcdir)/tests/test_l1_dm_easy_mesh.cpp \
 	$(top_srcdir)/tests/test_l1_ec_pa_configurator.cpp \
 	$(top_srcdir)/tests/test_l1_ec_manager.cpp
+
 onewifi_em_agent_test_CPPFLAGS = $(onewifi_em_agent_CPPFLAGS) \
-	-I$(PKG_CONFIG_SYSROOT_DIR)$(includedir)/gtest \
-	-DTESTING
-onewifi_em_agent_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST
+                                 -I$(PKG_CONFIG_SYSROOT_DIR)$(includedir)/gtest \
+                                 -DTESTING
+onewifi_em_agent_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -fno-omit-frame-pointer
+onewifi_em_agent_test_CXXFLAGS += -fsanitize=address -fsanitize=undefined
 onewifi_em_agent_test_LDFLAGS = -lcjson -lgtest -lgtest_main -lgmock -lpthread -lssl -lcrypto -lm -luuid -ldl -lwifi_webconfig -lrbus
+onewifi_em_agent_test_LDFLAGS += -fsanitize=address -fsanitize=undefined
 onewifi_em_agent_test_LDADD = $(onewifi_em_agent_LDADD)
-endif
+endif  #EM_UNITTEST

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -30,10 +30,12 @@ onewifi_em_ctrl_CPPFLAGS = \
     -I$(top_srcdir)/inc \
     -I$(top_srcdir)/src/utils \
     -I$(top_srcdir)/src/util \
-    -I$(top_srcdir)/src/util_crypto \
-    -DUNIT_TEST
+    -I$(top_srcdir)/src/util_crypto
 
-onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Wconversion -Werror -O2
+onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fno-omit-frame-pointer #-Wconversion -Werror -O2
+if EM_ASAN_CTRL
+onewifi_em_ctrl_CXXFLAGS += -fsanitize=address -fsanitize=undefined
+endif
 
 onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/em/em.cpp \
@@ -142,7 +144,11 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/utils/timer.cpp
  
  
-onewifi_em_ctrl_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lrbus -fsanitize=address -fsanitize=undefined -lmariadb
+onewifi_em_ctrl_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lrbus -lmariadb
+if EM_ASAN_CTRL
+onewifi_em_ctrl_LDFLAGS += -fsanitize=address -fsanitize=undefined
+endif
+
 onewifi_em_ctrl_LDADD = $(top_builddir)/src/al-sap/libalsap.la
 if EM_UNITTEST
 onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
@@ -230,10 +236,13 @@ onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
 	$(top_srcdir)/tests/test_l1_dm_easy_mesh.cpp \
 	$(top_srcdir)/tests/test_l1_ec_pa_configurator.cpp \
 	$(top_srcdir)/tests/test_l1_ec_manager.cpp
+
 onewifi_em_ctrl_test_CPPFLAGS = $(onewifi_em_ctrl_CPPFLAGS) \
                                 -I$(PKG_CONFIG_SYSROOT_DIR)$(includedir)/gtest \
                                 -DTESTING
-onewifi_em_ctrl_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST
-onewifi_em_ctrl_test_LDFLAGS = -lcjson -lgtest -lgtest_main -lgmock -lpthread -lssl -lcrypto -lm -luuid -lssl -lrbus -lmariadb -fsanitize=address -fsanitize=undefined
+onewifi_em_ctrl_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -fno-omit-frame-pointer
+onewifi_em_ctrl_test_CXXFLAGS += -fsanitize=address -fsanitize=undefined
+onewifi_em_ctrl_test_LDFLAGS = -lcjson -lgtest -lgtest_main -lgmock -lpthread -lssl -lcrypto -lm -luuid -lssl -lrbus -lmariadb
+onewifi_em_ctrl_test_LDFLAGS += -fsanitize=address -fsanitize=undefined
 onewifi_em_ctrl_test_LDADD = $(top_builddir)/src/al-sap/libalsap.la $(onewifi_em_ctrl_LDADD)
-endif
+endif  # EM_UNITTEST


### PR DESCRIPTION
…align build flags with em_agent
Reason for change: ASAN significantly increase binary size and memory consumed in run-time, so disable it by default and make ASAN configurable both for controller ```EM_ASAN_CTRL=true``` and for agent ```EM_ASAN_AGENT=true```.
Also:
- added CXXFLAGS to agent similar to controller.
- added ```-fno-omit-frame-pointer``` for both.
- removed `-DUNIT_TEST` from em_ctrl as unused.

Test procedure: controller and agent are able to run, no crashes

Priority: P2
Risk: Low