### PR TITLE
RDKBWIFI-449 Implement end-to-end Unassociated STA Link Metrics query/response handling

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -91,6 +91,11 @@ public:
     unsigned int    m_num_assoc_sta_mld;
     dm_assoc_sta_mld_t m_assoc_sta_mld[EM_MAX_ASSOC_STA_MLD];
     dm_tid_to_link_t m_tid_to_link;
+    em_unassoc_sta_metrics_rsp_t    m_unassoc_sta_metrics_rsp;
+    em_unassoc_query_list_t m_unassoc_query_list;
+
+    unsigned int m_num_unassoc_sta_metrics;
+    em_unassoc_sta_metric_entry_t  m_unassoc_sta_metrics[EM_MAX_UNASSOC_STA];
 
 public:
 
@@ -2251,6 +2256,8 @@ public:
 	 *       the network's configuration.
 	 */
 	dm_sta_t *find_sta(mac_address_t sta_mac, bssid_t bssid);
+
+	dm_sta_t *find_sta(mac_address_t sta_mac);
     
 	/**!
 	 * @brief Retrieves the first station associated with the given MAC address.

--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -327,6 +327,28 @@ public:
 	int analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 	int analyze_link_report(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 
+        /**!
+         * @brief Analyzes the Unassociated STA Link Metrics Result.
+         *
+         * This function processes the Unassociated STA Link Metrics
+         * Response received from the agent, extracts RCPI measurements,
+         * and populates the corresponding internal command structures.
+         *
+         * @param[in] evt Pointer to the event structure containing the
+         *                Unassociated STA Metrics Response.
+         * @param[in] pcmd Array of pointers to command structures used
+         *                 for further processing.
+         *
+         * @returns int Status code indicating success or failure.
+         * @retval 0 on success.
+         * @retval Non-zero error code on failure.
+         *
+         * @note The response may contain zero STA entries as per the
+         *       EasyMesh specification when no RCPI measurements could
+         *       be collected within the implementation-specific timeout.
+         */
+        int analyze_unassoc_sta_result(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
 	/**!
 	 * @brief Refreshes the OneWiFi subdocument.
 	 *

--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -35,6 +35,7 @@
 #include "db_client.h"
 #include "dm_easy_mesh_list.h"
 #include "em_network_topo.h"
+#include "dm_easy_mesh.h"
 
 class em_cmd_t;
 class dm_easy_mesh_t;
@@ -728,6 +729,29 @@ public:
 	 * this function.
 	 */
 	int analyze_bsta_cap_req(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
+	/**!
+         * @brief Analyzes the Unassociated STA Link Metrics Query event.
+         *
+         * This function processes the Unassociated STA Link Metrics Query
+         * received from the controller, validates the query parameters,
+         * and prepares the corresponding internal command structures for
+         * agent-side handling and RCPI measurement collection.
+         *
+         * @param[in] evt Pointer to the event structure containing the
+         *                Unassociated STA Link Metrics Query payload.
+         * @param[in] pcmd Array of pointers to command structures used
+         *                 for internal processing.
+         *
+         * @returns int Status code indicating success or failure.
+         * @retval 0 on success.
+         * @retval Non-zero error code on failure.
+         *
+         * @note The query may contain one or more operating classes,
+         *       channels, and STA MAC entries as defined by the
+         *       EasyMesh specification.
+         */
+         int analyze_unassoc_sta_metrics_query(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 
 	/**!
 	 * @brief Resets the configuration to its default state.

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -299,6 +299,67 @@ class em_agent_t : public em_mgr_t {
 
 	void handle_link_stats_report(em_bus_event_t *evt);
 
+       /**!
+        * @brief Handles an Unassociated STA Link Metrics Query event.
+        *
+        * This function processes the Unassociated STA Link Metrics Query
+        * received from the controller, parses the requested operating
+        * classes, channels and STA MAC addresses, and triggers the
+        * agent-side measurement workflow.
+        *
+        * @param[in] evt Pointer to the event structure containing the
+        *                Unassociated STA Query payload.
+        */
+       void handle_unassoc_sta_link_metrics_qry(em_bus_event_t *evt);
+
+       /**!
+        * @brief Handles the Unassociated STA Link Metrics Result event.
+        *
+        * This function processes the collected Unassociated STA RCPI
+        * measurements and prepares them for transmission back to the
+        * controller in one or more Unassociated STA Link Metrics
+        * Response messages.
+        *
+        * @param[in] evt Pointer to the event structure containing the
+        *                Unassociated STA Metrics result payload.
+        */
+       void handle_unassoc_sta_result(em_bus_event_t *evt);
+
+       /**!
+        * @brief Sends the Unassociated STA Query subdocument.
+        *
+        * This function constructs and publishes the Unassociated STA
+        * Query subdocument to the OneWiFi subsystem for RCPI measurement
+        * collection on the requested operating classes and channels.
+        *
+        * @param[in] desc Pointer to the WiFi bus descriptor.
+        * @param[in] bus_hdl Pointer to the bus handle used for communication.
+        * @param[in] work Pointer to the internal work list containing
+        *                 opclass, channel and STA information.
+        *
+        * @returns int Status code indicating success or failure.
+        * @retval 0 on success.
+        * @retval Non-zero error code on failure.
+        */
+       int send_unassoc_sta_query_subdoc(wifi_bus_desc_t *desc, bus_handle_t *bus_hdl, em_unassoc_work_list_t *work);
+
+       /**!
+        * @brief Callback invoked on receiving Unassociated STA Link Metrics results.
+        *
+        * This callback processes asynchronous Unassociated STA RCPI
+        * measurement results received from the OneWiFi subsystem and
+        * forwards them into the EasyMesh agent processing pipeline.
+        *
+        * @param[in] event_name Name of the event triggering the callback.
+        * @param[in] data Pointer to the raw event payload.
+        * @param[in] userData Pointer to user-specific callback context.
+        *
+        * @returns int Status code indicating success or failure.
+        * @retval 0 on success.
+        * @retval Non-zero error code on failure.
+        */
+       static int unassoc_sta_link_metrics_cb(char *event_name, bus_data_prop_t  *data, void *userData);
+
 	/**
 	 * @brief Send an action frame
 	 *

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -219,6 +219,9 @@ static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff
 #define EM_MAX_ASSOC_STA_MLD   64
 #define EM_MAX_PRE_SET_CHANNELS   6
 
+#define EM_MAX_CHANNELS_PER_OPCLASS   16
+#define EM_MAX_STA_PER_CHANNEL        64
+
 #define EM_MAX_CMD  16
 
 #define EM_BACKHAUL_DOWNMAC_ADDR 16
@@ -467,6 +470,138 @@ typedef struct {
     em_op_class_t   op_classes[0];
 } __attribute__((__packed__)) em_ap_radio_basic_cap_t;
 
+
+/**
+ * ============================================================================
+ * Unassociated STA Work List Structures
+ * ============================================================================
+ *
+ * These structures are used internally by the Controller/Agent to organize
+ * and process Unassociated STA Link Metrics operations grouped by:
+ *
+ *      Operating Class -> Channel -> STA List
+ *
+ * The work list acts as an intermediate runtime structure while preparing,
+ * scheduling, parsing, or processing Unassociated STA metrics queries.
+ * ============================================================================
+ */
+
+/**
+ * @brief Stores the list of STAs belonging to a specific channel.
+ *
+ * Each channel entry contains:
+ *  - Channel number
+ *  - Number of STAs associated with the channel
+ *  - List of STA MAC addresses to be queried
+ */
+typedef struct {
+    uint8_t channel;
+    uint8_t num_sta;
+    mac_address_t sta_list[EM_MAX_STA_PER_CHANNEL];
+} em_unassoc_work_channel_t;
+
+/**
+ * @brief Stores all channels belonging to a single operating class.
+ *
+ * Each operating class may contain multiple channels,
+ * and each channel may contain multiple STAs.
+ */
+typedef struct {
+    uint8_t op_class;
+    uint8_t num_channels;
+    em_unassoc_work_channel_t channel_list[EM_MAX_CHANNELS_PER_OPCLASS];
+} em_unassoc_work_opclass_t;
+
+/**
+ * @brief Top-level runtime work list for Unassociated STA processing.
+ *
+ * This structure groups all operating classes that are currently
+ * involved in Unassociated STA metrics processing.
+ */
+typedef struct {
+    uint8_t num_opclass;
+    em_unassoc_work_opclass_t opclass_list[EM_MAX_OPCLASS];
+} em_unassoc_work_list_t;
+
+/**
+ * @brief Represents a single channel entry in the query.
+ *
+ * Contains:
+ *  - Channel number
+ *  - Number of STAs on the channel
+ *  - List of STA MAC addresses requested for metrics reporting
+ */
+typedef struct {
+    uint8_t channel;
+    uint8_t num_sta;
+    mac_address_t sta_list[EM_MAX_STA_PER_CHANNEL];
+} em_unassoc_query_channel_t;
+
+/**
+ * @brief Represents an operating class entry in the query.
+ *
+ * Each operating class contains:
+ *  - Number of channels
+ *  - Channel-wise STA query information
+ */
+typedef struct {
+    uint8_t op_class;
+    uint8_t num_channels;
+    em_unassoc_query_channel_t channel_list[EM_MAX_CHANNELS_PER_OPCLASS];
+} em_unassoc_query_opclass_t;
+
+/**
+ * @brief Top-level query structure for Unassociated STA metrics.
+ *
+ * This structure is used by the Controller to organize all requested
+ * operating classes, channels, and STA lists before sending the query.
+ */
+typedef struct {
+    uint8_t num_opclass;
+    em_unassoc_query_opclass_t opclass_list[EM_MAX_OPCLASS];
+} em_unassoc_query_list_t;
+
+#define EM_MAX_UNASSOC_STA 64
+
+/**
+ * @brief Stores metrics information for a single Unassociated STA.
+ *
+ * This structure is populated after parsing an Unassociated STA
+ * Link Metrics Response TLV.
+ *
+ * Contains:
+ *  - STA MAC address
+ *  - Operating class
+ *  - Channel number
+ *  - RCPI value
+ *  - Time delta associated with the measurement
+ */
+typedef struct {
+    mac_address_t sta_mac;
+    unsigned char channel;
+    unsigned char op_class;
+    unsigned char rcpi;
+    unsigned int  time_delta;
+} em_unassoc_sta_metric_entry_t;
+
+typedef struct {
+    unsigned int num_entries;
+    em_unassoc_sta_metric_entry_t entry[EM_MAX_UNASSOC_STA];
+} em_unassoc_sta_metrics_rsp_t;
+
+//For TLV structure
+typedef struct {
+    mac_address_t sta_mac;
+    unsigned char channel;
+    unsigned int  time_delta;
+    unsigned char rcpi;
+}__attribute__((__packed__)) em_unassoc_sta_metric_t;
+
+typedef struct {
+    unsigned char op_class;
+    unsigned char num_sta;
+    em_unassoc_sta_metric_t sta_metric[0];
+}__attribute__((__packed__))em_unassoc_sta_link_metrics_rsp_t;
 
 typedef enum {
     mandatory,
@@ -1029,15 +1164,6 @@ typedef struct {
     unsigned char num_sta_mac_addr;
     mac_address_t sta_mac_addr;
 }__attribute__((__packed__)) em_unassoc_sta_link_metrics_query_t;
-
-typedef struct {
-    unsigned char op_class;
-    unsigned char num_sta_entries;
-    mac_address_t sta_mac_addr;
-    unsigned char channel_num;
-    unsigned int  time_delta_ms;
-    unsigned char uplink_rcpi;
-}__attribute__((__packed__)) em_unassoc_sta_link_metrics_rsp_t;
 
 typedef struct {
      mac_address_t sta_mac_addr;
@@ -2139,6 +2265,7 @@ typedef enum {
 	em_state_agent_channel_select_configuration_pending,
     em_state_agent_channel_report_pending,
 	em_state_agent_channel_scan_result_pending,
+    em_state_agent_unassoc_sta_metrics_report_pending,	
     em_state_agent_configured,
 	
 	// Transient agent stats
@@ -2180,6 +2307,7 @@ typedef enum {
     em_state_ctrl_avail_spectrum_inquiry_pending,
     em_state_ctrl_bsta_cap_pending,
     em_state_ctrl_topo_publish_pending,
+    em_state_ctrl_unassoc_sta_link_metrics_pending, 
 
     em_state_max,
 } em_state_t;
@@ -2232,6 +2360,8 @@ typedef enum {
     em_cmd_type_get_reset,
     em_cmd_type_bsta_cap,
     em_cmd_type_get_link_quality_report,
+    em_cmd_type_unassoc_sta_query,
+    em_cmd_type_unassoc_sta_result,
 
     em_cmd_type_max,
 } em_cmd_type_t;
@@ -2928,6 +3058,9 @@ typedef enum {
     em_bus_event_type_bsta_cap_req,
     em_bus_event_type_link_quality_report,
     em_bus_event_type_client_assoc_ctrl_req,
+    em_bus_event_type_unassoc_sta_query,
+    em_bus_event_type_unassoc_sta_link_metrics_query,
+    em_bus_event_type_unassoc_sta_result,
 
     em_bus_event_type_max
 } em_bus_event_type_t;
@@ -3017,7 +3150,10 @@ typedef enum {
     dm_orch_type_mld_reconfig,
     dm_orch_type_beacon_report,
     dm_orch_type_bsta_cap_query,
-    dm_orch_type_link_quality_report
+    dm_orch_type_link_quality_report,
+    dm_orch_type_unassoc_sta_link_req_query,
+    dm_orch_type_unassoc_sta_result,
+    
 } dm_orch_type_t;
 
 typedef struct {
@@ -3193,6 +3329,10 @@ typedef struct em_network_node {
     struct em_network_node     *child[EM_MAX_DM_CHILDREN];
 } em_network_node_t;
 
+typedef struct {
+    mac_address_t al_mac;
+} em_cmd_unassoc_sta_query_params_t;
+
 typedef em_scan_params_t em_cmd_scan_params_t;
 typedef struct {
     union {
@@ -3202,6 +3342,7 @@ typedef struct {
         em_cmd_disassoc_params_t	disassoc_params;
 		em_cmd_scan_params_t	scan_params;
         em_cmd_ap_metrics_rprt_params_t ap_metrics_params;
+        em_cmd_unassoc_sta_query_params_t unassoc_sta_query_params;
     } u;
 	em_network_node_t *net_node;
 } em_cmd_params_t;

--- a/inc/em_cmd_unassoc_sta_query.h
+++ b/inc/em_cmd_unassoc_sta_query.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_UNASSOC_STA_QUERY_H
+#define EM_CMD_UNASSOC_STA_QUERY_H
+
+#include "em_cmd.h"
+
+class em_cmd_unassoc_sta_query_t : public em_cmd_t {
+
+private:
+
+    em_unassoc_query_list_t m_query;
+
+public:
+
+    em_cmd_unassoc_sta_query_t(em_cmd_params_t param, dm_easy_mesh_t& dm, em_unassoc_query_list_t *query);
+
+    em_unassoc_query_list_t *get_query()
+    {
+        return &m_query;
+    }
+};
+
+#endif
+

--- a/inc/em_cmd_unassoc_sta_result.h
+++ b/inc/em_cmd_unassoc_sta_result.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_UNASSOC_STA_RESULT_H
+#define EM_CMD_UNASSOC_STA_RESULT_H
+
+#include "em_cmd.h"
+
+class em_cmd_unassoc_sta_result_t : public em_cmd_t {
+
+public:
+    /**!
+     * @brief Creates an unassociated STA link metrics result command.
+     *
+     * Initializes the unassociated STA result command using the provided
+     * command parameters and EasyMesh data model context.
+     *
+     * @param[in] param Command parameters associated with the unassociated
+     *                  STA metrics result.
+     * @param[in] dm Reference to the EasyMesh data model instance.
+     *
+     * @note Ensure that the provided data model instance is properly
+     * initialized before invoking this constructor.
+     */
+    em_cmd_unassoc_sta_result_t(em_cmd_params_t param, dm_easy_mesh_t& dm);	
+};
+#endif

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -458,6 +458,22 @@ public:
 
 	void handle_link_stats_alarm_report(em_bus_event_t *evt);
 
+        /**!
+         * @brief Handles an Unassociated STA Link Metrics Query event.
+         *
+         * This function processes the Unassociated STA Link Metrics Query
+         * received from the controller, validates the requested operating
+         * classes, channels and STA MAC entries, and initiates the
+         * corresponding agent-side RCPI measurement workflow.
+         *
+         * @param[in] evt Pointer to the event structure containing the
+         *                Unassociated STA Link Metrics Query payload.
+         *
+         * @note Ensure that the event structure is properly initialized
+         *       before calling this function.
+         */
+        void handle_unassoc_sta_metrics_query(em_bus_event_t *evt);
+
 	/**!
 	 * @brief 
 	 * This function handles input/output operations.

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -361,23 +361,6 @@ class em_metrics_t {
 	short create_assoc_ext_sta_link_metrics_tlv(unsigned char *buff, mac_address_t sta_mac, const dm_sta_t *const sta);
     
 	/**!
-	 * @brief Creates an error code TLV.
-	 *
-	 * This function generates a TLV (Type-Length-Value) structure for error codes.
-	 *
-	 * @param[out] buff Buffer where the TLV will be stored.
-	 * @param[in] sta MAC address of the station.
-	 * @param[in] sta_found Boolean indicating if the station was found.
-	 *
-	 * @returns Short integer representing the status of the TLV creation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure the buffer is large enough to hold the TLV.
-	 */
-	short create_error_code_tlv(unsigned char *buff, mac_address_t sta, bool sta_found);
-    
-	/**!
 	 * @brief Creates an association vendor STA link metrics TLV.
 	 *
 	 * This function generates a TLV (Type-Length-Value) structure for the association
@@ -544,6 +527,148 @@ class em_metrics_t {
 	short create_assoc_wifi6_sta_sta_report_tlv(unsigned char *buff, const dm_sta_t *const sta);
 
 	short create_link_stats_alarm_tlv(unsigned char *buff);
+
+        /*
+         * @brief Tracks whether an Unassociated STA Link Metrics Query
+         *        has already been transmitted and is awaiting response.
+         */
+        bool m_unassoc_query_sent = false;
+
+        /*
+         * @brief Tracks whether an Unassociated STA Link Metrics Response
+         *        has already been handled.
+         */
+	bool m_unassoc_in_progress = false;
+
+        /*
+         * @brief Sends an Unassociated STA Link Metrics Response message.
+         *
+         * @note Used by Agent to send measured RCPI metrics
+         *       for requested unassociated STAs.
+         */
+        void send_unassoc_sta_link_metrics_resp_msg();
+
+       /*!
+        * @brief Creates Unassociated STA Link Metrics Query TLV
+        *        for a given operating class.
+        *
+        * @param buff Output buffer where TLV is written.
+        * @param op   Operating class query structure.
+        *
+        * @return Length of generated TLV.
+        */
+        unsigned short create_unassoc_sta_link_metrics_query_tlv(unsigned char *buff, em_unassoc_query_opclass_t *op);
+
+       /*
+        * @brief Handles received Unassociated STA Link Metrics
+        *        Response CMDU.
+        *
+        * @param buff Incoming CMDU buffer.
+        * @param len  CMDU length.
+        *
+        * @return 0 on success.
+        */
+        int handle_unassoc_sta_link_metrics_rsp(unsigned char *buff, unsigned int len);
+
+       /*
+        * @brief Parses and processes an Unassociated STA
+        *        Link Metrics TLV.
+        *
+        * @param buff TLV payload buffer.
+	* @param tlv_len TLV length
+        *
+        * @return 0 on success.
+        */
+        int handle_unassoc_sta_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len);
+
+       /* 
+        * @brief Sends an Unassociated STA Link Metrics Query
+        *        message from Controller to Agent.
+        *
+        * @return 0 on success.
+        */
+        int send_unassoc_sta_link_metrics_query_msg();
+
+       /*
+        * @brief Handles received Unassociated STA Link Metrics Query.
+        *
+        * @param buff Incoming CMDU buffer.
+        * @param len  CMDU length.
+        *
+        * @return 0 on success.
+        */
+        int handle_unassoc_sta_link_metrics_query(unsigned char *buff, unsigned int len);
+
+       /*
+        * @brief Handles incoming 1905 ACK message.
+        *
+        * @param buff Incoming ACK CMDU buffer.
+        * @param len  CMDU length.
+        *
+        * @return 0 on success.
+        */
+        int handle_1905_ack(unsigned char *buff, unsigned int len);
+
+       /*
+        * @brief Sends a 1905 ACK for an Unassociated STA
+        *        Metrics Query request.
+        *
+        * @param sta_list List of queried STA MAC addresses.
+        * @param sta_count Number of STA MAC addresses.
+        * @param msg_id Original CMDU message ID being acknowledged.
+        *
+        * @return 0 on success.
+        */
+        int send_1905_ack_unassoc_sta_query(mac_address_t *sta_list, int sta_count, unsigned short msg_id);
+
+       /*
+        * @brief Creates Unassociated STA Link Metrics Response TLV.
+        *
+        * @param buff      Output buffer where TLV is written.
+        * @param op_class  Operating class of response metrics.
+        * @param rsp       Response metrics structure.
+        *
+        * @return Length of generated TLV.
+        */
+        unsigned short create_unassoc_sta_link_metrics_resp_tlv(unsigned char *buff, unsigned char op_class, em_unassoc_sta_metrics_rsp_t *rsp);
+
+       /*
+        * @brief Creates an Error Code TLV for STA metrics responses.
+        *
+        * @param buff          Output buffer where TLV is written.
+        * @param sta           STA MAC address associated with error.
+        * @param sta_found     Indicates whether STA was found.
+        * @param is_associated Indicates whether STA is associated.
+        *
+        * @return Length of generated TLV.
+        */
+        short create_error_code_tlv(unsigned char *buff, mac_address_t sta, bool sta_found, bool is_associated);
+
+       /*
+        * @brief Stores the CMDU Message ID of the last transmitted
+        *        Unassociated STA Link Metrics Query.
+        *
+        * @note Used for ACK tracking and response correlation.
+        */
+        unsigned short m_unassoc_sta_query_msg_id = 0;
+ 
+       /**
+        * @brief Get the current Unassociated STA Query message ID.
+        *
+        * Returns the message ID associated with the outstanding
+        * Unassociated STA Link Metrics Query.
+        *
+        * @return Message ID of the pending query.
+        */
+        unsigned short get_unassoc_sta_query_msg_id() const { return m_unassoc_sta_query_msg_id; }
+
+       /**
+        * @brief Clear the Unassociated STA Query message ID.
+        *
+        * Resets the stored query message ID after the corresponding
+        * ACK has been received and processed.
+        */
+        void clear_unassoc_sta_query_msg_id() { m_unassoc_sta_query_msg_id = 0; }	
 
 public:
 

--- a/inc/util.h
+++ b/inc/util.h
@@ -299,7 +299,6 @@ namespace util {
 	 */
 	std::pair<uint8_t, uint8_t> em_freq_to_chan(unsigned int frequency, const std::string& region="");
 
-
 	/**
 	 * @brief Translate an AKM literal to its OUI representation case-insensitively.
 	 *

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -99,6 +99,7 @@ onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_beacon_report.cpp \
      $(top_srcdir)/src/cmd/em_cmd_ap_metrics_report.cpp \
      $(top_srcdir)/src/cmd/em_cmd_link_stats_report.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_unassoc_sta_result.cpp \
      $(top_srcdir)/src/agent/dm_easy_mesh_agent.cpp \
      $(top_srcdir)/src/agent/em_agent.cpp \
      $(top_srcdir)/src/agent/em_cmd_agent.cpp \

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -52,6 +52,7 @@
 #include "em_cmd_sta_link_metrics.h"
 #include "em_cmd_ap_metrics_report.h"
 #include "em_cmd_link_stats_report.h"
+#include "em_cmd_unassoc_sta_result.h"
 
 #ifdef AL_SAP
 #include "al_service_access_point.h"
@@ -910,6 +911,117 @@ int dm_easy_mesh_agent_t::analyze_btm_response_action_frame(em_bus_event_t *evt,
     memcpy(btm_report_param.target, &btm_frame->u.action.u.bss_tm_resp.variable, sizeof(mac_addr_t));
 
     pcmd[num] = new em_cmd_btm_report_t(btm_report_param);
+    tmp = pcmd[num];
+    num++;
+
+    while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
+        tmp = pcmd[num];
+        num++;
+    }
+
+    return num;
+}
+
+int dm_easy_mesh_agent_t::analyze_unassoc_sta_result(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    em_cmd_t *tmp = NULL;
+    unsigned int num = 0;
+
+    cJSON *json;
+    cJSON *resp_array;
+
+    em_unassoc_sta_metrics_rsp_t *rsp;
+
+    translate_and_decode_onewifi_subdoc((char *)evt->u.raw_buff, webconfig_subdoc_type_em_unassoc_sta_link_metrics, "Unassoc STA Metrics Response");
+
+    json = cJSON_Parse((const char *)evt->u.raw_buff);
+
+    if (json == NULL) {
+        em_printfout("%s:%d JSON parse failed", __func__, __LINE__);
+        return 0;
+    }
+
+    resp_array = cJSON_GetObjectItemCaseSensitive(json, "UnassocStaLinkMetricsResponse");
+
+    if ((resp_array == NULL) || (!cJSON_IsArray(resp_array))) {
+        em_printfout("%s:%d UnassocStaLinkMetricsResponse missing", __func__, __LINE__);
+        cJSON_Delete(json);
+        return 0;
+    }
+
+    rsp = &m_unassoc_sta_metrics_rsp;
+    memset(rsp, 0, sizeof(*rsp));
+    unsigned int entry_idx = 0;
+    cJSON *opclass_obj = NULL;
+
+    cJSON_ArrayForEach(opclass_obj, resp_array)
+    {
+        cJSON *opclass_json = cJSON_GetObjectItemCaseSensitive(opclass_obj, "opclass");
+
+        if ((opclass_json == NULL) || (!cJSON_IsNumber(opclass_json))) {
+            continue;
+        }
+
+        unsigned char op_class = (unsigned char)opclass_json->valueint;
+
+        cJSON *channels = cJSON_GetObjectItemCaseSensitive(opclass_obj, "channels");
+        if ((channels == NULL) || (!cJSON_IsArray(channels))) {
+            continue;
+        }
+
+        cJSON *channel_obj = NULL;
+
+        cJSON_ArrayForEach(channel_obj, channels)
+        {
+            cJSON *channel_json = cJSON_GetObjectItemCaseSensitive(channel_obj, "channel");
+
+            if ((channel_json == NULL) || (!cJSON_IsNumber(channel_json))) {
+                continue;
+            }
+
+            unsigned char channel = (unsigned char)channel_json->valueint;
+
+            cJSON *sta_list = cJSON_GetObjectItemCaseSensitive(channel_obj, "sta_list");
+            if ((sta_list == NULL) || (!cJSON_IsArray(sta_list))) {
+                continue;
+            }
+
+            cJSON *sta_obj = NULL;
+
+            cJSON_ArrayForEach(sta_obj, sta_list)
+            {
+                if (entry_idx >= EM_MAX_UNASSOC_STA) {
+                    break;
+                }
+
+                cJSON *mac_json = cJSON_GetObjectItemCaseSensitive(sta_obj, "sta_mac");
+
+                cJSON *rcpi_json = cJSON_GetObjectItemCaseSensitive(sta_obj, "rcpi");
+
+                if ((mac_json == NULL) || (!cJSON_IsString(mac_json)) || (rcpi_json == NULL) || (!cJSON_IsNumber(rcpi_json))) {
+                    continue;
+                }
+
+                dm_easy_mesh_t::string_to_macbytes(mac_json->valuestring, rsp->entry[entry_idx].sta_mac);
+                rsp->entry[entry_idx].channel = channel;
+                rsp->entry[entry_idx].op_class = op_class;
+                rsp->entry[entry_idx].rcpi = (unsigned char)rcpi_json->valueint;
+                rsp->entry[entry_idx].time_delta = 0;
+                em_printfout("Parsed STA[%u] opclass=%u channel=%u rcpi=%u", entry_idx, op_class, channel, (unsigned char)rcpi_json->valueint);
+                entry_idx++;
+            }
+        }
+    }
+
+    rsp->num_entries = entry_idx;
+    cJSON_Delete(json);
+
+    if (rsp->num_entries == 0) {
+        em_printfout("%s:%d No valid STA metrics entries found", __func__, __LINE__);
+        return 0;
+    }
+
+    pcmd[num] = new em_cmd_unassoc_sta_result_t(evt->params, *this);
     tmp = pcmd[num];
     num++;
 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -852,6 +852,131 @@ void em_agent_t::handle_channel_scan_params(em_bus_event_t *evt)
     }
 }
 
+void em_agent_t::handle_unassoc_sta_result(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    unsigned int num;
+
+    if ((num = m_data_model.analyze_unassoc_sta_result(evt, pcmd)) == 0) {
+        em_printfout("Unassoc STA Links results failed\n");
+    } else if (m_orch->submit_commands(pcmd, num) > 0) {
+        em_printfout("Unassoc submitting commands");
+    }
+}
+
+int em_agent_t::send_unassoc_sta_query_subdoc(wifi_bus_desc_t *desc, bus_handle_t *bus_hdl, em_unassoc_work_list_t *work)
+{
+    if ((desc == NULL) || (bus_hdl == NULL) || (work == NULL)) {
+        em_printfout("%s:%d Invalid input params desc=%p bus_hdl=%p work=%p",
+                     __func__, __LINE__, desc, bus_hdl, work);
+        return -1;
+    }
+
+    cJSON *root = cJSON_CreateObject();
+    if (root == NULL) {
+        em_printfout("%s:%d root creation failed", __func__, __LINE__);
+        return -1;
+    }
+
+    cJSON_AddStringToObject(root, "Version", "1.0");
+    cJSON_AddStringToObject(root, "SubDocName", "UnassocStaQuery");
+
+    cJSON *query_list = cJSON_AddArrayToObject(root, "UnassocStaQueryList");
+
+    if (query_list == NULL) {
+        em_printfout("%s:%d query_list creation failed", __func__, __LINE__);
+        cJSON_Delete(root);
+        return -1;
+    }
+
+    for (uint8_t i = 0; i < work->num_opclass; i++) {
+        em_unassoc_work_opclass_t *op = &work->opclass_list[i];
+
+        if (op->num_channels == 0) {
+            continue;
+        }
+
+        cJSON *op_obj = cJSON_CreateObject();
+        if (op_obj == NULL) {
+            continue;
+        }
+
+        cJSON_AddNumberToObject(op_obj, "opclass", op->op_class);
+ 
+        cJSON_AddNumberToObject(op_obj, "channels_length", op->num_channels);
+        cJSON *channels = cJSON_AddArrayToObject(op_obj, "channels");
+        if (channels == NULL) {
+            cJSON_Delete(op_obj);
+            continue;
+        }
+
+        for (uint8_t ch_idx = 0; ch_idx < op->num_channels; ch_idx++) {
+            em_unassoc_work_channel_t *ch = &op->channel_list[ch_idx];
+
+            cJSON *ch_obj = cJSON_CreateObject();
+            if (ch_obj == NULL) {
+                continue;
+            }
+
+            cJSON_AddNumberToObject(ch_obj, "channel", ch->channel);
+            cJSON_AddNumberToObject(ch_obj, "sta_list_length", ch->num_sta);
+            cJSON *sta_arr = cJSON_AddArrayToObject(ch_obj, "sta_macs");
+           if (sta_arr == NULL) {
+                cJSON_Delete(ch_obj);
+                continue;
+            }
+
+            for (uint8_t sta_idx = 0; sta_idx < ch->num_sta; sta_idx++)
+            {
+                char mac_str[32] = {0};
+
+                snprintf(mac_str,
+                         sizeof(mac_str),
+                         "%02X:%02X:%02X:%02X:%02X:%02X",
+                         ch->sta_list[sta_idx][0],
+                         ch->sta_list[sta_idx][1],
+                         ch->sta_list[sta_idx][2],
+                         ch->sta_list[sta_idx][3],
+                         ch->sta_list[sta_idx][4],
+                         ch->sta_list[sta_idx][5]);
+
+                cJSON_AddItemToArray(sta_arr, cJSON_CreateString(mac_str));
+            }
+            cJSON_AddItemToArray(channels, ch_obj);
+        }
+        cJSON_AddItemToArray(query_list, op_obj);
+    }
+    char *json_str = cJSON_Print(root);
+
+    if (json_str == NULL) {
+        em_printfout("%s:%d JSON serialization failed",  __func__, __LINE__);
+        cJSON_Delete(root);
+        return -1;
+    }
+
+    em_printfout("========== Unassoc STA Query Subdoc ==========\n%s\n==============================================",
+        json_str);
+
+    raw_data_t bus_data;
+    memset(&bus_data, 0, sizeof(raw_data_t));
+    bus_data.data_type = bus_data_type_string;
+    bus_data.raw_data.bytes = json_str;
+    bus_data.raw_data_len = strlen(json_str);
+
+    if (desc->bus_set_fn(bus_hdl, "Device.WiFi.UnAssoc.STA", &bus_data) != 0) {
+        em_printfout("%s:%d Unassoc subdoc send failed",  __func__, __LINE__);
+        free(json_str);
+        cJSON_Delete(root);	
+        return -1;
+    }
+    em_printfout("%s:%d Unassoc STA Link Metrics Query subdoc send success", __func__, __LINE__);
+    
+    free(json_str);
+    cJSON_Delete(root);
+
+    return 0;
+}
+
 bool em_agent_t::send_scan_request(em_scan_params_t* scan_params, bool perform_fresh_scan, bool is_sta_vap){
     unsigned i, j;
     raw_data_t l_bus_data;
@@ -901,6 +1026,77 @@ bool em_agent_t::send_scan_request(em_scan_params_t* scan_params, bool perform_f
     }
     em_printfout("Sent channel scan request to bus\n");
     return true;
+}
+
+void em_agent_t::handle_unassoc_sta_link_metrics_qry(em_bus_event_t *evt)
+{
+    wifi_bus_desc_t *desc = get_bus_descriptor();
+
+    if ((evt == NULL) || (desc == NULL) || (evt->u.raw_buff == NULL) || (evt->data_len == 0)) {
+        em_printfout("%s:%d Invalid input evt=%p desc=%p buff=%p len=%u", __func__, __LINE__, evt, desc, (evt ? evt->u.raw_buff : NULL),
+                                                                                                 (evt ? evt->data_len : 0));
+        return;
+    }
+
+    unsigned char *buff = reinterpret_cast<unsigned char *>(evt->u.raw_buff);
+    unsigned int len = evt->data_len;
+    int pos = 0;
+
+    em_unassoc_work_list_t work;
+    memset(&work, 0, sizeof(work));
+    int op_idx = 0;
+
+    while ((pos + 2) <= (int)len && op_idx < EM_MAX_OP_CLASS) {
+        auto &op = work.opclass_list[op_idx];
+
+        op.op_class = buff[pos++];
+        op.num_channels = buff[pos++];
+
+        if (op.num_channels > EM_MAX_CHANNELS_PER_OPCLASS) {
+            em_printfout("%s:%d invalid num_channels=%u", __func__, __LINE__, op.num_channels);
+            return;
+        }
+
+        int chan_idx = 0;
+        for (int j = 0; j < op.num_channels; j++) {
+            if ((pos + 2) > (int)len) {
+                em_printfout("%s:%d buffer underrun channel", __func__, __LINE__);
+                return;
+            }
+
+            auto &ch = op.channel_list[chan_idx];
+            ch.channel = buff[pos++];
+            ch.num_sta = buff[pos++];
+
+            if (ch.num_sta > EM_MAX_STA_PER_CHANNEL) {
+                em_printfout("%s:%d invalid num_sta=%u", __func__, __LINE__, ch.num_sta);
+                return;
+            }
+
+            for (int k = 0; k < ch.num_sta; k++) {
+                if ((pos + sizeof(mac_address_t)) > (int)len) {
+                    em_printfout("%s:%d buffer underrun STA", __func__, __LINE__);
+                    return;
+                }
+
+                memcpy(ch.sta_list[k], &buff[pos], sizeof(mac_address_t));
+                pos += sizeof(mac_address_t);
+            }
+            chan_idx++;
+        }
+        op.num_channels = chan_idx;
+        op_idx++;
+    }
+
+    work.num_opclass = op_idx;
+
+    int rc = this->send_unassoc_sta_query_subdoc(desc, &m_bus_hdl, &work);
+
+    if (rc < 0) {
+        em_printfout("%s:%d Failed send subdoc rc=%d", __func__, __LINE__, rc);
+    } else {
+        em_printfout("%s:%d Successfully sent subdoc", __func__, __LINE__);
+    }
 }
 
 void em_agent_t::handle_set_policy(em_bus_event_t *evt)
@@ -1105,6 +1301,14 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
 
         case em_bus_event_type_link_quality_report:
             handle_link_stats_report(evt);
+            break;
+
+        case em_bus_event_type_unassoc_sta_link_metrics_query:
+            handle_unassoc_sta_link_metrics_qry(evt);
+            break;
+
+        case em_bus_event_type_unassoc_sta_result:
+            handle_unassoc_sta_result(evt);
             break;
 
         default:
@@ -1389,7 +1593,64 @@ void em_agent_t::input_listener()
         return;
     }
 
+   if(desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.NaStaResponse", (void *)&em_agent_t::unassoc_sta_link_metrics_cb, NULL, 0) != 0) {
+        printf("%s:%d bus get failed\n",__func__,__LINE__);
+        return;
+    }
+
     io(NULL);
+}
+
+int em_agent_t::unassoc_sta_link_metrics_cb(char *event_name, bus_data_prop_t *data, void *userData)
+{
+    (void)event_name;
+    (void)userData;
+
+    if ((data == NULL) || (data->value.raw_data.bytes == NULL))
+    {
+        em_printfout("%s:%d invalid input", __func__,  __LINE__);
+        return -1;
+    }
+
+    cJSON *json = cJSON_Parse((const char *)data->value.raw_data.bytes);
+
+    if (json == NULL) {
+        em_printfout("%s:%d JSON parse failed",  __func__,  __LINE__);
+        return -1;
+    }
+
+    cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
+
+    if ((subdoc_name == NULL) || (!cJSON_IsString(subdoc_name))) {
+        em_printfout("%s:%d SubDocName missing", __func__,  __LINE__);
+        cJSON_Delete(json);
+        return -1;
+    }
+
+    if (strcmp(subdoc_name->valuestring, "UnassocStaLinkMetricsResponse") != 0) {
+        em_printfout("%s:%d unexpected SubDocName=%s",__func__, __LINE__, subdoc_name->valuestring);
+        cJSON_Delete(json);
+        return -1;
+    }
+
+    cJSON *resp = cJSON_GetObjectItemCaseSensitive(json, "UnassocStaLinkMetricsResponse");
+    if ((resp == NULL) || (!cJSON_IsArray(resp))) {
+        em_printfout("%s:%d response array missing",__func__,__LINE__);
+        cJSON_Delete(json);
+        return -1;
+    }
+
+    char *str = cJSON_Print(json);
+    if (str != NULL) {
+        em_printfout("===== UNASSOC RESPONSE =====\n%s\n", str);
+        free(str);
+    }
+
+    g_agent.io_process(em_bus_event_type_unassoc_sta_result, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes),
+                                                                               data->value.raw_data_len);
+    cJSON_Delete(json);
+
+    return 1;
 }
 
 int em_agent_t::bss_info_cb(char *event_name, bus_data_prop_t *data, void *userData)
@@ -2001,6 +2262,20 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 	        }
 	        em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
            }
+           break;
+
+        case em_msg_type_unassoc_sta_link_metrics_query:
+           em = (em_t *)hash_map_get_first(m_em_map);
+           while (em != NULL) {
+                if ((em->is_al_interface_em() == false)) {
+                    break;
+                }
+                em = (em_t *)hash_map_get_next(m_em_map, em);
+            }
+            break;
+
+        case em_msg_type_unassoc_sta_link_metrics_rsp:
+           printf("%s:%d: Sending Unassoc STA Link Metrics response\n", __func__, __LINE__);
            break;
 
         default:

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -465,6 +465,11 @@ void em_cmd_t::init()
             strncpy(m_name, "get_alarm_report", strlen("get_alarm_report") + 1);
             m_svc = em_service_type_ctrl;
             break;
+        
+	case em_cmd_type_unassoc_sta_query:
+            snprintf(m_name, sizeof(m_name), "%s", "unassoc_sta_query");
+            m_svc = em_service_type_ctrl;
+            break;
 
         default:
             snprintf(m_name, sizeof(m_name), "%s", "unknown");
@@ -514,6 +519,9 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_mld_reconfig)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_reset)
         BUS_EVENT_TYPE_2S(em_bus_event_type_link_quality_report)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_query)
+	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_link_metrics_query)
+	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_result)
        
         default:
            break;
@@ -591,6 +599,8 @@ const char *em_cmd_t::get_orch_op_str(dm_orch_type_t type)
         ORCH_TYPE_2S(dm_orch_type_policy_cfg)
         ORCH_TYPE_2S(dm_orch_type_mld_reconfig)
         ORCH_TYPE_2S(dm_orch_type_topo_publish)
+        ORCH_TYPE_2S(dm_orch_type_unassoc_sta_link_req_query)
+	ORCH_TYPE_2S(dm_orch_type_unassoc_sta_result)
 
         default:
            break;
@@ -647,6 +657,8 @@ const char *em_cmd_t::get_cmd_type_str(em_cmd_type_t type)
         CMD_TYPE_2S(em_cmd_type_ap_metrics_report)
         CMD_TYPE_2S(em_cmd_type_get_reset)
         CMD_TYPE_2S(em_cmd_type_get_link_quality_report)
+        CMD_TYPE_2S(em_cmd_type_unassoc_sta_query)
+	CMD_TYPE_2S(em_cmd_type_unassoc_sta_result)
 
         default:
            break;
@@ -793,6 +805,14 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
             type = em_cmd_type_get_link_quality_report;
             break;
 
+      	case em_bus_event_type_unassoc_sta_query:
+            type = em_cmd_type_unassoc_sta_query;
+            break;
+
+      	case em_bus_event_type_unassoc_sta_result:
+            type = em_cmd_type_unassoc_sta_result;
+            break;
+
         default:
             break;
     }
@@ -843,6 +863,14 @@ em_bus_event_type_t em_cmd_t::cmd_2_bus_event_type(em_cmd_type_t ctype)
 
         case em_cmd_type_get_reset:
             type = em_bus_event_type_get_reset;
+            break;
+
+        case em_cmd_type_unassoc_sta_query:
+            type = em_bus_event_type_unassoc_sta_query;
+            break;
+
+        case em_cmd_type_unassoc_sta_result:
+            type = em_bus_event_type_unassoc_sta_result;
             break;
 
         default:

--- a/src/cmd/em_cmd_unassoc_sta_query.cpp
+++ b/src/cmd/em_cmd_unassoc_sta_query.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <cjson/cJSON.h>
+#include "em_cmd_unassoc_sta_query.h"
+
+em_cmd_unassoc_sta_query_t::em_cmd_unassoc_sta_query_t(em_cmd_params_t param, dm_easy_mesh_t& dm, em_unassoc_query_list_t *query)
+{
+    em_cmd_ctx_t ctx;
+
+    m_type = em_cmd_type_unassoc_sta_query;
+
+    memcpy(&m_param, &param, sizeof(em_cmd_params_t));
+
+    memset(&m_query, 0, sizeof(em_unassoc_query_list_t));
+
+    if (query != NULL) {
+        memcpy(&m_query, query, sizeof(em_unassoc_query_list_t));
+    }
+
+    memset(reinterpret_cast<unsigned char *>(&m_orch_desc[0]), 0, EM_MAX_CMD * sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+
+    m_num_orch_desc = 1;
+
+    m_orch_desc[0].op = dm_orch_type_unassoc_sta_link_req_query;
+
+    m_orch_desc[0].submit = true;
+
+    strncpy(m_name, "unassoc_sta_query", sizeof(m_name) - 1);
+
+    m_svc = em_service_type_ctrl;
+
+    init(dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+
+    ctx.type = m_orch_desc[0].op;
+
+    m_data_model.set_cmd_ctx(&ctx);
+}

--- a/src/cmd/em_cmd_unassoc_sta_result.cpp
+++ b/src/cmd/em_cmd_unassoc_sta_result.cpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <cjson/cJSON.h>
+#include "em_cmd_unassoc_sta_result.h"
+
+em_cmd_unassoc_sta_result_t::em_cmd_unassoc_sta_result_t(em_cmd_params_t param,  dm_easy_mesh_t& dm)
+{
+    em_cmd_ctx_t ctx;
+
+    m_type = em_cmd_type_unassoc_sta_result;
+
+    memcpy(&m_param, &param, sizeof(em_cmd_params_t));
+
+    memset(reinterpret_cast<unsigned char *>(&m_orch_desc[0]), 0, EM_MAX_CMD * sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+    m_num_orch_desc = 1;
+
+    m_orch_desc[0].op = dm_orch_type_unassoc_sta_result;
+    m_orch_desc[0].submit = true;
+
+    strncpy(m_name, "unassoc_sta_result", sizeof(m_name) - 1);
+
+    m_svc = em_service_type_agent;
+
+    init(dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+
+    ctx.type = m_orch_desc[0].op;
+
+    m_data_model.set_cmd_ctx(&ctx);
+}

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -95,6 +95,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
      $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
      $(top_srcdir)/src/cmd/em_cmd_bsta_cap.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_unassoc_sta_query.cpp \
      $(top_srcdir)/src/ctrl/dm_easy_mesh_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_cmd_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_ctrl.cpp \

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -57,6 +57,7 @@
 #include "em_cmd_get_mld_config.h"
 #include "em_cmd_mld_reconfig.h"
 #include "em_cmd_bsta_cap.h"
+#include "em_cmd_unassoc_sta_query.h"
 
 extern em_network_topo_t *g_network_topology;
 
@@ -1589,6 +1590,170 @@ cleanup:
     return rc;
 }
 
+int dm_easy_mesh_ctrl_t::analyze_unassoc_sta_metrics_query(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    int num = 0;
+    em_cmd_t *tmp = NULL;
+    em_subdoc_info_t *subdoc = NULL;
+
+    cJSON *obj = NULL;
+    cJSON *wfa_obj = NULL;
+
+    cJSON *al_mac_obj = NULL;
+    cJSON *query_list = NULL;
+
+    char wfa[128] = {0};
+
+    subdoc = &evt->u.subdoc;
+    if (subdoc == NULL) {
+        em_printfout("subdoc NULL");
+        return 0;
+    }
+
+    obj = cJSON_Parse(subdoc->buff);
+    if (obj == NULL) {
+        em_printfout("JSON parse failed");
+        return 0;
+    }
+
+    snprintf(wfa, sizeof(wfa), "wfa-dataelements:UnassocSTAQuery");
+
+    wfa_obj = cJSON_GetObjectItem(obj, wfa);
+
+    if (wfa_obj == NULL) {
+        em_printfout("Missing wfa object");
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    al_mac_obj = cJSON_GetObjectItem(wfa_obj, "AlMac");
+
+    query_list = cJSON_GetObjectItem(wfa_obj, "UnassocStaQueryList");
+
+    if ((al_mac_obj == NULL) || (query_list == NULL) || (!cJSON_IsArray(query_list))) {
+        em_printfout("Missing mandatory params");
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    em_cmd_params_t params = evt->params;
+
+    const char *al_mac_str = cJSON_GetStringValue(al_mac_obj);
+    if (al_mac_str == NULL) {
+        em_printfout("%s:%d: AlMac is not a string", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    char al_mac_buf[32] = {0};
+    strncpy(al_mac_buf, al_mac_str, sizeof(al_mac_buf) - 1);
+
+    dm_easy_mesh_t::string_to_macbytes(al_mac_buf, params.u.unassoc_sta_query_params.al_mac);
+
+    dm_easy_mesh_t dm = *this;
+
+    em_unassoc_query_list_t query;
+    memset(&query, 0, sizeof(query));
+
+    int opclass_count = cJSON_GetArraySize(query_list);
+
+    if (opclass_count > EM_MAX_OP_CLASS) {
+        opclass_count = EM_MAX_OP_CLASS;
+    }
+
+    query.num_opclass = static_cast<uint8_t>(opclass_count);
+
+    for (int i = 0; i < opclass_count; i++) {
+
+        cJSON *opclass_obj = cJSON_GetArrayItem(query_list, i);
+
+        if (opclass_obj == NULL) {
+            continue;
+        }
+
+        cJSON *opclass_val = cJSON_GetObjectItem(opclass_obj, "opclass");
+
+        cJSON *channels_array = cJSON_GetObjectItem(opclass_obj, "channels");
+
+        if ((opclass_val == NULL) || (channels_array == NULL) || (!cJSON_IsArray(channels_array))) {
+            continue;
+        }
+
+        auto &op = query.opclass_list[i];
+
+        op.op_class = static_cast<uint8_t>(opclass_val->valueint);
+
+        int channel_count = cJSON_GetArraySize(channels_array);
+
+        if (channel_count > EM_MAX_CHANNELS_PER_OPCLASS) {
+            channel_count = EM_MAX_CHANNELS_PER_OPCLASS;
+        }
+
+        op.num_channels = static_cast<uint8_t>(channel_count);
+
+        for (int j = 0; j < channel_count; j++) {
+
+            cJSON *channel_obj = cJSON_GetArrayItem(channels_array, j);
+
+            if (channel_obj == NULL) {
+                continue;
+            }
+
+            cJSON *channel_val = cJSON_GetObjectItem(channel_obj, "channel");
+            cJSON *sta_array = cJSON_GetObjectItem(channel_obj, "sta_macs");
+
+            if ((channel_val == NULL) || (sta_array == NULL) || (!cJSON_IsArray(sta_array))) {
+                continue;
+            }
+
+            auto &ch = op.channel_list[j];
+
+            ch.channel = static_cast<uint8_t>(channel_val->valueint);
+
+            int sta_count = cJSON_GetArraySize(sta_array);
+
+            if (sta_count > EM_MAX_STA_PER_CHANNEL) {
+                sta_count = EM_MAX_STA_PER_CHANNEL;
+            }
+
+            ch.num_sta = static_cast<uint8_t>(sta_count);
+
+            for (int k = 0; k < sta_count; k++) {
+                cJSON *sta_obj = cJSON_GetArrayItem(sta_array, k);
+
+                if ((sta_obj == NULL) || (sta_obj->valuestring == NULL)) {
+                    continue;
+                }
+
+                dm_easy_mesh_t::string_to_macbytes(sta_obj->valuestring, ch.sta_list[k]);
+            }
+        }
+    }
+
+    pcmd[num] = new em_cmd_unassoc_sta_query_t(params, dm, &query);
+
+    if (pcmd[num] == NULL) {
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    tmp = pcmd[num];
+    num++;
+
+    while ((pcmd[num] =
+            tmp->clone_for_next()) != NULL) {
+
+        tmp = pcmd[num];
+        num++;
+    }
+
+    cJSON_Delete(obj);
+
+    em_printfout("Returning successfully from analyze_unassoc_sta_metrics_query");
+
+    return num;
+}
+
 int dm_easy_mesh_ctrl_t::analyze_sta_link_metrics(em_cmd_t *pcmd[])
 {
     int num = 0;
@@ -1607,7 +1772,6 @@ int dm_easy_mesh_ctrl_t::analyze_sta_link_metrics(em_cmd_t *pcmd[])
 
     return num;
 }
-
 
 int dm_easy_mesh_ctrl_t::analyze_config_renew(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -398,6 +398,22 @@ void em_ctrl_t::handle_ap_metrics_req()
 
 }
 
+void em_ctrl_t::handle_unassoc_sta_metrics_query(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    int num;
+
+    if (m_orch->is_cmd_type_in_progress(evt) == true) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
+    } else if ((num = m_data_model.analyze_unassoc_sta_metrics_query(evt, pcmd)) == 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_success);
+    } else {
+        m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+    }
+}
+
 void em_ctrl_t::handle_client_metrics_req()
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -622,7 +638,11 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
         case em_bus_event_type_link_quality_report:
            handle_link_stats_alarm_report(evt);
            break;
-	
+
+	case em_bus_event_type_unassoc_sta_query:
+           handle_unassoc_sta_metrics_query(evt);
+           break;
+
         default:
             break;
     }
@@ -954,6 +974,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
         case em_msg_type_channel_sel_req:
         case em_msg_type_client_cap_query:
         case em_msg_type_assoc_sta_link_metrics_query:
+        case em_msg_type_unassoc_sta_link_metrics_query:	    
         case em_msg_type_beacon_metrics_query:
         case em_msg_type_client_steering_req:
         case em_msg_type_client_assoc_ctrl_req:
@@ -1056,6 +1077,16 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
             }
             break;
 
+	case em_msg_type_unassoc_sta_link_metrics_rsp:
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+            while (em != NULL) {
+                if ((em->is_al_interface_em() == false) && 
+	          (memcmp(em->get_data_model()->get_agent_al_interface_mac(), hdr->src, sizeof(mac_address_t)) == 0)) {
+                    break;
+                }
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
+            }
+            break;
 
         default:
             printf("%s:%d: Frame: 0x%04x not handled in controller\n", __func__, __LINE__, htons(cmdu->type));

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2857,6 +2857,22 @@ dm_sta_t *dm_easy_mesh_t::find_sta(mac_address_t sta_mac, bssid_t bssid)
     return NULL;
 }
 
+dm_sta_t *dm_easy_mesh_t::find_sta(mac_address_t sta_mac)
+{
+    for (unsigned int i = 0; i < get_num_bss(); i++) {
+        auto *bss = get_bss_info(i);
+        if (bss == NULL) {
+            continue;
+        }
+
+        auto *sta = find_sta(sta_mac, bss->bssid.mac);
+        if (sta != NULL) {
+            return sta;
+        }
+    }
+    return NULL;
+}
+
 dm_sta_t *dm_easy_mesh_t::get_first_sta(mac_address_t sta_mac)
 {
     dm_sta_t *sta;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -251,7 +251,15 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_agent_link_quality_report_pending);
             break;
 
-        default:
+        case em_cmd_type_unassoc_sta_query:
+            m_sm.set_state(em_state_ctrl_unassoc_sta_link_metrics_pending);
+            break;
+
+        case em_cmd_type_unassoc_sta_result:
+            m_sm.set_state(em_state_agent_unassoc_sta_metrics_report_pending);
+            break;
+        
+	default:
             break;
 
     }
@@ -325,6 +333,8 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_beacon_metrics_rsp:
         case em_msg_type_ap_metrics_rsp:
         case em_msg_type_topo_vendor:
+	case em_msg_type_unassoc_sta_link_metrics_query: 
+        case em_msg_type_unassoc_sta_link_metrics_rsp:	    
             em_metrics_t::process_msg(data, len);
             break;
 
@@ -349,6 +359,8 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
                 em_configuration_t::process_msg(data, len);
             } else if (m_sm.get_state() == em_state_ctrl_sta_steer_pending) {
                 em_steering_t::process_msg(data, len);
+            } else if (m_sm.get_state() == em_state_ctrl_unassoc_sta_link_metrics_pending) {
+                em_metrics_t::process_msg(data, len);		    
             } else {
                 em_policy_cfg_t::process_msg(data, len);
                 em_channel_t::process_msg(data, len);
@@ -480,6 +492,12 @@ void em_t::handle_agent_state()
             }
             break;
 
+        case em_cmd_type_unassoc_sta_result:
+            if (m_sm.get_state() == em_state_agent_unassoc_sta_metrics_report_pending) {
+                em_metrics_t::process_agent_state();
+            }
+            break;
+
         default:
             break;
     }
@@ -551,6 +569,10 @@ void em_t::handle_ctrl_state()
 
         case em_cmd_type_bsta_cap:
             em_capability_t::process_ctrl_state();
+            break;
+
+        case em_cmd_type_unassoc_sta_query:
+            em_metrics_t::process_ctrl_state();
             break;
 
         default:
@@ -2852,6 +2874,7 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_ctrl_avail_spectrum_inquiry_pending)
         EM_STATE_2S(em_state_ctrl_bsta_cap_pending)
         EM_STATE_2S(em_state_ctrl_topo_publish_pending)
+	EM_STATE_2S(em_state_ctrl_unassoc_sta_link_metrics_pending)
         EM_STATE_2S(em_state_agent_unconfigured)
         EM_STATE_2S(em_state_agent_autoconfig_rsp_pending)
         EM_STATE_2S(em_state_agent_wsc_m2_pending)
@@ -2869,9 +2892,10 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_agent_client_cap_report)
         EM_STATE_2S(em_state_agent_channel_pref_query)
         EM_STATE_2S(em_state_agent_sta_link_metrics_pending)
-        EM_STATE_2S(em_state_max)
         EM_STATE_2S(em_state_agent_beacon_report_pending)
         EM_STATE_2S(em_state_agent_channel_select_configuration_pending)
+	EM_STATE_2S(em_state_agent_unassoc_sta_metrics_report_pending)
+        EM_STATE_2S(em_state_max)
         default: break;
     }
 

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -44,6 +44,8 @@
 #include "util.h"
 #include "em.h"
 #include "em_cmd_exec.h"
+#include "dm_easy_mesh_agent.h"
+#include "em_cmd_unassoc_sta_query.h"
 
 static     const unsigned char em_vendor_oui[EM_VENDOR_OUI_SIZE] = {0xd8, 0x9c, 0x8e};
 
@@ -272,6 +274,106 @@ int em_metrics_t::handle_beacon_metrics_query(unsigned char *buff, unsigned int 
 
     memcpy(sta, tlv->value, sizeof(mac_address_t));
 
+    return 0;
+}
+
+int em_metrics_t::handle_unassoc_sta_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+
+    unsigned short pos = 0;
+    mac_addr_str_t mac_str;
+
+    if (tlv_len < 2) {
+        em_printfout("%s:%d Invalid TLV length=%u\n", __func__, __LINE__, tlv_len);
+        return -1;
+    }
+
+    unsigned char op_class = buff[pos++];
+    unsigned char num_sta  = buff[pos++];
+
+    for (unsigned int i = 0; i < num_sta; i++)
+    {
+        if (pos + sizeof(em_unassoc_sta_metric_t) > tlv_len) {
+            em_printfout("%s:%d Malformed Unassoc STA Link Metrics TLV: num_sta=%u parsed=%u tlv_len=%u\n", __func__, __LINE__, num_sta, i,tlv_len);
+            return -1;
+        }
+        em_unassoc_sta_metric_t *metric = reinterpret_cast<em_unassoc_sta_metric_t *>(buff + pos);
+
+        unsigned int idx = dm->m_num_unassoc_sta_metrics;
+
+        if (idx >= EM_MAX_UNASSOC_STA)
+        {
+            em_printfout("%s:%d Max STA limit reached",__func__, __LINE__);
+            break;
+        }
+
+        memcpy(dm->m_unassoc_sta_metrics[idx].sta_mac, metric->sta_mac,sizeof(mac_address_t));
+        dm->m_unassoc_sta_metrics[idx].channel = metric->channel;
+        dm->m_unassoc_sta_metrics[idx].op_class = op_class;
+        dm->m_unassoc_sta_metrics[idx].rcpi = metric->rcpi;
+        dm->m_unassoc_sta_metrics[idx].time_delta = ntohl(metric->time_delta);
+        dm_easy_mesh_t::macbytes_to_string(metric->sta_mac, mac_str);
+
+        dm->m_num_unassoc_sta_metrics++;
+
+        pos += sizeof(em_unassoc_sta_metric_t);
+    }
+    return 0;
+}
+
+int em_metrics_t::handle_unassoc_sta_link_metrics_rsp(unsigned char *buff, unsigned int len)
+{
+    em_tlv_t *tlv;
+    unsigned int tmp_len = 0;
+    unsigned int tlv_len = 0;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    if (m_unassoc_in_progress) {
+        return -1;
+    }
+
+    m_unassoc_in_progress = true;
+
+    if (em_msg_t(em_msg_type_unassoc_sta_link_metrics_rsp, get_profile_type(), buff, len).validate(errors) == 0) {
+        em_printfout("Unassoc STA Link Metrics Response validation failed");
+        m_unassoc_in_progress = false;
+        return -1;
+    }
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    memset(dm->m_unassoc_sta_metrics, 0, sizeof(dm->m_unassoc_sta_metrics));
+    dm->m_num_unassoc_sta_metrics = 0;
+
+    tlv = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    tmp_len = len - static_cast<unsigned int>(sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    while (tmp_len >= sizeof(em_tlv_t)) {
+        if (tlv->type == em_tlv_type_eom) {
+            break;
+        }
+
+        tlv_len = static_cast<unsigned int>(ntohs(tlv->len));
+
+        if ((sizeof(em_tlv_t) + tlv_len) > tmp_len) {
+            em_printfout("Malformed TLV detected in Unassoc STA Link Metrics Response");
+            break;
+        }
+    
+        if (tlv->type == em_tlv_type_unassoc_sta_link_metric_rsp) {
+            if (handle_unassoc_sta_link_metrics_tlv(tlv->value, tlv_len) < 0) {
+                em_printfout("%s:%d Failed to parse Unassoc STA Link Metrics TLV\n", __func__, __LINE__);
+                m_unassoc_in_progress = false;
+                return -1;
+            }
+        }
+        tmp_len -= static_cast<unsigned int>(sizeof(em_tlv_t)) + tlv_len;
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + sizeof(em_tlv_t) + tlv_len);
+    }
+
+    m_unassoc_in_progress = false;
     return 0;
 }
 
@@ -727,7 +829,7 @@ int em_metrics_t::send_associated_link_metrics_response(mac_address_t sta_mac, u
     //Error code  TLV 17.2.36
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_error_code;
-    sz = create_error_code_tlv(tlv->value, sta_mac, sta_found);
+    sz = create_error_code_tlv(tlv->value, sta_mac, sta_found, false);
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
@@ -895,7 +997,7 @@ int em_metrics_t::send_beacon_metrics_response()
     //Error code  TLV 17.2.36
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_error_code;
-    sz = create_error_code_tlv(tlv->value, sta->m_sta_info.id, sta_found);
+    sz = create_error_code_tlv(tlv->value, sta->m_sta_info.id, sta_found, false);
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
@@ -1650,7 +1752,7 @@ short em_metrics_t::create_link_stats_alarm_tlv(unsigned char *buff)
     return static_cast<short> (len);
 }
 
-short em_metrics_t::create_error_code_tlv(unsigned char *buff, mac_address_t sta, bool sta_found)
+short em_metrics_t::create_error_code_tlv(unsigned char *buff, mac_address_t sta, bool sta_found, bool is_associated)
 {
     short len = 0;
     unsigned char *tmp = buff;
@@ -1661,6 +1763,13 @@ short em_metrics_t::create_error_code_tlv(unsigned char *buff, mac_address_t sta
         reason = 0x02;
     } */
 
+    (void)sta_found;
+    if (is_associated) {
+        reason = 0x01;   // STA is associated (Unassoc Query error)
+    } else {
+        reason = 0x00;   // default / no error / legacy behavior
+    }
+
     memcpy(tmp, &reason, sizeof(unsigned char));
     tmp += sizeof(unsigned char);
     len += static_cast<short> (sizeof(unsigned char));
@@ -1670,6 +1779,615 @@ short em_metrics_t::create_error_code_tlv(unsigned char *buff, mac_address_t sta
     len += static_cast<short> (sizeof(mac_address_t));
 
     return len;
+}
+
+int em_metrics_t::handle_1905_ack(unsigned char *buff, unsigned int len)
+{
+    std::vector<em_t *> em_radios;
+    em_t *matched_em = nullptr;
+    mac_address_t src_mac;
+
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+
+    unsigned short response_msg_id = ntohs(cmdu->id);
+
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+
+    memcpy(src_mac, hdr->src, sizeof(mac_address_t));
+
+    get_mgr()->get_all_em_for_al_mac(src_mac, em_radios);
+
+    for (auto &em : em_radios)
+    {
+        if ((em->get_state() == em_state_ctrl_unassoc_sta_link_metrics_pending) &&
+            (response_msg_id == em->get_unassoc_sta_query_msg_id()))
+        {
+            matched_em = em;
+	    em->clear_unassoc_sta_query_msg_id();
+            break;
+        }
+    }
+
+    if (matched_em != nullptr) {
+        matched_em->set_state(em_state_ctrl_configured);
+    }
+
+    em_radios.clear();
+    em_printfout("Unassociated STA Link Metrics Query Ack handled successfully");
+    return 0;
+}
+
+int em_metrics_t::send_1905_ack_unassoc_sta_query(mac_address_t *sta_list, 
+		                        int sta_count, unsigned short msg_id)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    unsigned int len = 0;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    // --------------------------------------
+    // Ethernet Header and CMDU
+    // --------------------------------------
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len +=  static_cast<short> (sizeof(mac_address_t));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len +=  static_cast<short> (sizeof(mac_address_t));
+
+    memcpy(tmp, &type, sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += static_cast<unsigned int>(sizeof(unsigned short));;
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+
+    cmdu->type = htons(em_msg_type_1905_ack);
+    cmdu->id = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    tmp += sizeof(em_cmdu_t);
+    len += static_cast<unsigned int>(sizeof(em_cmdu_t));
+
+    // Error Code TLVs (if any)
+    for (int i = 0; i < sta_count; i++) {
+
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_error_code;
+
+        short sz =  create_error_code_tlv(tlv->value, sta_list[i], true, true);
+
+	tlv->len = htons(static_cast<short unsigned int> (sz));
+
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_3, buff, len).validate(errors) == 0) {
+        printf("%s:%d: ACK validation failed\n", __func__, __LINE__);
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        printf("%s:%d: ACK send failed, error:%d\n", __func__, __LINE__, errno);
+        return -1;
+    }
+    printf("%s:%d: ACK sent (Unassoc STA Query)\n", __func__, __LINE__);
+
+    return static_cast<int> (len);
+}
+
+int em_metrics_t::handle_unassoc_sta_link_metrics_query(unsigned char *buff, unsigned int len)
+{
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    if (em_msg_t(em_msg_type_unassoc_sta_link_metrics_query, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("%s:%d validation failed", __func__,__LINE__);
+        return -1;
+    }
+
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+
+    uint16_t msg_id = ntohs(cmdu->id);
+
+    dm_easy_mesh_t *dm = get_data_model();
+    dm->set_msg_id(msg_id);
+
+    mac_address_t error_sta_list[EM_MAX_STA_PER_AGENT];
+    int error_sta_count = 0;
+
+    unsigned char work_buff[MAX_EM_BUFF_SZ] = {0};
+    unsigned char *work_ptr = work_buff;
+
+    auto remaining_work_buf = [&](unsigned char *ptr) -> size_t {
+	    return MAX_EM_BUFF_SZ - static_cast<size_t>(ptr - work_buff);
+        };
+
+    unsigned char *tlv_ptr = buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t);
+
+    unsigned char *cmdu_end = buff + len;
+
+    while (tlv_ptr + sizeof(em_tlv_t) <= cmdu_end) {
+
+        em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tlv_ptr);
+
+        if (tlv->type == em_tlv_type_eom) {
+            break;
+        }
+
+        uint16_t tlv_len = ntohs(tlv->len);
+
+        if ((tlv_ptr + sizeof(em_tlv_t) + tlv_len) > cmdu_end) {
+            em_printfout("%s:%d TLV overflow", __func__,__LINE__);
+            return -1;
+        }
+
+        if (tlv->type == em_tlv_type_unassoc_sta_link_metric_query) {
+
+            unsigned char *query_ptr = tlv->value;
+            unsigned char *query_end = query_ptr + tlv_len;
+
+            while (query_ptr + 2 <= query_end) {
+
+                uint8_t op_class = *query_ptr++;
+                uint8_t num_channels = *query_ptr++;
+
+                if (num_channels > EM_MAX_CHANNELS_PER_OPCLASS) {
+                    em_printfout("%s:%d Invalid num_channels=%u (max=%u)", __func__, __LINE__, num_channels, EM_MAX_CHANNELS_PER_OPCLASS);
+                    return -1;
+                }
+
+                if (remaining_work_buf(work_ptr) < 2) {
+                    em_printfout("%s:%d work buffer exhausted", __func__, __LINE__);
+                    return -1;
+                }
+
+                unsigned char *opclass_start = work_ptr;
+
+                *work_ptr++ = op_class;
+
+                uint8_t *num_channels_field = work_ptr++;
+                uint8_t valid_channel_count = 0;
+
+                for (uint8_t channel_idx = 0; channel_idx < num_channels; channel_idx++) {
+
+                    if (query_ptr + 2 > query_end) {
+                        break;
+                    }
+
+                    uint8_t channel = *query_ptr++;
+                    uint8_t num_sta = *query_ptr++;
+
+		    if (num_sta > EM_MAX_STA_PER_CHANNEL) {
+                        em_printfout("%s:%d Invalid num_sta=%u (max=%u)",__func__, __LINE__, num_sta, EM_MAX_STA_PER_CHANNEL);
+                        return -1;
+                    }
+
+                    constexpr size_t CHANNEL_BUF_SIZE = 2 + (EM_MAX_STA_PER_CHANNEL * sizeof(mac_address_t));
+
+                    unsigned char channel_buf[CHANNEL_BUF_SIZE];
+                    unsigned char *channel_ptr = channel_buf;
+
+                    *channel_ptr++ = channel;
+
+                    uint8_t *num_sta_field = channel_ptr++;
+                    uint8_t valid_sta_count = 0;
+
+                    for (uint8_t sta_idx = 0; sta_idx < num_sta; sta_idx++) {
+
+                        if (query_ptr + sizeof(mac_address_t) > query_end) {
+                            break;
+                        }
+
+                        mac_address_t sta;
+                        memcpy(sta, query_ptr, sizeof(mac_address_t));
+
+                        query_ptr += sizeof(mac_address_t);
+
+			// Check if the STA is associated with any BSS on this agent
+                        dm_sta_t *assoc_sta = dm->get_first_sta(sta);
+		        bool sta_is_associated = (assoc_sta != NULL);
+                        
+		        if (sta_is_associated) {
+                            bool already_added = false;
+
+                            for (int err_idx = 0; err_idx < error_sta_count; err_idx++) {
+                                if (memcmp(error_sta_list[err_idx], sta, sizeof(mac_address_t)) == 0) {
+                                    already_added = true;
+                                    break;
+                                }
+                            }
+
+                            if (!already_added && error_sta_count < EM_MAX_STA_PER_AGENT) {
+                                memcpy(error_sta_list[error_sta_count], sta, sizeof(mac_address_t));
+                                error_sta_count++;
+                            }
+                        } else {
+                            size_t required = sizeof(mac_address_t);
+
+                            if (static_cast<size_t>(channel_ptr - channel_buf) + required > CHANNEL_BUF_SIZE) {
+
+                                em_printfout("%s:%d channel buffer overflow",__func__, __LINE__);
+                                return -1;
+                            }
+
+                            memcpy(channel_ptr, sta, sizeof(mac_address_t));
+                            channel_ptr += sizeof(mac_address_t);
+                            valid_sta_count++;
+                        }
+                    }
+
+                    if (valid_sta_count > 0) {
+                        *num_sta_field = valid_sta_count;
+
+                        uint16_t channel_len = static_cast<uint16_t>(2 + (valid_sta_count * sizeof(mac_address_t)));
+
+                        if (remaining_work_buf(work_ptr) < channel_len) {
+                            em_printfout("%s:%d work buffer overflow", __func__,  __LINE__);
+                            return -1;
+                        }
+
+                        memcpy(work_ptr, channel_buf, channel_len);
+                        work_ptr += channel_len;
+                        valid_channel_count++;
+                    }
+                }
+
+                if (valid_channel_count == 0) {
+                    /* rollback empty opclass */
+                    work_ptr = opclass_start;
+                } else {
+                    *num_channels_field = valid_channel_count;
+                }
+            }
+        }
+        tlv_ptr += sizeof(em_tlv_t) + tlv_len;
+    }
+    send_1905_ack_unassoc_sta_query(error_sta_list, error_sta_count, msg_id);
+
+    if (work_ptr > work_buff) {
+        uint16_t work_len = static_cast<uint16_t>(work_ptr - work_buff);
+        get_mgr()->io_process(em_bus_event_type_unassoc_sta_link_metrics_query, work_buff, work_len);
+        em_printfout("%s:%d Sent Unassoc STA Query to Agent len=%u", __func__, __LINE__, work_len);
+    }
+    return 0;
+}
+
+unsigned short em_metrics_t::create_unassoc_sta_link_metrics_query_tlv(unsigned char *buff, em_unassoc_query_opclass_t *op)
+{
+    unsigned char *ptr = buff;
+    unsigned short len = 0;
+
+    if (op == NULL) {
+        em_printfout("op is NULL");
+        return 0;
+    }
+
+    *ptr++ = op->op_class;
+    len++;
+
+    *ptr++ = op->num_channels;
+    len++;
+
+    for (int j = 0; j < op->num_channels; j++) {
+        auto &ch = op->channel_list[j];
+
+	*ptr++ = ch.channel;
+        len++;
+
+        *ptr++ = ch.num_sta;
+        len++;
+        for (int k = 0; k < ch.num_sta; k++) {
+            //Adding STA
+            memcpy(ptr, ch.sta_list[k], sizeof(mac_address_t));
+            ptr += sizeof(mac_address_t);
+            len += static_cast<short>(sizeof(mac_address_t));	    
+        }
+    }
+    return len;
+}
+
+int em_metrics_t::send_unassoc_sta_link_metrics_query_msg()
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+    unsigned int len = 0;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (dm == NULL) {
+        return -1;
+    }
+
+    em_cmd_unassoc_sta_query_t *cmd = static_cast<em_cmd_unassoc_sta_query_t *>(get_current_cmd());
+    if (cmd == NULL) {
+        return -1;
+    }
+
+    em_unassoc_query_list_t *query = cmd->get_query();
+
+    if (query == NULL) {
+        return -1;
+    }
+
+    memset(buff, 0, sizeof(buff));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(),  sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    unsigned short type = htons(ETH_P_1905);
+    memcpy(tmp, &type, sizeof(type));
+    tmp += sizeof(type);
+    len += sizeof(type);
+
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(cmdu, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(em_msg_type_unassoc_sta_link_metrics_query);
+
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    cmdu->last_frag_ind = 1;
+    cmdu->relay_ind = 0;
+
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    // TLVs
+    for (int i = 0; i < query->num_opclass; i++) {
+        auto &op = query->opclass_list[i];
+        unsigned int required_payload = 2;   // op_class + num_channels
+
+        for (int j = 0; j < op.num_channels; j++) {
+            required_payload += 2;     // channel + num_sta
+            required_payload += static_cast<unsigned int>(op.channel_list[j].num_sta) * sizeof(mac_address_t);
+        }
+
+        unsigned int remaining = MAX_EM_BUFF_SZ - static_cast<unsigned int>(tmp - buff);
+
+        if (remaining < (sizeof(em_tlv_t) + required_payload)) {
+            em_printfout("%s:%d insufficient buffer space (remaining=%u required=%u)", __func__, __LINE__, remaining, sizeof(em_tlv_t) + required_payload);
+            return -1;
+        }
+
+        em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_unassoc_sta_link_metric_query;
+       
+        unsigned int sz = static_cast<unsigned int>(create_unassoc_sta_link_metrics_query_tlv(tlv->value, &op));
+       tlv->len = htons(static_cast<uint16_t>(sz));
+
+       tmp += sizeof(em_tlv_t) + static_cast<size_t>(sz);
+   
+       len += static_cast<unsigned int>(sizeof(em_tlv_t) + static_cast<size_t>(sz));
+    }
+   
+    unsigned int remaining = MAX_EM_BUFF_SZ - static_cast<unsigned int>(tmp - buff);
+
+    if (remaining < sizeof(em_tlv_t)) {
+        em_printfout("%s:%d insufficient buffer space for EOM TLV", __func__, __LINE__);
+        return -1;
+    } 
+
+    em_tlv_t *eom = reinterpret_cast<em_tlv_t *>(tmp);
+    eom->type = em_tlv_type_eom;
+    eom->len = 0;
+
+    tmp += sizeof(em_tlv_t);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t));;
+
+    if (em_msg_t(em_msg_type_unassoc_sta_link_metrics_query, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("Unassociated STA Link Metrics Query validation failed");
+        return -1;
+    }
+
+   if (send_frame(buff, len) < 0) {
+        em_printfout("%s:%d: Unassoc Query send failed errno=%d",__func__, __LINE__, errno);
+        return -1;
+    }
+
+    em_printfout("%s:%d: Unassoc Query sent to Agent successfully", __func__, __LINE__);
+
+    em_t *em = static_cast<em_t *>(this);
+    em->m_unassoc_sta_query_msg_id = ntohs(cmdu->id);
+    em_printfout("%s:%d Stored query msg_id=%u", 
+             __func__, __LINE__, em->m_unassoc_sta_query_msg_id);
+
+    m_unassoc_sta_query_msg_id  =  ntohs(cmdu->id);
+    
+    return static_cast<int>(len);
+}
+
+//Unassociated STA Link Metrics Response Part
+/*
+ * create_unassoc_sta_link_metrics_tlv()
+ *
+ * Purpose:
+ * --------
+ * Creates ONE TLV for ONE operating class.
+ *
+ * Output:
+ * -------
+ * TLV contains:
+ * - op_class
+ * - num_sta
+ * - all STA metrics for that op_class
+ */
+
+unsigned short em_metrics_t::create_unassoc_sta_link_metrics_resp_tlv(unsigned char *buff, unsigned char op_class, em_unassoc_sta_metrics_rsp_t *rsp)
+{
+    em_unassoc_sta_link_metrics_rsp_t *tlv = reinterpret_cast<em_unassoc_sta_link_metrics_rsp_t *>(buff);
+
+    unsigned short len = 0;
+    unsigned char count = 0;
+
+    tlv->op_class = op_class;
+
+
+    /*
+     * Advance length for op_class field
+     */
+    len += 1;
+
+    /*
+     * Reserve space for num_sta field.
+     *
+     * We do not yet know how many STA entries
+     * belong to this op_class.
+     *
+     * We'll fill tlv->num_sta later.
+     */
+    len += 1;
+
+    /*
+     * TLV buffer layout:
+     *
+     * --------------------------------------------------
+     * | op_class | num_sta | STA metric entries ... |
+     * --------------------------------------------------
+     *
+     * Each STA metric entry contains:
+     *   - STA MAC
+     *   - channel
+     *   - time_delta
+     *   - rcpi
+     */
+    for (unsigned int i = 0; i < rsp->num_entries; i++) {
+        /*
+         * Skip entries belonging to
+         * different operating classes.
+         */
+        if (rsp->entry[i].op_class != op_class) {
+            continue;
+        }
+        
+        em_unassoc_sta_metric_t *sta_metric = reinterpret_cast<em_unassoc_sta_metric_t *>(buff + len);
+
+        memcpy(sta_metric->sta_mac, rsp->entry[i].sta_mac, sizeof(mac_address_t));
+        sta_metric->channel = rsp->entry[i].channel;
+        sta_metric->time_delta = htonl(rsp->entry[i].time_delta);
+        sta_metric->rcpi = rsp->entry[i].rcpi;
+        len += sizeof(em_unassoc_sta_metric_t);
+        count++;
+    }
+
+    tlv->num_sta = count;
+
+    return len;
+}
+
+/*
+ * send_unassoc_sta_link_metrics_response()
+ *
+ * Builds and sends ONE response message
+ * containing ONE Unassoc STA Link Metrics TLV
+ * for ONE operating class.
+ */
+void em_metrics_t::send_unassoc_sta_link_metrics_resp_msg()	
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+
+    size_t len = 0;
+
+    bool sent_opclass[256] = {false};
+    unsigned short type = htons(ETH_P_1905);
+    unsigned short msg_type = em_msg_type_unassoc_sta_link_metrics_rsp;
+
+    dm_easy_mesh_t *dm = get_data_model();
+    unsigned short msg_id = dm->get_msg_id();
+    em_unassoc_sta_metrics_rsp_t *rsp = &dm->m_unassoc_sta_metrics_rsp;
+
+    memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, &type, sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(cmdu, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    tmp += sizeof(em_cmdu_t);
+    len +=  static_cast<unsigned int>(sizeof(em_cmdu_t)); 
+
+    for (unsigned int i = 0; i < rsp->num_entries; i++) {
+
+        unsigned char op_class = rsp->entry[i].op_class;
+
+        if (sent_opclass[op_class]) {
+            continue;
+        }
+
+        em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        memset(tlv, 0, sizeof(em_tlv_t));
+
+        tlv->type = em_tlv_type_unassoc_sta_link_metric_rsp;
+
+        unsigned short sz = create_unassoc_sta_link_metrics_resp_tlv(tlv->value, op_class, rsp);
+
+        unsigned int required = sizeof(em_tlv_t) + sz;
+
+        if ((len + required) > MAX_EM_BUFF_SZ) {
+            em_printfout("%s:%d insufficient buffer space for Unassoc STA Metrics TLV (len=%u required=%u max=%u)",__func__, __LINE__,
+                                       static_cast<unsigned int>(len), required, MAX_EM_BUFF_SZ);
+            return;
+        }
+
+        tlv->len = htons(sz);
+
+        tmp += required;
+        len += required;
+        sent_opclass[op_class] = true;
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (send_frame(buff, static_cast<unsigned int>(len)) < 0) {
+        em_printfout("%s:%d: UnAssociated STA Link Metrics Response send failed, error:%d\n", __func__, __LINE__, errno);
+	return;
+    }
+    /*
+     * Clear the processed entries after successfully sending the response.
+     * This prevents the same Unassociated STA metrics data from being
+     * retransmitted if the command is executed again or the state handler 
+     * is invoked multiple times for the same response object.
+     */
+    em_printfout("%s:%d Clearing num_entries after successful response send\n",__func__, __LINE__);
+    rsp->num_entries = 0;
+    set_state(em_state_agent_configured);
 }
 
 void em_metrics_t::process_msg(unsigned char *data, unsigned int len)
@@ -1699,6 +2417,15 @@ void em_metrics_t::process_msg(unsigned char *data, unsigned int len)
         case em_msg_type_topo_vendor:
             handle_vendor_msg(data, len);
             break;
+        case em_msg_type_unassoc_sta_link_metrics_query:
+            handle_unassoc_sta_link_metrics_query(data, len);
+            break;
+        case em_msg_type_unassoc_sta_link_metrics_rsp:
+            handle_unassoc_sta_link_metrics_rsp(data, len);
+            break;
+        case em_msg_type_1905_ack:
+            handle_1905_ack(data, len);
+            break;
 
         default:
             break;
@@ -1711,6 +2438,10 @@ void em_metrics_t::process_ctrl_state()
         case em_state_ctrl_sta_link_metrics_pending:
             send_all_associated_sta_link_metrics_msg();
             break;
+        case em_state_ctrl_unassoc_sta_link_metrics_pending:
+            send_unassoc_sta_link_metrics_query_msg();
+            break;
+	    
         default:
             printf("%s:%d: unhandled case %s\n", __func__, __LINE__, em_t::state_2_str(get_state()));
             break;
@@ -1730,6 +2461,10 @@ void em_metrics_t::process_agent_state()
 
         case em_state_agent_link_quality_report_pending:
             send_link_quality_report();
+            break;
+
+        case em_state_agent_unassoc_sta_metrics_report_pending:
+            send_unassoc_sta_link_metrics_resp_msg();
             break;
 
         default:

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -139,6 +139,12 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
+        case em_cmd_type_unassoc_sta_result:
+            if (em->get_state() == em_state_agent_configured) {
+                return true;
+            }
+            break;
+
         default:
             if ((em->get_state() == em_state_agent_unconfigured) ||
                     (em->get_state() == em_state_agent_configured) ||
@@ -190,6 +196,11 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
     } else if (pcmd->m_type == em_cmd_type_get_link_quality_report) {
         if ((em->get_state() >= em_state_agent_topo_synchronized) ||
             ((em->get_state() == em_state_agent_link_quality_report_pending))) {
+            return true;
+        }
+    } else if (pcmd->m_type == em_cmd_type_unassoc_sta_result) {
+        if ((em->get_state() == em_state_agent_configured) ||
+            ((em->get_state() ==em_state_agent_unassoc_sta_metrics_report_pending))) {
             return true;
         }
     }
@@ -488,7 +499,17 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
                 }
                 break;
 
-			default:
+            case em_cmd_type_unassoc_sta_result:
+                // Unassociated STA metrics response is processed only once.
+                // Select the first non-AL EM instance as the candidate and
+                // avoid queuing additional EMs for the same response.		
+                if (!(em->is_al_interface_em()) && (count == 0)) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+                break;
+
+            default:
                 break;
         }
         em = static_cast<em_t *> (hash_map_get_next(m_mgr->m_em_map, em));	

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -286,6 +286,12 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
+	case em_cmd_type_unassoc_sta_query:
+            if (em->get_state() == em_state_ctrl_configured) {
+                return true;
+            }
+            break;
+
         default:
             break;
     }
@@ -344,6 +350,7 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_scan_channel:
         case em_cmd_type_set_policy:
         case em_cmd_type_bsta_cap:
+	case em_cmd_type_unassoc_sta_query:
             if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             }
@@ -743,10 +750,16 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                     break;
                 }
                 break;
-
-            default:
-                break;
-        }
+            case em_cmd_type_unassoc_sta_query:
+		if (count == 0 && memcmp(em->get_data_model()->get_agent_al_interface_mac(),
+					pcmd->m_param.u.unassoc_sta_query_params.al_mac, sizeof(mac_address_t)) == 0) {
+		    queue_push(pcmd->m_em_candidates, em);
+		    count++;
+		}		
+		break;
+	    default:
+		break;
+	}
         em = static_cast<em_t *>(hash_map_get_next(m_mgr->m_em_map, em));
     }
 

--- a/src/rdkb-cli/Makefile.am
+++ b/src/rdkb-cli/Makefile.am
@@ -72,6 +72,7 @@ libemcli_la_SOURCES = \
  $(top_srcdir)/src/cmd/em_cmd_btm_report.cpp \
  $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
  $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_unassoc_sta_query.cpp \
  $(top_srcdir)/src/dm/dm_device.cpp \
  $(top_srcdir)/src/dm/dm_ieee_1905_security.cpp \
  $(top_srcdir)/src/dm/dm_easy_mesh.cpp  \

--- a/src/rdkb-cli/em_cmd_cli.cpp
+++ b/src/rdkb-cli/em_cmd_cli.cpp
@@ -69,6 +69,7 @@ em_cmd_params_t spec_params[] = {
     {.u = {.args = {2, {"", "", "", "", ""}, "MLDConfig"}}},
     {.u = {.args = {2, {"", "", "", "", ""}, "MLDReconfig"}}},
     {.u = {.args = {2, {"", "", "", "", ""}, "WifiReset"}}},
+    {.u = {.args = {2, {"", "", "", "", ""}, "UnassocSTAQuery.json"}}},
 	{.u = {.args = {0, {"", "", "", "", ""}, "max"}}},
 };
 
@@ -103,7 +104,8 @@ em_cmd_t em_cmd_cli_t::m_client_cmd_spec[] = {
     em_cmd_t(em_cmd_type_get_mld_config, spec_params[26]),
     em_cmd_t(em_cmd_type_mld_reconfig, spec_params[27]),
     em_cmd_t(em_cmd_type_get_reset, spec_params[28]),
-    em_cmd_t(em_cmd_type_max, spec_params[29]),
+    em_cmd_t(em_cmd_type_unassoc_sta_query, spec_params[29]),
+    em_cmd_t(em_cmd_type_max, spec_params[30]),
 };
 
 int em_cmd_cli_t::get_edited_node(em_network_node_t *node, const char *header, char *buff)
@@ -454,6 +456,20 @@ int em_cmd_cli_t::execute(char *result)
             snprintf(info->name, sizeof(info->name), "%s", param->u.args.fixed_args);
             break;
 
+       case em_cmd_type_unassoc_sta_query:
+
+           bevt->type = em_bus_event_type_unassoc_sta_query;
+           info = &bevt->u.subdoc;
+
+           strncpy(info->name, param->u.args.fixed_args, sizeof(info->name) - 1);
+           info->name[sizeof(info->name) - 1] = '\0';
+
+           if ((bevt->data_len = get_edited_node(m_cmd.m_param.net_node, "UnassocSTAQuery", info->buff)) < 0) {
+               em_printfout("%s:%d: failed to get UnassocSTAQuery node\n", __func__, __LINE__);
+               return -1;
+           }
+           break;
+	   
         default:
             break;
     }

--- a/src/rdkb-cli/main.go
+++ b/src/rdkb-cli/main.go
@@ -635,6 +635,22 @@ type Obstacle struct {
 	Material    string    `json:"material,omitempty"`
 }
 
+// Holds parameters for Unassociated STA Link Metrics Query
+type unassocStaChannel struct {
+        Channel     int      `json:"channel"`
+        StaMacList  []string `json:"sta_macs"`
+}
+
+type unassocStaOpClass struct {
+        OpClass int                  `json:"opclass"`
+        Channels []unassocStaChannel `json:"channels"`
+}
+
+type unassocStaQueryRequest struct {
+        AlMac string                  `json:"AlMac"`
+        QueryList []unassocStaOpClass `json:"UnassocStaQueryList"`
+}
+
 //ckp cov end
 // ===== GLOBAL VARIABLES =====
 var (
@@ -2889,6 +2905,9 @@ func main() {
 	//system setting Wifi Reset
 	api.HandleFunc("/wifireset", WifiResetHandler).Methods("GET", "POST")
 
+	// Unassoc STA 
+	api.HandleFunc("/unassoc_sta_query", unassocStaQueryHandler).Methods("POST")
+
 	// Enable CORS
 	router.Use(corsMiddleware)
 
@@ -3499,6 +3518,104 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
             http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
     }
 }
+
+
+/*
+ * func: unassocStaQueryHandler()
+ *
+ * Description:
+ * Handles POST /unassoc_sta_query requests.
+ * Parses payload and triggers Unassociated STA Link Metrics Query.
+ */
+func unassocStaQueryHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method != http.MethodPost {
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+        return
+    }
+
+    defer r.Body.Close()
+    
+    const maxRequestSize = 64 * 1024 // 64 KB
+    r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
+
+    var req unassocStaQueryRequest
+    log.Printf("[DEBUG][HTTP] Received unassoc STA query request")
+
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "Invalid request payload", http.StatusBadRequest)
+        return
+    }
+
+    if req.AlMac == "" {
+        http.Error(w, "AlMac required", http.StatusBadRequest)
+        return
+    }
+
+    if len(req.QueryList) == 0 {
+        http.Error(w, "UnassocStaQueryList required", http.StatusBadRequest)
+        return
+    }
+
+    for _, op := range req.QueryList {
+
+        if len(op.Channels) == 0 {
+            http.Error(w, "Each opclass must contain channels", http.StatusBadRequest)
+            return
+        }
+
+        for _, ch := range op.Channels {
+
+            if len(ch.StaMacList) == 0 {
+                http.Error(w, "Each channel must contain STA list", http.StatusBadRequest)
+                return
+            }
+        }
+    }
+
+    for i, op := range req.QueryList {
+        log.Printf("[DEBUG][HTTP] OpClass[%d]=%d Channels=%d", i, op.OpClass, len(op.Channels))
+
+        for j, ch := range op.Channels {
+            log.Printf("[DEBUG][HTTP]   Channel[%d]=%d STA Count=%d", j, ch.Channel, len(ch.StaMacList))
+        }
+    }
+
+    jsonBytes, err := json.Marshal(req)
+    if err != nil {
+        log.Printf("[ERROR][HTTP] Failed to marshal request: %v", err)
+        http.Error(w, "Failed to process request", http.StatusInternalServerError)
+        return
+    }
+
+    cJsonStr := C.CString(string(jsonBytes))
+    defer C.free(unsafe.Pointer(cJsonStr))
+
+    node := C.get_network_tree(cJsonStr)
+    if node == nil {
+        http.Error(w, "Failed to create network tree", http.StatusInternalServerError)
+        return
+    }
+    defer C.free_network_tree(node)
+
+    cmd := C.CString("unassoc_sta_query OneWifiMesh")
+    defer C.free(unsafe.Pointer(cmd))
+    result := C.exec(cmd, C.strlen(cmd), node)
+
+    if result == nil {
+        http.Error(w, "Command execution failed", http.StatusInternalServerError)
+        return
+    }
+    defer C.free_network_tree(result)
+
+    //log.Printf("[CLI] Unassoc STA Query sent: %+v", req)
+
+    w.Header().Set("Content-Type", "application/json")
+
+    if err := json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "message": "Unassoc STA Query sent",}); err != nil {
+        log.Printf("[ERROR][HTTP] Failed to encode response: %v", err)
+    }    
+}
+
 
 //------------------------------------------------------------
 //                    Helper Functions


### PR DESCRIPTION
 Add end-to-end Unassociated STA Link Metrics query/response handling
    - Added Unassociated STA Link Metrics Query handling
    - Added 1905 ACK generation with Error Code TLV and transmission for query messages
    - Added forwarding of query details to OneWiFi through subdoc interface
    - Added handling of OneWiFi response
    - Added Unassociated STA Link Metrics TLV creation and parsing
    - Added response message build and transmission to controller
    - Added per-opclass response handling and storing the data in the dm
    - Added debug logs for query, ACK, subdoc, and response flow
    
Signed-off-by: Sangeetha <sangeetha.s1@tataelxsi.co.in>

Dep PR: https://github.com/rdkcentral/OneWifi/pull/1152