### PR TITLE
RDKBWIFI-438: Fixing warnings in em_agent

### DIFF
--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -481,14 +481,14 @@ typedef struct {
 } __attribute__((packed)) gtk_1905_kde_t;
 
 // Used to avoid many many if-not-null checks
-#define ASSERT_MSG_FALSE(x, ret, errMsg, ...) \
+#define ASSERT_MSG_FALSE(x, ret, ...) \
     if(x) { \
-        fprintf(stderr, errMsg, ## __VA_ARGS__); \
+        fprintf(stderr, __VA_ARGS__); \
         return ret; \
     }
 
-#define ASSERT_MSG_TRUE(x, ret, errMsg, ...) ASSERT_MSG_FALSE(!(x), ret, errMsg, ## __VA_ARGS__)
-#define ASSERT_NOT_NULL(x, ret, errMsg, ...) ASSERT_MSG_FALSE(x == NULL, ret, errMsg, ## __VA_ARGS__)
+#define ASSERT_MSG_TRUE(x, ret, ...) ASSERT_MSG_FALSE(!(x), ret, __VA_ARGS__)
+#define ASSERT_NOT_NULL(x, ret, ...) ASSERT_MSG_FALSE(x == NULL, ret, __VA_ARGS__)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 3 pointers and returns a value
@@ -497,13 +497,12 @@ typedef struct {
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
  * @param ptr3 Third pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+#define ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, ...) \
     do { \
         if(x == NULL) { \
-            fprintf(stderr, errMsg, ## __VA_ARGS__); \
+            fprintf(stderr, __VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
             void *_tmp3 = (ptr3); \
@@ -523,19 +522,19 @@ typedef struct {
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 2 pointers and returns a value
  */
-#define ASSERT_NOT_NULL_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
-    ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+#define ASSERT_NOT_NULL_FREE2(x, ret, ptr1, ptr2, ...) \
+    ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees one pointer and returns a value
  */
-#define ASSERT_NOT_NULL_FREE(x, ret, ptr1, errMsg, ...) \
-    ASSERT_NOT_NULL_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+#define ASSERT_NOT_NULL_FREE(x, ret, ptr1, ...) \
+    ASSERT_NOT_NULL_FREE2(x, ret, ptr1, NULL, __VA_ARGS__)
 
 
-#define ASSERT_NULL(x, ret, errMsg, ...) ASSERT_MSG_TRUE(x == 0, ret, errMsg, ## __VA_ARGS__)
-#define ASSERT_EQUALS(x, y, ret, errMsg, ...) ASSERT_MSG_TRUE(x == y, ret, errMsg, ## __VA_ARGS__)
-#define ASSERT_NOT_EQUALS(x, y, ret, errMsg, ...) ASSERT_MSG_FALSE(x == y, ret, errMsg, ## __VA_ARGS__)
+#define ASSERT_NULL(x, ret, ...) ASSERT_MSG_TRUE(x == 0, ret, __VA_ARGS__)
+#define ASSERT_EQUALS(x, y, ret, ...) ASSERT_MSG_TRUE(x == y, ret, __VA_ARGS__)
+#define ASSERT_NOT_EQUALS(x, y, ret, ...) ASSERT_MSG_FALSE(x == y, ret, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and if it doesn't, frees up to 3 pointers and returns a value
@@ -544,13 +543,12 @@ typedef struct {
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
  * @param ptr3 Third pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+#define ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, ...) \
     do { \
         if(!x.has_value()) { \
-            fprintf(stderr, errMsg, ## __VA_ARGS__); \
+            fprintf(stderr, __VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
             void *_tmp3 = (ptr3); \
@@ -573,31 +571,28 @@ typedef struct {
  * @param ret The value to return if x is nullopt
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
-    ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+#define ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, ...) \
+    ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and if it doesn't, frees a pointer and returns a value
  * @param x The std::optional to check for a value
  * @param ret The value to return if x is nullopt
  * @param ptr1 First pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, errMsg, ...) \
-    ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+#define ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, ...) \
+    ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and returns a value if it doesn't
  * @param x The std::optional to check for a value
  * @param ret The value to return if x is nullopt
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_OPT_HAS_VALUE(x, ret, errMsg, ...) ASSERT_MSG_TRUE(x.has_value(), ret, errMsg, ## __VA_ARGS__)
+#define ASSERT_OPT_HAS_VALUE(x, ret, ...) ASSERT_MSG_TRUE(x.has_value(), ret, __VA_ARGS__)
 
 #ifndef SSL_KEY
 #if OPENSSL_VERSION_NUMBER < 0x30000000L

--- a/inc/util.h
+++ b/inc/util.h
@@ -360,22 +360,22 @@ namespace util {
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
-#define em_printf(format, ...)  util::em_util_print(EM_LOG_LVL_INFO, EM_AGENT, __func__, __LINE__, format, ##__VA_ARGS__)// general log
-#define em_printfout(format, ...)  util::em_util_print(EM_LOG_LVL_INFO, EM_STDOUT, __FILENAME__, __LINE__, format, ##__VA_ARGS__)// general log
-#define em_util_dbg_print(module, format, ...)  util::em_util_print(EM_LOG_LVL_DEBUG, module, __func__, __LINE__, format, ##__VA_ARGS__)
-#define em_util_info_print(module, format, ...)  util::em_util_print(EM_LOG_LVL_INFO, module, __func__, __LINE__, format, ##__VA_ARGS__)
-#define em_util_error_print(module, format, ...)  util::em_util_print(EM_LOG_LVL_ERROR, module, __func__, __LINE__, format, ##__VA_ARGS__)
+#define em_printf(...)  util::em_util_print(EM_LOG_LVL_INFO, EM_AGENT, __func__, __LINE__, __VA_ARGS__)// general log
+#define em_printfout(...)  util::em_util_print(EM_LOG_LVL_INFO, EM_STDOUT, __FILENAME__, __LINE__, __VA_ARGS__)// general log
+#define em_util_dbg_print(module, ...)  util::em_util_print(EM_LOG_LVL_DEBUG, module, __func__, __LINE__, __VA_ARGS__)
+#define em_util_info_print(module, ...)  util::em_util_print(EM_LOG_LVL_INFO, module, __func__, __LINE__, __VA_ARGS__)
+#define em_util_error_print(module, ...)  util::em_util_print(EM_LOG_LVL_ERROR, module, __func__, __LINE__, __VA_ARGS__)
 
 
 // Used to avoid many many if-not-null checks
-#define EM_ASSERT_MSG_FALSE(x, ret, errMsg, ...) \
+#define EM_ASSERT_MSG_FALSE(x, ret, ...) \
     if(x) { \
-        em_printfout(errMsg, ## __VA_ARGS__); \
+        em_printfout(__VA_ARGS__); \
         return ret; \
     }
 
-#define EM_ASSERT_MSG_TRUE(x, ret, errMsg, ...) EM_ASSERT_MSG_FALSE(!(x), ret, errMsg, ## __VA_ARGS__)
-#define EM_ASSERT_NOT_NULL(x, ret, errMsg, ...) EM_ASSERT_MSG_FALSE(x == NULL, ret, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_MSG_TRUE(x, ret, ...) EM_ASSERT_MSG_FALSE(!(x), ret, __VA_ARGS__)
+#define EM_ASSERT_NOT_NULL(x, ret, ...) EM_ASSERT_MSG_FALSE(x == NULL, ret, __VA_ARGS__)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 3 pointers and returns a value
@@ -384,13 +384,12 @@ namespace util {
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
  * @param ptr3 Third pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+#define EM_ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, ...) \
     do { \
         if(x == NULL) { \
-            em_printfout(errMsg, ## __VA_ARGS__); \
+            em_printfout(__VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
             void *_tmp3 = (ptr3); \
@@ -410,19 +409,19 @@ namespace util {
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 2 pointers and returns a value
  */
-#define EM_ASSERT_NOT_NULL_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
-    EM_ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_NOT_NULL_FREE2(x, ret, ptr1, ptr2, ...) \
+    EM_ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees one pointer and returns a value
  */
-#define EM_ASSERT_NOT_NULL_FREE(x, ret, ptr1, errMsg, ...) \
-    EM_ASSERT_NOT_NULL_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_NOT_NULL_FREE(x, ret, ptr1, ...) \
+    EM_ASSERT_NOT_NULL_FREE2(x, ret, ptr1, NULL, __VA_ARGS__)
 
 
-#define EM_ASSERT_NULL(x, ret, errMsg, ...) EM_ASSERT_MSG_TRUE(x == 0, ret, errMsg, ## __VA_ARGS__)
-#define EM_ASSERT_EQUALS(x, y, ret, errMsg, ...) EM_ASSERT_MSG_TRUE(x == y, ret, errMsg, ## __VA_ARGS__)
-#define EM_ASSERT_NOT_EQUALS(x, y, ret, errMsg, ...) EM_ASSERT_MSG_FALSE(x == y, ret, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_NULL(x, ret, ...) EM_ASSERT_MSG_TRUE(x == 0, ret, __VA_ARGS__)
+#define EM_ASSERT_EQUALS(x, y, ret, ...) EM_ASSERT_MSG_TRUE(x == y, ret, __VA_ARGS__)
+#define EM_ASSERT_NOT_EQUALS(x, y, ret, ...) EM_ASSERT_MSG_FALSE(x == y, ret, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and if it doesn't, frees up to 3 pointers and returns a value
@@ -431,13 +430,12 @@ namespace util {
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
  * @param ptr3 Third pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+#define EM_ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, ...) \
     do { \
         if(!x.has_value()) { \
-            em_printfout(errMsg, ## __VA_ARGS__); \
+            em_printfout(__VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
             void *_tmp3 = (ptr3); \
@@ -460,30 +458,27 @@ namespace util {
  * @param ret The value to return if x is nullopt
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
-    EM_ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, ...) \
+    EM_ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and if it doesn't, frees a pointer and returns a value
  * @param x The std::optional to check for a value
  * @param ret The value to return if x is nullopt
  * @param ptr1 First pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, errMsg, ...) \
-    EM_ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, ...) \
+    EM_ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and returns a value if it doesn't
  * @param x The std::optional to check for a value
  * @param ret The value to return if x is nullopt
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_OPT_HAS_VALUE(x, ret, errMsg, ...) EM_ASSERT_MSG_TRUE(x.has_value(), ret, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_OPT_HAS_VALUE(x, ret, ...) EM_ASSERT_MSG_TRUE(x.has_value(), ret, __VA_ARGS__)
 
 #endif

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -88,10 +88,10 @@ int dm_easy_mesh_agent_t::analyze_dev_init(em_bus_event_t *evt, em_cmd_t *pcmd[]
     pcmd[num] = new em_cmd_dev_init_t(evt->params, dm);
     tmp = pcmd[num];
 
-    for (int i = 0; i < pcmd[num]->m_data_model.m_num_radios; i++) {
-        em_printfout("dm num_role:%d for radio[%d]:%s\n", dm.get_radio_cap_info(i)->wifi6_cap.num_role,
+    for (int i = 0; i < static_cast<int>(pcmd[num]->m_data_model.m_num_radios); i++) {
+        em_printfout("dm num_role:%u for radio[%d]:%s\n", dm.get_radio_cap_info(i)->wifi6_cap.num_role,
                 i, util::mac_to_string(dm.get_radio_cap_info(i)->ruid.mac).c_str());
-        em_printfout("num_role:%d\n", pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi6_cap.num_role);
+        em_printfout("num_role:%u\n", pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi6_cap.num_role);
         // em_printfout("su_beam:%d\n", pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi6_cap.su_beam_former);
         em_printfout("wifi 7 rad mac:%s\n", util::mac_to_string(pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi7_cap.mlo_cap_support.ruid).c_str());
         em_printfout("he cap rad mac:%s\n", util::mac_to_string(pcmd[num]->m_data_model.get_radio_cap_info(i)->he_cap.ruid).c_str());
@@ -114,13 +114,10 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
     em_cmd_t *tmp = NULL;
     em_long_string_t key;
     mac_addr_str_t radio_str;
-    em_cmd_params_t *evt_param = NULL;
     mac_addr_str_t  sta_mac_str, bss_mac_str, radio_mac_str;
 
     num_radios = get_num_radios();
     dm.init();
-
-    evt_param = &evt->params;
 
     num_radios = m_num_radios;
     for (unsigned int i = 0; i < m_num_radios; i++) {
@@ -136,9 +133,9 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
         webconfig_subdoc_type_associated_clients, "Assoc clients");
 
     for ( i = 0; i < num_radios; i++) {
-        evt_param->u.args.num_args = 1;
+        evt->params.u.args.num_args = 1;
         dm_easy_mesh_t::macbytes_to_string(get_radio_by_ref(i).get_radio_interface_mac(), radio_str);
-        strncpy(evt_param->u.args.args[0], radio_str, strlen(radio_str) + 1);
+        snprintf(evt->params.u.args.args[0], sizeof(evt->params.u.args.args[0]), "%s", radio_str);
 
         pcmd[num] = new em_cmd_sta_list_t(evt->params, dm);
 
@@ -272,11 +269,11 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
     unsigned int j = 0, index = 0;
     dm_easy_mesh_agent_t  dm;
     em_cmd_t *tmp;
-	mac_addr_str_t mac_str;
-	em_commit_target_t cm_config;
-	dm_radio_t *radio;
-	em_freq_band_t freq_band;
-	const char *json_data = reinterpret_cast<char *> (evt->u.raw_buff);
+    mac_addr_str_t mac_str;
+    em_commit_target_t cm_config;
+    dm_radio_t *radio;
+    em_freq_band_t freq_band = em_freq_band_unknown;
+    const char *json_data = reinterpret_cast<char *> (evt->u.raw_buff);
 
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
@@ -328,6 +325,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
 				memcpy(dm.get_bss(index)->get_bss_info()->ruid.mac, radio->get_radio_interface_mac(), sizeof(mac_address_t));
 			}
 		}
+		cJSON_Delete(json);
 	}
 	dm_easy_mesh_t::macbytes_to_string(dm.get_bss(index)->get_bss_info()->ruid.mac, mac_str);
 	em_printfout("%s in owconfig", mac_str);
@@ -392,7 +390,6 @@ int dm_easy_mesh_agent_t::analyze_channel_pref_query(em_bus_event_t *evt, em_cmd
 {
     int num = 0;
     dm_easy_mesh_agent_t  dm;
-    em_radio_info_t *radio;
     em_bus_event_type_channel_pref_query_params_t *params;
     
     params = reinterpret_cast<em_bus_event_type_channel_pref_query_params_t *> (evt->u.raw_buff);
@@ -407,10 +404,9 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
 {
     unsigned int i = 0, j = 0, noofopclass = 0;
     op_class_channel_sel *channel_sel;
-    em_op_class_info_t *dm_op_class;
+    em_op_class_info_t *dm_op_class = nullptr;
     em_tx_power_limit_t *tx_power_limit;
     em_spatial_reuse_req_t *spatial_reuse_req;
-    em_eht_operations_t *eht_ops;
     bool found_mesh_sta = false;
     em_bss_info_t *bss_info;
     dm_radio_t* radio = NULL;
@@ -420,7 +416,9 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     em_printfout("No of opclass=%d tx=%d", channel_sel->num, channel_sel->tx_power.tx_power_eirp);
     tx_power_limit =  const_cast<em_tx_power_limit_t*> (&channel_sel->tx_power);
     spatial_reuse_req =  const_cast<em_spatial_reuse_req_t*> (&channel_sel->spatial_reuse_req);
-    eht_ops =  const_cast<em_eht_operations_t*> (&channel_sel->eht_ops);
+#ifdef REL_6_FEATURE
+    em_eht_operations_t *eht_ops = const_cast<em_eht_operations_t*> (&channel_sel->eht_ops);
+#endif
 
     if (channel_sel->num == 0) {
         // UNEXPECTED: Channel Selection Request will have atleast one OPCLASS in Channel Preference TLV
@@ -494,7 +492,7 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     // Ensure highest preference is non-zero to update current channel
     if (highest_anticipated_preference > 0) {
 	//Get beacon channel for the preferred opclass/channel
-        most_preferred_channel = dm_easy_mesh_t::get_beaconchannel_by_opclass(most_preferred_opclass, most_preferred_channel);
+        most_preferred_channel = static_cast<unsigned int>(dm_easy_mesh_t::get_beaconchannel_by_opclass(static_cast<int>(most_preferred_opclass), static_cast<int>(most_preferred_channel)));
         // Update the most preferred channel/opclass in the datamodel
         for (i = 0; i < noofopclass; i++) {
             dm_op_class = this->get_op_class_info(i);
@@ -622,12 +620,13 @@ int dm_easy_mesh_agent_t::analyze_csa_beacon_frame(em_bus_event_t *evt, wifi_bus
 
     bool found_mesh_sta = false;
     bool csa_found = false;
-    int i, j, ie_len;
+    int ie_len;
+    unsigned int i = 0, j = 0;
     uint8_t tag_number, tag_length;
     uint8_t switch_mode = 0, new_channel = 0, switch_count = 0;
 
     em_bss_info_t *mesh_sta_bss, *bss_info;
-    em_op_class_info_t *op_class_info, *info;
+    em_op_class_info_t *op_class_info = nullptr, *info = nullptr;
     dm_radio_t *radio;
     em_freq_band_t freq_band;
 
@@ -760,7 +759,11 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
 
     len = sizeof(ieeeframe->u.action.category) + sizeof(ieeeframe->u.action.u.bss_tm_req) \
         + sizeof(em_80211_neighbor_report_t);
-    aframe = static_cast<action_frame_params_t *> (malloc(sizeof(action_frame_params_t) + len));
+    aframe = static_cast<action_frame_params_t *> (malloc(sizeof(action_frame_params_t) + static_cast<size_t>(len)));
+    if (aframe == NULL) {
+        printf("%s:%d Failed to allocate action frame\n", __func__, __LINE__);
+        return -1;
+    }
     // Point ieeeframe to aframe->frame_data
     ieeeframe = reinterpret_cast<struct ieee80211_mgmt *> (aframe->frame_data);
 
@@ -784,7 +787,7 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
     ieeeframe->u.action.u.bss_tm_req.validity_interval = 0;
 
     // Copy the variable part
-    em_80211_btm_req_var_t *bss_list = (em_80211_btm_req_var_t *)&ieeeframe->u.action.u.bss_tm_req.variable;
+    em_80211_btm_req_var_t *bss_list = reinterpret_cast<em_80211_btm_req_var_t *>(&ieeeframe->u.action.u.bss_tm_req.variable);
     bss_list->bss_transition_cand_list[0].elem_id = 52;
     bss_list->bss_transition_cand_list[0].length = 13;
     memcpy(bss_list->bss_transition_cand_list[0].bssid, steer_req->target_bssids, sizeof(bssid_t));
@@ -801,21 +804,23 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
     aframe->frequency = 2412;
     aframe->ap_index = 0;
     //here sendng only the btm_req union to onewifi as header is dealt internally
-    aframe->frame_len = len;
-    memcpy(aframe->frame_data, &ieeeframe->u.action, len);
+    aframe->frame_len = static_cast<unsigned int>(len);
+    memcpy(aframe->frame_data, &ieeeframe->u.action, static_cast<size_t>(len));
 
     l_bus_data.data_type = bus_data_type_bytes;
-    l_bus_data.raw_data.bytes = (void *)aframe;
-    l_bus_data.raw_data_len = len + sizeof(action_frame_params_t);
+    l_bus_data.raw_data.bytes = static_cast<void *>(aframe);
+    l_bus_data.raw_data_len = static_cast<size_t>(len) + sizeof(action_frame_params_t);
 
     if (desc->bus_set_fn(bus_hdl, "Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx", &l_bus_data)== 0) {
         printf("%s:%d Frame subdoc send successfull\n",__func__, __LINE__);
     }
     else {
         printf("%s:%d Frame subdoc send fail\n",__func__, __LINE__);
+        free(aframe);
         return -1;
     }
 
+    free(aframe);
     return 1;
 }
 
@@ -824,11 +829,8 @@ int dm_easy_mesh_agent_t::analyze_btm_response_action_frame(em_bus_event_t *evt,
     //TODO: if callback would give for multiple entries or one by one
     dm_easy_mesh_agent_t  dm;
     em_cmd_t *tmp;
-    em_cmd_params_t *evt_param;
     int num = 0;
-    em_steering_btm_rprt_t btm;
-    mac_addr_str_t mac_str;
-    struct ieee80211_mgmt *btm_frame = (struct ieee80211_mgmt *)&evt->u.raw_buff;
+    struct ieee80211_mgmt *btm_frame = reinterpret_cast<struct ieee80211_mgmt *>(&evt->u.raw_buff);
 
     em_cmd_btm_report_params_t  btm_report_param;
     memcpy(btm_report_param.source, btm_frame->bssid, sizeof(mac_addr_t));
@@ -873,22 +875,25 @@ int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcm
         return 0;
     }
 
-    json = cJSON_Parse((const char *)evt->u.raw_buff);
+    json = cJSON_Parse(reinterpret_cast<const char *>(evt->u.raw_buff));
+    if (json == NULL) {
+        printf("%s:%d Unable to parse scan result JSON\n", __func__, __LINE__);
+        return 0;
+    }
     scanner_mac_obj = cJSON_GetObjectItemCaseSensitive(json, "ScannerMac");
     if ((scanner_mac_obj == NULL) || (cJSON_IsString(scanner_mac_obj) == false) || (scanner_mac_obj->valuestring == NULL) ) {
         printf("%s:%d Unable to find scanner mac\n", __func__, __LINE__);
+        cJSON_Delete(json);
         return 0;
     }
 
-    if ((webconfig_easymesh_decode(&config, (char *)evt->u.raw_buff, &ext, &type)) == webconfig_error_none) {
+    if ((webconfig_easymesh_decode(&config, reinterpret_cast<char *>(evt->u.raw_buff), &ext, &type)) == webconfig_error_none) {
         printf("%s:%d scanner mac: %s - analyze_scan_result subdoc decode success\n",__func__, __LINE__, scanner_mac_obj->valuestring);
     } else {
         printf("%s:%d scanner mac: %s - analyze_scan_result subdoc decode fail\n",__func__, __LINE__, scanner_mac_obj->valuestring);
     }
 
-    em_cmd_params_t *evt_param = NULL;
-    evt_param = &evt->params;
-    dm_easy_mesh_t::string_to_macbytes(scanner_mac_obj->valuestring, evt_param->u.scan_params.ruid);
+    dm_easy_mesh_t::string_to_macbytes(scanner_mac_obj->valuestring, evt->params.u.scan_params.ruid);
 
     pcmd[num] = new em_cmd_scan_result_t(evt->params, dm);
     tmp = pcmd[num];
@@ -899,12 +904,13 @@ int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcm
         num++;
     }
 
-    return num;  
+    cJSON_Delete(json);
+    return static_cast<int>(num);
 }
 
 int dm_easy_mesh_agent_t::analyze_set_policy(em_bus_event_t *evt, wifi_bus_desc_t *desc, bus_handle_t *bus_hdl)
 {
-    em_policy_cfg_params_t *policy_cfg = (em_policy_cfg_params_t *)evt->u.raw_buff;
+    em_policy_cfg_params_t *policy_cfg = reinterpret_cast<em_policy_cfg_params_t *>(evt->u.raw_buff);
 
     return refresh_onewifi_subdoc(desc, bus_hdl, "Policy", webconfig_subdoc_type_em_config, NULL, policy_cfg);
 }
@@ -913,36 +919,32 @@ int dm_easy_mesh_agent_t::analyze_beacon_report(em_bus_event_t *evt, em_cmd_t *p
 {
     dm_sta_t *sta = NULL;
     em_cmd_t *tmp = NULL;
-    em_cmd_params_t *evt_param = NULL;
     dm_easy_mesh_agent_t  dm;
-    unsigned int num = 0, num_radios = 0;
+    unsigned int num = 0;
     mac_addr_str_t macstr;
 
     dm.init();
 
-    evt_param = &evt->params;
-
-    num_radios = m_num_radios;
     for (unsigned int i = 0; i < m_num_radios; i++) {
-        memcpy(&dm.m_radio[i], &m_radio[i], sizeof(dm_radio_t));
+        dm.m_radio[i] = m_radio[i];
     }
 
     dm.m_num_bss = m_num_bss;
     for (unsigned int i = 0; i < EM_MAX_BSSS; i++) {
-        memcpy(&dm.m_bss[i], &m_bss[i], sizeof(dm_bss_t));
+        dm.m_bss[i] = m_bss[i];
     }
 
-    dm.translate_and_decode_onewifi_subdoc((char *)evt->u.raw_buff, webconfig_subdoc_type_beacon_report, "Beacon Report");
+    dm.translate_and_decode_onewifi_subdoc(reinterpret_cast<char *>(evt->u.raw_buff), webconfig_subdoc_type_beacon_report, "Beacon Report");
 
-    sta = (dm_sta_t *)hash_map_get_first((hash_map_t *)dm.m_sta_map);
+    sta = static_cast<dm_sta_t *>(hash_map_get_first(dm.m_sta_map));
     if (sta != NULL) {
-        evt_param->u.args.num_args = 2;
+        evt->params.u.args.num_args = 2;
 
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, macstr);
-        strncpy(evt_param->u.args.args[0], macstr, strlen(macstr) + 1);
+        snprintf(evt->params.u.args.args[0], sizeof(evt->params.u.args.args[0]), "%s", macstr);
 
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, macstr);
-        strncpy(evt_param->u.args.args[1], macstr, strlen(macstr) + 1);
+        snprintf(evt->params.u.args.args[1], sizeof(evt->params.u.args.args[1]), "%s", macstr);
     }
 
     pcmd[num] = new em_cmd_beacon_report_t(evt->params, dm);
@@ -955,24 +957,27 @@ int dm_easy_mesh_agent_t::analyze_beacon_report(em_bus_event_t *evt, em_cmd_t *p
         num++;
     }
 
-    return num;
+    return static_cast<int>(num);
 }
 
 int dm_easy_mesh_agent_t::analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     em_cmd_t *tmp = NULL;
-    em_cmd_params_t *evt_param = NULL;
     unsigned int num = 0;
-    mac_addr_str_t macstr;
-    cJSON *json, *emap_metrics_report, *param_obj, *arr_obj;
-    int radio_index = 0;
+    cJSON *json, *emap_metrics_report, *param_obj;
+    unsigned int radio_index = 0;
     
-    translate_and_decode_onewifi_subdoc((char *)evt->u.raw_buff, webconfig_subdoc_type_em_ap_metrics_report, "AP Metrics Report");
+    translate_and_decode_onewifi_subdoc(reinterpret_cast<char *>(evt->u.raw_buff), webconfig_subdoc_type_em_ap_metrics_report, "AP Metrics Report");
 
-    json = cJSON_Parse((const char *)evt->u.raw_buff);
+    json = cJSON_Parse(reinterpret_cast<const char *>(evt->u.raw_buff));
+    if (json == NULL) {
+        em_printfout("Failed to parse AP metrics report JSON");
+        return 0;
+    }
     emap_metrics_report = cJSON_GetObjectItem(json, "EMAPMetricsReport");
     if (emap_metrics_report == NULL || !cJSON_IsArray(emap_metrics_report)) {
         em_printfout("Invalid or missing EMAPMetricsReport");
+        cJSON_Delete(json);
         return 0;
     }
 
@@ -980,37 +985,38 @@ int dm_easy_mesh_agent_t::analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_
         cJSON *arr_obj = cJSON_GetArrayItem(emap_metrics_report, i);
         if (arr_obj == NULL) {
             em_printfout("Invalid EMAPMetricsReport object at index %d\n", i);
+            cJSON_Delete(json);
             return 0;
         }
 
         param_obj = cJSON_GetObjectItemCaseSensitive(arr_obj, "Radio Index");
         if ((param_obj == NULL) || (cJSON_IsNumber(param_obj) == false) ) {
             em_printfout("Unable to find scanner mac");
+            cJSON_Delete(json);
             return 0;
         }
 
-        radio_index = param_obj->valueint;
-        evt_param = &evt->params;
-        memcpy(evt_param->u.ap_metrics_params.ruid[i], get_radio_by_ref(radio_index).get_radio_interface_mac(), sizeof(mac_addr_t));
+        radio_index = static_cast<unsigned int>(param_obj->valueint);
+        memcpy(evt->params.u.ap_metrics_params.ruid[i], get_radio_by_ref(radio_index).get_radio_interface_mac(), sizeof(mac_addr_t));
     }
-    evt_param->u.ap_metrics_params.num_radios = cJSON_GetArraySize(emap_metrics_report);
+    evt->params.u.ap_metrics_params.num_radios = cJSON_GetArraySize(emap_metrics_report);
 
-    if (strstr((const char *)evt->u.raw_buff, "Associated STA Traffic Stats") != NULL) {
-        evt_param->u.ap_metrics_params.sta_traffic_stats_include = true;
+    if (strstr(reinterpret_cast<const char *>(evt->u.raw_buff), "Associated STA Traffic Stats") != NULL) {
+        evt->params.u.ap_metrics_params.sta_traffic_stats_include = true;
     } else {
-        evt_param->u.ap_metrics_params.sta_traffic_stats_include = false;
-    }
-
-    if (strstr((const char *)evt->u.raw_buff, "Associated STA Link Metrics Report") != NULL) {
-        evt_param->u.ap_metrics_params.sta_link_metrics_include = true;
-    } else {
-        evt_param->u.ap_metrics_params.sta_link_metrics_include = false;
+        evt->params.u.ap_metrics_params.sta_traffic_stats_include = false;
     }
 
-    if (strstr((const char *)evt->u.raw_buff, "Associated Wi-Fi 6 STA Status Report") != NULL) {
-        evt_param->u.ap_metrics_params.wifi6_status_report_include = true;
+    if (strstr(reinterpret_cast<const char *>(evt->u.raw_buff), "Associated STA Link Metrics Report") != NULL) {
+        evt->params.u.ap_metrics_params.sta_link_metrics_include = true;
     } else {
-        evt_param->u.ap_metrics_params.wifi6_status_report_include = false;
+        evt->params.u.ap_metrics_params.sta_link_metrics_include = false;
+    }
+
+    if (strstr(reinterpret_cast<const char *>(evt->u.raw_buff), "Associated Wi-Fi 6 STA Status Report") != NULL) {
+        evt->params.u.ap_metrics_params.wifi6_status_report_include = true;
+    } else {
+        evt->params.u.ap_metrics_params.wifi6_status_report_include = false;
     }
 
     pcmd[num] = new em_cmd_ap_metrics_report_t(evt->params, *(this));
@@ -1022,31 +1028,28 @@ int dm_easy_mesh_agent_t::analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_
         num++;
     }
 
-    return num;
+    cJSON_Delete(json);
+    return static_cast<int>(num);
 }
 
 int dm_easy_mesh_agent_t::analyze_link_report(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     dm_sta_t *sta = NULL;
     em_cmd_t *tmp = NULL;
-    em_cmd_params_t *evt_param = NULL;
     dm_easy_mesh_agent_t  dm;
-    unsigned int num = 0, num_radios = 0;
+    unsigned int num = 0;
     mac_addr_str_t macstr;
-    webconfig_subdoc_type_t type;
+    webconfig_subdoc_type_t type = webconfig_subdoc_type_em_sta_link_metrics;
 
     dm.init();
 
-    evt_param = &evt->params;
-
-    num_radios = m_num_radios;
     for (unsigned int i = 0; i < m_num_radios; i++) {
-        memcpy(&dm.m_radio[i], &m_radio[i], sizeof(dm_radio_t));
+        dm.m_radio[i] = m_radio[i];
     }
 
     dm.m_num_bss = m_num_bss;
     for (unsigned int i = 0; i < EM_MAX_BSSS; i++) {
-        memcpy(&dm.m_bss[i], &m_bss[i], sizeof(dm_bss_t));
+        dm.m_bss[i] = m_bss[i];
     }
 
     dm.translate_and_decode_onewifi_subdoc(reinterpret_cast<char *> (evt->u.raw_buff), type,
@@ -1059,15 +1062,15 @@ int dm_easy_mesh_agent_t::analyze_link_report(em_bus_event_t *evt, em_cmd_t *pcm
         sta = static_cast<dm_sta_t *> (hash_map_get_next(dm.m_sta_map, sta));
     }
 
-    sta = (dm_sta_t *)hash_map_get_first((hash_map_t *)dm.m_sta_map);
+    sta = static_cast<dm_sta_t *>(hash_map_get_first(dm.m_sta_map));
     if (sta != NULL) {
-        evt_param->u.args.num_args = 2;
+        evt->params.u.args.num_args = 2;
 
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, macstr);
-        strncpy(evt_param->u.args.args[0], macstr, strlen(macstr) + 1);
+        snprintf(evt->params.u.args.args[0], sizeof(evt->params.u.args.args[0]), "%s", macstr);
 
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, macstr);
-        strncpy(evt_param->u.args.args[1], macstr, strlen(macstr) + 1);
+        snprintf(evt->params.u.args.args[1], sizeof(evt->params.u.args.args[1]), "%s", macstr);
     }
 
     pcmd[num] = new em_cmd_link_quality_report_t(evt->params, dm);
@@ -1080,13 +1083,13 @@ int dm_easy_mesh_agent_t::analyze_link_report(em_bus_event_t *evt, em_cmd_t *pcm
         num++;
     }
 
-    return num;
+    return static_cast<int>(num);
 }
 
 void dm_easy_mesh_agent_t::translate_and_decode_onewifi_subdoc(char *str, webconfig_subdoc_type_t type, const char* logname)
 {
-    webconfig_t config;
-    webconfig_external_easymesh_t extdata = {0};
+    webconfig_t config = {};
+    webconfig_external_easymesh_t extdata = {};
 
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -761,7 +761,7 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
         + sizeof(em_80211_neighbor_report_t);
     aframe = static_cast<action_frame_params_t *> (malloc(sizeof(action_frame_params_t) + static_cast<size_t>(len)));
     if (aframe == NULL) {
-        printf("%s:%d Failed to allocate action frame\n", __func__, __LINE__);
+        em_printfout("Error: Failed to allocate action frame");
         return -1;
     }
     // Point ieeeframe to aframe->frame_data
@@ -799,7 +799,7 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
     bss_list->bss_transition_cand_list[0].phy_type = 0;
 
     dm_easy_mesh_t::macbytes_to_string(steer_req->sta_mac_addr, mac_str);
-    printf("%s:%d STA MAC for BTM request %s\n", __func__, __LINE__, mac_str);
+    em_printfout("STA MAC for BTM request %s", mac_str);
     memcpy(aframe->dest_addr, steer_req->sta_mac_addr, sizeof(mac_addr_t));
     aframe->frequency = 2412;
     aframe->ap_index = 0;
@@ -812,10 +812,10 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
     l_bus_data.raw_data_len = static_cast<size_t>(len) + sizeof(action_frame_params_t);
 
     if (desc->bus_set_fn(bus_hdl, "Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx", &l_bus_data)== 0) {
-        printf("%s:%d Frame subdoc send successfull\n",__func__, __LINE__);
+        em_printfout("Frame subdoc send successfull\n");
     }
     else {
-        printf("%s:%d Frame subdoc send fail\n",__func__, __LINE__);
+        em_printfout("Error: Frame subdoc send fail\n");
         free(aframe);
         return -1;
     }
@@ -871,26 +871,26 @@ int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcm
     config.apply_data =  webconfig_dummy_apply;
 
     if (webconfig_init(&config) != webconfig_error_none) {
-        printf( "[%s]:%d Init WiFi Web Config  fail\n",__func__,__LINE__);
+        em_printfout( "Error: Init WiFi Web Config  fail");
         return 0;
     }
 
     json = cJSON_Parse(reinterpret_cast<const char *>(evt->u.raw_buff));
     if (json == NULL) {
-        printf("%s:%d Unable to parse scan result JSON\n", __func__, __LINE__);
+        em_printfout("Error: Unable to parse scan result JSON");
         return 0;
     }
     scanner_mac_obj = cJSON_GetObjectItemCaseSensitive(json, "ScannerMac");
     if ((scanner_mac_obj == NULL) || (cJSON_IsString(scanner_mac_obj) == false) || (scanner_mac_obj->valuestring == NULL) ) {
-        printf("%s:%d Unable to find scanner mac\n", __func__, __LINE__);
+        em_printfout("Error: Unable to find scanner mac");
         cJSON_Delete(json);
         return 0;
     }
 
     if ((webconfig_easymesh_decode(&config, reinterpret_cast<char *>(evt->u.raw_buff), &ext, &type)) == webconfig_error_none) {
-        printf("%s:%d scanner mac: %s - analyze_scan_result subdoc decode success\n",__func__, __LINE__, scanner_mac_obj->valuestring);
+        em_printfout("scanner mac: %s - analyze_scan_result subdoc decode success", scanner_mac_obj->valuestring);
     } else {
-        printf("%s:%d scanner mac: %s - analyze_scan_result subdoc decode fail\n",__func__, __LINE__, scanner_mac_obj->valuestring);
+        em_printfout("Error: scanner mac: %s - analyze_scan_result subdoc decode fail", scanner_mac_obj->valuestring);
     }
 
     dm_easy_mesh_t::string_to_macbytes(scanner_mac_obj->valuestring, evt->params.u.scan_params.ruid);
@@ -1101,7 +1101,7 @@ void dm_easy_mesh_agent_t::translate_and_decode_onewifi_subdoc(char *str, webcon
     config.apply_data =  webconfig_dummy_apply;
 
     if (webconfig_init(&config) != webconfig_error_none) {
-        em_printfout( "Init WiFi Web Config  fail");
+        em_printfout( "Init WiFi Web Config fail");
         return;
     }
 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -574,14 +574,14 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
         sizeof(uint8_t[3]);  // oui field
 
     if (frame_len <= fixed_full_header_len){
-        printf("%s:%d Recieved WFA Action frame is too short! Must have at least the OUI type in the data field\n", __func__, __LINE__);
+        em_printfout("Error: Received WFA Action frame is too short! Must have at least the OUI type in the data field");
         return;
     }
     auto mgmt_frame = reinterpret_cast<struct ieee80211_mgmt *>(mgmt_frame_buff);
     auto vs_action_data = mgmt_frame->u.action.u.vs_public_action.variable;
     auto vs_data_len = frame_len - fixed_full_header_len;
 
-    printf("%s:%d: Received WFA action frame: Full Length: %zu, VS Action Data Length: %zu\n", __func__, __LINE__, frame_len, vs_data_len);
+    em_printfout("Received WFA action frame: Full Length: %zu, VS Action Data Length: %zu", frame_len, vs_data_len);
 
     std::string dest_mac_str = util::mac_to_string(mgmt_frame->da);
     em_printfout("Dest Mac Str: %s", dest_mac_str.c_str());
@@ -592,19 +592,19 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
 
     bool is_bcast = (memcmp(mgmt_frame->da, BROADCAST_MAC_ADDR, ETH_ALEN) == 0);
     if (is_bcast) {
-        printf("Received WFA action frame with broadcast destination MAC address\n");
+        em_printfout("Received WFA action frame with broadcast destination MAC address");
     } else {
         // Dest MAC is not necsessarily the same as the radio node's MAC address, so we need to look it up
         em_bss_info_t* dest_bss = m_data_model.get_bss_info_with_mac(mgmt_frame->da);
         if (dest_bss == NULL) {
-            em_printfout("No BSS found for dest mac %s\n", dest_mac_str.c_str());
+            em_printfout("No BSS found for dest mac %s", dest_mac_str.c_str());
             return;
         }
 
         std::string ruid_str = util::mac_to_string(dest_bss->ruid.mac);
         dest_radio_node = static_cast<em_t*>(hash_map_get(g_agent.m_em_map, ruid_str.c_str()));
         if (dest_radio_node == NULL) {
-            em_printfout("No radio node found for dest mac %s\n", dest_mac_str.c_str());
+            em_printfout("No radio node found for dest mac %s", dest_mac_str.c_str());
             return;
         }
     }
@@ -617,7 +617,7 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
 
     switch (oui_type) {
     case DPP_OUI_TYPE: {
-        printf("%s:%d: Received DPP action frame\n", __func__, __LINE__);
+        em_printfout("Received DPP action frame");
         em_t* al_node = get_al_node();
 
         if (al_node != NULL) {
@@ -1158,84 +1158,84 @@ void em_agent_t::input_listener()
     bus_init(&m_bus_hdl);
 
     if((desc = get_bus_descriptor()) == NULL) {
-        printf("%s:%d descriptor is null\n", __func__, __LINE__);
+        em_printfout("Error: descriptor is null");
     }
 
     if (desc->bus_open_fn(&m_bus_hdl, service_name) != 0) {
-        printf("%s:%d bus open failed\n",__func__, __LINE__);
+        em_printfout("Error: bus open failed");
         return;
     }
 
-    printf("%s:%d he_bus open success\n", __func__, __LINE__);
+    em_printfout("bus open success");
 
     memset(&data, 0, sizeof(raw_data_t));
 
     while ((bus_error_val = desc->bus_data_get_fn(&m_bus_hdl, WIFI_WEBCONFIG_INIT_DML_DATA, &data)) != bus_error_success) {
-        printf("%s:%d bus get failed, error:%d, ", __func__, __LINE__, bus_error_val);
+        em_printfout("Error: bus get failed, error: %d", bus_error_val);
 		usleep(RETRY_SLEEP_INTERVAL_IN_MS * 1000);
 		num_retry++;
-		printf("retrying %d\n", num_retry);
+		em_printfout("retrying %d", num_retry);
 
         if (num_retry % 5 == 0) {
             if (access(EM_CFG_FILE, F_OK) != -1) {
-                printf("Check that OneWifi is running.\n");
+                em_printfout("Check that OneWifi is running.");
             } else {
-                printf("EasymeshCfg.json does not exist. Generate via the unified-wifi-mesh CLI/TUI (if co-located) or by adding the `--interface` flag to the agent (if not)\n");
+                em_printfout("EasymeshCfg.json does not exist. Generate via the unified-wifi-mesh CLI/TUI (if co-located) or by adding the `--interface` flag to the agent (if not)");
             }
         }
     }
-    printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, reinterpret_cast<char *>(data.raw_data.bytes));
+    em_printfout("Received data:\r\n%s\r\n", reinterpret_cast<char *>(data.raw_data.bytes));
 
     g_agent.io_process(em_bus_event_type_dev_init, reinterpret_cast<unsigned char *>(data.raw_data.bytes), data.raw_data_len);
     free(data.raw_data.bytes);
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_DOC_DATA_NORTH, reinterpret_cast<void *>(&em_agent_t::onewifi_cb), NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+        em_printfout("Error: bus get failed");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_GET_ASSOC, reinterpret_cast<void *>(&em_agent_t::sta_cb), NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+        em_printfout("Error: bus get failed");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.STALinkMetricsReport", reinterpret_cast<void *>(&em_agent_t::assoc_stats_cb), NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+        em_printfout("Error: bus get failed");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_EM_CHANNEL_SCAN_REPORT, reinterpret_cast<void *>(&em_agent_t::channel_scan_cb), NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+        em_printfout("Error: bus get failed");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.BeaconReport", reinterpret_cast<void *>(&em_agent_t::beacon_report_cb), NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+        em_printfout("Error: bus get failed");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.AssociationStatus", reinterpret_cast<void *>(&em_agent_t::association_status_cb), nullptr, 0) != 0) {
-        em_printfout("Failed to subscribe to 'Device.WiFi.EM.AssociationStatus'");
+        em_printfout("Error: Failed to subscribe to 'Device.WiFi.EM.AssociationStatus'");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EC.BSSInfo", reinterpret_cast<void *>(&em_agent_t::bss_info_cb), nullptr, 0) != 0) {
-        em_printfout("Failed to subscribe to 'Device.WiFi.EC.BSSInfo', dynamic DPP channel list for Reconfiguration Announcement is not available");
+        em_printfout("Error: Failed to subscribe to 'Device.WiFi.EC.BSSInfo', dynamic DPP channel list for Reconfiguration Announcement is not available");
         // This is fine, not a fatal error
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.APMetricsReport", reinterpret_cast<void *>(&em_agent_t::report_cb), NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+        em_printfout("Error: bus get failed");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl,  WIFI_QUALITY_LINKREPORT, reinterpret_cast<void *>(&em_agent_t::report_cb), NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+        em_printfout("Error: bus get failed");
         return;
     }
 
    if(desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.CSABeaconFrameRecieved", reinterpret_cast<void *>(&em_agent_t::mgmt_csa_beacon_frame_cb), NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n",__func__,__LINE__);
+        em_printfout("Error: bus get failed");
         return;
     }
 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -60,7 +60,7 @@ void em_agent_t::handle_sta_list(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num;
 
-    if ((num = m_data_model.analyze_sta_list(evt, pcmd)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_sta_list(evt, pcmd))) == 0) {
         printf("analyze_sta_list failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("analyze_sta_list submit complete\n");
@@ -74,7 +74,7 @@ void em_agent_t::handle_sta_link_metrics(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         printf("analyze_sta_link_metrics in progress\n");
-    } else if ((num = m_data_model.analyze_sta_link_metrics(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_sta_link_metrics(evt, pcmd))) == 0) {
         printf("analyze_sta_link_metrics failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("analyze_sta_link_metrics submit complete\n");
@@ -88,7 +88,7 @@ void em_agent_t::handle_ap_cap_query(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_ap_cap_query(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_ap_cap_query(evt, pcmd))) == 0) {
         m_agent_cmd->send_result(em_cmd_out_status_no_change);
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         m_agent_cmd->send_result(em_cmd_out_status_success);
@@ -105,7 +105,7 @@ void em_agent_t::handle_radio_config(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_radio_config(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_radio_config(evt, pcmd))) == 0) {
         m_agent_cmd->send_result(em_cmd_out_status_no_change);
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         m_agent_cmd->send_result(em_cmd_out_status_success);
@@ -122,7 +122,7 @@ void em_agent_t::handle_vap_config(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_vap_config(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_vap_config(evt, pcmd))) == 0) {
         m_agent_cmd->send_result(em_cmd_out_status_no_change);
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         m_agent_cmd->send_result(em_cmd_out_status_success);
@@ -141,7 +141,7 @@ void em_agent_t::handle_dev_init(em_bus_event_t *evt)
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
         return;
     }
-    if ((num = m_data_model.analyze_dev_init(evt, pcmd)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_dev_init(evt, pcmd))) == 0) {
         m_agent_cmd->send_result(em_cmd_out_status_no_change);
         return;
     }
@@ -158,7 +158,7 @@ void em_agent_t::handle_dev_init(em_bus_event_t *evt)
     }
 
     // Iterate through all of the BSSs and subscribe to receive management action frames
-    for (int bss_idx = 0; bss_idx < m_data_model.m_num_bss; bss_idx++) {
+    for (unsigned int bss_idx = 0; bss_idx < m_data_model.m_num_bss; bss_idx++) {
         auto bss_info = m_data_model.get_bss_info(bss_idx);
         unsigned int vap_index = bss_info->vap_index; // The actual OneWifi VAP index
 
@@ -176,7 +176,7 @@ void em_agent_t::handle_dev_init(em_bus_event_t *evt)
 
 
         std::string path = "Device.WiFi.AccessPoint." + std::to_string(vap_index + 1) + ".RawFrame.Mgmt.Action.Rx";
-        if (desc->bus_event_subs_fn(&m_bus_hdl, path.c_str(), (void *)&em_agent_t::mgmt_action_frame_cb, NULL, 0) != 0) {
+        if (desc->bus_event_subs_fn(&m_bus_hdl, path.c_str(), reinterpret_cast<void *>(&em_agent_t::mgmt_action_frame_cb), NULL, 0) != 0) {
             em_printfout("Subscription failed for path %s", path.c_str());
             continue;
         }
@@ -202,7 +202,7 @@ void em_agent_t::handle_channel_pref_query(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_channel_pref_query(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_channel_pref_query(evt, pcmd))) == 0) {
         printf("%s:%d query send fail \n", __func__, __LINE__);
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("%s:%d send success \n", __func__, __LINE__);
@@ -213,7 +213,6 @@ void em_agent_t::handle_channel_sel_req(em_bus_event_t *evt)
 {
     unsigned int num;
     wifi_bus_desc_t *desc;
-    raw_data_t l_bus_data;
 
     if((desc = get_bus_descriptor()) == NULL) {
        printf("descriptor is null");
@@ -221,7 +220,7 @@ void em_agent_t::handle_channel_sel_req(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_channel_sel_req(evt, desc, &m_bus_hdl)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_channel_sel_req(evt, desc, &m_bus_hdl))) == 0) {
             printf("handle_channel_sel_req complete");
     }
 }
@@ -235,7 +234,7 @@ void em_agent_t::handle_csa_beacon_frame(em_bus_event_t *evt)
        printf("descriptor is null");
     }
 
-    if ((num = m_data_model.analyze_csa_beacon_frame(evt, desc, &m_bus_hdl)) == 1) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_csa_beacon_frame(evt, desc, &m_bus_hdl))) == 1) {
         printf("analyze_csa_beacon_frame completed\n");
     }
 }
@@ -244,7 +243,6 @@ void em_agent_t::handle_m2ctrl_configuration(em_bus_event_t *evt)
 {
     unsigned int num;
     wifi_bus_desc_t *desc;
-    raw_data_t l_bus_data;
 
     if((desc = get_bus_descriptor()) == NULL) {
        printf("descriptor is null");
@@ -252,7 +250,7 @@ void em_agent_t::handle_m2ctrl_configuration(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_m2ctrl_configuration(evt, desc, &m_bus_hdl)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_m2ctrl_configuration(evt, desc, &m_bus_hdl))) == 0) {
 	    printf("analyze_onewifi_private_subdoc complete");
     }
 }
@@ -269,7 +267,7 @@ void em_agent_t::handle_onewifi_private_cb(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_onewifi_vap_cb(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_onewifi_vap_cb(evt, pcmd))) == 0) {
         em_printfout("analyze_onewifi_vap_cb completed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         em_printfout("submitted command for orchestration");
@@ -288,7 +286,7 @@ void em_agent_t::handle_onewifi_mesh_sta_cb(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_onewifi_vap_cb(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_onewifi_vap_cb(evt, pcmd))) == 0) {
         em_printfout("analyze_onewifi_vap_cb completed");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         em_printfout("submitted command for orchestration");
@@ -307,7 +305,7 @@ void em_agent_t::handle_onewifi_radio_cb(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_onewifi_radio_cb(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_onewifi_radio_cb(evt, pcmd))) == 0) {
         em_printfout("analyze_onewifi_radio_cb completed");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         em_printfout("submitted command for orchestration");
@@ -351,14 +349,14 @@ void em_agent_t::handle_frame_event(em_frame_event_t *evt)
 {
     struct ieee80211_frame *frame;
 
-    frame = (struct ieee80211_frame *)evt->frame;
+    frame = reinterpret_cast<struct ieee80211_frame *>(evt->frame);
     assert(IEEE80211_IS_MGMT(frame));
 
     printf("%s:%d: Received management 'frame event' type %d\n", __func__, __LINE__, frame->i_fc[0] & 0x0f);
     
     // handle action frames only 
     if ((frame->i_fc[0] & 0x0f) == IEEE80211_FC0_SUBTYPE_ACTION) {
-        handle_action_frame((struct ieee80211_mgmt *)frame);        
+        handle_action_frame(reinterpret_cast<struct ieee80211_mgmt *>(frame));
     }
 }
 
@@ -369,7 +367,7 @@ void em_agent_t::handle_autoconfig_renew(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
 	printf("handle_autoconfig_renew in progress\n");
-    }  else if ((num = m_data_model.analyze_autoconfig_renew(evt, pcmd)) == 0) {
+    }  else if ((num = static_cast<unsigned int>(m_data_model.analyze_autoconfig_renew(evt, pcmd))) == 0) {
         printf("handle_autoconfig_renew cmd creation failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
     }
@@ -385,7 +383,7 @@ void em_agent_t::handle_btm_request_action_frame(em_bus_event_t *evt)
        printf("descriptor is null");
     }
 
-    if ((num = m_data_model.analyze_btm_request_action_frame(evt, desc, &m_bus_hdl)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_btm_request_action_frame(evt, desc, &m_bus_hdl))) == 0) {
 	    printf("analyze_btm_request_action_frame failed\n");
     }
 }
@@ -422,7 +420,7 @@ void em_agent_t::handle_bss_info(em_bus_event_t *event)
     unsigned int len = event->data_len;
 
     if (len % expected_size != 0) {
-        em_printfout("Expected event size divisible by %d, got %d, not handling", expected_size, event->data_len);
+        em_printfout("Expected event size divisible by %zu, got %u, not handling", expected_size, event->data_len);
         return;
     }
 
@@ -458,7 +456,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
     }
     const size_t full_frame_length = evt->data_len;
     const size_t mgmt_hdr_len = offsetof(struct ieee80211_mgmt, u);
-    ieee80211_mgmt *mgmt_frame = (ieee80211_mgmt *)evt->u.raw_buff;
+    ieee80211_mgmt *mgmt_frame = reinterpret_cast<ieee80211_mgmt *>(evt->u.raw_buff);
 
     std::string dest_mac_str = util::mac_to_string(mgmt_frame->da);
     // Validate that it is a broadcast frame or we have a node that should have received it
@@ -485,7 +483,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
 
     em_t* al_node = get_al_node();
 
-    auto gas_frame_base = (ec_gas_frame_base_t *)(evt->u.raw_buff + mgmt_hdr_len);
+    auto gas_frame_base = reinterpret_cast<ec_gas_frame_base_t *>(evt->u.raw_buff + mgmt_hdr_len);
 
     bool is_wfa_ec_gas = false;
 
@@ -493,7 +491,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
     case dpp_gas_action_type_t::dpp_gas_initial_req: {
         printf("%s:%d: Received GAS Initial Request\n", __func__, __LINE__);
         ec_gas_initial_request_frame_t *gas_initial_req_frame =
-            (ec_gas_initial_request_frame_t *)gas_frame_base;
+            reinterpret_cast<ec_gas_initial_request_frame_t *>(gas_frame_base);
         uint8_t *ap_proto_id = gas_initial_req_frame->ape_id;
         if (ap_proto_id[0] == 0xDD) {
             // Vendor specific GAS frame
@@ -508,7 +506,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
     case dpp_gas_action_type_t::dpp_gas_initial_resp: {
         printf("%s:%d: Received GAS Initial Response\n", __func__, __LINE__);
         ec_gas_initial_response_frame_t *gas_initial_resp_frame =
-            (ec_gas_initial_response_frame_t *)gas_frame_base;
+            reinterpret_cast<ec_gas_initial_response_frame_t *>(gas_frame_base);
         uint8_t *ap_proto_id = gas_initial_resp_frame->ape_id;
         if (ap_proto_id[0] == 0xDD) {
             // Vendor specific GAS frame
@@ -583,7 +581,7 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
     auto vs_action_data = mgmt_frame->u.action.u.vs_public_action.variable;
     auto vs_data_len = frame_len - fixed_full_header_len;
 
-    printf("%s:%d: Received WFA action frame: Full Length: %d, VS Action Data Length: %d\n", __func__, __LINE__, frame_len, vs_data_len);
+    printf("%s:%d: Received WFA action frame: Full Length: %zu, VS Action Data Length: %zu\n", __func__, __LINE__, frame_len, vs_data_len);
 
     std::string dest_mac_str = util::mac_to_string(mgmt_frame->da);
     em_printfout("Dest Mac Str: %s", dest_mac_str.c_str());
@@ -642,7 +640,7 @@ void em_agent_t::handle_btm_response_action_frame(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         printf("analyze_btm_response_action_frame in progress\n");
-    } else if ((num = m_data_model.analyze_btm_response_action_frame(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_btm_response_action_frame(evt, pcmd))) == 0) {
         printf("analyze_btm_response_action_frame failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("submitted handle_btm_response_action_frame command for orchestration\n");
@@ -676,7 +674,7 @@ void em_agent_t::handle_client_assoc_ctrl_req(em_bus_event_t *evt)
 
     memset(&raw, 0, sizeof(raw_data_t));
     raw.data_type = bus_data_type_bytes;
-    raw.raw_data.bytes = (void *)&req_data;
+    raw.raw_data.bytes = static_cast<void *>(&req_data);
     raw.raw_data_len = sizeof(client_assoc_ctrl_req_t);
 
     if (desc->bus_set_fn(&m_bus_hdl,WIFI_EM_CLIENT_ASSOC_CTRL_REQ, &raw) != 0) {
@@ -690,7 +688,7 @@ void em_agent_t::handle_channel_scan_result(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num;
 
-    if ((num = m_data_model.analyze_scan_result(evt, pcmd)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_scan_result(evt, pcmd))) == 0) {
         printf("scan results failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
 		;
@@ -701,16 +699,15 @@ void em_agent_t::handle_channel_scan_params(em_bus_event_t *evt)
 {
     printf("%s:%d: Scan Parameters received\n", __func__, __LINE__);
 #ifdef SCAN_RESULT_TEST
-	m_simulator.configure(m_data_model, (em_scan_params_t *)evt->u.raw_buff);
+	m_simulator.configure(m_data_model, reinterpret_cast<em_scan_params_t *>(evt->u.raw_buff));
 #endif
-    unsigned int num;
     wifi_bus_desc_t *desc;
 
     if((desc = get_bus_descriptor()) == NULL) {
        printf("descriptor is null");
     }
 
-    if (!send_scan_request((em_scan_params_t *)&evt->u.raw_buff, true)) {
+    if (!send_scan_request(reinterpret_cast<em_scan_params_t *>(&evt->u.raw_buff), true)) {
         printf("send_scan_request failed\n");
         return;
     }
@@ -718,7 +715,6 @@ void em_agent_t::handle_channel_scan_params(em_bus_event_t *evt)
 
 bool em_agent_t::send_scan_request(em_scan_params_t* scan_params, bool perform_fresh_scan, bool is_sta_vap){
     unsigned i, j;
-    mac_addr_str_t radio_mac_str;
     raw_data_t l_bus_data;
     
 
@@ -747,7 +743,7 @@ bool em_agent_t::send_scan_request(em_scan_params_t* scan_params, bool perform_f
     }
 
     l_bus_data.data_type = bus_data_type_bytes;
-    l_bus_data.raw_data.bytes = (void *)&scan_data;
+    l_bus_data.raw_data.bytes = static_cast<void *>(&scan_data);
     l_bus_data.raw_data_len = sizeof(channel_scan_request_t);
 
     wifi_bus_desc_t *desc;
@@ -770,10 +766,8 @@ bool em_agent_t::send_scan_request(em_scan_params_t* scan_params, bool perform_f
 
 void em_agent_t::handle_set_policy(em_bus_event_t *evt)
 {
-    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num;
     wifi_bus_desc_t *desc;
-    raw_data_t l_bus_data;
 
     if((desc = get_bus_descriptor()) == NULL) {
        printf("descriptor is null");
@@ -781,7 +775,7 @@ void em_agent_t::handle_set_policy(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         printf("set policy in progress\n");
-    } else if ((num = m_data_model.analyze_set_policy(evt, desc, &m_bus_hdl)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_set_policy(evt, desc, &m_bus_hdl))) == 0) {
         printf("set policy failed\n");
     }
 }
@@ -793,7 +787,7 @@ void em_agent_t::handle_beacon_report(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         printf("analyze_beacon_report in progress\n");
-    } else if ((num = m_data_model.analyze_beacon_report(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_beacon_report(evt, pcmd))) == 0) {
         printf("analyze_beacon_report failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("submitted beacon report cmd for orch\n");
@@ -806,7 +800,7 @@ void em_agent_t::handle_ap_metrics_report(em_bus_event_t *evt)
     unsigned int num;
 
     // populate data model first
-    if ((num = m_data_model.analyze_ap_metrics_report(evt, pcmd)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_ap_metrics_report(evt, pcmd))) == 0) {
         em_printfout("analyze_ap_metrics_report failed");
         return;
     }
@@ -854,7 +848,7 @@ void em_agent_t::handle_link_stats_report(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         em_printfout("analyze_link_report in progress");
-    } else if ((num = m_data_model.analyze_link_report(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_link_report(evt, pcmd))) == 0) {
         em_printfout("analyze_link_report failed");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         em_printfout("Submitted Link Stats report cmd for orch");
@@ -1045,7 +1039,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
 
     int vap_idx = -1;
 
-    for (int bss_idx = 0; bss_idx < m_data_model.m_num_bss; bss_idx++) {
+    for (unsigned int bss_idx = 0; bss_idx < m_data_model.m_num_bss; bss_idx++) {
         auto bss_info = m_data_model.get_bss_info(bss_idx);
         if (bss_info == nullptr) {
             continue;
@@ -1056,7 +1050,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
         if (op_class_info == nullptr) {
             continue;
         }
-        vap_idx = bss_info->vap_index;
+        vap_idx = static_cast<int>(bss_info->vap_index);
         // Found a matching BSS, no need to continue searching
         break;
     }
@@ -1077,7 +1071,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
     EM_ASSERT_NOT_NULL(action_frame, false, "action_frame is null");
 
     // Allocate memory for the action frame parameters, ieee80211 header and action frame body
-    action_frame_params_t *act_frame_params = (action_frame_params_t*) calloc(sizeof(action_frame_params_t) + action_frame_len, 1);
+    action_frame_params_t *act_frame_params = static_cast<action_frame_params_t *>(calloc(sizeof(action_frame_params_t) + action_frame_len, 1));
     EM_ASSERT_NOT_NULL(act_frame_params, false, "calloc failed");
 
     act_frame_params->ap_index = vap_idx;
@@ -1091,7 +1085,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
 
     raw_data_t raw_act_frame;
     memset(&raw_act_frame, 0, sizeof(raw_data_t));
-    raw_act_frame.raw_data.bytes = (uint8_t *)act_frame_params;
+    raw_act_frame.raw_data.bytes = reinterpret_cast<uint8_t *>(act_frame_params);
     raw_act_frame.raw_data_len = sizeof(action_frame_params_t) + action_frame_len;
     raw_act_frame.data_type = bus_data_type_bytes;
 
@@ -1190,32 +1184,32 @@ void em_agent_t::input_listener()
             }
         }
     }
-    printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, (char *)data.raw_data.bytes);
+    printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, reinterpret_cast<char *>(data.raw_data.bytes));
 
-    g_agent.io_process(em_bus_event_type_dev_init, (unsigned char *)data.raw_data.bytes, data.raw_data_len);
+    g_agent.io_process(em_bus_event_type_dev_init, reinterpret_cast<unsigned char *>(data.raw_data.bytes), data.raw_data_len);
     free(data.raw_data.bytes);
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_DOC_DATA_NORTH, (void *)&em_agent_t::onewifi_cb, NULL, 0) != 0) {
+    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_DOC_DATA_NORTH, reinterpret_cast<void *>(&em_agent_t::onewifi_cb), NULL, 0) != 0) {
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_GET_ASSOC, (void *)&em_agent_t::sta_cb, NULL, 0) != 0) {
+    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_GET_ASSOC, reinterpret_cast<void *>(&em_agent_t::sta_cb), NULL, 0) != 0) {
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.STALinkMetricsReport", (void *)&em_agent_t::assoc_stats_cb, NULL, 0) != 0) {
+    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.STALinkMetricsReport", reinterpret_cast<void *>(&em_agent_t::assoc_stats_cb), NULL, 0) != 0) {
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_EM_CHANNEL_SCAN_REPORT, (void *)&em_agent_t::channel_scan_cb, NULL, 0) != 0) {
+    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_EM_CHANNEL_SCAN_REPORT, reinterpret_cast<void *>(&em_agent_t::channel_scan_cb), NULL, 0) != 0) {
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.BeaconReport", (void *)&em_agent_t::beacon_report_cb, NULL, 0) != 0) {
+    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.BeaconReport", reinterpret_cast<void *>(&em_agent_t::beacon_report_cb), NULL, 0) != 0) {
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
     }
@@ -1230,17 +1224,17 @@ void em_agent_t::input_listener()
         // This is fine, not a fatal error
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.APMetricsReport", (void *)&em_agent_t::report_cb, NULL, 0) != 0) {
+    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.APMetricsReport", reinterpret_cast<void *>(&em_agent_t::report_cb), NULL, 0) != 0) {
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl,  WIFI_QUALITY_LINKREPORT, (void *)&em_agent_t::report_cb, NULL, 0) != 0) {
+    if (desc->bus_event_subs_fn(&m_bus_hdl,  WIFI_QUALITY_LINKREPORT, reinterpret_cast<void *>(&em_agent_t::report_cb), NULL, 0) != 0) {
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
     }
 
-   if(desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.CSABeaconFrameRecieved", (void *)&em_agent_t::mgmt_csa_beacon_frame_cb, NULL, 0) != 0) {
+   if(desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.CSABeaconFrameRecieved", reinterpret_cast<void *>(&em_agent_t::mgmt_csa_beacon_frame_cb), NULL, 0) != 0) {
         printf("%s:%d bus get failed\n",__func__,__LINE__);
         return;
     }
@@ -1273,18 +1267,21 @@ int em_agent_t::channel_scan_cb(char *event_name, bus_data_prop_t *data, void *u
     (void)userData;
     cJSON *json, *channel_stats_arr;
 
-    json = cJSON_Parse((const char *)data->value.raw_data.bytes);
+    json = cJSON_Parse(reinterpret_cast<const char *>(data->value.raw_data.bytes));
     if (json != NULL) {
         channel_stats_arr = cJSON_GetObjectItem(json, "ChannelScanResponse");
         if ((channel_stats_arr == NULL) && (cJSON_IsObject(channel_stats_arr) == false)) {
+            cJSON_Delete(json);
             return -1;
         }
         if (cJSON_IsArray(channel_stats_arr) && cJSON_GetArraySize(channel_stats_arr) == 0) {
+            cJSON_Delete(json);
             return -1;
         }
+        cJSON_Delete(json);
     }
 
-    g_agent.io_process(em_bus_event_type_scan_result, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+    g_agent.io_process(em_bus_event_type_scan_result, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     return 1;
 }
@@ -1295,10 +1292,10 @@ int em_agent_t::report_cb(char *event_name, bus_data_prop_t *data, void *userDat
     (void)userData;
 
     if (strncmp(event_name, "Device.WiFi.EM.APMetricsReport", sizeof("Device.WiFi.EM.APMetricsReport"))==0) {
-        g_agent.io_process(em_bus_event_type_ap_metrics_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+        g_agent.io_process(em_bus_event_type_ap_metrics_report, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     } else if (strncmp(event_name, WIFI_QUALITY_LINKREPORT, sizeof(WIFI_QUALITY_LINKREPORT))==0) {
         em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
-        cJSON *json = cJSON_Parse((const char *)data->value.raw_data.bytes);
+        cJSON *json = cJSON_Parse(reinterpret_cast<const char *>(data->value.raw_data.bytes));
         if (json != NULL) {
             cJSON *link_report_arr;
             cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
@@ -1306,15 +1303,18 @@ int em_agent_t::report_cb(char *event_name, bus_data_prop_t *data, void *userDat
                 em_printfout("Found SubDocName: LinkReport");
                 link_report_arr = cJSON_GetObjectItem(json, "LinkReport");
                 if ((link_report_arr == NULL) && (cJSON_IsObject(link_report_arr) == false)) {
+                    cJSON_Delete(json);
                     return 0;
                 }
                 if (cJSON_IsArray(link_report_arr) && cJSON_GetArraySize(link_report_arr) == 0) {
                     em_printfout("LinkReport is NULL");
+                    cJSON_Delete(json);
                     return -1;
                 }
             }
+            cJSON_Delete(json);
         }
-        g_agent.io_process(em_bus_event_type_link_quality_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+        g_agent.io_process(em_bus_event_type_link_quality_report, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     }
 
     return 0;
@@ -1325,7 +1325,7 @@ int em_agent_t::beacon_report_cb(char *event_name, bus_data_prop_t *data, void *
     //printf("%s:%d Received Frame data for event [%s] and data :\n%s\n", __func__, __LINE__, event_name, data->value.raw_data.bytes);
     (void)userData;
 
-    g_agent.io_process(em_bus_event_type_beacon_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+    g_agent.io_process(em_bus_event_type_beacon_report, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     return 0;
 }
@@ -1338,18 +1338,18 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, bus_data_prop_t *data, vo
     EM_ASSERT_MSG_TRUE(data != NULL && data->value.raw_data.bytes != NULL && data->value.raw_data_len > 0, -1,
                    "Invalid data in mgmt_action_frame_cb");
 
-    uint8_t* mgmt_frame_data = (uint8_t*)data->value.raw_data.bytes;
+    uint8_t* mgmt_frame_data = reinterpret_cast<uint8_t *>(data->value.raw_data.bytes);
     unsigned int mgmt_hdr_len = data->value.raw_data_len;
 
     // The frequency (and other wifi data) is prepended to the action frame data
     mgmt_frame_data += sizeof(wifi_frame_t);
     mgmt_hdr_len -= sizeof(wifi_frame_t);
 
-    struct ieee80211_mgmt *mgmt_frame = (struct ieee80211_mgmt *)mgmt_frame_data;
+    struct ieee80211_mgmt *mgmt_frame = reinterpret_cast<struct ieee80211_mgmt *>(mgmt_frame_data);
     
     
 
-    //util::print_hex_dump(data->value.raw_data_len, (uint8_t*)data->value.raw_data.bytes);
+    //util::print_hex_dump(data->value.raw_data_len, reinterpret_cast<uint8_t *>(data->value.raw_data.bytes));
 
     //printf("Received Frame data for event %s \n", event_name);
     if (mgmt_frame->u.action.u.bss_tm_resp.action == WLAN_WNM_BTM_RESPONSE) {
@@ -1380,10 +1380,10 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, bus_data_prop_t *data, vo
 int em_agent_t::assoc_stats_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
-    //printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, (char *)data->value.raw_data.bytes);
+    //printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, reinterpret_cast<char *>(data->value.raw_data.bytes));
     cJSON *json, *assoc_stats_arr;
 
-    json = cJSON_Parse((const char *)data->value.raw_data.bytes);
+    json = cJSON_Parse(reinterpret_cast<const char *>(data->value.raw_data.bytes));
     if (json != NULL) {
         cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
         if ((strcmp(subdoc_name->valuestring, "Easymesh STA link metrics") == 0)) {
@@ -1392,16 +1392,18 @@ int em_agent_t::assoc_stats_cb(char *event_name, bus_data_prop_t *data, void *us
             printf("%s:%d Found SubDocName: AssociatedDeviceStats\n", __func__, __LINE__);
             assoc_stats_arr = cJSON_GetObjectItem(json, "AssociatedDeviceStats");
             if ((assoc_stats_arr == NULL) && (cJSON_IsObject(assoc_stats_arr) == false)) {
+                cJSON_Delete(json);
                 return -1;
             }
             if (cJSON_IsArray(assoc_stats_arr) && cJSON_GetArraySize(assoc_stats_arr) == 0) {
                 printf("%s:%d AssociatedDeviceStats is NULL\n", __func__, __LINE__);
+                cJSON_Delete(json);
                 return -1;
             }
         }
     }
 
-    g_agent.io_process(em_bus_event_type_sta_link_metrics, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+    g_agent.io_process(em_bus_event_type_sta_link_metrics, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     cJSON_Delete(json);
 
     return 1;
@@ -1410,18 +1412,18 @@ int em_agent_t::assoc_stats_cb(char *event_name, bus_data_prop_t *data, void *us
 void em_agent_t::sta_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
-    //printf("%s:%d Recv data from onewifi:\r\n%s\r\n", __func__, __LINE__, (char *)data->value.raw_data.bytes);
-    g_agent.io_process(em_bus_event_type_sta_list, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+    //printf("%s:%d Recv data from onewifi:\r\n%s\r\n", __func__, __LINE__, reinterpret_cast<char *>(data->value.raw_data.bytes));
+    g_agent.io_process(em_bus_event_type_sta_list, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
 }
 
 void em_agent_t::onewifi_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
         (void)userData;
-	const char *json_data = (char *)data->value.raw_data.bytes;
+	const char *json_data = reinterpret_cast<char *>(data->value.raw_data.bytes);
 	cJSON *json = cJSON_Parse(json_data);
 
-	//printf("%s:%dRecv data from onewifi:\r\n%s\r\n", __func__, __LINE__, (char *)data->value.raw_data.bytes);
+	//printf("%s:%dRecv data from onewifi:\r\n%s\r\n", __func__, __LINE__, reinterpret_cast<char *>(data->value.raw_data.bytes));
 
 	if (json == NULL) {
 		em_printfout("Error parsing JSON");
@@ -1436,15 +1438,15 @@ void em_agent_t::onewifi_cb(char *event_name, bus_data_prop_t *data, void *userD
     em_printfout("Found SubDocName: %s", subdoc_name->valuestring);
     if ((strcmp(subdoc_name->valuestring, "private") == 0) || (strcmp(subdoc_name->valuestring, "Vap_6G") == 0) ||
         (strcmp(subdoc_name->valuestring, "Vap_5G") == 0) || (strcmp(subdoc_name->valuestring, "Vap_2.4G") == 0)) {
-        g_agent.io_process(em_bus_event_type_onewifi_private_cb, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_private_cb, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     } else if ((strcmp(subdoc_name->valuestring, "radio") == 0) || (strcmp(subdoc_name->valuestring, "radio_6G") == 0) ||
         (strcmp(subdoc_name->valuestring, "radio_5G") == 0) || (strcmp(subdoc_name->valuestring, "radio_2.4G") == 0)) {
-        g_agent.io_process(em_bus_event_type_onewifi_radio_cb, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_radio_cb, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     } else if ((strcmp(subdoc_name->valuestring, "mesh_sta") == 0) || 
                (strcmp(subdoc_name->valuestring, "mesh backhaul sta") == 0)) {
-        g_agent.io_process(em_bus_event_type_onewifi_mesh_sta_cb, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_mesh_sta_cb, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     } else {
         em_printfout("SubDocName (%s) not matching private, mesh_sta, or radio", subdoc_name->valuestring);
@@ -1458,7 +1460,7 @@ int em_agent_t::mgmt_csa_beacon_frame_cb(char *event_name, bus_data_prop_t *data
 {
     printf("%s:%d Received Frame data for event [%s] and data of len:\n%d\n", __func__, __LINE__, event_name, data->value.raw_data_len);
 
-    g_agent.io_process(em_bus_event_type_recv_csa_beacon_frame, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+    g_agent.io_process(em_bus_event_type_recv_csa_beacon_frame, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     return 1;
 }
 
@@ -1490,15 +1492,12 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 {
     em_raw_hdr_t *hdr;
     em_cmdu_t *cmdu;
-    em_interface_t intf;
     em_freq_band_t band = em_freq_band_unknown;
     dm_easy_mesh_t *dm;
     em_t *em = NULL;
     mac_address_t ruid;
-    em_profile_type_t profile;
     mac_addr_str_t mac_str1, mac_str2;
     bssid_t bss_mac;
-    mac_address_t client_mac;
     bool found = false;
     em_string_t al_mac_str;
     em_bss_info_t *em_bss = NULL;
@@ -1508,13 +1507,13 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         return NULL;
     }
    
-    hdr = (em_raw_hdr_t *)data;
+    hdr = reinterpret_cast<em_raw_hdr_t *>(data);
 
     if (hdr->type != htons(ETH_P_1905)) {
         return NULL;
     }
    
-    cmdu = (em_cmdu_t *)(data + sizeof(em_raw_hdr_t));
+    cmdu = reinterpret_cast<em_cmdu_t *>(data + sizeof(em_raw_hdr_t));
 
     switch (htons(cmdu->type)) {
 	case em_msg_type_autoconf_resp:
@@ -1529,7 +1528,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             return al_em;
         }
 
-		em = (em_t *)hash_map_get_first(m_em_map);
+		em = static_cast<em_t *>(hash_map_get_first(m_em_map));
 		while (em != NULL) {
 			if (!(em->is_al_interface_em())) {
 				if (em->is_matching_freq_band(&band) == true) {
@@ -1542,7 +1541,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 					}
 				}
 			}
-			em = (em_t *)hash_map_get_next(m_em_map, em);
+			em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
 		}
 		if (found == false) {
 			printf("%s:%d: Could not find em with matching band%d and expected state \n", __func__, __LINE__, band);
@@ -1565,12 +1564,12 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 		}
 		dm_easy_mesh_t::macbytes_to_string(ruid, al_mac_str);
 		strcat(al_mac_str, "_al");
-		if ((em = (em_t *)hash_map_get(m_em_map, al_mac_str)) != NULL) {
+		if ((em = static_cast<em_t *>(hash_map_get(m_em_map, al_mac_str))) != NULL) {
 			printf("%s:%d: Found existing AL MAC:%s\n", __func__, __LINE__, al_mac_str);
 		} else {
 			return NULL;
 		}
-		em = (em_t *)hash_map_get_first(m_em_map);
+		em = static_cast<em_t *>(hash_map_get_first(m_em_map));
 		while (em != NULL) {
 			if (!(em->is_al_interface_em())) {
 				if (em->is_matching_freq_band(&band) == true) {
@@ -1583,7 +1582,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 					}
 				}
 			}
-			em = (em_t *)hash_map_get_next(m_em_map, em);
+			em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
 		}
 		if (found == false) {
 			printf("%s:%d: Could not find em with matching band%d and expected state \n", __func__, __LINE__, band);
@@ -1597,7 +1596,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 			}
 
 			dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
-        	if ((em = (em_t *)hash_map_get(m_em_map, mac_str1)) != NULL) {
+         if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) != NULL) {
             	printf("%s:%d: Found existing radio:%s\n", __func__, __LINE__, mac_str1);
         	} else {
 				return NULL;
@@ -1610,7 +1609,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             em_string_t al_mac_str;
             dm_easy_mesh_t::macbytes_to_string(hdr->dst, al_mac_str);
             strcat(al_mac_str, "_al");
-            if ((em = (em_t *)hash_map_get(m_em_map, al_mac_str)) != NULL) {
+            if ((em = static_cast<em_t *>(hash_map_get(m_em_map, al_mac_str))) != NULL) {
                 em_printfout("Received query message, found al_mac agent:%s", al_mac_str);
             } else {
                 em_printfout("Discarding query message, al_mac agent:%s not found",
@@ -1630,7 +1629,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             }
 
             dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
-            if ((em = (em_t *)hash_map_get(m_em_map, mac_str1)) != NULL) {
+            if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) != NULL) {
                 if (em->is_al_interface_em() == false) {
                     printf("%s:%d: Received em_msg_type_channel_sel_req, found existing radio:%s\n", __func__, __LINE__, mac_str1);
                 } else {
@@ -1681,12 +1680,12 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case em_msg_type_assoc_sta_link_metrics_query:
             printf("\n%s:%d: Rcvd Assoc STA Link Metrics Query\n", __func__, __LINE__);
 
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == false)) {
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
             break;
 
@@ -1696,13 +1695,13 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 
         case em_msg_type_client_steering_req:
             printf("\n%s:%d: Rcvd Client steering request\n", __func__, __LINE__);
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == false)) {
                     //printf("%s:%d: Found em\n", __func__, __LINE__);
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
             break;
 
@@ -1717,7 +1716,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 			}
 
 			dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
-        	if ((em = (em_t *)hash_map_get(m_em_map, mac_str1)) == NULL) {
+         if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) == NULL) {
 				return NULL;
 			}
 			
@@ -1726,13 +1725,13 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case  em_msg_type_ap_mld_config_req:
             printf("%s:%d: Received em_msg_type_ap_mld_config_req\n", __func__, __LINE__);
 
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == false)) {
                     //printf("%s:%d: Found em\n", __func__, __LINE__);
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
 
             break;
@@ -1742,12 +1741,12 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case em_msg_type_channel_pref_rprt:
         case em_msg_type_1905_ack:
         case em_msg_type_map_policy_config_req:
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == false)) {
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
             break;
 
@@ -1773,13 +1772,13 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             break;
 
         case em_msg_type_bh_sta_cap_query:
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == true)) {
                     em_printfout("Rcvd bsta cap Query");
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
             break;
 
@@ -1787,13 +1786,13 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             break;
 
         case em_msg_type_client_assoc_ctrl_req:
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
 	        if ((em->is_al_interface_em() == true)) {
 	            em_printfout("Rceived client assoc ctrl request from controller");
 	            break;
 	        }
-	        em = (em_t *)hash_map_get_next(m_em_map, em);
+	        em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
            }
            break;
 
@@ -1950,6 +1949,7 @@ bool em_agent_t::try_start_dpp_onboarding()  {
 }
 
 em_agent_t::em_agent_t()
+    : m_orch(nullptr), m_data_model(), m_data_model_path{}, m_agent_cmd(nullptr), m_simulator(), m_bus_hdl{}
 {
 
 }
@@ -1977,7 +1977,7 @@ AlServiceAccessPoint* em_agent_t::al_sap_register(const std::string& data_socket
         }
         std::cout << std::dec << std::endl;
     } else {
-        std::cout << "Registration failed with error: " << (int)result << std::endl;
+        std::cout << "Registration failed with error: " << static_cast<int>(result) << std::endl;
     }
 
     return sap;

--- a/src/agent/em_cmd_agent.cpp
+++ b/src/agent/em_cmd_agent.cpp
@@ -42,19 +42,19 @@
 #include "em_cmd_agent.h"
 
 em_cmd_t em_cmd_agent_t::m_client_cmd_spec[] = {
-    em_cmd_t(em_cmd_type_none,em_cmd_params_t{0, {"", "", "", "", ""}, "none"}),
-    em_cmd_t(em_cmd_type_dev_init,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Network"}),
-    em_cmd_t(em_cmd_type_cfg_renew, em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Renew"}),
-    em_cmd_t(em_cmd_type_vap_config,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:BssConfig"}),
-    em_cmd_t(em_cmd_type_sta_list,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:StaList"}),
-    em_cmd_t(em_cmd_type_ap_cap_query,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:CapReport"}),
-    em_cmd_t(em_cmd_type_max,em_cmd_params_t{0, {"", "", "", "", ""}, "max"}),
+    em_cmd_t(em_cmd_type_none,em_cmd_params_t{0, {"", "", "", "", ""}, "none", nullptr}),
+    em_cmd_t(em_cmd_type_dev_init,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Network", nullptr}),
+    em_cmd_t(em_cmd_type_cfg_renew, em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Renew", nullptr}),
+    em_cmd_t(em_cmd_type_vap_config,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:BssConfig", nullptr}),
+    em_cmd_t(em_cmd_type_sta_list,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:StaList", nullptr}),
+    em_cmd_t(em_cmd_type_ap_cap_query,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:CapReport", nullptr}),
+    em_cmd_t(em_cmd_type_max,em_cmd_params_t{0, {"", "", "", "", ""}, "max", nullptr}),
 };
 
 int em_cmd_agent_t::execute(em_long_string_t result)
 {
-    int ret, lsock, dsock;
-    unsigned int sz = EM_MAX_EVENT_DATA_LEN, i, offset, iter;
+    int ret, lsock;
+    unsigned int sz = EM_MAX_EVENT_DATA_LEN;
     unsigned char *tmp;
 
     m_cmd.reset();
@@ -81,7 +81,7 @@ int em_cmd_agent_t::execute(em_long_string_t result)
 
         printf("%s:%d: Connection accepted from client\n", __func__, __LINE__);
 
-        tmp = (unsigned char *)get_event();
+        tmp = reinterpret_cast<unsigned char *>(get_event());
 
         if ((ret = recv(m_dsock, tmp, sizeof(em_event_t) + EM_MAX_EVENT_DATA_LEN, 0)) <= 0) {
             printf("%s:%d: listen error on socket, err:%d\n", __func__, __LINE__, errno);
@@ -113,7 +113,7 @@ int em_cmd_agent_t::send_result(em_cmd_out_status_t status)
     em_status_string_t str;
     unsigned char *tmp;
 
-    tmp = (unsigned char *)m_cmd.status_to_string(status, str);
+    tmp = reinterpret_cast<unsigned char *>(m_cmd.status_to_string(status, str));
 
     if ((ret = send(m_dsock, tmp, sizeof(em_status_string_t), 0)) <= 0) {
         printf("%s:%d: write error on socket, err:%d\n", __func__, __LINE__, errno);
@@ -129,7 +129,7 @@ em_event_t *em_cmd_agent_t::create_event(char *buff)
     // here is the entry point of RBUS subdocuments
     em_cmd_type_t   type = em_cmd_type_none;
     cJSON *obj, *child_obj;
-    char *tmp;
+    const char *tmp;
     em_cmd_t    *cmd;
     unsigned int idx;
     em_event_t *evt;
@@ -151,7 +151,7 @@ em_event_t *em_cmd_agent_t::create_event(char *buff)
             type = em_cmd_agent_t::m_client_cmd_spec[idx].get_type(); continue;
         }
 
-        tmp = (char *)cmd->get_arg();
+        tmp = cmd->get_arg();
 
         if ((child_obj = cJSON_GetObjectItem(obj, tmp)) != NULL) {
             break;
@@ -169,7 +169,8 @@ em_event_t *em_cmd_agent_t::create_event(char *buff)
         return NULL;
     }
 
-    evt = (em_event_t *)malloc(sizeof(em_event_t));
+    unsigned int buff_len = static_cast<unsigned int>(strlen(buff)) + 1;
+    evt = reinterpret_cast<em_event_t *>(malloc(sizeof(em_event_t) + buff_len));
     evt->type = em_event_type_bus;
     bevt = &evt->u.bevt;
 
@@ -199,22 +200,22 @@ em_event_t *em_cmd_agent_t::create_event(char *buff)
     }
 
     memcpy(&bevt->params, &cmd->m_param, sizeof(em_cmd_params_t));
-    memcpy(&bevt->u.subdoc.buff, buff, EM_MAX_EVENT_DATA_LEN);
-    bevt->data_len = strlen(buff) + 1;   
+    memcpy(&bevt->u.subdoc.buff, buff, buff_len);
+    bevt->data_len = buff_len;
     return evt;
 }
 
-em_cmd_agent_t::em_cmd_agent_t(em_cmd_t& obj)
+em_cmd_agent_t::em_cmd_agent_t(em_cmd_t& obj) : m_dsock(-1)
 {
     memcpy(&m_cmd.m_param, &obj.m_param, sizeof(em_cmd_params_t));
 }
 
-em_cmd_agent_t::em_cmd_agent_t(em_cmd_type_t type)
+em_cmd_agent_t::em_cmd_agent_t(em_cmd_type_t type) : m_dsock(-1)
 {
     memcpy(&m_cmd.m_param, &em_cmd_agent_t::m_client_cmd_spec[type].m_param, sizeof(em_cmd_params_t));
 }
 
-em_cmd_agent_t::em_cmd_agent_t()
+em_cmd_agent_t::em_cmd_agent_t() : m_dsock(-1)
 {
 
 }

--- a/src/agent/em_simulator.cpp
+++ b/src/agent/em_simulator.cpp
@@ -41,7 +41,7 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 	unsigned int i, j, k;
 	em_scan_result_t	scan_result;
 	dm_scan_result_t *res;
-	em_long_string_t key;
+	em_2xlong_string_t key;
 	mac_addr_str_t dev_mac_str, scanner_mac_str;
 	mac_address_t nbr_mac_base = {0x00, 0x01, 0x03, 0x04, 0x05, 0x06};
 
@@ -53,7 +53,7 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 
         for (j = 0; j < m_param.u.scan_params.op_class[i].num_channels; j++) {
 
-			strncpy(scan_result.id.net_id, dm.m_network.m_net_info.id, strlen(dm.m_network.m_net_info.id) + 1);
+			snprintf(scan_result.id.net_id, sizeof(scan_result.id.net_id), "%s", dm.m_network.m_net_info.id);
 			memcpy(scan_result.id.dev_mac, dm.m_device.m_device_info.id.dev_mac, sizeof(mac_address_t));
 			memcpy(scan_result.id.scanner_mac, m_param.u.scan_params.ruid, sizeof(mac_address_t));
 			scan_result.id.op_class = m_param.u.scan_params.op_class[i].op_class;
@@ -63,15 +63,15 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 			dm_easy_mesh_t::macbytes_to_string(dm.m_device.m_device_info.id.dev_mac, dev_mac_str);
 			dm_easy_mesh_t::macbytes_to_string(m_param.u.scan_params.ruid, scanner_mac_str);
 
-			snprintf(key, sizeof(em_long_string_t), "%s@%s@%s@%d@%d@%d", scan_result.id.net_id, dev_mac_str, scanner_mac_str,
+			snprintf(key, sizeof(em_2xlong_string_t), "%s@%s@%s@%d@%d@%d", scan_result.id.net_id, dev_mac_str, scanner_mac_str,
 				scan_result.id.op_class, scan_result.id.channel, scan_result.id.scanner_type);
 
-			if ((res = (dm_scan_result_t *)hash_map_get(dm.m_scan_result_map, key)) == NULL) {
+			if ((res = reinterpret_cast<dm_scan_result_t *>(hash_map_get(dm.m_scan_result_map, key))) == NULL) {
 				res = new dm_scan_result_t(&scan_result);
 				hash_map_put(dm.m_scan_result_map, strdup(key), res);
 			}
 			
-			strncpy(res->m_scan_result.id.net_id, dm.m_network.m_net_info.id, strlen(dm.m_network.m_net_info.id) + 1);
+			snprintf(res->m_scan_result.id.net_id, sizeof(res->m_scan_result.id.net_id), "%s", dm.m_network.m_net_info.id);
 			memcpy(res->m_scan_result.id.dev_mac, dm.m_device.m_device_info.intf.mac, sizeof(mac_address_t));
 			memcpy(res->m_scan_result.id.scanner_mac, m_param.u.scan_params.ruid, sizeof(mac_address_t));
 			res->m_scan_result.id.op_class = m_param.u.scan_params.op_class[i].op_class;
@@ -80,7 +80,7 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 
 			util::get_date_time_rfc3399(time_date, sizeof(time_date));
 
-			strncpy(res->m_scan_result.timestamp, time_date, strlen(time_date) + 1);
+			snprintf(res->m_scan_result.timestamp, sizeof(res->m_scan_result.timestamp), "%s", time_date);
 			res->m_scan_result.util = 20;
 			res->m_scan_result.noise = 10;
 
@@ -89,7 +89,7 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 			for (k = 0; k < res->m_scan_result.num_neighbors; k++) {
 				nbr_mac_base[5]++;
 				memcpy(res->m_scan_result.neighbor[k].bssid, nbr_mac_base, sizeof(mac_address_t));
-				strncpy(res->m_scan_result.neighbor[k].ssid, "test", strlen("test") + 1);
+				snprintf(res->m_scan_result.neighbor[k].ssid, sizeof(res->m_scan_result.neighbor[k].ssid), "%s", "test");
 				res->m_scan_result.neighbor[k].signal_strength = 30;
 				res->m_scan_result.neighbor[k].bandwidth = WIFI_CHANNELBANDWIDTH_40MHZ;
 				res->m_scan_result.neighbor[k].bss_color = 0x8f;
@@ -127,8 +127,8 @@ void em_simulator_t::configure(dm_easy_mesh_agent_t& dm, em_scan_params_t *param
 }
 
 em_simulator_t::em_simulator_t()
+    : m_param{}, m_can_run_scan_res(false)
 {
-	m_can_run_scan_res = false;
 }
 
 em_simulator_t::~em_simulator_t()


### PR DESCRIPTION
Reason for change: fixing warnings in easymesh agent
Also fixed warnings coming from em_printf and derived functions,
as well as memory leaks and using snprintf instead of strncpy in agent

Test procedure: controller and agent are able to run, no crashes

Priority: P2
Risk: Low