### PR TITLE
RDKBWIFI-428: easy-mesh: add radio supported standards vendor TLV support

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -100,6 +100,7 @@ public:
 
     char* get_ht_caps_str(em_ap_ht_cap_t *ht, char *buf, size_t buf_len);
     char* get_vht_caps_str(em_ap_vht_cap_t *vht, char *buf, size_t buf_len);
+    char* get_supported_standards_str(wifi_ieee80211Variant_t variant, char *buf, size_t buf_size);
     bus_error_t rcaps_get(char* event_name, raw_data_t* p_data);
     static bus_error_t rcaps_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t rcaps_tget_inner(dm_easy_mesh_t *dm, const char *root, bus_data_prop_t **property);

--- a/inc/em.h
+++ b/inc/em.h
@@ -843,7 +843,7 @@ public:
 	 * @note Ensure that the buffer is properly allocated before calling this function.
 	 */
 	short create_ht_tlv(unsigned char *buff);
-    
+
 	/**!
 	 * @brief Creates a VHT TLV (Very High Throughput Tag Length Value) structure.
 	 *
@@ -1074,6 +1074,21 @@ public:
 	cJSON *create_bss_dpp_response_obj(const em_bss_info_t *bss_info, bool is_sta_response, bool tear_down_bss, dm_easy_mesh_t *data_model = NULL);
 
 	// END: DPP Callbacks for BSS information
+
+	/**
+	 * @brief Creates Airties radio capability vendor TLV.
+	 *
+	 * Builds a vendor-specific TLV containing radio capability information
+	 * (supported 802.11 standards) using Airties OUI and TLV ID.
+	 *
+	 * @param buff Output buffer for TLV data.
+	 *
+	 * @return TLV length in bytes, or 0 if radio capability is unavailable.
+	 *
+	 * @note Uses network byte order for multi-byte fields.
+	 */
+
+	short create_airties_radio_capability_tlv(unsigned char *buff);
 
 	int handle_wifi6_cap_tlv(unsigned char *buff);
 	int handle_wifi7_agent_cap_tlv(unsigned char *buff);

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -687,6 +687,10 @@ typedef enum {
 } em_tlv_type_t;
 
 typedef enum {
+    em_tlv_type_radio_capability = 0x0013,
+} em_vendor_airties_tlv_type_t;
+
+typedef enum {
     em_channel_pref_reason_unspecified = 0x00,
     em_channel_pref_reason_proximate_non_80211_interferer = 0x01,
     em_channel_pref_reason_intra_network_obss_interference_mgmt = 0x02,
@@ -1557,6 +1561,17 @@ typedef struct {
     unsigned char num;
     em_vendor_data_t  data[0];
 } __attribute__((__packed__)) em_vendor_specific_t;
+
+typedef struct {
+    unsigned char  vendor_oui[3];
+    unsigned char  data[0];
+} __attribute__((__packed__)) em_vendor_specific_v_t;
+
+typedef struct {
+    mac_address_t interface_mac;
+    unsigned char supported_standards[2];
+    unsigned char reserved[2];
+}__attribute__((__packed__)) em_radio_capability_vendor_t;
 
 typedef struct {
     unsigned char  destination;    
@@ -2652,6 +2667,7 @@ typedef struct {
 
 typedef struct {
     em_interface_t  ruid;
+    wifi_ieee80211Variant_t mode;
     em_ap_ht_cap_t  ht_cap;
     em_ap_vht_cap_t vht_cap;
     em_ap_he_cap_t  he_cap;
@@ -3472,6 +3488,8 @@ static const SecurityTypeMap securityTypeMap[] = {
     { "WPA3 Personal",   EM_AUTH_WPA3_PERSONAL },
     { "WPA3 Transition", EM_AUTH_WPA3_TRANSITION }
 };
+
+static const unsigned char airties_vendor_oui[EM_VENDOR_OUI_SIZE] = {0x88, 0x41, 0xfc};
 
 #ifndef SSL_KEY
 #if OPENSSL_VERSION_NUMBER < 0x30000000L

--- a/inc/em_capability.h
+++ b/inc/em_capability.h
@@ -275,8 +275,8 @@ class em_capability_t {
 	 *
 	 * @note This is a pure virtual function and must be implemented by derived classes.
 	 */
+
 	virtual short create_ht_tlv(unsigned char *buff) = 0;
-    
 	/**!
 	 * @brief Creates a VHT TLV.
 	 *
@@ -321,6 +321,21 @@ class em_capability_t {
 	 * @note This is a pure virtual function and must be implemented by derived classes.
 	 */
 	virtual short create_wifi6_tlv(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates Airties radio capability vendor TLV.
+	 *
+	 * Builds a vendor-specific TLV containing radio capability information
+	 * (supported 802.11 standards) using Airties OUI and TLV ID.
+	 *
+	 * @param buff Output buffer for TLV data.
+	 *
+	 * @return TLV length in bytes, or 0 if radio capability is unavailable.
+	 *
+	 * @note This is a pure virtual function and must be implemented by derived classes.
+	 */
+
+	virtual short create_airties_radio_capability_tlv(unsigned char *buff) = 0;
 
 	virtual int handle_wifi6_cap_tlv(unsigned char *buff) = 0;
 	virtual int handle_wifi7_agent_cap_tlv(unsigned char *buff) = 0;

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -100,6 +100,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define MAX_TIME_STRLEN         24
 #define MAX_ZONE_STRLEN         8
 #define MAX_TIMESTAMP_STRLEN    64
+#define MAX_STDLEN              64
 #define ARRAY_SIZE(a)           (sizeof(a) / sizeof(a[0]))
 
 /* Device.WiFi.DataElements.Network */
@@ -216,6 +217,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_RADIO_BSSNOE         DE_DEVICE_RADIO         "BSSNumberOfEntries"
 #define DE_RADIO_NOUNASSCSTA    DE_DEVICE_RADIO         "UnassociatedSTANumberOfEntries"
 #define DE_RADIO_CHSCANREQ      DE_DEVICE_RADIO         "ChannelScanRequest()"
+#define DE_RADIO_XAIRTIES_OPERSTANDARDS DE_DEVICE_RADIO "X_AIRTIES_OperatingStandards"
 /* Device.WiFi.DataElements.Network.Device.Radio.BackhaulSta */
 #define DE_RADIO_BHSTA          DE_DEVICE_RADIO         "BackhaulSta."
 #define DE_BHSTA_MACADDR        DE_RADIO_BHSTA          "MACAddress"

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -4701,6 +4701,38 @@ char* dm_easy_mesh_ctrl_t::get_vht_caps_str(em_ap_vht_cap_t *vht, char *buf, siz
     return buf;
 }
 
+char* dm_easy_mesh_ctrl_t::get_supported_standards_str(wifi_ieee80211Variant_t variant, char *buf, size_t buf_size)
+{
+    if (!buf || buf_size == 0)
+        return nullptr;
+
+    buf[0] = '\0';
+    size_t len = 0;
+
+    auto append = [&](const char* s) {
+        size_t slen = strlen(s);
+        size_t needed = (len == 0) ? slen : (slen + 1);
+        if (len + needed + 1 > buf_size) return;
+        if (len != 0) {
+            buf[len++] = ',';
+        }
+        memcpy(buf + len, s, slen);
+        len += slen;
+        buf[len] = '\0';
+    };
+
+    if (variant & WIFI_80211_VARIANT_A)  append("a");
+    if (variant & WIFI_80211_VARIANT_B)  append("b");
+    if (variant & WIFI_80211_VARIANT_G)  append("g");
+    if (variant & WIFI_80211_VARIANT_N)  append("n");
+    if (variant & WIFI_80211_VARIANT_AC) append("ac");
+    if (variant & WIFI_80211_VARIANT_AX) append("ax");
+    if (variant & WIFI_80211_VARIANT_BE) append("be");
+    if (variant & WIFI_80211_VARIANT_BN) append("bn");
+
+    return buf;
+}
+
 bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     (void) user_data;
@@ -4755,7 +4787,7 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p
     } else if (strcmp(param, "Noise") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, static_cast<unsigned int> (ri->noise));
     } else if (strcmp(param, "Utilization") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, ri->utilization);
+        rc = dm_ctrl->raw_data_set(p_data, static_cast<unsigned int> (ri->utilization));
     } else if (strcmp(param, "Transmit") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, 0U);
     } else if (strcmp(param, "ReceiveSelf") == 0) {
@@ -4818,6 +4850,7 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_params(dm_easy_mesh_t *dm, const cha
 {
     char path[512];
     char caps_str[MAX_CAPS_STR_LEN] = { 0 };
+    char supported_standards[MAX_STDLEN] = { 0 };
     bus_error_t rc = bus_error_success;
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
 
@@ -4837,7 +4870,7 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_params(dm_easy_mesh_t *dm, const cha
 #endif
         dm_ctrl->property_append_tail(property, root, idx, "Enabled", ri->enabled);
         dm_ctrl->property_append_tail(property, root, idx, "Noise", static_cast<unsigned int> (ri->noise));
-        dm_ctrl->property_append_tail(property, root, idx, "Utilization", ri->utilization);
+        dm_ctrl->property_append_tail(property, root, idx, "Utilization", static_cast<unsigned int> (ri->utilization));
         dm_ctrl->property_append_tail(property, root, idx, "Transmit", 0U);
         dm_ctrl->property_append_tail(property, root, idx, "ReceiveSelf", 0U);
         dm_ctrl->property_append_tail(property, root, idx, "ReceiveOther", 0U);
@@ -4860,6 +4893,8 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_params(dm_easy_mesh_t *dm, const cha
         dm_radio_cap_t *radio_cap = dm->get_radio_cap(ri->id.ruid);
         if (radio_cap != NULL) {
             em_radio_cap_info_t *rci = radio_cap->get_radio_cap_info();
+            dm_ctrl->get_supported_standards_str(rci->mode, supported_standards, sizeof(supported_standards));
+            dm_ctrl->property_append_tail(property, root, idx, "X_AIRTIES_OperatingStandards", supported_standards);
             dm_ctrl->get_ht_caps_str(&rci->ht_cap, caps_str, sizeof(caps_str));
             dm_ctrl->property_append_tail(property, root, idx, "Capabilities.HTCapabilities", caps_str);
             dm_ctrl->get_vht_caps_str(&rci->vht_cap, caps_str, sizeof(caps_str));
@@ -4951,6 +4986,7 @@ bus_error_t dm_easy_mesh_ctrl_t::rcaps_get_inner(char *event_name, raw_data_t *p
     const char *param;
     char caps_str[MAX_CAPS_STR_LEN] = { 0 };
     char instance[MAX_INSTANCE_LEN] = { 0 };
+    char supported_standards[MAX_STDLEN] = { 0 };
     bool is_num;
     int radio_instance = 0;
     bus_error_t rc;
@@ -5001,6 +5037,9 @@ bus_error_t dm_easy_mesh_ctrl_t::rcaps_get_inner(char *event_name, raw_data_t *p
         rc = dm_ctrl->raw_data_set(p_data, caps_str);
     } else if (strcmp(param, "CapableOperatingClassProfileNumberOfEntries") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, 0U);
+    } else if (strcmp(param, "X_AIRTIES_OperatingStandards") == 0) {
+        dm_ctrl->get_supported_standards_str(rci->mode, supported_standards, sizeof(supported_standards));
+        rc = dm_ctrl->raw_data_set(p_data, supported_standards);
     } else {
         em_printfout("Invalid param: %s", param);
         rc = bus_error_invalid_input;

--- a/src/ctrl/tr_181/wfa_data_model/Data_Elements_JSON_Schema_v3.0.json
+++ b/src/ctrl/tr_181/wfa_data_model/Data_Elements_JSON_Schema_v3.0.json
@@ -3059,6 +3059,12 @@
                                             "type": "integer",
                                             "minimum": -127,
                                             "maximum": 127
+                                        },
+                                        "X_AIRTIES_OperatingStandards": {
+                                            "type": "string",
+                                            "description": "List of 802.11 standards in operation for this radio instance",
+                                            "enum": ["a", "b", "g", "n", "ac", "ax", "be", "bn"]
+                                        }
                                         }
                                     }
                                 }

--- a/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
@@ -135,6 +135,7 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_RADIO_CHIPVENDOR,       CALLBACK_GETTER(radio_get)),
         ELEMENT(DE_RADIO_CURROPNOE,        CALLBACK_GETTER(radio_get)),
         ELEMENT(DE_RADIO_BSSNOE,           CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_XAIRTIES_OPERSTANDARDS, CALLBACK_GETTER(rcaps_get)),
         ELEMENT(DE_RCAPS_HTCAPS,           CALLBACK_GETTER(rcaps_get)),
         ELEMENT(DE_RCAPS_VHTCAPS,          CALLBACK_GETTER(rcaps_get)),
         ELEMENT(DE_RCAPS_CAPOPNOE,         CALLBACK_GETTER(rcaps_get)),

--- a/src/dm/dm_radio_cap.cpp
+++ b/src/dm/dm_radio_cap.cpp
@@ -91,6 +91,7 @@ bool dm_radio_cap_t::operator == (const dm_radio_cap_t& obj)
     ret += (memcmp(&this->m_radio_cap_info.vht_cap,&obj.m_radio_cap_info.vht_cap,sizeof(em_ap_vht_cap_t)) != 0);
     ret += (memcmp(&this->m_radio_cap_info.he_cap,&obj.m_radio_cap_info.he_cap,sizeof(em_ap_he_cap_t)) != 0);
     ret += !(this->m_radio_cap_info.num_op_classes == obj.m_radio_cap_info.num_op_classes);
+    ret += !(this->m_radio_cap_info.mode == obj.m_radio_cap_info.mode);
     ret += (memcmp(&this->m_radio_cap_info.wifi6_cap,&obj.m_radio_cap_info.wifi6_cap,sizeof(em_radio_wifi6_cap_data_t)) != 0);
     ret += (memcmp(&this->m_radio_cap_info.wifi7_cap,&obj.m_radio_cap_info.wifi7_cap,sizeof(em_wifi7_agent_cap_t)) != 0);
     ret += (memcmp(&this->m_radio_cap_info.ch_scan,&obj.m_radio_cap_info.ch_scan,sizeof(em_channel_scan_cap_radio_t)) != 0);
@@ -124,6 +125,7 @@ void dm_radio_cap_t::operator = (const dm_radio_cap_t& obj)
     memcpy(&this->m_radio_cap_info.cac_cap,&obj.m_radio_cap_info.cac_cap,sizeof(em_cac_cap_radio_t));
     memcpy(&this->m_radio_cap_info.metric_interval,&obj.m_radio_cap_info.metric_interval,sizeof(em_metric_cltn_interval_t));
     this->m_radio_cap_info.num_op_classes = obj.m_radio_cap_info.num_op_classes;
+    this->m_radio_cap_info.mode = obj.m_radio_cap_info.mode;
 
 }
 

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -161,6 +161,14 @@ int em_capability_t::send_ap_cap_report_msg(unsigned char *dst, unsigned short m
         tmp += (sizeof(em_tlv_t) + sz);
         len += static_cast<unsigned int>(sizeof(em_tlv_t) + sz);
 
+        // Airties Radio Capability TLV
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_vendor_specific;
+        sz = static_cast<unsigned short>(em->create_airties_radio_capability_tlv(tlv->value));
+        tlv->len = htons(static_cast<uint16_t>(sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
+        len += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
+
         em->set_state(em_state_agent_ap_cap_report);
     }
     em_radios.clear();
@@ -1181,6 +1189,21 @@ int em_capability_t::handle_eht_operations_tlv(unsigned char *buff)
     return 0;
 }
 
+
+static wifi_ieee80211Variant_t airties_standards_to_variant(uint16_t std) {
+
+    wifi_ieee80211Variant_t variant = static_cast<wifi_ieee80211Variant_t>(0);
+    if (std & (1 << 15)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_A);
+    if (std & (1 << 14)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_B);
+    if (std & (1 << 13)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_G);
+    if (std & (1 << 12)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_N);
+    if (std & (1 << 11)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_AC);
+    if (std & (1 << 10)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_AX);
+    if (std & (1 <<  9)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_BE);
+    if (std & (1 <<  8)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_BN);
+    return variant;
+}
+
 int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
 {
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
@@ -1375,8 +1398,45 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
 
                 adv += sizeof(em_ap_radio_advanced_cap_t);
             }
-        }
+        } else if (tlv->type == em_tlv_type_vendor_specific) {
+            em_vendor_specific_v_t *vendor_tlv = reinterpret_cast<em_vendor_specific_v_t *> (tlv->value);
+            uint16_t value_len = ntohs(tlv->len);
+            dm_easy_mesh_t  *dm;
+            dm = get_data_model();
 
+            if (memcmp(vendor_tlv->vendor_oui, airties_vendor_oui, sizeof(airties_vendor_oui)) == 0) {
+                uint16_t tlv_id;
+                memcpy(&tlv_id, vendor_tlv->data, sizeof(tlv_id));
+                tlv_id = ntohs(tlv_id);
+                if (tlv_id == em_tlv_type_radio_capability) {
+                    if (value_len < sizeof(em_radio_capability_vendor_t) + sizeof(tlv_id) + sizeof(em_vendor_specific_v_t)) {
+                        em_printfout("Invalid TLV length for em_radio_capability_vendor_t");
+                        return -1;
+                    }
+                    em_printfout("Received Radio Capability TLV");
+                    em_radio_capability_vendor_t radio_capability;
+                    memcpy(&radio_capability, vendor_tlv->data + sizeof(tlv_id), sizeof(em_radio_capability_vendor_t));
+                    mac_address_t mac;
+                    memcpy(mac, radio_capability.interface_mac, sizeof(mac_address_t));
+                    uint16_t supported_standards;
+                    memcpy(&supported_standards,
+                           radio_capability.supported_standards,
+                           sizeof(supported_standards));
+                    supported_standards = ntohs(supported_standards);
+
+                    dm_radio_cap_t *radio_cap = dm->get_radio_cap(mac);
+                    if (radio_cap) {
+                        em_radio_cap_info_t *cap_info = radio_cap->get_radio_cap_info();
+                        if (cap_info) {
+                            cap_info->mode = airties_standards_to_variant(supported_standards);
+                        }
+                    }
+                    em_printfout("Parsed Radio Capability TLV - MAC:%s standards:0x%04x",
+                                 util::mac_to_string(mac).c_str(),
+                                 supported_standards);
+                }
+            }
+        }
         tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
         tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
     }

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1161,6 +1161,61 @@ short em_t::create_ht_tlv(unsigned char *buff)
     return len;
 }
 
+static uint16_t variant_to_airties_standards(wifi_ieee80211Variant_t current_variant)
+{
+    uint16_t std = 0;
+
+    if (current_variant & WIFI_80211_VARIANT_A)  std |= (1 << 15);
+    if (current_variant & WIFI_80211_VARIANT_B)  std |= (1 << 14);
+    if (current_variant & WIFI_80211_VARIANT_G)  std |= (1 << 13);
+    if (current_variant & WIFI_80211_VARIANT_N)  std |= (1 << 12);
+    if (current_variant & WIFI_80211_VARIANT_AC) std |= (1 << 11);
+    if (current_variant & WIFI_80211_VARIANT_AX) std |= (1 << 10);
+    if (current_variant & WIFI_80211_VARIANT_BE) std |= (1 << 9);
+    if (current_variant & WIFI_80211_VARIANT_BN) std |= (1 << 8);
+
+    return std;
+}
+
+short em_t::create_airties_radio_capability_tlv(unsigned char *buff)
+{
+    short len = 0;
+    dm_easy_mesh_t  *dm;
+    dm = get_data_model();
+    dm_radio_cap_t *radio_cap = dm->get_radio_cap(get_radio_interface_mac());
+
+    if (radio_cap == NULL) {
+        em_printfout("radio_cap NULL for MAC %s",
+                     util::mac_to_string(get_radio_interface_mac()).c_str());
+        return 0;
+    } else {
+        em_radio_cap_info_t* cap_info = radio_cap->get_radio_cap_info();
+        if (cap_info == NULL) {
+            em_printfout("No data Found");
+            return 0;
+        }
+        uint16_t supported_standards = htons(variant_to_airties_standards(cap_info->mode));
+        em_vendor_specific_v_t *vendor = reinterpret_cast<em_vendor_specific_v_t *>(buff);
+        if (vendor == NULL) {
+            em_printfout("No data Found");
+            return 0;
+        }
+        memcpy(reinterpret_cast<unsigned char *> (vendor->vendor_oui), airties_vendor_oui, EM_VENDOR_OUI_SIZE);
+        len += EM_VENDOR_OUI_SIZE;
+        uint16_t tlv_type = htons(static_cast<uint16_t>(em_tlv_type_radio_capability));
+        memcpy(reinterpret_cast<unsigned char *> (vendor->data), &tlv_type, sizeof(tlv_type));
+        len += static_cast<short>(sizeof(tlv_type));
+        em_radio_capability_vendor_t *tmp = reinterpret_cast<em_radio_capability_vendor_t *> (vendor->data + sizeof(tlv_type));
+        memcpy(tmp->interface_mac, get_radio_interface_mac(), sizeof(mac_address_t));
+        len += static_cast<short>(sizeof(mac_address_t));
+        memcpy(tmp->supported_standards, &supported_standards, sizeof(supported_standards));
+        len += static_cast<short>(sizeof(supported_standards));
+        len += 2; //reserved
+    }
+    return len;
+}
+
+
 short em_t::create_vht_tlv(unsigned char *buff)
 {
     short len = 0;


### PR DESCRIPTION
Introduce Airties vendor-specific TLV to report supported IEEE 802.11 standards per radio interface within EasyMesh capability reporting.

This change adds:
- New supported standards bitmask representation (a/b/g/n/ac/ax/be/bn)
- Conversion logic from internal WiFi variant flags to TLV format
- Airties vendor-specific TLV creation and parsing logic
- Data model exposure via X_AIRTIES_OperatingStandards parameter
- JSON schema and TR-181 mapping updates
- EasyMesh controller propagation for radio capability updates

The supported standards are now included in AP capability reports and processed by controllers using a vendor OUI-based TLV extension.

Issue: RDKBWIFI-428