### PR TITLE
RDKBWIFI-430: Update build.yml container with ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
             container: 'ubuntu:20.04'
             setup-cmd: 'apt-get update && apt-get install -y libssl1.1 libssl-dev'
           - openssl-version: '3.0'
-            container: 'ubuntu:latest'
+            container: 'ubuntu:20.04'
             setup-cmd: 'apt-get update && apt-get install -y libssl-dev'
       # Add this to continue jobs even if one matrix job fails
       fail-fast: false


### PR DESCRIPTION
build check fails because github updated ubuntu:latest  
Updating the .github/workflows/build.yml as suggested in PR 671 (https://github.com/rdkcentral/unified-wifi-mesh/pull/671)

- container: 'ubuntu:latest'
+ container: 'ubuntu:24.04' #'ubuntu:latest'
