### PR TITLE
RDKBWIFI-448: Fixing various easymesh issues

### DIFF
--- a/inc/dm_radio_cap.h
+++ b/inc/dm_radio_cap.h
@@ -74,7 +74,7 @@ public:
 	 */
 	void encode(cJSON *obj);
 
-    bool operator == (const dm_radio_cap_t& obj);
+    bool operator == (const dm_radio_cap_t& obj) const;
     void operator = (const dm_radio_cap_t& obj);
 
     

--- a/inc/em_cmd.h
+++ b/inc/em_cmd.h
@@ -29,7 +29,7 @@
 class em_cmd_t {
 public:
     em_cmd_type_t   m_type;
-    em_service_type_t   m_svc;
+    em_service_type_t   m_svc = em_service_type_none;
     em_cmd_params_t m_param;
     em_event_t  *m_evt;
     em_string_t m_name;

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -180,7 +180,10 @@ char *em_cmd_t::status_to_string(em_cmd_out_status_t status, char *str)
 
 void em_cmd_t::deinit()
 {
-    queue_destroy(m_em_candidates);
+    if (m_em_candidates != nullptr) {
+        queue_destroy(m_em_candidates);
+        m_em_candidates = nullptr;
+    }
     m_data_model.deinit();
 	//free(m_evt);
 }
@@ -886,7 +889,7 @@ int em_cmd_t::dump_bus_event(em_bus_event_t *evt)
 }   
 
 em_cmd_t::em_cmd_t(em_cmd_type_t type, em_cmd_params_t param, dm_easy_mesh_t& dm)
-    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_db_cfg_type(db_cfg_type_none)
+    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_em_candidates(nullptr), m_db_cfg_type(db_cfg_type_none)
 {
     auto raw = static_cast<std::underlying_type_t<em_cmd_type_t>>(type);
     m_type = (raw >= static_cast<decltype(raw)>(em_cmd_type_max))
@@ -898,7 +901,7 @@ em_cmd_t::em_cmd_t(em_cmd_type_t type, em_cmd_params_t param, dm_easy_mesh_t& dm
 }
 
 em_cmd_t::em_cmd_t(em_cmd_type_t type, em_cmd_params_t param)
-    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_db_cfg_type(db_cfg_type_none)
+    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_em_candidates(nullptr), m_db_cfg_type(db_cfg_type_none)
 {
     auto raw = static_cast<std::underlying_type_t<em_cmd_type_t>>(type);
     m_type = (raw >= static_cast<decltype(raw)>(em_cmd_type_max))
@@ -909,7 +912,7 @@ em_cmd_t::em_cmd_t(em_cmd_type_t type, em_cmd_params_t param)
 }
 
 em_cmd_t::em_cmd_t()
-    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_db_cfg_type(db_cfg_type_none)
+    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_em_candidates(nullptr), m_db_cfg_type(db_cfg_type_none)
 {
 	m_evt = static_cast<em_event_t *> (malloc(sizeof(em_event_t) + EM_MAX_EVENT_DATA_LEN));
 }

--- a/src/dm/dm_device_list.cpp
+++ b/src/dm/dm_device_list.cpp
@@ -245,7 +245,7 @@ bool dm_device_list_t::search_db(db_client_t& db_client, void *ctx, void *key)
 
 int dm_device_list_t::sync_db(db_client_t& db_client, void *ctx)
 {
-    em_device_info_t info;
+    em_device_info_t info = {};
     mac_addr_str_t	mac;
     em_long_string_t   str;
     int rc = 0;
@@ -302,7 +302,7 @@ int dm_device_list_t::sync_db(db_client_t& db_client, void *ctx)
 
 bool dm_device_list_t::compare_db(db_client_t& db_client, const dm_device_t& sta)
 {
-    em_device_info_t info;
+    em_device_info_t info = {};
     mac_addr_str_t mac;
     em_long_string_t   str;
     db_query_t    query;

--- a/src/dm/dm_radio_cap.cpp
+++ b/src/dm/dm_radio_cap.cpp
@@ -82,49 +82,15 @@ void dm_radio_cap_t::encode(cJSON *obj)
 */
 }
 
-bool dm_radio_cap_t::operator == (const dm_radio_cap_t& obj)
+bool dm_radio_cap_t::operator == (const dm_radio_cap_t& obj) const
 {
-    int ret = 0;
-    ret += (memcmp(&this->m_radio_cap_info.ruid.mac ,&obj.m_radio_cap_info.ruid.mac,sizeof(mac_address_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.ruid.name,&obj.m_radio_cap_info.ruid.name,sizeof(em_interface_name_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.ht_cap,&obj.m_radio_cap_info.ht_cap,sizeof(em_ap_ht_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.vht_cap,&obj.m_radio_cap_info.vht_cap,sizeof(em_ap_vht_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.he_cap,&obj.m_radio_cap_info.he_cap,sizeof(em_ap_he_cap_t)) != 0);
-    ret += !(this->m_radio_cap_info.num_op_classes == obj.m_radio_cap_info.num_op_classes);
-    ret += (memcmp(&this->m_radio_cap_info.wifi6_cap,&obj.m_radio_cap_info.wifi6_cap,sizeof(em_radio_wifi6_cap_data_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.wifi7_cap,&obj.m_radio_cap_info.wifi7_cap,sizeof(em_wifi7_agent_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.ch_scan,&obj.m_radio_cap_info.ch_scan,sizeof(em_channel_scan_cap_radio_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.radio_ad_cap,&obj.m_radio_cap_info.radio_ad_cap,sizeof(em_ap_radio_advanced_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.prof_2_ap_cap,&obj.m_radio_cap_info.prof_2_ap_cap,sizeof(em_profile_2_ap_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.cac_cap,&obj.m_radio_cap_info.cac_cap,sizeof(em_cac_cap_radio_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.metric_interval,&obj.m_radio_cap_info.metric_interval,sizeof(em_metric_cltn_interval_t)) != 0);
-   
-     //em_util_info_print(EM_MGR, "%s:%d: MUH ret=%d\n", __func__, __LINE__,ret);
-
-     if (ret > 0)
-        return false;
-    else
-        return true;
-
+    return (memcmp(&this->m_radio_cap_info, &obj.m_radio_cap_info, sizeof(em_radio_cap_info_t)) == 0);
 }
 
 void dm_radio_cap_t::operator = (const dm_radio_cap_t& obj)
 {
     if (this == &obj) { return; }
-    memcpy(&this->m_radio_cap_info.ruid.mac ,&obj.m_radio_cap_info.ruid.mac,sizeof(mac_address_t));
-    memcpy(&this->m_radio_cap_info.ruid.name,&obj.m_radio_cap_info.ruid.name,sizeof(em_interface_name_t));
-    memcpy(&this->m_radio_cap_info.ht_cap,&obj.m_radio_cap_info.ht_cap,sizeof(em_ap_ht_cap_t));
-    memcpy(&this->m_radio_cap_info.vht_cap,&obj.m_radio_cap_info.vht_cap,sizeof(em_ap_vht_cap_t));
-    memcpy(&this->m_radio_cap_info.he_cap,&obj.m_radio_cap_info.he_cap,sizeof(em_ap_he_cap_t));
-    memcpy(&this->m_radio_cap_info.wifi6_cap,&obj.m_radio_cap_info.wifi6_cap,sizeof(em_radio_wifi6_cap_data_t));
-    memcpy(&this->m_radio_cap_info.wifi7_cap,&obj.m_radio_cap_info.wifi7_cap,sizeof(em_wifi7_agent_cap_t));
-    memcpy(&this->m_radio_cap_info.ch_scan,&obj.m_radio_cap_info.ch_scan,sizeof(em_channel_scan_cap_radio_t));
-    memcpy(&this->m_radio_cap_info.radio_ad_cap,&obj.m_radio_cap_info.radio_ad_cap,sizeof(em_ap_radio_advanced_cap_t));
-    memcpy(&this->m_radio_cap_info.prof_2_ap_cap,&obj.m_radio_cap_info.prof_2_ap_cap,sizeof(em_profile_2_ap_cap_t));
-    memcpy(&this->m_radio_cap_info.cac_cap,&obj.m_radio_cap_info.cac_cap,sizeof(em_cac_cap_radio_t));
-    memcpy(&this->m_radio_cap_info.metric_interval,&obj.m_radio_cap_info.metric_interval,sizeof(em_metric_cltn_interval_t));
-    this->m_radio_cap_info.num_op_classes = obj.m_radio_cap_info.num_op_classes;
-
+    memcpy(&this->m_radio_cap_info, &obj.m_radio_cap_info, sizeof(em_radio_cap_info_t));
 }
 
 dm_radio_cap_t::dm_radio_cap_t(em_radio_cap_info_t *radio_cap)

--- a/src/dm/dm_scan_result.cpp
+++ b/src/dm/dm_scan_result.cpp
@@ -252,8 +252,8 @@ bool dm_scan_result_t::has_same_id(em_scan_result_id_t *id)
 }
 
 dm_scan_result_t::dm_scan_result_t(em_scan_result_t *scan_result)
+    : m_scan_result{}
 {
-	memset(&m_scan_result, 0, sizeof(em_scan_result_t));
 	if (scan_result == nullptr) {
 		em_printfout("Error: scan_result is null");
 		return;
@@ -262,18 +262,20 @@ dm_scan_result_t::dm_scan_result_t(em_scan_result_t *scan_result)
 }
 
 dm_scan_result_t::dm_scan_result_t(const dm_scan_result_t& scan_result)
+    : m_scan_result{}
 {
     memcpy(&m_scan_result, &scan_result.m_scan_result, sizeof(em_scan_result_t));
 }
 
 dm_scan_result_t::dm_scan_result_t(const em_scan_result_t& scan_result)
+    : m_scan_result{}
 {
     memcpy(&m_scan_result, &scan_result, sizeof(em_scan_result_t));
 }
 
 dm_scan_result_t::dm_scan_result_t()
+    : m_scan_result{}
 {
-	memset(&m_scan_result, 0, sizeof(em_scan_result_t));
 }
 
 dm_scan_result_t::~dm_scan_result_t()

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -240,7 +240,7 @@ int em_capability_t::send_ap_cap_report_msg(unsigned char *dst, unsigned short m
     len += static_cast<unsigned int>((sizeof(em_tlv_t)));
 
     /*if (em_msg_t(em_msg_type_ap_cap_rprt, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("Topology Response msg failed validation in tnx end");
+        em_printfout("Error: Topology Response msg failed validation in tnx end");
 
         return -1;
     }*/

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -240,17 +240,17 @@ int em_capability_t::send_ap_cap_report_msg(unsigned char *dst, unsigned short m
     len += static_cast<unsigned int>((sizeof(em_tlv_t)));
 
     /*if (em_msg_t(em_msg_type_ap_cap_rprt, em_profile_type_3, buff, len).validate(errors) == 0) {
-        em_printfout("Error: Topology Response msg failed validation in tnx end");
+        em_printfout("Error: AP Capability Report msg validation failed in tnx end");
 
         return -1;
     }*/
 
     if (send_frame(buff, len)  < 0) {
-        em_printfout("AP capability report send failed, error:%d", errno);
+        em_printfout("Error: AP Capability Report msg send failed, error: %d", errno);
         return -1;
     }
     set_state(em_state_agent_ap_cap_report);
-    em_printfout("AP Cap report sent successfully, len[%d]", len);
+    em_printfout("AP Capability Report msg sent successfully, len[%d]", len);
     return static_cast<int> (len);
 }
 
@@ -312,17 +312,17 @@ int em_capability_t::send_client_cap_query()
     tmp += (sizeof (em_tlv_t));
     len += (sizeof (em_tlv_t));
     if (em_msg_t(em_msg_type_client_cap_query, em_profile_type_3, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        em_printfout("Capability Query msg failed validation in tnx end");
+        em_printfout("Error: Client Capability Query msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        em_printfout("Capability Query msg failed, error:%d", errno);
+        em_printfout("Error: Client Capability Query msg send failed, error: %d", errno);
         return -1;
     }
 
     m_cap_query_tx_cnt++;
-    em_printfout("Capability Query (%d) Send Successful for sta:%s", m_cap_query_tx_cnt, evt_param->u.args.args[2]);
+    em_printfout("Client Capability Query msg (%d) sent successfully for sta: %s", m_cap_query_tx_cnt, evt_param->u.args.args[2]);
 
     return static_cast<int> (len);
 }
@@ -509,17 +509,17 @@ int em_capability_t::send_client_cap_report_msg(mac_address_t sta, bssid_t bss, 
     len += (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_client_cap_rprt, em_profile_type_3, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        printf("%s:%d: Client capability report validation failed\n", __func__, __LINE__);
+        em_printfout("Error: Client Capability Report msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: Client Capablity report send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: Client Capability Report msg send failed, error: %d", errno);
         return -1;
     }
 
     dm_easy_mesh_t::macbytes_to_string(sta, mac_str);
-    printf("%s:%d: Client Capablity report Send Successful for sta:%s\n", __func__, __LINE__, mac_str);
+    em_printfout("Client Capability Report msg sent successfully for sta: %s", mac_str);
 
     return static_cast<int> (len);
 }
@@ -571,15 +571,15 @@ int em_capability_t::send_ap_cap_query_msg()
     len += static_cast<unsigned int> (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_ap_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
-        em_printfout("AP capability Query msg failed validation in tnx end");
+        em_printfout("Error: AP Capability Query msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, len)  < 0) {
-        em_printfout("%s:%d: AP capability Query send failed, error:%d", errno);
+        em_printfout("Error: AP Capability Query msg send failed, error: %d", errno);
         return -1;
     }
-    em_printfout("AP capability Query Sent for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
+    em_printfout("AP Capability Query msg sent successfully for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
 
     return 0;
 }
@@ -631,16 +631,16 @@ int em_capability_t::send_bsta_cap_query_msg()
     len += static_cast<unsigned int> (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_bh_sta_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("Backhaul Sta capability Query msg failed validation in tnx end\n");
+        em_printfout("Error: Backhaul Sta Capability Query msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, len)  < 0) {
-        printf("%s:%d: Backhaul Sta capability Query send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: Backhaul Sta Capability Query msg send failed, error: %d", errno);
         return -1;
     }
 
-    em_printfout("Backhaul Sta capability Query Sent for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
+    em_printfout("Backhaul Sta Capability Query msg sent successfully for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
 
     return 0;
 }
@@ -716,16 +716,16 @@ int em_capability_t::send_bsta_cap_report_msg(unsigned short msg_id)
     len += (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_bh_sta_cap_rprt, em_profile_type_3, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        em_printfout("Backhaul Sta capability report validation failed");
+        em_printfout("Error: Backhaul Sta Capability Report msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        em_printfout("Backhaul Sta capability report send failed");
+        em_printfout("Error: Backhaul Sta Capability Report msg send failed");
         return -1;
     }
 
-    em_printfout("Backhaul Sta capability report Send Successful");
+    em_printfout("Backhaul Sta Capability Report msg sent successfully");
 
     return static_cast<int> (len);
 }
@@ -745,7 +745,7 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     dm = get_data_model();
 
     if (em_msg_t(em_msg_type_client_cap_rprt, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("%s:%d:Client Capability query message validation failed\n",__func__,__LINE__);
+        em_printfout("Error: Client Capability Report msg validation failed");
         return -1;
     }
 
@@ -766,7 +766,7 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     }
 
     if (found_client_info == false) {
-        printf("%s:%d: Could not find client info\n", __func__, __LINE__);
+        em_printfout("Error: Could not find client info");
         return -1;
     }
 
@@ -791,7 +791,7 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     }
 
     if (found_cap_report == false) {
-        printf("%s:%d: Could not find client cap report\n", __func__, __LINE__);
+        em_printfout("Error: Could not find client cap report");
         return -1;
     }
 
@@ -818,7 +818,7 @@ void em_capability_t::handle_client_cap_query(unsigned char *buff, unsigned int 
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
 
     if (em_msg_t(em_msg_type_client_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
-        em_printfout("Client Capability query message validation failed");
+        em_printfout("Error: Client Capability Query msg validation failed");
         return;
     }
 
@@ -838,11 +838,11 @@ int em_capability_t::handle_bsta_cap_query(unsigned char *buff, unsigned int len
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
 
     if (em_msg_t(em_msg_type_bh_sta_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
-        em_printfout("Backhaul Sta Capability query message validation failed");
+        em_printfout("Error: Backhaul Sta Capability Query msg validation failed");
         return -1;
     }
 
-    em_printfout("Backhaul Sta Capability query message rcvd");
+    em_printfout("Backhaul Sta Capability Query msg rcvd");
 
     send_bsta_cap_report_msg(ntohs(cmdu->id));
 
@@ -858,7 +858,7 @@ int em_capability_t::handle_bsta_radio_cap(unsigned char *tlv_buff, unsigned int
 
     if (!tlv_len || ((tlv_len != sizeof(em_bh_sta_radio_cap_t)) && (tlv_len != offsetof(em_bh_sta_radio_cap_t, bsta_addr))))
     {
-        em_printfout("Invalid TLV length:%d Must be %d or %d for bsta radio cap TLV",
+        em_printfout("Error: Invalid TLV length:%d Must be %d or %d for bsta radio cap TLV",
 		     static_cast<int>(tlv_len),
                      static_cast<int>(offsetof(em_bh_sta_radio_cap_t, bsta_addr)),
                      static_cast<int>(sizeof(em_bh_sta_radio_cap_t)));
@@ -890,14 +890,14 @@ int em_capability_t::handle_bsta_radio_cap(unsigned char *tlv_buff, unsigned int
     dm_easy_mesh_t *dm = get_data_model();
 
     if (!dm) {
-        em_printfout("Could not find data model");
+        em_printfout("Error: Could not find data model");
         return -1;
     }
 
     em_device_info_t *dev = dm->get_device_info();
     if (!dev)
     {
-        em_printfout("Could not find device in data model");
+        em_printfout("Error: Could not find device in data model");
         return -1;
     }
 
@@ -914,7 +914,7 @@ int em_capability_t::handle_client_info(unsigned char *tlv_buff, unsigned int tl
     }
 
     if (tlv_len != sizeof(em_client_info_t)) {
-        em_printfout("Invalid TLV length for client info TLV: received %u, expected %d", tlv_len, static_cast<int>(sizeof(em_client_info_t)));
+        em_printfout("Error: Invalid TLV length for client info TLV: received %u, expected %d", tlv_len, static_cast<int>(sizeof(em_client_info_t)));
         return -1;
     }
 
@@ -923,7 +923,7 @@ int em_capability_t::handle_client_info(unsigned char *tlv_buff, unsigned int tl
     dm_easy_mesh_t *dm = get_data_model();
 
     if (!dm) {
-        em_printfout("Could not find data model");
+        em_printfout("Error: Could not find data model");
         return -1;
     }
 
@@ -1395,11 +1395,11 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
     }
 
     /*if (em_msg_t(em_msg_type_ap_cap_rprt, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("%s:%d:AP Capability report message validation failed\n",__func__,__LINE__);
+        em_printfout("Error: AP Capability Report msg validation failed");
         return -1;
     }*/
 
-    em_printfout("AP Capability report message rcvd for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
+    em_printfout("AP Capability Report msg rcvd for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
 
     return 0;
 }

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -851,6 +851,7 @@ void em_configuration_t::handle_ap_vendor_operational_bss(unsigned char *value, 
 			dm_bss = dm->get_bss(radio->ruid, bss->bssid);
 			if (dm_bss == NULL) {
 				dm_bss = &dm->m_bss[dm->m_num_bss];
+				dm_bss->init();
 				dm->set_num_bss(dm->get_num_bss() + 1);
 			}
 			// fill up id first
@@ -1459,6 +1460,7 @@ int em_configuration_t::handle_ap_operational_bss(unsigned char *buff, unsigned 
 		
 			if (dm_bss == NULL) {
 				dm_bss = &dm->m_bss[dm->m_num_bss];
+				dm_bss->init();
 
 				// fill up id first
 				strncpy(dm_bss->m_bss_info.id.net_id, dm->m_device.m_device_info.id.net_id, sizeof(em_long_string_t));
@@ -3605,7 +3607,7 @@ int em_configuration_t::handle_wsc_m1(unsigned char *buff, unsigned int len)
     unsigned int tmp_len;
     unsigned short id;
     mac_addr_str_t mac_str;
-    em_device_info_t    dev_info;
+    em_device_info_t    dev_info = {};
     dm_easy_mesh_t *dm;
     em_freq_band_t  band;
     dm_radio_t *radio;
@@ -5048,16 +5050,21 @@ int em_configuration_t::handle_autoconfig_resp(unsigned char *buff, unsigned int
     }
 
     printf("Received resp and validated...creating M1 msg\n");
-    sz = static_cast<unsigned int> (create_autoconfig_wsc_m1_msg(msg, hdr->src));
+    int msg_len = create_autoconfig_wsc_m1_msg(msg, hdr->src);
+    if (msg_len < 0) {
+        em_printfout("Error: Failed to create autoconfig wsc m1 msg");
+        return -1;
+    }
+    sz = static_cast<unsigned int>(msg_len);
 
     if (em_msg_t(em_msg_type_autoconf_wsc, em_profile_type_3, msg, sz).validate(errors) == 0) {
-        printf("autoconfig wsc m1 validation failed\n");
+        em_printfout("Error: autoconfig wsc m1 validation failed");
 
         return -1;
     }
 
     if (send_frame(msg, sz)  < 0) {
-        printf("%s:%d: autoconfig wsc m1 send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: autoconfig wsc m1 send failed, error:%d", errno);
 
         return -1;
     }
@@ -5109,19 +5116,24 @@ int em_configuration_t::handle_autoconfig_search(unsigned char *buff, unsigned i
         return ec_mgr.handle_autoconf_chirp(reinterpret_cast<em_dpp_chirp_value_t*>(dpp_chirp_tlv->value), SWAP_LITTLE_ENDIAN(dpp_chirp_tlv->len), al_mac, ntohs(cmdu->id));
     }
     
-    sz = static_cast<unsigned int> (create_autoconfig_resp_msg(msg, band, al_mac, ntohs(cmdu->id)));
+    int msg_len = create_autoconfig_resp_msg(msg, band, al_mac, ntohs(cmdu->id));
+    if (msg_len < 0) {
+        em_printfout("Error: Failed to create autoconfig response msg");
+        return -1;
+    }
+    sz = static_cast<unsigned int>(msg_len);
     if (em_msg_t(em_msg_type_autoconf_resp, em_profile_type_3, msg, sz).validate(errors) == 0) {
-        printf("%s:%d: autoconfig rsp validation failed\n", __func__, __LINE__);
+        em_printfout("Error: autoconfig rsp validation failed");
 
         //return -1;
     }
 
     if (send_frame(msg, sz)  < 0) {
-        printf("%s:%d: autoconfig rsp send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: autoconfig rsp send failed, error:%d", errno);
 
         return -1;
     }
-    printf("%s:%d: autoconfig rsp send success\n", __func__, __LINE__);
+    em_printfout("autoconfig rsp send success");
 
     if (!get_is_dpp_onboarding()) {
         set_state(em_state_ctrl_wsc_m1_pending);
@@ -5332,20 +5344,25 @@ void em_configuration_t::handle_state_config_none()
     unsigned char buff[MAX_EM_BUFF_SZ];
     unsigned int sz;
     char* errors[EM_MAX_TLV_MEMBERS] = {0};
-
-    sz = static_cast<unsigned int> (create_autoconfig_search_msg(buff));
+    int len = create_autoconfig_search_msg(buff);
+    if (len < 0) {
+        em_printfout("Error: Failed to create autoconfig_search msg");
+        return;
+    }
+    sz = static_cast<unsigned int>(len);
     if (em_msg_t(em_msg_type_autoconf_search, em_profile_type_3, buff, sz).validate(errors) == 0) {
-        printf("Autoconfig_search validation failed\n");
+        em_printfout("Error: Autoconfig_search validation failed");
 
         return;
     }
 
     if (send_frame(buff, sz, true)  < 0) {
-        printf("%s:%d: failed, err:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: failed, err:%d\n", errno);
         return;
     }
     em_printf("autoconfig_search send successful");
-    printf("%s:%d: autoconfig_search send successful\n", __func__, __LINE__);
+    em_printfout("autoconfig_search send successful");
+
     set_state(em_state_agent_autoconfig_rsp_pending);
 
     return;
@@ -5361,18 +5378,23 @@ void em_configuration_t::handle_state_autoconfig_renew()
 
 
     memcpy(ctrl_src, get_current_cmd()->get_data_model()->get_controller_interface_mac(), sizeof(mac_address_t));
-    sz = static_cast<unsigned int> (create_autoconfig_wsc_m1_msg(msg, ctrl_src));
+    int msg_len = create_autoconfig_wsc_m1_msg(msg, ctrl_src);
+    if (msg_len < 0) {
+        em_printfout("Error: Failed to create autoconfig wsc m1 msg");
+        return ;
+    }
+    sz = static_cast<unsigned int>(msg_len);
 
     if (em_msg_t(em_msg_type_autoconf_wsc, em_profile_type_3, msg, sz).validate(errors) == 0) {
-        printf("autoconfig wsc m1 validation failed\n");
+        em_printfout("Error: autoconfig wsc m1 validation failed");
         return ;
     }
 
     if (send_frame(msg, sz)  < 0) {
-        printf("%s:%d: autoconfig wsc m1 send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: autoconfig wsc m1 send failed, error:%d", errno);
         return ;
     }
-    printf("%s:%d: autoconfig wsc m1 send success\n", __func__, __LINE__);
+    em_printfout("autoconfig wsc m1 send success");
     set_state(em_state_agent_wsc_m2_pending);
 
     return ;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1635,7 +1635,7 @@ short em_t::create_device_inventory_tlv(unsigned char *buff)
     static constexpr size_t EM_INVENTORY_STR_MAX = 64;
 
     // 1. Serial Number
-    slen = (info->serial_number) ? strlen(info->serial_number) : 0;
+    slen = (info) ? strlen(info->serial_number) : 0;
     if (slen > sizeof(info->serial_number) - 1) slen = sizeof(info->serial_number) - 1;
     if (slen > EM_INVENTORY_STR_MAX) slen = EM_INVENTORY_STR_MAX;
     data_len = static_cast<unsigned char>(slen);
@@ -1647,7 +1647,7 @@ short em_t::create_device_inventory_tlv(unsigned char *buff)
     len += (1 + data_len);
 
     // 2. Software Version
-    slen = (info->software_ver) ? strlen(info->software_ver) : 0;
+    slen = (info) ? strlen(info->software_ver) : 0;
     if (slen > sizeof(info->software_ver) - 1) slen = sizeof(info->software_ver) - 1;
     if (slen > EM_INVENTORY_STR_MAX) slen = EM_INVENTORY_STR_MAX;
     data_len = static_cast<unsigned char>(slen);
@@ -1659,7 +1659,7 @@ short em_t::create_device_inventory_tlv(unsigned char *buff)
     len += (1 + data_len);
 
     // 3. Environment
-    slen = (info->environment) ? strlen(info->environment) : 0;
+    slen = (info) ? strlen(info->environment) : 0;
     if (slen > sizeof(info->environment) - 1) slen = sizeof(info->environment) - 1;
     if (slen > EM_INVENTORY_STR_MAX) slen = EM_INVENTORY_STR_MAX;
     data_len = static_cast<unsigned char>(slen);
@@ -1684,7 +1684,7 @@ short em_t::create_device_inventory_tlv(unsigned char *buff)
         tmp += sizeof(mac_address_t);
         len += static_cast<short>(sizeof(mac_address_t));
 
-        slen = (dm->get_radio_info(i)->chip_vendor) ? strlen(dm->get_radio_info(i)->chip_vendor) : 0;
+        slen = (dm->get_radio_info(i)) ? strlen(dm->get_radio_info(i)->chip_vendor) : 0;
         if (slen > sizeof(dm->get_radio_info(i)->chip_vendor) - 1) slen = sizeof(dm->get_radio_info(i)->chip_vendor) - 1;
         if (slen > EM_INVENTORY_STR_MAX) slen = EM_INVENTORY_STR_MAX;
         data_len = static_cast<unsigned char>(slen);

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -62,6 +62,8 @@ bool em_msg_t::get_client_mac_info(mac_address_t *mac)
             memcpy(mac, &cltinfo->client_mac_addr, sizeof(mac_address_t));
             return true;
         }
+        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
     }
     return false;
 }

--- a/tests/test_l1_dm_device.cpp
+++ b/tests/test_l1_dm_device.cpp
@@ -355,7 +355,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceWithEmptyInterfaceName) {
 /**
  * @brief Test to verify the retrieval of AL Interface MAC Address with a valid MAC address
  *
- * This test checks if the `get_al_interface_mac` function correctly retrieves the MAC address
+ * This test checks if the `get_backhaul_al_interface_mac` function correctly retrieves the MAC address
  * that has been set in the `m_device_info.backhaul_alid.mac` field of the `dm_device_t` object.
  *
  * **Test Group ID:** Basic: 01@n
@@ -370,7 +370,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceWithEmptyInterfaceName) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the expected MAC address in the `m_device_info.backhaul_alid.mac` field | expected_mac = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E} | MAC address should be set successfully | Should be successful |
- * | 02 | Retrieve the MAC address using `get_al_interface_mac` function | None | MAC address should not be null | Should Pass |
+ * | 02 | Retrieve the MAC address using `get_backhaul_al_interface_mac` function | None | MAC address should not be null | Should Pass |
  * | 03 | Verify each byte of the retrieved MAC address against the expected MAC address | expected_mac = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E} | Each byte should match the expected MAC address | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithValidMACAddress) {
@@ -393,7 +393,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithValidMACAddress) {
 /**
  * @brief Test to verify the retrieval of AL Interface MAC Address when it is set to all zeros.
  *
- * This test checks if the `get_al_interface_mac` function correctly retrieves the MAC address when it is set to all zeros. 
+ * This test checks if the `get_backhaul_al_interface_mac` function correctly retrieves the MAC address when it is set to all zeros. 
  * It ensures that the function does not return a null pointer and that the retrieved MAC address matches the expected all-zero MAC address.
  *
  * **Test Group ID:** Basic: 01@n
@@ -408,7 +408,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithValidMACAddress) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the device's backhaul ALID MAC address to all zeros | expected_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00} | None | Should be successful |
- * | 02 | Retrieve the AL Interface MAC address using `get_al_interface_mac` | None | mac should not be null | Should Pass |
+ * | 02 | Retrieve the AL Interface MAC address using `get_backhaul_al_interface_mac` | None | mac should not be null | Should Pass |
  * | 03 | Verify that the retrieved MAC address matches the expected all-zero MAC address | mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00} | Each byte of mac should match expected_mac | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllZeroMACAddress) {
@@ -431,7 +431,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllZeroMACAddress) {
 /**
  * @brief Test to verify the retrieval of AL Interface MAC Address when all bytes are set to FF
  *
- * This test checks if the `get_al_interface_mac` function correctly retrieves the MAC address when all bytes are set to 0xFF. 
+ * This test checks if the `get_backhaul_al_interface_mac` function correctly retrieves the MAC address when all bytes are set to 0xFF. 
  * It ensures that the function returns the expected MAC address and that the returned pointer is not null.
  *
  * **Test Group ID:** Basic: 01@n
@@ -446,7 +446,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllZeroMACAddress) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the MAC address in the device to all 0xFF | expected_mac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF} | None | Should be successful |
- * | 02 | Retrieve the AL Interface MAC address using `get_al_interface_mac` | None | mac != nullptr | Should Pass |
+ * | 02 | Retrieve the AL Interface MAC address using `get_backhaul_al_interface_mac` | None | mac != nullptr | Should Pass |
  * | 03 | Verify each byte of the retrieved MAC address matches the expected value | expected_mac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF} | Each byte of mac should be equal to expected_mac | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
@@ -469,7 +469,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
 /**
  * @brief Test to verify retrieval of AL interface name with a valid AL interface name.
  *
- * This test checks if the function `get_al_interface_name` correctly retrieves the AL interface name when a valid name is set in the device's backhaul ALID.
+ * This test checks if the function `get_backhaul_al_interface_name` correctly retrieves the AL interface name when a valid name is set in the device's backhaul ALID.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 014@n
@@ -483,7 +483,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the AL interface name in the device's backhaul ALID | expected_name = "eth0" | None | Should be successful |
- * | 02 | Retrieve the AL interface name using `get_al_interface_name` | None | result = "eth0" | Should Pass |
+ * | 02 | Retrieve the AL interface name using `get_backhaul_al_interface_name` | None | result = "eth0" | Should Pass |
  * | 03 | Verify the retrieved AL interface name matches the expected name | result = "eth0", expected_name = "eth0" | Assertion should pass | Should Pass |
  */
  TEST(dm_device_t_Test, RetrieveALInterfaceNameWithValidALInterfaceName) {
@@ -504,7 +504,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
 /**
  * @brief Test to verify the retrieval of AL Interface Name when it is empty.
  *
- * This test checks the behavior of the get_al_interface_name() method when the AL Interface Name is set to an empty string. 
+ * This test checks the behavior of the get_backhaul_al_interface_name() method when the AL Interface Name is set to an empty string. 
  * It ensures that the method correctly returns an empty string in this scenario.
  *
  * **Test Group ID:** Basic: 01@n
@@ -519,7 +519,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the AL Interface Name to an empty string | expected_name = "" | None | Should be successful |
- * | 02 | Retrieve the AL Interface Name using get_al_interface_name() | None | result = "" | Should Pass |
+ * | 02 | Retrieve the AL Interface Name using get_backhaul_al_interface_name() | None | result = "" | Should Pass |
  * | 03 | Verify the retrieved AL Interface Name is an empty string | result = "", expected_name = "" | result == expected_name | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceNameWithEmptyALInterfaceName) {
@@ -540,7 +540,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceNameWithEmptyALInterfaceName) {
 /**
  * @brief Test to retrieve AL interface name with special characters in AL interface name
  *
- * This test verifies that the function `get_al_interface_name` correctly retrieves the AL interface name when it contains special characters. This is important to ensure that the function can handle and return names with special characters accurately.
+ * This test verifies that the function `get_backhaul_al_interface_name` correctly retrieves the AL interface name when it contains special characters. This is important to ensure that the function can handle and return names with special characters accurately.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 016@n
@@ -554,7 +554,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceNameWithEmptyALInterfaceName) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the AL interface name with special characters | expected_name = "eth0@# 123" | None | Should be successful |
- * | 02 | Retrieve the AL interface name using `get_al_interface_name` | None | result = "eth0@# 123" | Should Pass |
+ * | 02 | Retrieve the AL interface name using `get_backhaul_al_interface_name` | None | result = "eth0@# 123" | Should Pass |
  * | 03 | Verify the retrieved AL interface name matches the expected name | result = "eth0@# 123", expected_name = "eth0@# 123" | Assertion check: result == expected_name | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceNameWithSpecialCharactersInALInterfaceName) {

--- a/tests/test_l1_dm_easy_mesh.cpp
+++ b/tests/test_l1_dm_easy_mesh.cpp
@@ -2716,8 +2716,8 @@ TEST(dm_easy_mesh_t, decode_client_cap_config_null_radio_mac) {
  * **Test Procedure:**
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Invoke decode_config with JSON template for "SetAnticipatedChannelPreference" | input: subdoc->buff = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": {\"Network\": {\"ID\": \"TestNetwork\", \"AnticipatedChannelPreference\": [{ \"Class\": 1, \"ChannelList\": [1,6,11] }]}} } }", key = "SetAnticipatedChannelPreference", num pointer = valid address | API return value is 0 and ASSERT_NE(subdoc, nullptr) passes | Should Pass |
- * | 02 | Invoke decode_config with JSON template for "ChannelScanRequest" | input: subdoc->buff = "{ \"wfa-dataelements:ChannelScanRequest\": {\"Network\": {\"ID\": \"TestNetwork\", \"ChannelScanParameters\": [{ \"Class\": 1, \"ChannelList\": [1,6,11] }]}} } }", key = "ChannelScanRequest", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
+ * | 01 | Invoke decode_config with JSON template for "SetAnticipatedChannelPreference" | input: subdoc->buff = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"AnticipatedChannelPreference\": [{ \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }] }]}} } }", key = "SetAnticipatedChannelPreference", num pointer = valid address | API return value is 0 and ASSERT_NE(subdoc, nullptr) passes | Should Pass |
+ * | 02 | Invoke decode_config with JSON template for "ChannelScanRequest" | input: subdoc->buff = "{ \"wfa-dataelements:ChannelScanRequest\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"RadioList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"ChannelScanParameters\": [{ \"Class\": 1, \"ChannelList\": [1,6,11] }] }] }]}} } }", key = "ChannelScanRequest", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
  * | 03 | Invoke decode_config with JSON template for "SetPolicy" | input: subdoc->buff = "{ \"wfa-dataelements:SetPolicy\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"Policy\": { \"AP Metrics Reporting Policy\": {} }}]}} } }", key = "SetPolicy", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
  * | 04 | Invoke decode_config with JSON template for "RadioEnable" | input: subdoc->buff = "{ \"wfa-dataelements:RadioEnable\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"RadioList\": [{ \"ID\": \"Radio1\", \"Enable\": true }]}]}} } }", key = "RadioEnable", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
  */
@@ -2739,8 +2739,12 @@ TEST(dm_easy_mesh_t, decode_config_supported_routing)
     "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": {"
     "  \"Network\": {"
     "    \"ID\": \"TestNetwork\","
-    "    \"AnticipatedChannelPreference\": ["
-    "      { \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }"
+    "    \"DeviceList\": ["
+    "      { \"ID\": \"AA:BB:CC:DD:EE:FF\","
+    "        \"AnticipatedChannelPreference\": ["
+    "          { \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }"
+    "        ]"
+    "      }"
     "    ]"
     "  }"
     "} }",
@@ -2749,8 +2753,16 @@ TEST(dm_easy_mesh_t, decode_config_supported_routing)
     "{ \"wfa-dataelements:ChannelScanRequest\": {"
     "  \"Network\": {"
     "    \"ID\": \"TestNetwork\","
-    "    \"ChannelScanParameters\": ["
-    "      { \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }"
+    "    \"DeviceList\": ["
+    "      { \"ID\": \"AA:BB:CC:DD:EE:FF\","
+    "        \"RadioList\": ["
+    "          { \"ID\": \"AA:BB:CC:DD:EE:FF\","
+    "            \"ChannelScanParameters\": ["
+    "              { \"Class\": 1, \"ChannelList\": [1,6,11] }"
+    "            ]"
+    "          }"
+    "        ]"
+    "      }"
     "    ]"
     "  }"
     "} }",
@@ -3372,7 +3384,7 @@ TEST(dm_easy_mesh_t, decode_config_reset_null_key_pointer)
  * @brief Verify that decode_config_set_channel correctly decodes anticipated channel configuration with valid input.
  *
  * This test validates that the decode_config_set_channel API correctly processes a valid JSON configuration containing anticipated channel preferences.
- * It ensures that the function returns a status of 0 and that the output parameter (num) is set to 0 when provided with a valid anticipated channel configuration.
+ * It ensures that the function returns a status of 0 and that the output parameter (num) is set to 1 when provided with a valid anticipated channel configuration.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 075@n
@@ -3386,9 +3398,9 @@ TEST(dm_easy_mesh_t, decode_config_reset_null_key_pointer)
  * | Variation / Step | Description                                                                                             | Test Data                                                                                                                                                                              | Expected Result                                      | Notes          |
  * | :--------------: | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------------- |
  * | 01               | Initialize dm_easy_mesh_t object and subdoc structure; print entering message                           | None                                                                                                                                                                                   | Objects initialized and entering message printed   | Should be successful  |
- * | 02               | Setup JSON string in subdoc->buff for anticipated channel configuration                                  | json = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": { \"Network\": { \"ID\": \"TestNet\", \"AnticipatedChannelPreference\": [{ \"Class\": 81, \"ChannelList\": [1, 6, 11] }] } } }" | subdoc->buff correctly assigned the JSON configuration | Should be successful  |
- * | 03               | Invoke decode_config_set_channel API with valid input parameters                                        | subdoc (with valid JSON), key = "wfa-dataelements:SetAnticipatedChannelPreference", offset = 0, num pointer                                                     | API returns 0 and updates num to 0                   | Should Pass    |
- * | 04               | Assert that the return value and output parameter (num) are as expected                                   | ret = 0, num = 0                                                                                                                                                                       | EXPECT_EQ(ret, 0) and EXPECT_EQ(num, 0)               | Should Pass    |
+ * | 02               | Setup JSON string in subdoc->buff for anticipated channel configuration                                  | json = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": { \"Network\": { \"ID\": \"TestNet\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"AnticipatedChannelPreference\": [{ \"Class\": 81, \"ChannelList\": [1, 6, 11], \"ChannelPrefList\": [0, 0, 0] }] }] } } }" | subdoc->buff correctly assigned the JSON configuration | Should be successful  |
+ * | 03               | Invoke decode_config_set_channel API with valid input parameters                                        | subdoc (with valid JSON), key = "wfa-dataelements:SetAnticipatedChannelPreference", offset = 0, num pointer                                                     | API returns 0 and updates num to 1                   | Should Pass    |
+ * | 04               | Assert that the return value and output parameter (num) are as expected                                   | ret = 0, num = 1                                                                                                                                                                       | EXPECT_EQ(ret, 0) and EXPECT_EQ(num, 1)               | Should Pass    |
  */
 TEST(dm_easy_mesh_t, decode_config_set_channel_valid_anticipated)
 {
@@ -3401,11 +3413,16 @@ TEST(dm_easy_mesh_t, decode_config_set_channel_valid_anticipated)
         " \"wfa-dataelements:SetAnticipatedChannelPreference\": {"
         "   \"Network\": {"
         "     \"ID\": \"TestNet\","
-        "     \"AnticipatedChannelPreference\": ["
+        "     \"DeviceList\": ["
         "       {"
-        "         \"Class\": 81,"
-        "         \"ChannelList\": [1, 6, 11],"
-        "         \"ChannelPrefList\": [0, 0, 0]"
+        "         \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "         \"AnticipatedChannelPreference\": ["
+        "           {"
+        "             \"Class\": 81,"
+        "             \"ChannelList\": [1, 6, 11],"
+        "             \"ChannelPrefList\": [0, 0, 0]"
+        "           }"
+        "         ]"
         "       }"
         "     ]"
         "   }"
@@ -3421,7 +3438,7 @@ TEST(dm_easy_mesh_t, decode_config_set_channel_valid_anticipated)
         &num
     );
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(num, 0);
+    EXPECT_EQ(num, 1);
     std::cout << "Exiting decode_config_set_channel_valid_anticipated\n";
 }
 

--- a/tests/test_l1_dm_radio_cap.cpp
+++ b/tests/test_l1_dm_radio_cap.cpp
@@ -483,14 +483,14 @@ TEST(dm_radio_cap_t_Test, NullRadioCapPointer) {
 * **Test Procedure:**@n
 * | Variation / Step | Description | Test Data | Expected Result | Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
-* | 01 | Create invalid radio capability structure | radio_cap.ch_scan.intf.media = 9999, radio_cap.ch_scan.band = 9999 | None | Should be successful |
+* | 01 | Create invalid radio capability structure | radio_cap.ruid.media = 9999, radio_cap.num_op_classes = UINT_MAX | None | Should be successful |
 * | 02 | Initialize dm_radio_cap_t object with invalid structure | dm_radio_cap_t radio_cap_obj(&radio_cap) | None | Should be successful |
 */
 TEST(dm_radio_cap_t_Test, InvalidRadioCapStructure) {
     std::cout << "Entering InvalidRadioCapStructure test";
     em_radio_cap_info_t radio_cap{};
-    radio_cap.ch_scan.scan_impact = static_cast<unsigned char>(3);
-    radio_cap.ch_scan.op_classes_num = static_cast<unsigned char>(255);
+    radio_cap.ruid.media = static_cast<em_media_type_t>(9999);
+    radio_cap.num_op_classes = UINT_MAX;
     dm_radio_cap_t radio_cap_obj(&radio_cap);
     std::cout << "Exiting InvalidRadioCapStructure test";
 }
@@ -877,16 +877,18 @@ TEST(dm_radio_cap_t_Test, AssigningMixedValues) {
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01 | Create two dm_radio_cap_t objects | obj1, obj2 | Objects created successfully | Should be successful |
 * | 02 | Assign an invalid enum value to obj2's media type | 0x9999 (not defined in em_media_type_t) | Value assigned without compile-time error | Invalid value handled |
-* | 03 | Assign obj2 to obj1 | obj1 = obj2 | Assignment successful | Should be successful |
-* | 04 | Compare the media type values of obj1 and obj2 | obj2.m_radio_cap_info.ruid.media != obj1.m_radio_cap_info.ruid.media | Should not be the same | Should Pass |
+* | 03 | Verify obj2 has a different media type than the default-initialised obj1 | obj2.m_radio_cap_info.ruid.media != obj1.m_radio_cap_info.ruid.media | EXPECT_NE passes; objects are not equal before assignment | Should Pass |
+* | 04 | Assign obj2 to obj1 | obj1 = obj2 | Assignment successful | Should be successful |
+* | 05 | Verify obj1 has the same media type as obj2 after assignment | obj1.m_radio_cap_info.ruid.media == obj2.m_radio_cap_info.ruid.media | EXPECT_EQ passes; assignment correctly copied the invalid value | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, AssigningInvalidValue) {
     std::cout << "Entering AssigningInvalidValue test";
     dm_radio_cap_t obj1{};
-    dm_radio_cap_t obj2{}; 
-    obj2.m_radio_cap_info.ruid.media = em_media_type_max;
-    obj1 = obj2;
+    dm_radio_cap_t obj2{};
+    obj2.m_radio_cap_info.ruid.media = static_cast<em_media_type_t>(0x9999);
     EXPECT_NE(obj2.m_radio_cap_info.ruid.media, obj1.m_radio_cap_info.ruid.media);
+    obj1 = obj2;
+    EXPECT_EQ(obj1.m_radio_cap_info.ruid.media, obj2.m_radio_cap_info.ruid.media);
     std::cout << "Exiting AssigningInvalidValue test";
 }
 
@@ -910,7 +912,8 @@ TEST(dm_radio_cap_t_Test, AssigningInvalidValue) {
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01 | Create first dm_radio_cap_t object | obj1 = dm_radio_cap_t() | None | Should be successful |
 * | 02 | Create second dm_radio_cap_t object | obj2 = dm_radio_cap_t() | None | Should be successful |
-* | 03 | Compare the two objects using equality operator | obj1 == obj2 | EXPECT_TRUE(obj1 == obj2) | Should Pass |
+* | 03 | Set wifi7_cap.mlo_cap_support.ruid[0] and ch_scan.min_scan_interval to the same values in both objects | obj1.m_radio_cap_info.wifi7_cap.mlo_cap_support.ruid[0] = 2, obj1.m_radio_cap_info.ch_scan.min_scan_interval = 80, same for obj2 | None | Should be successful |
+* | 04 | Verify that both objects have the same field values | EXPECT_EQ on ruid[0] and min_scan_interval | EXPECT_EQ passes | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareIdenticalObjects) {
     std::cout << "Entering CompareIdenticalObjects" << std::endl;
@@ -944,8 +947,8 @@ TEST(dm_radio_cap_t_Test, CompareIdenticalObjects) {
 * | Variation / Step | Description | Test Data |Expected Result |Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01| Initialize obj1 and obj2 | obj1 = dm_radio_cap_t(), obj2 = dm_radio_cap_t() | Objects initialized | Should be successful |
-* | 02| Set number_of_bss for obj2 | obj2.m_radio_cap_info.ch_scan.number_of_bss = 5 | obj2.m_radio_cap_info.ch_scan.number_of_bss = 5 | Should be successful |
-* | 03| Compare obj1 and obj2 using equality operator | obj1 == obj2 | EXPECT_FALSE(obj1 == obj2) | Should Pass |
+* | 02| Set op_classes_num for obj1 to 2 and obj2 to 5 | obj1.m_radio_cap_info.ch_scan.op_classes_num = 2, obj2.m_radio_cap_info.ch_scan.op_classes_num = 5 | Values set | Should be successful |
+* | 03| Compare obj1 and obj2 using EXPECT_NE | obj1.ch_scan.op_classes_num != obj2.ch_scan.op_classes_num | EXPECT_NE passes | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentNumberOfBSS) {
     std::cout << "Entering CompareDifferentNumberOfBSS" << std::endl;
@@ -1008,7 +1011,7 @@ TEST(dm_radio_cap_t_Test, CompareDifferentMediaType) {
 * | Variation / Step | Description | Test Data | Expected Result | Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01 | Initialize obj1 and obj2 | obj1, obj2 | Objects initialized | Should be successful |
-* | 02 | Set obj2.m_radio_cap_info.ch_scan.enabled to true | obj2.m_radio_cap_info.ch_scan.enabled = true | Value set | Should be successful |
+* | 02 | Set obj1.m_radio_cap_info.ch_scan.boot_only to 0 and obj2 to 1 | obj1.m_radio_cap_info.ch_scan.boot_only = 0, obj2.m_radio_cap_info.ch_scan.boot_only = 1 | Values set | Should be successful |
 * | 03 | Compare obj1 and obj2 using equality operator | obj1, obj2 | EXPECT_FALSE(obj1 == obj2) | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentEnabledValue) {
@@ -1040,7 +1043,7 @@ TEST(dm_radio_cap_t_Test, CompareDifferentEnabledValue) {
 * | Variation / Step | Description | Test Data | Expected Result | Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01 | Initialize two `dm_radio_cap_t` objects | obj1, obj2 | Objects initialized | Should be successful |
-* | 02 | Set `chip_vendor` of `obj2` to "VendorX" | obj2.m_radio_cap_info.ch_scan.chip_vendor = "VendorX" | `chip_vendor` set to "VendorX" | Should be successful |
+* | 02 | Set `ch_scan.ruid` of `obj1` to "vndA" and `obj2` to "vndX" | obj1.m_radio_cap_info.ch_scan.ruid = "vndA\0\0", obj2.m_radio_cap_info.ch_scan.ruid = "vndX\0\0" | `ruid` set with different values | Should be successful |
 * | 03 | Compare `obj1` and `obj2` using equality operator | obj1, obj2 | EXPECT_FALSE(obj1 == obj2) | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentChipVendor) {
@@ -1072,7 +1075,7 @@ TEST(dm_radio_cap_t_Test, CompareDifferentChipVendor) {
 * | Variation / Step | Description | Test Data |Expected Result |Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01| Create two dm_radio_cap_t objects | obj1, obj2 | Objects created successfully | Should be successful |
-* | 02| Set srg_bss_color_bitmap[0] of obj2 to 1 | obj2.m_radio_cap_info.ch_scan.srg_bss_color_bitmap[0] = 1 | Value set successfully | Should be successful |
+* | 02| Set ch_scan.ruid[0] of obj2 to 1 and obj1 to 0 | obj1.m_radio_cap_info.ch_scan.ruid[0] = 0, obj2.m_radio_cap_info.ch_scan.ruid[0] = 1 | Value set successfully | Should be successful |
 * | 03| Compare obj1 and obj2 using equality operator | obj1 == obj2 | EXPECT_FALSE(obj1 == obj2) | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentBSSColorBitmap) {
@@ -1199,7 +1202,7 @@ TEST(dm_radio_cap_t_Test, CompareDifferentEHTOpsReserved) {
 * | Variation / Step | Description | Test Data |Expected Result |Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01| Create two dm_radio_cap_t objects | obj1, obj2 | Objects created successfully | Should be successful |
-* | 02| Set EHT capability for obj2 | obj2.m_radio_cap_info.eht_cap = "EHT Capability" | EHT capability set successfully | Should be successful |
+* | 02| Set eht_ops.radios_num of obj1 to 1 and obj2 to 2 | obj1.m_radio_cap_info.eht_ops.radios_num = 1, obj2.m_radio_cap_info.eht_ops.radios_num = 2 | EHT ops radios_num set with different values | Should be successful |
 * | 03| Compare obj1 and obj2 using equality operator | obj1 == obj2 | EXPECT_FALSE(obj1 == obj2) | Should Fail |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentEHTCap) {

--- a/tests/test_l1_em_cmd.cpp
+++ b/tests/test_l1_em_cmd.cpp
@@ -185,7 +185,7 @@ TEST(em_cmd_t, bus_2_cmd_type_ValidConversion)
         { em_bus_event_type_client_cap_query,   em_cmd_type_client_cap_query },
         { em_bus_event_type_listener_stop,      em_cmd_type_none },
         { em_bus_event_type_dm_commit,          em_cmd_type_none },
-        { em_bus_event_type_m2_tx,              em_cmd_type_none },
+        { em_bus_event_type_m2_tx,              em_cmd_type_em_config },
         { em_bus_event_type_topo_sync,          em_cmd_type_em_config },
         { em_bus_event_type_onewifi_mesh_sta_cb,em_cmd_type_none },
         { em_bus_event_type_onewifi_radio_cb,   em_cmd_type_none },
@@ -3062,9 +3062,9 @@ TEST(em_cmd_t, get_svc_valid_none) {
     std::cout << "Exiting get_svc_valid_none test" << std::endl;
 }
 /**
- * @brief Validate that the get_svc function returns the invalid service type when m_svc is explicitly set to an out-of-range value.
+ * @brief Validate that the get_svc function returns em_service_type_none when m_svc is explicitly set to an out-of-range value.
  *
- * This test verifies that when the m_svc member of the em_cmd_t object is assigned an invalid value (-1), the get_svc() method correctly returns this invalid value. This helps ensure that the API does not modify or incorrectly process invalid input values.
+ * This test verifies that when the m_svc member of the em_cmd_t object is assigned an invalid value (cast from -1), the get_svc() method returns em_service_type_none. This helps ensure that the API handles out-of-range input gracefully and consistently.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 067@n
@@ -3075,9 +3075,9 @@ TEST(em_cmd_t, get_svc_valid_none) {
  * **User Interaction:** None@n
  *
  * **Test Procedure:**@n
- * | Variation / Step | Description                                                         | Test Data                               | Expected Result                                            | Notes      |
- * | :--------------: | ------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------- | ---------- |
- * | 01               | Instantiate em_cmd_t, set m_svc to -1, and invoke get_svc() method.   | m_svc = -1, output svc = -1               | get_svc() returns -1 and the EXPECT_EQ assertion passes.   | Should Pass|
+ * | Variation / Step | Description                                                                                          | Test Data                                                       | Expected Result                                                                | Notes      |
+ * | :--------------: | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------ | ---------- |
+ * | 01               | Instantiate em_cmd_t, set m_svc to static_cast<em_service_type_t>(-1), and invoke get_svc() method. | m_svc = static_cast<em_service_type_t>(-1)                      | get_svc() returns em_service_type_none and the EXPECT_EQ assertion passes.     | Should Pass|
  */
 TEST(em_cmd_t, get_svc_invalid_value_check) {
     std::cout << "Entering get_svc_invalid_value_check test" << std::endl;
@@ -3086,7 +3086,7 @@ TEST(em_cmd_t, get_svc_invalid_value_check) {
     std::cout << "Invoking get_svc()" << std::endl;
     em_service_type_t svc = cmd.get_svc();
     std::cout << "get_svc() returned value: " << static_cast<unsigned int>(svc) << std::endl;
-    EXPECT_EQ(svc, -1);
+    EXPECT_EQ(svc, em_service_type_none);
     std::cout << "Exiting get_svc_invalid_value_check test" << std::endl;
 }
 /**

--- a/tests/test_l1_em_cmd_em_config.cpp
+++ b/tests/test_l1_em_cmd_em_config.cpp
@@ -65,7 +65,7 @@ TEST(em_cmd_em_config_t, em_cmd_em_config_t_full_valid) {
     EXPECT_EQ(configCmd.m_param.u.args.num_args, 2);
     EXPECT_STREQ(configCmd.m_param.u.args.args[0], arg0);
     EXPECT_STREQ(configCmd.m_param.u.args.args[1], arg1);
-    EXPECT_EQ(configCmd.m_num_orch_desc, 10);
+    EXPECT_EQ(configCmd.m_num_orch_desc, 9);
     EXPECT_EQ(configCmd.m_orch_desc[0].op, dm_orch_type_bss_delete);
     EXPECT_FALSE(configCmd.m_orch_desc[0].submit);
     EXPECT_EQ(configCmd.m_svc, em_service_type_ctrl);
@@ -89,7 +89,7 @@ TEST(em_cmd_em_config_t, em_cmd_em_config_t_full_valid) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Initialize empty em_cmd_params_t and dm_easy_mesh_t objects, then create an instance of em_cmd_em_config_t using these parameters. | params = {}, dm = {} | Instance is created with m_type set to em_cmd_type_em_config, m_name set to "em_config", fixed_args as an empty string, and num_args as 0. | Should Pass |
- * | 02 | Validate that the orchestration fields are correctly initialized. | m_num_orch_desc = 8, orch_desc[0].op = dm_orch_type_bss_delete, orch_desc[0].submit = false, m_svc = em_service_type_ctrl | All field values match the expected configuration. | Should Pass |
+ * | 02 | Validate that the orchestration fields are correctly initialized. | m_num_orch_desc = 9, orch_desc[0].op = dm_orch_type_bss_delete, orch_desc[0].submit = false, m_svc = em_service_type_ctrl | All field values match the expected configuration. | Should Pass |
  * | 03 | Invoke configCmd.deinit() to release resources. | No input | deinit completes without errors. | Should be successful |
  */
 TEST(em_cmd_em_config_t, em_cmd_em_config_t_empty) {
@@ -101,7 +101,7 @@ TEST(em_cmd_em_config_t, em_cmd_em_config_t_empty) {
     EXPECT_STREQ(configCmd.m_name, "em_config");
     EXPECT_STREQ(configCmd.m_param.u.args.fixed_args, "");
     EXPECT_EQ(configCmd.m_param.u.args.num_args, 0);
-    EXPECT_EQ(configCmd.m_num_orch_desc, 10);
+    EXPECT_EQ(configCmd.m_num_orch_desc, 9);
     EXPECT_EQ(configCmd.m_orch_desc[0].op, dm_orch_type_bss_delete);
     EXPECT_FALSE(configCmd.m_orch_desc[0].submit);
     EXPECT_EQ(configCmd.m_svc, em_service_type_ctrl);
@@ -163,7 +163,7 @@ TEST(em_cmd_em_config_t, em_cmd_em_config_t_max_boundary) {
     EXPECT_EQ(configCmd.m_param.u.args.num_args, 2);
     EXPECT_STREQ(configCmd.m_param.u.args.args[0], maxArg);
     EXPECT_STREQ(configCmd.m_param.u.args.args[1], maxArg);
-    EXPECT_EQ(configCmd.m_num_orch_desc, 10);
+    EXPECT_EQ(configCmd.m_num_orch_desc, 9);
     EXPECT_EQ(configCmd.m_orch_desc[0].op, dm_orch_type_bss_delete);
     EXPECT_FALSE(configCmd.m_orch_desc[0].submit);
     EXPECT_EQ(configCmd.m_svc, em_service_type_ctrl);

--- a/tests/test_l1_em_cmd_set_channel.cpp
+++ b/tests/test_l1_em_cmd_set_channel.cpp
@@ -38,7 +38,7 @@
  * **Test Procedure:**
  * | Variation / Step | Description                                                                | Test Data                                                                                                                                                                                                                          | Expected Result                                                                                                                                                                     | Notes      |
  * | :--------------: | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
- * | 01               | Initialize parameters and environment, then invoke em_cmd_set_channel_t API with fixed_args set to "6" | input: param.u.args.fixed_args = "6", dm_easy_mesh_t instance; output: cmd.m_type, cmd.m_name, cmd.m_param.u.args.fixed_args, cmd.m_param.u.args.num_args, cmd.m_svc, cmd.m_num_orch_desc, cmd.m_orch_desc[0].op, cmd.m_orch_desc[0].submit | Command object has m_type equal to em_cmd_type_set_channel, m_name equal to "set_channel", fixed_args equal to "6", num_args equal to 0, m_svc equal to em_service_type_ctrl, m_num_orch_desc equal to 2, orch_desc[0].op equal to dm_orch_type_channel_sel, orch_desc[0].submit equal to true | Should Pass |
+ * | 01               | Initialize parameters and environment, then invoke em_cmd_set_channel_t API with fixed_args set to "6" | input: param.u.args.fixed_args = "6", dm_easy_mesh_t instance; output: cmd.m_type, cmd.m_name, cmd.m_param.u.args.fixed_args, cmd.m_param.u.args.num_args, cmd.m_svc, cmd.m_num_orch_desc, cmd.m_orch_desc[0].op, cmd.m_orch_desc[0].submit | Command object has m_type equal to em_cmd_type_set_channel, m_name equal to "set_channel", fixed_args equal to "6", num_args equal to 0, m_svc equal to em_service_type_ctrl, m_num_orch_desc equal to 1, orch_desc[0].op equal to dm_orch_type_channel_sel, orch_desc[0].submit equal to true | Should Pass |
  */
 TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_6) {
     std::cout << "Entering em_cmd_set_channel_t_valid_channel_6 test" << std::endl;
@@ -53,7 +53,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_6) {
     EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "6");
     EXPECT_EQ(cmd.m_param.u.args.num_args, 0);
     EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
-    EXPECT_EQ(cmd.m_num_orch_desc, 2);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_channel_sel);
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     cmd.deinit();
@@ -75,7 +75,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_6) {
  * **Test Procedure:**
  * | Variation / Step | Description                                                                                          | Test Data                                                                                        | Expected Result                                                                                                                                         | Notes      |
  * | :--------------: | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
- * | 01               | Initialize the command parameters with fixed_args set to "11", invoke em_cmd_set_channel_t, and verify property values | param.u.args.fixed_args = "11", dm_easy_mesh_t dm = default, output: m_type, m_name, fixed_args, m_svc, m_num_orch_desc, m_orch_desc[0].op, m_orch_desc[0].submit | m_type equals em_cmd_type_set_channel, m_name equals "set_channel", fixed_args equals "11", m_svc equals em_service_type_ctrl, m_num_orch_desc equals 2, m_orch_desc[0].op equals dm_orch_type_channel_sel, m_orch_desc[0].submit is true | Should Pass |
+ * | 01               | Initialize the command parameters with fixed_args set to "11", invoke em_cmd_set_channel_t, and verify property values | param.u.args.fixed_args = "11", dm_easy_mesh_t dm = default, output: m_type, m_name, fixed_args, m_svc, m_num_orch_desc, m_orch_desc[0].op, m_orch_desc[0].submit | m_type equals em_cmd_type_set_channel, m_name equals "set_channel", fixed_args equals "11", m_svc equals em_service_type_ctrl, m_num_orch_desc equals 1, m_orch_desc[0].op equals dm_orch_type_channel_sel, m_orch_desc[0].submit is true | Should Pass |
  */
 TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_11) {
     std::cout << "Entering em_cmd_set_channel_t_valid_channel_11 test" << std::endl;
@@ -89,7 +89,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_11) {
     EXPECT_STREQ(cmd.m_name, "set_channel");
     EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "11");
     EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
-    EXPECT_EQ(cmd.m_num_orch_desc, 2);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_channel_sel);
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     cmd.deinit();
@@ -116,7 +116,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_11) {
  * | Variation / Step | Description | Test Data | Expected Result |Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Initialize input parameters with empty channel string and default dm object | param.u.args.fixed_args[0] = '\0', param.u.args.fixed_args[last] = '\0', dm = default constructed dm_easy_mesh_t | Parameters initialized without errors; no output produced | Should be successful |
- * | 02 | Call em_cmd_set_channel_t constructor with the prepared parameters | input: param (with empty fixed_args), dm object | cmd.m_type equals em_cmd_type_set_channel, cmd.m_name equals "set_channel", cmd.m_param.u.args.fixed_args equals empty string, cmd.m_svc equals em_service_type_ctrl, cmd.m_num_orch_desc equals 2, cmd.m_orch_desc[0].op equals dm_orch_type_channel_sel, cmd.m_orch_desc[0].submit equals true | Should Pass |
+ * | 02 | Call em_cmd_set_channel_t constructor with the prepared parameters | input: param (with empty fixed_args), dm object | cmd.m_type equals em_cmd_type_set_channel, cmd.m_name equals "set_channel", cmd.m_param.u.args.fixed_args equals empty string, cmd.m_svc equals em_service_type_ctrl, cmd.m_num_orch_desc equals 1, cmd.m_orch_desc[0].op equals dm_orch_type_channel_sel, cmd.m_orch_desc[0].submit equals true | Should Pass |
  * | 03 | Deinitialize the command object | API call: cmd.deinit() | Resources associated with cmd are freed successfully | Should be successful |
  */
 TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_empty_channel_input) {
@@ -131,7 +131,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_empty_channel_input) {
     EXPECT_STREQ(cmd.m_name, "set_channel");
     EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "");
     EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
-    EXPECT_EQ(cmd.m_num_orch_desc, 2);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_channel_sel);
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     cmd.deinit();
@@ -153,7 +153,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_empty_channel_input) {
  * **Test Procedure:**
  * | Variation / Step | Description                                                                                                          | Test Data                                                                                                                                                 | Expected Result                                                                                                                                                    | Notes      |
  * | :--------------: | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
- * | 01               | Invoke em_cmd_set_channel_t with fixed_args set to a non-numeric string "abc".                                       | input: fixed_args = "abc", dm_easy_mesh_t = default, output: m_type = em_cmd_type_set_channel, m_name = "set_channel", m_param.u.args.fixed_args = "abc", m_svc = em_service_type_ctrl, m_num_orch_desc = 2, m_orch_desc[0].op = dm_orch_type_channel_sel, m_orch_desc[0].submit = true | The command object should be initialized correctly; all EXPECT assertions in the test should pass confirming the expected behavior when a non-numeric channel is provided. | Should Pass |
+ * | 01               | Invoke em_cmd_set_channel_t with fixed_args set to a non-numeric string "abc".                                       | input: fixed_args = "abc", dm_easy_mesh_t = default, output: m_type = em_cmd_type_set_channel, m_name = "set_channel", m_param.u.args.fixed_args = "abc", m_svc = em_service_type_ctrl, m_num_orch_desc = 1, m_orch_desc[0].op = dm_orch_type_channel_sel, m_orch_desc[0].submit = true | The command object should be initialized correctly; all EXPECT assertions in the test should pass confirming the expected behavior when a non-numeric channel is provided. | Should Pass |
  */
 TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_non_numeric_channel_input) {
     std::cout << "Entering em_cmd_set_channel_t_non_numeric_channel_input test" << std::endl;
@@ -167,7 +167,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_non_numeric_channel_input) {
     EXPECT_STREQ(cmd.m_name, "set_channel");
     EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "abc");
     EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
-    EXPECT_EQ(cmd.m_num_orch_desc, 2);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_channel_sel);
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     cmd.deinit();

--- a/tests/test_l1_em_msg.cpp
+++ b/tests/test_l1_em_msg.cpp
@@ -3590,7 +3590,10 @@ TEST(em_msg_t, get_next_tlv_buff_len_zero) {
 /**
  * @brief Test the retrieval of valid client MAC information from a TLV buffer.
  *
- * This test verifies that the API successfully parses a TLV buffer containing valid client information including the MAC address, correctly extracting and returning the MAC address. The test ensures the API works as expected and confirms the integrity of the TLV parsing.
+ * This test verifies that the get_client_mac_info API successfully parses a TLV buffer containing a valid
+ * em_client_info_t structure (comprising both a BSSID and a client MAC address), and correctly extracts
+ * the client MAC address into the output buffer. The test ensures the API returns true and that the
+ * extracted MAC address matches the expected value.
  *
  * **Test Group ID:** Basic: 01
  * **Test Case ID:** 101
@@ -3601,18 +3604,23 @@ TEST(em_msg_t, get_next_tlv_buff_len_zero) {
  * **User Interaction:** None
  *
  * **Test Procedure:**
- * | Variation / Step | Description                                                                                  | Test Data                                                                                                     | Expected Result                                                                                            | Notes            |
- * | :--------------: | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- |
- * |      01        | Initialize the TLV buffer and write valid client info including MAC using write_tlv            | buffer size = TLV_HEADER_SIZE + 6, mac_val = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB}                             | Buffer contains valid TLV with correct client information                                                  | Should be successful |
- * |      02        | Create an instance of em_msg_t using the prepared TLV buffer                                   | buffer, buffer length = TLV_HEADER_SIZE + 6                                                                   | em_msg_t object is successfully created                                                                    | Should be successful |
- * |      03        | Call get_client_mac_info to extract the MAC address and compare it with the expected MAC value | output pointer to mac (6 bytes), expected mac_val = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB}                         | Function returns true and the extracted MAC address matches the expected value as per EXPECT_TRUE and EXPECT_EQ | Should Pass       |
+ * | Variation / Step | Description                                                                                        | Test Data                                                                                                                                                                           | Expected Result                                                                                            | Notes                |
+ * | :--------------: | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------- |
+ * |      01        | Populate an em_client_info_t structure with a known BSSID and client MAC address                     | bssid = {0x00,0x11,0x22,0x33,0x44,0x55}, mac_val = {0x01,0x23,0x45,0x67,0x89,0xAB}                                                                                                  | em_client_info_t fields are set to the expected values                                                     | Should be successful |
+ * |      02        | Write the em_client_info_t structure as a client info TLV into the buffer using write_tlv            | buffer size = TLV_HEADER_SIZE + sizeof(em_client_info_t), TLV type = em_tlv_type_client_info, value = reinterpret_cast of em_client_info_t, length = sizeof(em_client_info_t)       | Buffer contains a valid em_tlv_type_client_info TLV with the correct payload                               | Should be successful |
+ * |      03        | Create an instance of em_msg_t using the prepared TLV buffer                                         | buffer, buffer length = sizeof(buffer)                                                                                                                                              | em_msg_t object is successfully created                                                                    | Should be successful |
+ * |      04        | Call get_client_mac_info to extract the client MAC address and compare with the expected value       | output pointer to mac (6 bytes, initialized to zeros), expected mac_val = {0x01,0x23,0x45,0x67,0x89,0xAB}                                                                           | function returns true, the extracted MAC address matches mac_val as verified by EXPECT_TRUE and EXPECT_EQ  | Should Pass          |
  */
 TEST(em_msg_t, get_client_mac_info_valid_client_info_tlv)
 {
     std::cout << "Entering get_client_mac_info_valid_client_info_tlv test" << std::endl;
-    unsigned char buffer[TLV_HEADER_SIZE + 6];
+    unsigned char buffer[TLV_HEADER_SIZE + sizeof(em_client_info_t)];
+    unsigned char bssid[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
     unsigned char mac_val[6] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB};
-    write_tlv(buffer, em_tlv_type_client_info, mac_val, sizeof(mac_val));
+    em_client_info_t client_info;
+    memcpy(client_info.bssid, bssid, sizeof(bssid));
+    memcpy(client_info.client_mac_addr, mac_val, sizeof(mac_val));
+    write_tlv(buffer, em_tlv_type_client_info, reinterpret_cast<unsigned char*>(&client_info), sizeof(client_info));
     em_msg_t msg(buffer, sizeof(buffer));
     unsigned char mac[6] = {0};
     bool ret = msg.get_client_mac_info(reinterpret_cast<mac_address_t*>(mac));


### PR DESCRIPTION
Reason for change: there are several issues found by testing, which fixed by this PR, in particular
initializing variables,  added correct/full checks, advancing pointers in the loop,  
also updated tests according to the sources.

Test procedure: controller and agent are able to run, no crashes

Priority: P2
Risk: Low