### PR TITLE
RDKBWIFI-445: Fixed binary data comparison in webconfig

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -1752,8 +1752,8 @@ public:
 
 	void remove_assoc_sta_mld_info(mac_address_t sta_mld_mac);
 
-	em_radio_cap_info_t *get_radio_cap_info(int index);
-	static em_radio_cap_info_t *get_radio_cap_info(void *dm, int index) { return (static_cast<dm_easy_mesh_t *>(dm))->get_radio_cap_info(index); }
+	em_radio_cap_info_t *get_radio_cap_info(unsigned int index);
+	static em_radio_cap_info_t *get_radio_cap_info(void *dm, unsigned int index) { return (static_cast<dm_easy_mesh_t *>(dm))->get_radio_cap_info(index); }
 
 	/**!
 	 * @brief Retrieves the Data Model DPP object.
@@ -1930,7 +1930,7 @@ public:
 	 * @note Ensure that the MAC address provided is valid and registered in the system.
 	 */
 	dm_radio_cap_t *get_radio_cap(mac_address_t mac);
-	dm_radio_cap_t *get_radio_cap(int index);
+	dm_radio_cap_t *get_radio_cap(unsigned int index);
 
     
 	/**!

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -88,8 +88,8 @@ int dm_easy_mesh_agent_t::analyze_dev_init(em_bus_event_t *evt, em_cmd_t *pcmd[]
     pcmd[num] = new em_cmd_dev_init_t(evt->params, dm);
     tmp = pcmd[num];
 
-    for (int i = 0; i < static_cast<int>(pcmd[num]->m_data_model.m_num_radios); i++) {
-        em_printfout("dm num_role:%u for radio[%d]:%s\n", dm.get_radio_cap_info(i)->wifi6_cap.num_role,
+    for (unsigned int i = 0; i < pcmd[num]->m_data_model.m_num_radios; i++) {
+        em_printfout("dm num_role:%u for radio[%u]:%s\n", dm.get_radio_cap_info(i)->wifi6_cap.num_role,
                 i, util::mac_to_string(dm.get_radio_cap_info(i)->ruid.mac).c_str());
         em_printfout("num_role:%u\n", pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi6_cap.num_role);
         // em_printfout("su_beam:%d\n", pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi6_cap.su_beam_former);

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -2189,16 +2189,16 @@ dm_radio_cap_t *dm_easy_mesh_t::get_radio_cap(mac_address_t mac)
     return NULL;
 }
 
-dm_radio_cap_t *dm_easy_mesh_t::get_radio_cap(int index)
+dm_radio_cap_t *dm_easy_mesh_t::get_radio_cap(unsigned int index)
 {
-    if ((index < 0) || (index >= EM_MAX_BANDS)) {
+    if (index >= EM_MAX_BANDS) {
         return nullptr;
     }
 
     return &m_radio_cap[index];
 }
 
-em_radio_cap_info_t *dm_easy_mesh_t::get_radio_cap_info(int index)
+em_radio_cap_info_t *dm_easy_mesh_t::get_radio_cap_info(unsigned int index)
 {
     dm_radio_cap_t *cap = get_radio_cap(index);
     return cap ? cap->get_radio_cap_info() : nullptr;

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -1418,7 +1418,7 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
         if (dm->get_num_radios() > 0) {
             em_printfout("handle_wifi6_cap_tlv: update dm_radio_cap's radio mac");
             for (unsigned int i = 0; i < dm->get_num_radios(); i++) {
-                dm_radio_cap = dm->get_radio_cap(static_cast<int>(i));
+                dm_radio_cap = dm->get_radio_cap(i);
                 if (dm_radio_cap != NULL) {
                     memcpy(dm_radio_cap->m_radio_cap_info.ruid.mac, dm->m_radio[i].m_radio_info.id.ruid, sizeof(mac_address_t));
                     em_printfout("handle_wifi6_cap_tlv: dm_radio_cap updated for MAC %s",

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1767,7 +1767,7 @@ short em_t::create_metric_col_int_tlv(unsigned char *buff)
         return 0;
     }
 
-    memcpy(&clt, &cap_info->metric_interval, sizeof(em_metric_cltn_interval_t));
+    memcpy(clt, &cap_info->metric_interval, sizeof(em_metric_cltn_interval_t));
     len = sizeof(em_metric_cltn_interval_t);
     return len;
 }

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -1476,8 +1476,8 @@ short em_t::create_wifi7_tlv(unsigned char *buff)
     offset += static_cast<short>(sizeof(unsigned char));
     em_printfout("  offset:%d", offset);
     for (unsigned int i = 0; i < dm->get_num_radios(); i++) {
-        em_wifi7_cap = &dm->get_radio_cap_info(static_cast<int>(i))->wifi7_cap;
-        em_printfout("Radio[%d]: %s", i, util::mac_to_string(dm->get_radio_cap_info(static_cast<int>(i))->ruid.mac).c_str());
+        em_wifi7_cap = &dm->get_radio_cap_info(i)->wifi7_cap;
+        em_printfout("Radio[%u]: %s", i, util::mac_to_string(dm->get_radio_cap_info(i)->ruid.mac).c_str());
 
         // MLO Support Capabilities
         mlo_mand = reinterpret_cast<em_wifi7_mlo_cap_support_tlv_t *>(buff + offset);
@@ -1595,7 +1595,7 @@ short em_t::create_channelscan_tlv(unsigned char *buff)
         }
        em_radio_cap_info_t *cap_info = radio_cap->get_radio_cap_info();
         if (cap_info == NULL) {
-            em_printfout("create_channelscan_tlv: cap_info NULL for index %d", i);
+            em_printfout("create_channelscan_tlv: cap_info NULL for index %u", i);
             return 0;
         }
 
@@ -1752,7 +1752,7 @@ short em_t::create_metric_col_int_tlv(unsigned char *buff)
     short len = 0;
     dm_easy_mesh_t  *dm;
     dm = get_data_model();
-    dm_radio_cap_t *radio_cap = dm->get_radio_cap(0);//todo: it is dev specific
+    dm_radio_cap_t *radio_cap = dm->get_radio_cap(0u);//todo: it is dev specific
 
     if (radio_cap == NULL) {
         em_printfout("create_metric_col_int_tlv: radio_cap NULL for MAC %s",
@@ -1809,7 +1809,7 @@ short em_t::create_cac_cap_tlv(unsigned char *buff)
         if (dm->get_radio_by_ref(index).m_radio_info.band != em_freq_band_5) {
             continue;
         }
-        dm_radio_cap_t *radio_cap = dm->get_radio_cap(static_cast<int>(index));
+        dm_radio_cap_t *radio_cap = dm->get_radio_cap(index);
         if (radio_cap == NULL) {
             em_printfout("create_cac_cap_tlv: radio[%u] get_radio_cap returned NULL", index);
             continue;
@@ -2052,7 +2052,7 @@ int em_t::handle_eht_operations_tlv(unsigned char *buff, unsigned short tlv_len)
         memcpy(&num_bss, tmp, sizeof(unsigned char));
 
         if (num_bss > EM_MAX_BSS_PER_RADIO) {
-            em_printfout("Invalid num_bss=%d for radio %d, max allowed=%d", num_bss, i, EM_MAX_BSS_PER_RADIO);
+            em_printfout("Invalid num_bss=%d for radio %u, max allowed=%d", num_bss, i, EM_MAX_BSS_PER_RADIO);
             return -1;
         }
 
@@ -2635,25 +2635,25 @@ int em_t::handle_wifi7_agent_cap_tlv(unsigned char *buff)
 
     // Number of radios
     unsigned char *num_radios_ptr = reinterpret_cast<unsigned char *>(buff + offset);
-    int num_radios = static_cast<int>(*num_radios_ptr);
-    em_printfout("Number of radios in wifi7 agent cap: %d", num_radios);
+    unsigned int num_radios = static_cast<unsigned int>(*num_radios_ptr);
+    em_printfout("Number of radios in wifi7 agent cap: %u", num_radios);
     offset += static_cast<short>(sizeof(unsigned char));
 
     if (dm != NULL) {
-        int dm_num_radios = static_cast<int>(dm->get_num_radios());
+        unsigned int dm_num_radios = dm->get_num_radios();
         if (num_radios > EM_MAX_RADIO_PER_AGENT) {
-            em_printfout("Clamping num_radios from %d to EM_MAX_RADIO_PER_AGENT (%d)", num_radios, EM_MAX_RADIO_PER_AGENT);
+            em_printfout("Clamping num_radios from %u to EM_MAX_RADIO_PER_AGENT (%d)", num_radios, EM_MAX_RADIO_PER_AGENT);
             num_radios = EM_MAX_RADIO_PER_AGENT;
         }
         if (num_radios > dm_num_radios) {
-            em_printfout("Clamping num_radios from %d to dm->get_num_radios() (%d)", num_radios, dm_num_radios);
+            em_printfout("Clamping num_radios from %u to dm->get_num_radios() (%u)", num_radios, dm_num_radios);
             num_radios = dm_num_radios;
         }
     }
 
-    for (int idx = 0; idx < num_radios; idx++) {
+    for (unsigned int idx = 0; idx < num_radios; idx++) {
         em_wifi7_cap = &dm->get_radio_cap_info(idx)->wifi7_cap;
-        em_printfout("Updating wifi7 cap for radio[%d]:%s", idx, util::mac_to_string(dm->get_radio_cap_info(idx)->ruid.mac).c_str());
+        em_printfout("Updating wifi7 cap for radio[%u]:%s", idx, util::mac_to_string(dm->get_radio_cap_info(idx)->ruid.mac).c_str());
 
         // Extract MLO support info
         mlo_support = reinterpret_cast<em_wifi7_mlo_cap_support_tlv_t *>(buff + offset);


### PR DESCRIPTION
Reason for change: OneWifi updated with `typedef em_radio_cap_info_t * (*ext_proto_get_radio_cap_t)(void *data_model, unsigned int radio_index);` which is required to align `index` data type to `unsigned int` in easymesh

Dependent PR: [OneWifi/#1144](https://github.com/rdkcentral/OneWifi/pull/1144)
Test procedure: UWM build pass  with updated OneWifi package

Priority: Critical
Risk: Low
