### PR TITLE
RDKBWIFI-436: [RDK Controller] Update Channel selection request generation on Controller

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -102,8 +102,8 @@ public:
 	unsigned int get_ssid_mismatch_check_time() const { return ssid_mismatch_check_time; }
 	void set_last_topo_query_sent_time(unsigned int time) { last_topo_query_sent_time = time; }
 	unsigned int get_last_topo_query_sent_time() const { return last_topo_query_sent_time; }
-
-	static em_e4_table_t m_e4_table[];
+        static em_e4_table_t m_e4_table[];
+        static const size_t m_e4_table_size;
 
        /**!
         * @brief Retrieves the beacon channel based on center channel and bandwidth.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -182,6 +182,16 @@ extern "C"
 #define EM_CH_PREF_NON_OPERABLE 0x00
 #define EM_CH_PREF_MAX          0x0F
 
+#define CTRL_DEFAULT_CH_PREF    0x01 // Least preferred
+#define AGENT_DEFAULT_CH_PREF   0x0F // Most preferred
+
+/**
+ * Bit shift for preference value (high nibble of preference byte).
+ * Preference bytes store the preference value in bits 7-4.
+ * Use this macro when shifting preference values to/from the high nibble.
+ */
+#define EM_CH_PREF_SHIFT 4
+
 /* Flags indicating whether a channel preference entry
    is considered valid or invalid */
 #define EM_CH_PREF_ENTRY_VALID      0x01

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -205,6 +205,52 @@ public:
 	short create_channel_pref_tlv(unsigned char *buff);
 
 	/**!
+	 * @brief Updates map with non-operable and unsupported channels as per
+	 * Agent's Capability and Channel Preference Report
+	 *
+	 * Marks non-op channels for the operating classes from AP Capability Report with preference 0
+	 * Updates non-operable/operable preference from Preference Report. Preference report
+	 * overrides operable/non-operable preference from AP Capability Report
+	 * Removes unsupported opclasses as per AP Capability Report from the map
+	 *
+	 * @param[in] ruid Radio unique identifier (MAC address)
+	 * @param[in,out] opclass_channel_prefs Map keyed by op-class (outer key = opclass ID).
+	 * Each entry in outer map has an inner map keyed by channel number with preference byte as value
+	 */
+	void update_map_with_agent_capability_preference(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs);
+
+	/**!
+	 * @brief This function updates the map with ctrl anticipated preferences
+	 *
+	 * Create a merged list of anticipated entries for Global, Device and RUID from datamodel
+	 * Assumes, only one entry for an OPCLASS for Global, Device or RUID in the datamodel
+	 * For an OPCLASS, RUID entry overrides the Global/Device ID entry
+	 * Updates the preferences for operable channels in the map with anticipated preferences
+	 *
+	 * @param[in] ruid Radio unique identifier (MAC address)
+	 * @param[in,out] opclass_channel_prefs Map keyed by op-class (outer key = opclass ID).
+	 * Each entry in outer map has an inner map keyed by channel number with preference byte as value
+	 *
+	 * @returns bool
+	 * @retval true if at least one entry was updated with anticipated preference for the RUID
+	 * @retval false otherwise
+	 *
+	 */
+	bool update_map_with_ctrl_anticipated(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs);
+
+	/**!
+	 * @brief This function fills the map with opclass->channel entries from m_e4_table
+	 * with default preference for controller/agent
+	 *
+	 * This function is responsible for filling the map which is keyed by op-class (outer key = opclass ID).
+	 * Each entry in outer map has an inner map keyed by channel number with preference byte as value
+	 * Default preference is CTRL_DEFAULT_CH_PREF / AGENT_DEFAULT_CH_PREF
+	 *
+	 * @param[in,out] opclass_channel_prefs Map to fill with opclass and channel entries
+	 */
+	void fill_map_with_opclass_channel_prefs(std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs);
+
+	/**!
 	 * @brief Creates an operating channel report TLV.
 	 *
 	 * This function generates a TLV (Type-Length-Value) report for the operating channel

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2329,6 +2329,8 @@ em_e4_table_t dm_easy_mesh_t::m_e4_table[] = {
 	{ 137, em_freq_band_6, 320, false, 6, {31, 63, 95, 127, 159, 191} }
 };
 
+const size_t dm_easy_mesh_t::m_e4_table_size = sizeof(dm_easy_mesh_t::m_e4_table) / sizeof(dm_easy_mesh_t::m_e4_table[0]);
+
 int dm_easy_mesh_t::get_beaconchannel_by_bandwidth(int center_channel, int bandwidth)
 {
     switch(bandwidth) {

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -227,22 +227,13 @@ short em_channel_t::create_channel_scan_req_tlv(unsigned char *buff)
 short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
 {
     short len = 0;
-    unsigned int i, j;
     em_channel_pref_t *pref;
     em_channel_pref_op_class_t *pref_op_class;
-    dm_easy_mesh_t *dm;
-    dm_op_class_t *op_class;
     unsigned char *tmp;
     unsigned char pref_bits = 0xee;
     unsigned int num_of_channel = 0;
     em_channels_list_t *channel_list;
 
-    //Stores a merged list of index of Anticipated entries for Global, Device or Radio ID
-    unsigned int merged_anticipated_opclass_idx[EM_MAX_OPCLASS] = {0};
-    bool merged_anticipated_is_ruid_based[EM_MAX_OPCLASS] = {0};
-    unsigned int merged_anticipated_opclass_count = 0;
-
-    dm = get_data_model();
     pref = reinterpret_cast<em_channel_pref_t *> (buff);
     memcpy(pref->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
     pref_op_class = pref->op_classes;
@@ -251,100 +242,61 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
     tmp = reinterpret_cast<unsigned char *> (pref_op_class);
     len += static_cast<short unsigned int> (sizeof(em_channel_pref_t));
 
-    em_printfout("[CHANNEL_SEL] radio %s Creating channel preference TLV\n",
+    em_printfout("[CHANNEL_SEL] radio %s Creating channel preference TLV",
                  util::mac_to_string(pref->ruid).c_str());
 
-    for (i = 0; i < dm->m_num_opclass; i++) {
-        op_class = &dm->m_op_class[i];
+    // Map for opclass with list of channels and their preference
+    std::map<unsigned char, std::map<unsigned char, unsigned char>> opclass_channel_prefs;
 
-        // Only handle anticipated entries for RUID, Device or for Global address for the Radio band
-        if (((op_class->m_op_class_info.id.type == em_op_class_type_anticipated) &&
-            ((memcmp(op_class->m_op_class_info.id.ruid, pref->ruid, sizeof(mac_address_t)) == 0) ||
-            (((memcmp(op_class->m_op_class_info.id.ruid, EM_GLOBAL_MAC_ADDRESS, sizeof(mac_address_t)) == 0) ||
-            (memcmp(op_class->m_op_class_info.id.ruid, dm->get_device()->get_dev_interface_mac(), sizeof(mac_address_t)) == 0)) &&
-            get_band() == dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int>(op_class->m_op_class_info.id.op_class))))) == false) {
-            continue;
-        }
+    // Fill the map with OPCLASS/Channels in E4 table with default preference
+    fill_map_with_opclass_channel_prefs(opclass_channel_prefs);
 
-        // Create a merged list of anticipated entries for Global, Device and RUID
-        // Assumes, only one entry for an OPCLASS for Global, Device or RUID
-        // If entry for same OPCLASS exists for both Global, Device and RUID, RUID is stored in the merged list
-        unsigned char class_num = op_class->m_op_class_info.op_class;
-        bool is_current_entry_ruid_based =
-            (memcmp(op_class->m_op_class_info.id.ruid, pref->ruid, sizeof(mac_address_t)) == 0);
+    // Update the map to remove non-operable opclass/channels reported by the Agent
+    update_map_with_agent_capability_preference(pref->ruid, opclass_channel_prefs);
 
-        // Find current op_class entry in the merged array
-        int merged_idx = -1;
-        for (j = 0; j < merged_anticipated_opclass_count; j++) {
-            if (dm->m_op_class[merged_anticipated_opclass_idx[j]].m_op_class_info.op_class == class_num) {
-                merged_idx = static_cast<int>(j);
-                break;
-            }
-        }
+    // Update map with the anticipated preferences in data model
+    bool anticipated_configured = update_map_with_ctrl_anticipated(pref->ruid, opclass_channel_prefs);
+    if (!anticipated_configured) {
+        em_printfout("[CHANNEL_SEL] no anticipated preferences found for radio %s, sending empty TLV",
+                     util::mac_to_string(pref->ruid).c_str());
 
-        if (merged_idx == -1) {
-            // New op-class entry
-            if (merged_anticipated_opclass_count >= EM_MAX_OPCLASS) {
-                em_printfout("Merged op-classes exceeded limit\n");
-                continue;
-            }
-            merged_anticipated_opclass_idx[merged_anticipated_opclass_count] = i;
-            merged_anticipated_is_ruid_based[merged_anticipated_opclass_count] = is_current_entry_ruid_based;
-            merged_anticipated_opclass_count++;
-            em_printfout("Initializing merged new op-class %d (RUID-based: %d)\n",
-                        class_num, is_current_entry_ruid_based);
-        } else {
-            // Op-class already exists
-            bool existing_is_ruid_based = merged_anticipated_is_ruid_based[merged_idx];
-
-            // Existing is Global MAC-based or Device-based, new is RUID-based so REPLACE existing
-            if (!existing_is_ruid_based && is_current_entry_ruid_based) {
-                em_printfout("Op-class %d: Replacing Global MAC-based with RUID-based entry\n",
-                            class_num);
-                merged_anticipated_opclass_idx[merged_idx] = i;
-                merged_anticipated_is_ruid_based[merged_idx] = true;
-                continue;
-            }
-        }
+        // No anticipated opclasses configured
+        // Send empty TLV with no opclasses
+        return len;
     }
 
-    // Create TLVs from merged anticipated op-classes
-    for (i = 0; i < merged_anticipated_opclass_count; i++) {
-        dm_op_class_t *merged_op_class = &dm->m_op_class[merged_anticipated_opclass_idx[i]];
-        em_op_class_info_t &merged_op = merged_op_class->m_op_class_info;
+    /*
+     * Add Channel preference TLV for each opclass from the map opclass_channel_prefs:
+     * - Consider opclass applicable for the band
+     * - Group channels by pref_byte
+     */
+    for (const auto &oc_pair : opclass_channel_prefs) {
+        unsigned char opclass = oc_pair.first;
+        em_freq_band_t oc_band = dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int>(opclass));
+        if (oc_band != get_band())
+            continue;
 
-        // Get list of Non-operable channels for the RUID OPClass
-        std::vector<unsigned char> non_oper_channels = get_non_operable_channels(
-            merged_op.op_class, merged_op.id.ruid);
-
-        // Group operable channels by preference bits, skip non-operable channels for agent
+        /* Group channels by preference */
         std::map<unsigned char, std::vector<unsigned char>> channels_per_pref;
-
-        for (j = 0; j < merged_op.num_channels; j++) {
-            bool is_anticipated_channel_non_operable_by_agent =
-                std::find(non_oper_channels.begin(),non_oper_channels.end(),
-                          merged_op.channels[j]) != non_oper_channels.end();
-            if (is_anticipated_channel_non_operable_by_agent) {
-                em_printfout("Channel %d in Op-Class %d is marked non-operable by agent, skipping this channel\n",
-                             merged_op.channels[j], merged_op.op_class);
-                continue; // Skip channels non-operable for agent
-            }
-            // Assign the preference value for channels
-            pref_bits = merged_op.channel_pref[j];
-            channels_per_pref[pref_bits].push_back(merged_op.channels[j]);;
+        for (const auto &ch_pair : oc_pair.second) {
+            channels_per_pref[ch_pair.second].push_back(ch_pair.first);
         }
 
         // Create TLV entries for each group of channels with the same preference bits
         for (auto& pair : channels_per_pref) {
             pref_bits = pair.first;
             auto& channels = pair.second;
-            if ((static_cast<unsigned char>(pref_bits) >> 4) >= EM_CH_PREF_MAX) {
-                em_printfout("Preference bits 0x%02x exceed max allowed value, skipping channels in Op-Class %d\n",
-                             pref_bits, merged_op.op_class);
+
+            if (channels.empty())
+                continue;
+
+            if ((static_cast<unsigned char>(pref_bits) >> EM_CH_PREF_SHIFT) >= EM_CH_PREF_MAX) {
+                em_printfout("Preference bits 0x%02x exceed max allowed value, skipping channels in Op-Class %d",
+                             pref_bits, opclass);
                 continue; // Skip if preference bits exceed max allowed value
             }
 
-            pref_op_class->op_class = static_cast<unsigned char>(merged_op.op_class);
+            pref_op_class->op_class = static_cast<unsigned char>(opclass);
             num_of_channel = channels.size();
             channel_list = &pref_op_class->channels;
 
@@ -364,8 +316,191 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
             pref->op_classes_num++;
         }
     }
-
     return len;
+}
+
+// Fill the map with opclass/channel from m_e4_table with default preference
+void em_channel_t::fill_map_with_opclass_channel_prefs(std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs)
+{
+    em_service_type_t service_type = get_service_type();
+    unsigned char default_pref = ((service_type == em_service_type_ctrl) ? CTRL_DEFAULT_CH_PREF : AGENT_DEFAULT_CH_PREF) << EM_CH_PREF_SHIFT;
+
+    opclass_channel_prefs.clear();
+
+    size_t table_sz = dm_easy_mesh_t::m_e4_table_size;
+    for (size_t idx = 0; idx < table_sz; ++idx) {
+        em_e4_table_t *entry = &dm_easy_mesh_t::m_e4_table[idx];
+        unsigned char opclass = static_cast<unsigned char>(entry->op_class);
+        for (int ch = 0; ch < entry->num_channels; ++ch) {
+            unsigned char channel = static_cast<unsigned char>(entry->channels[ch]);
+            // Assign default preference
+            opclass_channel_prefs[opclass][channel] = default_pref;
+        }
+    }
+}
+
+void em_channel_t::update_map_with_agent_capability_preference(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    unsigned int i, j;
+
+    // Mark non-operable channels and add supported operating classes from Agent's Capability Report
+    std::set<unsigned int> supported_opclasses;
+    for (i = 0; i < dm->get_num_op_class(); i++) {
+        dm_op_class_t *op_class = &dm->m_op_class[i];
+        em_op_class_info_t *info = &op_class->m_op_class_info;
+
+        if ((info->id.type == em_op_class_type_capability) &&
+            (memcmp(info->id.ruid, ruid, sizeof(mac_address_t)) == 0)) {
+            unsigned int opclass = info->op_class;
+            supported_opclasses.insert(opclass);
+
+            // Mark non-operable channels in the supported opclass with preference 0
+            for (j = 0; j < info->num_channels; j++) {
+                unsigned int channel = info->channels[j];
+                if (opclass_channel_prefs.find(opclass) != opclass_channel_prefs.end()) {
+                    opclass_channel_prefs[opclass][channel] = EM_CH_PREF_NON_OPERABLE;
+                }
+            }
+        }
+    }
+
+    // Update non-operable/operable preference from Agent's Preference Report
+    for (i = 0; i < dm->get_num_op_class(); i++) {
+
+        dm_op_class_t *op_class = &dm->m_op_class[i];
+        em_op_class_info_t *info = &op_class->m_op_class_info;
+        if ((info->id.type == em_op_class_type_preference) &&
+            (memcmp(info->id.ruid, ruid, sizeof(mac_address_t)) == 0)) {
+
+            for (j = 0; j < info->num_channels; j++) {
+                unsigned char channel = static_cast<unsigned char>(info->channels[j]);
+                unsigned char pref = static_cast<unsigned char> (info->channel_pref[j]);
+                unsigned char pref_value = pref >> EM_CH_PREF_SHIFT;
+
+                // Update preference, it overrides operable/non-operable pref from Capability report
+                pref = pref_value ? (CTRL_DEFAULT_CH_PREF << EM_CH_PREF_SHIFT) : pref;
+                opclass_channel_prefs[static_cast<unsigned char>(info->op_class)][channel] = pref;
+            }
+        }
+    }
+
+    // Remove unsupported opclasses from the map
+    for (auto& oc_pair : opclass_channel_prefs) {
+        unsigned int opclass = oc_pair.first;
+        if (supported_opclasses.find(opclass) == supported_opclasses.end()) {
+            // Opclass not present in AP Capability Report.
+            opclass_channel_prefs.erase(opclass);
+            break;
+        }
+    }
+}
+
+bool em_channel_t::update_map_with_ctrl_anticipated(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs)
+{
+    unsigned int i, j;
+    bool anticipated_config_updated = false;
+
+    if (ruid == NULL)
+        return false;
+
+    dm_easy_mesh_t *dm = get_data_model();
+    if (!dm)
+        return false;
+
+    // Create a merged list of indexes of Anticipated entries for Global/Device or Radio ID
+    unsigned int merged_anticipated_opclass_idx[EM_MAX_OPCLASS] = {0};
+    bool merged_anticipated_is_ruid_based[EM_MAX_OPCLASS] = {0};
+    unsigned int merged_anticipated_opclass_count = 0;
+
+    for (i = 0; i < dm->m_num_opclass; ++i) {
+        dm_op_class_t *dm_opclass = &dm->m_op_class[i];
+        em_op_class_info_t &info = dm_opclass->m_op_class_info;
+
+        // Only handle anticipated entries for RUID, Device or for Global address for the Radio band
+        if (((info.id.type == em_op_class_type_anticipated) &&
+             ((memcmp(info.id.ruid, ruid, sizeof(mac_address_t)) == 0) ||
+             (((memcmp(info.id.ruid, EM_GLOBAL_MAC_ADDRESS, sizeof(mac_address_t)) == 0) ||
+             (memcmp(info.id.ruid, dm->get_device()->get_dev_interface_mac(), sizeof(mac_address_t)) == 0)) &&
+             (get_band() == dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int>(info.op_class)))))) == false) {
+             continue;
+        }
+
+        // Create a merged list of anticipated entries for Global, Device and RUID
+        // Assumes, only one entry for an OPCLASS for Global, Device or RUID
+        // If entry for same OPCLASS exists for both Global/Device and RUID, RUID is stored in the merged list
+        unsigned char class_num = info.op_class;
+        bool is_current_entry_ruid_based =
+            (memcmp(info.id.ruid, ruid, sizeof(mac_address_t)) == 0);
+
+        // Find current op_class entry in the merged array
+        int merged_idx = -1;
+        for (j = 0; j < merged_anticipated_opclass_count; j++) {
+            if (dm->m_op_class[merged_anticipated_opclass_idx[j]].m_op_class_info.op_class == class_num) {
+                merged_idx = static_cast<int>(j);
+                break;
+            }
+        }
+
+        if (merged_idx == -1) {
+            // New op-class entry
+            if (merged_anticipated_opclass_count >= EM_MAX_OPCLASS) {
+                em_printfout("Merged op-classes exceeded limit");
+                continue;
+            }
+            merged_anticipated_opclass_idx[merged_anticipated_opclass_count] = i;
+            merged_anticipated_is_ruid_based[merged_anticipated_opclass_count] = is_current_entry_ruid_based;
+            merged_anticipated_opclass_count++;
+            em_printfout("Adding op-class %d (RUID-based: %d) to merged list",
+                        class_num, is_current_entry_ruid_based);
+        } else {
+            // Op-class already exists
+            bool existing_is_ruid_based = merged_anticipated_is_ruid_based[merged_idx];
+
+            // Existing is Global MAC-based or Device-based, new is RUID-based so REPLACE existing
+            if (!existing_is_ruid_based && is_current_entry_ruid_based) {
+                em_printfout("Op-class %d: Replacing Global MAC-based with RUID-based entry",
+                            class_num);
+                merged_anticipated_opclass_idx[merged_idx] = i;
+                merged_anticipated_is_ruid_based[merged_idx] = true;
+                continue;
+            }
+        }
+    }
+
+    // Update the map with preferences from merged list
+    for (i = 0; i < merged_anticipated_opclass_count; i++) {
+
+        dm_op_class_t *dm_opclass = &dm->m_op_class[merged_anticipated_opclass_idx[i]];
+        em_op_class_info_t &info = dm_opclass->m_op_class_info;
+
+        // Opclass shall be present in map if supported by agent
+        unsigned char opclass = static_cast<unsigned char>(info.op_class);
+        if (opclass_channel_prefs.find(opclass) == opclass_channel_prefs.end()) {
+            em_printfout("Unsupported anticipated entry for opclass %u", opclass);
+            continue;
+        }
+
+        for (unsigned int ch_idx = 0; ch_idx < info.num_channels; ++ch_idx) {
+            unsigned char channel = static_cast<unsigned char>(info.channels[ch_idx]);
+            unsigned char pref_byte = info.channel_pref[ch_idx];
+
+            // Update if channel entry exists and pref is non-zero
+            if (opclass_channel_prefs[opclass].find(channel) == opclass_channel_prefs[opclass].end()) {
+                em_printfout("Unsupported anticipated entry for opclass %u ch %u", opclass, channel);
+                continue;
+            }
+
+            if ((opclass_channel_prefs[opclass][channel] >> EM_CH_PREF_SHIFT) != 0) {
+                unsigned char before = opclass_channel_prefs[opclass][channel];
+                opclass_channel_prefs[opclass][channel] = pref_byte;
+                em_printfout("Updated anticipated preference for opclass %u ch %u pref: 0x%02x -> 0x%02x",
+                            opclass, channel, before, pref_byte);
+                anticipated_config_updated = true;
+            }
+        }
+    }
+    return anticipated_config_updated;
 }
 
 std::vector<unsigned char> em_channel_t::get_non_operable_channels(unsigned char op_class, const unsigned char *ruid)


### PR DESCRIPTION
Update generation of Channel Selection Request on controller to include OPCLASS/Channels as per E4 table
       -- Create a map which includes all opclass->channel with default preference as per E4 Table
	-- Update the preference in the map for non-operable channels reported by agent in Capability and Preference report
	-- Remove unsupported opclasses from the map as per the capability report
        -- Create a merged list of anticipated entries in datamodel for Global, Device and RUID
        -- Update preferences in the map from anticipated entries

Building the message
        -- Add Channel preference TLV for each opclass from the map grouped by preference

Initial tests: Channel change is working fine with PRPL Agent on all radio bands to set different channels in an opclass