### PR TITLE
RDKBWIFI-426: Trigger orchestration immediately on command queueing to improve responsiveness

### DIFF
--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -853,6 +853,15 @@ public:
 	em_service_type_t get_service_type() { return em_service_type_agent; }
     
 	/**!
+	 * @brief Get the orchestration instance.
+	 *
+	 * This function returns a pointer to the orchestration instance.
+	 *
+	 * @return em_orch_t* Pointer to the orchestration instance.
+	 */
+	em_orch_t *get_orch() override { return m_orch; }
+
+	/**!
 	 * @brief Finds the EM for a given message type.
 	 *
 	 * This function searches for the EM (Event Manager) associated with a specific message type

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2188,6 +2188,7 @@ typedef enum {
     em_event_type_bus,
     em_event_type_nb,
     em_event_type_cmd,
+    em_event_type_orch,
 
     em_event_type_max
 } em_event_type_t;

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -71,6 +71,13 @@ public:
 
 	dm_easy_mesh_ctrl_t *get_dm_ctrl() { return &m_data_model; }
 
+    /**!
+     * @brief Get the orchestration instance.
+     *
+     * This function returns a pointer to the orchestration instance.
+     *
+     * @return em_orch_t* Pointer to the orchestration instance.
+     */
 	em_orch_t *get_orch() override { return m_orch; }
     
 	/**!

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -548,7 +548,15 @@ int em_mgr_t::start()
                     continue;
                 }
                 pthread_mutex_unlock(&m_queue.lock);
-                if (((evt->type == em_event_type_bus) && ((evt->u.bevt.type == em_bus_event_type_reset) ||
+                if (evt->type == em_event_type_orch) {
+                    if (is_data_model_initialized() == true && started == true) {
+                        // Immediately process orchestration queue for the event
+                        em_orch_t *orch = get_orch();
+                        if (orch != nullptr) {
+                            orch->handle_timeout();
+                        }
+                    }
+                } else if (((evt->type == em_event_type_bus) && ((evt->u.bevt.type == em_bus_event_type_reset) ||
                       (evt->u.bevt.type == em_bus_event_type_get_reset))) ||
 						(is_data_model_initialized() == true)) {
 

--- a/src/orch/em_orch.cpp
+++ b/src/orch/em_orch.cpp
@@ -141,6 +141,15 @@ bool em_orch_t::submit_command(em_cmd_t *pcmd)
     } else {
         queue_push(m_pending, pcmd);
         push_stats(pcmd);
+        // trigger orchestration event to process the command
+        em_event_t *evt = static_cast<em_event_t *>(malloc(sizeof(em_event_t)));
+        if (evt == nullptr) {
+            em_printfout("Failed to allocate memory for orchestration event");
+            // Command is queued for processing, count not submit event
+        } else {
+            evt->type = em_event_type_orch;
+            m_mgr->push_to_queue(evt);
+        }
         submitted = true;
     }
 


### PR DESCRIPTION

Changes to trigger orchestration event on queuing a command for immediate processing
- Added em_event_type_orch to event enumeration
- Updated em_mgr_t::start() to call the orchestration handler on event
- Updated em_orch_t::submit_command() to trigger orchestration event on queuing command

This ensures commands are processed with minimal latency, improving orchestration responsiveness.