### PR TITLE
RDKBWIFI-278: Refactor CACR add multi-STA support and received subdoc from UWM

### DIFF
--- a/inc/em.h
+++ b/inc/em.h
@@ -769,6 +769,21 @@ public:
 	 */
 	dm_sta_t *find_sta(mac_address_t sta_mac, bssid_t bssid);
 
+	/**!
+	 * @brief Finds a BSS based on its BSSID.
+	 *
+	 * This function searches for a BSS (Basic Service Set) in the network using
+	 * the provided BSSID, and returns a pointer to the BSS information if found.
+	 *
+	 * @param[in] bssid The BSSID of the BSS to find.
+	 *
+	 * @returns A pointer to the BSS information (dm_bss_t) if the BSS is found,
+	 * or NULL if the BSS is not found or belongs to a different radio.
+	 *
+	 * @note Ensure that the BSSID is valid and corresponds to a BSS on the
+	 * current radio interface.
+	 */
+	dm_bss_t *find_bss(bssid_t bssid);
     
 	/**!
 	 * @brief Pushes an event to the queue.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -106,6 +106,7 @@ extern "C"
 #define EM_MAX_CLIENT_ASSOC_CTRL_REQ_TX_THRESH  5
 #define MAX_STA_TO_DISASSOC		32
 #define EM_MAX_DB_CFG_CRITERIA	32
+#define MAX_STA_LIST 20
 
 #define EM_CLI_MAX_ARGS 5
 
@@ -365,6 +366,10 @@ static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff
 #define EM_HE_PHY4_MU_BEAMFORMER     0x02
 #define EM_HE_PHY4_BFEE_STS_LE80_MASK  (0x07 << 2) /* beamformee STS <= 80 MHz */
 #define EM_HE_PHY4_BFEE_STS_GT80_MASK  (0x07 << 5) /* beamformee STS > 80 MHz */
+
+//CACR assoc control values
+#define ASSOC_CONTROL_BLOCK 0x00
+#define ASSOC_CONTROL_UNBLOCK 0x01
 
 typedef char em_interface_name_t[32];
 typedef unsigned char em_nonce_t[16];
@@ -1098,8 +1103,8 @@ typedef struct {
     bssid_t 	bssid;
     unsigned char assoc_control;
     unsigned short validity_period;
-    unsigned char count;
-    mac_address_t sta_mac;
+    unsigned char sta_count;
+    mac_address_t sta_list[MAX_STA_LIST];
 }__attribute__((__packed__)) em_client_assoc_ctrl_req_t;
 
 typedef struct {
@@ -2339,6 +2344,7 @@ typedef enum {
     em_state_ctrl_bsta_cap_pending,
     em_state_ctrl_topo_publish_pending,
     em_state_ctrl_unassoc_sta_link_metrics_pending,
+    em_state_ctrl_client_assoc_ctrl_req_pending,
 
     //common states
     em_state_beacon_report_pending,
@@ -2397,6 +2403,7 @@ typedef enum {
     em_cmd_type_get_link_quality_report,
     em_cmd_type_unassoc_sta_query,
     em_cmd_type_unassoc_sta_result,
+    em_cmd_type_client_assoc_ctrl_req,
 
     em_cmd_type_max,
 } em_cmd_type_t;
@@ -3195,6 +3202,7 @@ typedef enum {
     dm_orch_type_link_quality_report,
     dm_orch_type_unassoc_sta_link_req_query,
     dm_orch_type_unassoc_sta_result,
+    dm_orch_type_client_assoc
 
 } dm_orch_type_t;
 
@@ -3320,6 +3328,14 @@ typedef struct {
 } em_cmd_btm_report_params_t;
 
 typedef struct {
+    bssid_t 	bssid;
+    unsigned char assoc_control;
+    unsigned short validity_period;
+    unsigned char sta_count;
+    mac_address_t sta_list[MAX_STA_LIST];
+}em_cmd_client_assoc_params_t;
+
+typedef struct {
     mac_address_t	sta_mac;
     bssid_t	bssid;
     unsigned int disassoc_time;
@@ -3384,6 +3400,7 @@ typedef struct {
         em_cmd_steer_params_t	steer_params;
         em_cmd_btm_report_params_t  btm_report_params;
         em_cmd_disassoc_params_t	disassoc_params;
+        em_cmd_client_assoc_params_t   client_assoc_params;
 		em_cmd_scan_params_t	scan_params;
         em_cmd_ap_metrics_rprt_params_t ap_metrics_params;
         em_cmd_unassoc_sta_query_params_t unassoc_sta_query_params;

--- a/inc/em_cmd_client_assoc_ctrl_req.h
+++ b/inc/em_cmd_client_assoc_ctrl_req.h
@@ -1,0 +1,21 @@
+#ifndef EM_CMD_CLIENT_ASSOC_CTRL_REQ_H
+#define EM_CMD_CLIENT_ASSOC_CTRL_REQ_H
+
+#include "em_cmd.h"
+
+class em_cmd_client_assoc_ctrl_req_t: public em_cmd_t {
+
+public:
+
+    /**!
+     * @brief Constructs a client assoc ctrl req command.
+     *
+     * @param[in] params The client assoc ctrl req parameters.
+     * @param[in] dm     dm reference.
+     * @param[in] svc    Service type (controller or agent). Defaults to controller.
+     */
+    em_cmd_client_assoc_ctrl_req_t(em_cmd_client_assoc_params_t params, dm_easy_mesh_t& dm,
+        em_service_type_t svc = em_service_type_ctrl);
+};
+
+#endif

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -220,7 +220,18 @@ public:
 	 * @note Ensure that the event structure is properly initialized before calling this function.
 	 */
 	void handle_client_steer(em_bus_event_t *evt);
-    
+
+	/**!
+	 * @brief Handles client assoc ctrl req based on the event provided.
+	 *
+	 * This function processes the client assoc ctrl request event and performs necessary actions.
+	 *
+	 * @param[in] evt Pointer to the event structure containing client assoc ctrl information.
+	 *
+	 * @note Ensure that the event structure is properly initialized before calling this function.
+	 */
+	void handle_client_assoc(em_bus_event_t *evt);
+
 	/**!
 	 * @brief Handles the disassociation of a client.
 	 *

--- a/inc/em_steering.h
+++ b/inc/em_steering.h
@@ -20,6 +20,7 @@
 #define EM_STEERING_H
 
 #include "em_base.h"
+#include <vector>
 
 class em_steering_t {
 
@@ -107,6 +108,25 @@ class em_steering_t {
 	int send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_id, unsigned char reason = 0, unsigned char *dst = nullptr);
     
 	/**!
+	 * @brief Sends a 1905 acknowledgment message for one or more STA MACs.
+	 *
+	 * This function is responsible for sending a consolidated acknowledgment message.
+	 *
+	 * @param[in] sta_list List of STA MAC addresses to include in the ACK.
+	 * @param[in] msg_id The message ID of the original message being acknowledged.
+	 * @param[in] reason The reason code used in Error Code TLV.
+	 * @param[in] dst Destination AL MAC to use when controller AL MAC is unknown).
+	 *
+	 * @returns int Number of bytes sent on success.
+	 * @retval >0 Frame length in bytes.
+	 * @retval 0 No destination available (nothing sent).
+	 * @retval -1 on failure
+	 * @note Ensure that the MAC address is valid and the station is reachable
+	 * before calling this function.
+	 */
+	int send_consolidated_1905_ack_message(const std::vector<const unsigned char*>& sta_list, unsigned short msg_id, unsigned char reason, unsigned char *dst);
+
+	/**!
 	 * @brief Handles the client steering request.
 	 *
 	 * This function processes the steering request received from a client.
@@ -184,7 +204,7 @@ class em_steering_t {
 	 *
 	 * @note Ensure the buffer is large enough to hold the TLV structure.
 	 */
-	short create_error_code_tlv(unsigned char *buff, int val, mac_addr_t sta_mac);
+	short create_error_code_tlv(unsigned char *buff, int val, const mac_addr_t sta_mac);
     
 	/**!
 	 * @brief Creates a BTM report TLV.
@@ -342,7 +362,32 @@ public:
 	 */
 	void set_client_assoc_ctrl_req_tx_count(unsigned int cnt) { m_client_assoc_ctrl_req_tx_cnt = cnt; }
 
-    
+	/*
+	 * @brief Stores the CMDU Message ID of the last transmitted
+	 * Client Assoc Ctrl Req message..
+	 *
+	 * @note Used for ACK tracking and response correlation.
+	 */
+	unsigned short m_client_assoc_ctrl_req_msg_id = 0;
+
+	/**
+	 * @brief Get the current Client Assoc Ctrl Req message ID.
+	 *
+	 * Returns the message ID associated with the outstanding
+	 * Client Assoc Ctrl Req message
+	 *
+	 * @return Message ID of the pending request.
+	 */
+	unsigned short get_client_assoc_ctrl_req_msg_id() const { return m_client_assoc_ctrl_req_msg_id; }
+
+	/**
+	 * @brief Clear the Client Assoc Ctrl Req message ID.
+	 *
+	 * Resets the stored cacr message ID after the corresponding
+	 * ACK has been received and processed.
+	 */
+	void clear_client_assoc_ctrl_req_msg_id() { m_client_assoc_ctrl_req_msg_id = 0; }
+
 	/**!
 	 * @brief Processes a message with the given data and length.
 	 *

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -752,37 +752,92 @@ void em_agent_t::handle_btm_response_action_frame(em_bus_event_t *evt)
 void em_agent_t::handle_client_assoc_ctrl_req(em_bus_event_t *evt)
 {
     wifi_bus_desc_t *desc;
-    raw_data_t raw;
-    client_assoc_ctrl_req_t req_data;
 
-    em_client_assoc_ctrl_req_t *steer_req = reinterpret_cast<em_client_assoc_ctrl_req_t*> (&evt->u.raw_buff);
+    if ((evt == NULL) || (evt->u.raw_buff == NULL) || (evt->data_len == 0)) {
+        em_printfout("%s:%d Invalid event (evt=%p buff=%p len=%u)", __func__, __LINE__, evt,
+            (evt ? evt->u.raw_buff : NULL), (evt ? evt->data_len : 0));
+        return;
+    }
 
+    em_client_assoc_ctrl_req_t *client_assoc = reinterpret_cast<em_client_assoc_ctrl_req_t *>(evt->u.raw_buff);
     if ((desc = get_bus_descriptor()) == NULL) {
-        em_printfout("bus descriptor is null");
+        em_printfout("%s:%d bus descriptor is null", __func__, __LINE__);
         return;
     }
 
-    if (steer_req->count != 1) {
-        em_printfout("station count:%d is more than one", steer_req->count);
+    const size_t fixed_len = sizeof(bssid_t) + sizeof(unsigned char) + sizeof(unsigned short) + sizeof(unsigned char);
+    if (evt->data_len < fixed_len) {
+        em_printfout("%s:%d Invalid CACR payload (data_len=%u expected_min=%zu)",
+            __func__, __LINE__, evt->data_len, fixed_len);
         return;
     }
-    memset(&req_data, 0, sizeof(client_assoc_ctrl_req_t));
 
-    memcpy(req_data.bssid, steer_req->bssid, sizeof(bssid_t));
-    req_data.assoc_control = steer_req->assoc_control;
-    req_data.validity_period = ntohs(steer_req->validity_period);
-    req_data.count = steer_req->count;
-    memcpy(req_data.sta_mac, steer_req->sta_mac, sizeof(mac_address_t));
-
-    memset(&raw, 0, sizeof(raw_data_t));
-    raw.data_type = bus_data_type_bytes;
-    raw.raw_data.bytes = static_cast<void *>(&req_data);
-    raw.raw_data_len = sizeof(client_assoc_ctrl_req_t);
-
-    if (desc->bus_set_fn(&m_bus_hdl,WIFI_EM_CLIENT_ASSOC_CTRL_REQ, &raw) != 0) {
-        em_printfout("%s:%d Failed to send client assoc ctrl request to bus",__func__, __LINE__);
+    const uint8_t sta_count = client_assoc->sta_count;
+    const size_t required_len = fixed_len + (static_cast<size_t>(sta_count) * sizeof(mac_address_t));
+    if (sta_count == 0 || sta_count > MAX_STA_LIST || evt->data_len < required_len) {
+        em_printfout("%s:%d Invalid CACR payload (sta_count=%u data_len=%u required_min=%zu max=%u)",
+            __func__, __LINE__, sta_count, evt->data_len, required_len, MAX_STA_LIST);
+        return;
     }
-    em_printfout("%s:%d Sent client assoc ctrl request to bus, OneWifi will process the bus event",__func__, __LINE__);
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        em_printfout("%s:%d Failed to create JSON root object", __func__, __LINE__);
+        return;
+    }
+
+    cJSON_AddStringToObject(root, "Version", "1.0");
+    cJSON_AddStringToObject(root, "SubDocName", "ClientAssocCtrlRequest");
+
+    cJSON *req = cJSON_AddObjectToObject(root, "ClientAssocCtrlRequest");
+    if (!req) {
+        cJSON_Delete(root);
+        return;
+    }
+
+    std::string bssid_str = util::mac_to_string(client_assoc->bssid);
+    cJSON_AddStringToObject(req, "Bssid", bssid_str.c_str());
+
+    cJSON_AddNumberToObject(req, "AssocControl", client_assoc->assoc_control);
+
+    uint16_t vp = ntohs(client_assoc->validity_period);
+    cJSON_AddNumberToObject(req, "ValidityPeriod", vp);
+
+    cJSON *sta_arr = cJSON_AddArrayToObject(req, "StaMacList");
+    if (!sta_arr) {
+        cJSON_Delete(root);
+        return;
+    }
+
+    for (uint8_t i = 0; i < client_assoc->sta_count; i++) {
+        std::string mac_str = util::mac_to_string(client_assoc->sta_list[i]);
+        cJSON_AddItemToArray(sta_arr, cJSON_CreateString(mac_str.c_str()));
+    }
+
+    char *json_str = cJSON_Print(root);
+    if (!json_str) {
+        em_printfout("%s:%d JSON serialization failed", __func__, __LINE__);
+        cJSON_Delete(root);
+        return;
+    }
+
+    em_printfout("%s:%d Received data for event [%s] and data:\n%s\n ", __func__, __LINE__,WIFI_EM_CLIENT_ASSOC_CTRL_REQ, json_str );
+
+    raw_data_t bus_data;
+    memset(&bus_data, 0, sizeof(bus_data));
+
+    bus_data.data_type = bus_data_type_string;
+    bus_data.raw_data.bytes = json_str;
+    bus_data.raw_data_len = strlen(json_str);
+
+    if (desc->bus_set_fn(&m_bus_hdl, WIFI_EM_CLIENT_ASSOC_CTRL_REQ, &bus_data) != 0) {
+        em_printfout("%s:%d Failed to send CACR subdoc", __func__, __LINE__);
+    } else {
+        em_printfout("%s:%d Sent CACR subdoc successfully", __func__, __LINE__);
+    }
+
+    cJSON_free(json_str);
+    cJSON_Delete(root);
 }
 
 void em_agent_t::handle_channel_scan_result(em_bus_event_t *evt)

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -476,6 +476,11 @@ void em_cmd_t::init()
             m_svc = em_service_type_ctrl;
             break;
 
+        case em_cmd_type_client_assoc_ctrl_req:
+            strncpy(m_name, "client_assoc", strlen("client_assoc") + 1);
+            m_svc = em_service_type_ctrl;
+            break;
+
         default:
             snprintf(m_name, sizeof(m_name), "%s", "unknown");
             m_svc = em_service_type_none;
@@ -529,6 +534,7 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_link_metrics_query)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_result)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_failed_conn)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_client_assoc_ctrl_req)
        
         default:
            break;
@@ -608,6 +614,7 @@ const char *em_cmd_t::get_orch_op_str(dm_orch_type_t type)
         ORCH_TYPE_2S(dm_orch_type_topo_publish)
         ORCH_TYPE_2S(dm_orch_type_unassoc_sta_link_req_query)
 	ORCH_TYPE_2S(dm_orch_type_unassoc_sta_result)
+        ORCH_TYPE_2S(dm_orch_type_client_assoc)
 
         default:
            break;
@@ -666,6 +673,7 @@ const char *em_cmd_t::get_cmd_type_str(em_cmd_type_t type)
         CMD_TYPE_2S(em_cmd_type_get_link_quality_report)
         CMD_TYPE_2S(em_cmd_type_unassoc_sta_query)
 	CMD_TYPE_2S(em_cmd_type_unassoc_sta_result)
+        CMD_TYPE_2S(em_cmd_type_client_assoc_ctrl_req)
 
         default:
            break;
@@ -824,6 +832,10 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
             type = em_cmd_type_set_channel;
             break;
 
+        case em_bus_event_type_client_assoc_ctrl_req:
+            type = em_cmd_type_client_assoc_ctrl_req;
+            break;
+
         default:
             break;
     }
@@ -882,6 +894,10 @@ em_bus_event_type_t em_cmd_t::cmd_2_bus_event_type(em_cmd_type_t ctype)
 
         case em_cmd_type_unassoc_sta_result:
             type = em_bus_event_type_unassoc_sta_result;
+            break;
+
+        case em_cmd_type_client_assoc_ctrl_req:
+            type = em_bus_event_type_client_assoc_ctrl_req;
             break;
 
         default:

--- a/src/cmd/em_cmd_client_assoc_ctrl_req.cpp
+++ b/src/cmd/em_cmd_client_assoc_ctrl_req.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "em_cmd_client_assoc_ctrl_req.h"
+
+em_cmd_client_assoc_ctrl_req_t::em_cmd_client_assoc_ctrl_req_t(em_cmd_client_assoc_params_t params,
+    dm_easy_mesh_t& dm, em_service_type_t svc)
+{
+    em_cmd_ctx_t ctx;
+
+    m_type = em_cmd_type_client_assoc_ctrl_req;
+    memcpy(&m_param.u.client_assoc_params, &params, sizeof(em_cmd_client_assoc_params_t));
+
+    memset(reinterpret_cast<unsigned char *>(&m_orch_desc[0]), 0, EM_MAX_CMD * sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+    m_num_orch_desc = 1;
+    m_orch_desc[0].op = dm_orch_type_client_assoc;
+    m_orch_desc[0].submit = true;
+
+    strncpy(m_name, "client_assoc", strlen("client_assoc") + 1);
+    m_svc = svc;
+    init(dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+    ctx.type = m_orch_desc[0].op;
+    m_data_model.set_cmd_ctx(&ctx);
+}

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -86,6 +86,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_set_ssid.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_assoc.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_disassoc.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_client_assoc_ctrl_req.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_link_metrics.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_list.cpp \
      $(top_srcdir)/src/cmd/em_cmd_start_dpp.cpp \

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -64,6 +64,7 @@
 #include "em_cmd_mld_reconfig.h"
 #include "em_cmd_bsta_cap.h"
 #include "em_cmd_unassoc_sta_query.h"
+#include "em_cmd_client_assoc_ctrl_req.h"
 
 extern em_network_topo_t *g_network_topology;
 
@@ -3059,6 +3060,151 @@ int dm_easy_mesh_ctrl_t::analyze_command_steer(em_bus_event_t *evt, em_cmd_t *cm
         }
     }
     cJSON_free(obj);
+
+    return num;
+}
+
+int dm_easy_mesh_ctrl_t::analyze_client_assoc(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    cJSON *obj, *wfa_obj;
+    cJSON *sta_list_obj, *bssid_obj, *validity_period_obj, *assoc_control_obj;
+    int num = 0;
+    em_cmd_t *tmp = NULL;
+    em_subdoc_info_t *subdoc;
+    em_long_string_t wfa;
+    em_cmd_client_assoc_params_t assoc_param;
+    dm_easy_mesh_t dm = *this;
+
+    subdoc = &evt->u.subdoc;
+    obj = cJSON_Parse(subdoc->buff);
+    if (obj == NULL) {
+        em_printfout("%s:%d: Failed to parse: %s", __func__, __LINE__, subdoc->buff);
+        return EM_PARSE_ERR_GEN;
+    }
+
+    snprintf(wfa, sizeof(wfa), "wfa-dataelements:ClientAssocCtrlRequest");
+
+    if ((wfa_obj = cJSON_GetObjectItem(obj, wfa)) == NULL) {
+        em_printfout("%s:%d: Failed to get ClientAssocCtrlRequest object", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    memset(&assoc_param, 0, sizeof(em_cmd_client_assoc_params_t));
+
+    if ((bssid_obj = cJSON_GetObjectItem(wfa_obj, "Bssid")) == NULL) {
+        em_printfout("%s:%d: Failed to get Bssid", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    const char *bssid_str = cJSON_GetStringValue(bssid_obj);
+    if (bssid_str == NULL) {
+        em_printfout("%s:%d: Bssid is not a string", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    unsigned int mac[6] = {0};
+    int parsed = (strchr(bssid_str, ':') != NULL)
+        ? sscanf(bssid_str, "%02x:%02x:%02x:%02x:%02x:%02x", &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5])
+        : sscanf(bssid_str, "%02x%02x%02x%02x%02x%02x", &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+    if (parsed != 6) {
+        em_printfout("%s:%d: Invalid Bssid MAC string: %s", __func__, __LINE__, bssid_str);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    for (int i = 0; i < 6; i++) {
+        assoc_param.bssid[i] = static_cast<unsigned char>(mac[i]);
+    }
+
+    if ((assoc_control_obj = cJSON_GetObjectItem(wfa_obj, "AssocControl")) != NULL) {
+        if (!cJSON_IsNumber(assoc_control_obj)) {
+            em_printfout("%s:%d: AssocControl is not a number", __func__, __LINE__);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        double v = cJSON_GetNumberValue(assoc_control_obj);
+        if (v != 0.0 && v != 1.0) {
+            em_printfout("%s:%d: Invalid AssocControl=%g (allowed: 0=Block, 1=Unblock)", __func__, __LINE__, v);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        assoc_param.assoc_control = static_cast<unsigned char>(v);
+    }
+
+    if ((validity_period_obj = cJSON_GetObjectItem(wfa_obj, "ValidityPeriod")) != NULL) {
+        if (!cJSON_IsNumber(validity_period_obj)) {
+            em_printfout("%s:%d: ValidityPeriod is not a number", __func__, __LINE__);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        double v = cJSON_GetNumberValue(validity_period_obj);
+        const unsigned short vp = static_cast<unsigned short>(v);
+        if (v < 0.0 || v > 65535.0 || static_cast<double>(vp) != v) {
+            em_printfout("%s:%d: Invalid ValidityPeriod=%g (allowed: integer 0..65535)", __func__, __LINE__, v);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        assoc_param.validity_period = vp;
+    }
+
+    if ((sta_list_obj = cJSON_GetObjectItem(wfa_obj, "StaMacList")) == NULL) {
+        em_printfout("%s:%d: Failed to get StaMacList", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    if (!cJSON_IsArray(sta_list_obj)) {
+        em_printfout("%s:%d: StaMacList is not an array", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    int sta_count = cJSON_GetArraySize(sta_list_obj);
+    if (sta_count <= 0) {
+        em_printfout("%s:%d: StaMacList cannot be empty", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+    if (sta_count > MAX_STA_LIST) {
+        em_printfout("%s:%d: StaMacList too large (%d), max allowed=%d", __func__, __LINE__, sta_count, MAX_STA_LIST);
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    for (int i = 0; i < sta_count; i++) {
+        cJSON *sta_obj = cJSON_GetArrayItem(sta_list_obj, i);
+        const char *sta_str = cJSON_GetStringValue(sta_obj);
+        if (sta_str == NULL) {
+            em_printfout("%s:%d: StaMacList contains a non-string entry", __func__, __LINE__);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        unsigned int mac[6] = {0};
+        int parsed = (strchr(sta_str, ':') != NULL)
+            ? sscanf(sta_str, "%02x:%02x:%02x:%02x:%02x:%02x", &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5])
+            : sscanf(sta_str, "%02x%02x%02x%02x%02x%02x", &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+        if (parsed != 6) {
+            em_printfout("%s:%d: Invalid STA MAC string: %s", __func__, __LINE__, sta_str);
+            cJSON_Delete(obj);
+            return 0;
+        }
+        for (int k = 0; k < 6; k++) {
+            assoc_param.sta_list[i][k] = static_cast<unsigned char>(mac[k]);
+        }
+    }
+
+    assoc_param.sta_count = static_cast<unsigned char>(sta_count);
+
+    cJSON_Delete(obj);
+
+    pcmd[num] = new em_cmd_client_assoc_ctrl_req_t(assoc_param, dm);
+    tmp = pcmd[num];
+    num++;
+
+    while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
+        tmp = pcmd[num];
+        num++;
+    }
 
     return num;
 }

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -130,6 +130,22 @@ void em_ctrl_t::handle_client_steer(em_bus_event_t *evt)
     }
 }
 
+void em_ctrl_t::handle_client_assoc(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    int num;
+
+    if (m_orch->is_cmd_type_in_progress(evt) == true) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
+    } else if ((num = m_data_model.analyze_client_assoc(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
+    } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_success);
+    } else {
+        m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+    }
+}
+
 void em_ctrl_t::handle_client_disassoc(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -800,6 +816,10 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
 
 	case em_bus_event_type_unassoc_sta_query:
            handle_unassoc_sta_metrics_query(evt);
+           break;
+
+        case em_bus_event_type_client_assoc_ctrl_req:
+           handle_client_assoc(evt);
            break;
 
         default:

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -254,6 +254,10 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_beacon_report_pending);
             break;
 
+        case em_cmd_type_client_assoc_ctrl_req:
+            m_sm.set_state(em_state_ctrl_client_assoc_ctrl_req_pending);
+            break;
+
         case em_cmd_type_unassoc_sta_query:
             m_sm.set_state(em_state_ctrl_unassoc_sta_link_metrics_pending);
             break;
@@ -365,14 +369,13 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_1905_ack:
             if (m_sm.get_state() == em_state_ctrl_ap_mld_configured) {
                 em_configuration_t::process_msg(data, len);
-            } else if (m_sm.get_state() == em_state_ctrl_sta_steer_pending) {
-                em_steering_t::process_msg(data, len);
             } else if (m_sm.get_state() == em_state_ctrl_unassoc_sta_link_metrics_pending) {
                 em_metrics_t::process_msg(data, len);		    
             } else {
                 em_policy_cfg_t::process_msg(data, len);
                 em_channel_t::process_msg(data, len);
                 em_metrics_t::process_msg(data, len);
+                em_steering_t::process_msg(data, len);
             }
             break;
 
@@ -582,6 +585,10 @@ void em_t::handle_ctrl_state()
 
         case em_cmd_type_unassoc_sta_query:
             em_metrics_t::process_ctrl_state();
+            break;
+
+        case em_cmd_type_client_assoc_ctrl_req:
+            em_steering_t::process_ctrl_state();
             break;
 
         default:
@@ -963,6 +970,30 @@ void em_t::push_to_queue(em_event_t *evt)
 em_event_t *em_t::pop_from_queue()
 {
     return reinterpret_cast<em_event_t *>(queue_pop(m_iq.queue));
+}
+
+dm_bss_t *em_t::find_bss(bssid_t bssid)
+{
+    dm_bss_t *bss;
+    em_bss_info_t *bss_info;
+
+    bss_info = get_data_model()->get_bss_info_with_mac(bssid);
+    if (bss_info == NULL) {
+        return NULL;
+    }
+
+    // Get the BSS object from the data model
+    bss = get_data_model()->get_bss(bss_info->ruid.mac, bssid);
+    if (bss == NULL) {
+        return NULL;
+    }
+
+    // the bss can be from a different radio
+    if (memcmp(bss_info->ruid.mac, get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
+        return bss;
+    }
+
+    return NULL;
 }
 
 dm_sta_t *em_t::find_sta(mac_address_t sta_mac, bssid_t bssid)

--- a/src/em/steering/em_steering.cpp
+++ b/src/em/steering/em_steering.cpp
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <openssl/rand.h>
+#include <vector>
 #include "em.h"
 #include "em_msg.h"
 #include "em_cmd.h"
@@ -50,37 +51,41 @@ int em_steering_t::send_client_assoc_ctrl_req_msg()
     if (!pcmd || !dm)
         return -1;
 
-    for (unsigned int i = 0; i < pcmd->m_param.u.disassoc_params.num; i++) {
-        em_disassoc_params_t *disassoc_param = &pcmd->m_param.u.disassoc_params.params[i];
+    em_cmd_client_assoc_params_t *assoc_param = &pcmd->m_param.u.client_assoc_params;
 
-        for (unsigned int j = 0; j < dm->m_num_bss; j++) {
-            if ((memcmp(disassoc_param->bssid, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(bssid_t)) == 0) &&
-                (memcmp(dm->m_bss[j].m_bss_info.ruid.mac, get_radio_interface_mac(), sizeof(mac_address_t)) == 0)) {
+    if (assoc_param->sta_count == 0 || assoc_param->sta_count > MAX_STA_LIST) {
+        em_printfout("ERROR: Invalid sta_count=%u (max %u)", assoc_param->sta_count, MAX_STA_LIST);
+        set_state(em_state_ctrl_configured);
+        return -1;
+    }
 
-                em_client_assoc_ctrl_req_t assoc_ctrl;
-                memset(&assoc_ctrl, 0, sizeof(assoc_ctrl));
+    if (assoc_param->assoc_control != ASSOC_CONTROL_BLOCK && assoc_param->assoc_control != ASSOC_CONTROL_UNBLOCK) {
+        em_printfout("ERROR: Invalid assoc_control=%u. Allowed: 0 (Block), 1 (Unblock)",
+                 assoc_param->assoc_control);
+        set_state(em_state_ctrl_configured);
+        return -1;  // Reject request
+    }
 
-                memcpy(&assoc_ctrl.bssid, &disassoc_param->bssid, sizeof(bssid_t));
-                //Current Implementation for One Sta Per Message
-                assoc_ctrl.count = 1;
-                memcpy(&assoc_ctrl.sta_mac, &disassoc_param->sta_mac, sizeof(mac_address_t));
+    for (unsigned int j = 0; j < dm->m_num_bss; j++) {
+        if ((memcmp(assoc_param->bssid, dm->m_bss[j].m_bss_info.bssid.mac, sizeof(mac_address_t)) == 0) &&
+         (memcmp(dm->m_bss[j].m_bss_info.ruid.mac, get_radio_interface_mac(), sizeof(mac_address_t)) == 0)) {
 
-                if (disassoc_param->disassoc_time > 0) {
-                    // BLOCK
-                    assoc_ctrl.assoc_control  = 0x00;
-                    assoc_ctrl.validity_period = htons(static_cast<uint16_t>(disassoc_param->disassoc_time));
-                } else {
-                    // UNBLOCK
-                    assoc_ctrl.assoc_control  = 0x01;
-                    assoc_ctrl.validity_period = 0;
-                }
+            em_client_assoc_ctrl_req_t assoc_ctrl;
+            memset(&assoc_ctrl, 0, sizeof(assoc_ctrl));
 
-                send_client_assoc_ctrl_req_msg(&assoc_ctrl);
+            memcpy(&assoc_ctrl.bssid, &assoc_param->bssid, sizeof(bssid_t));
+
+            assoc_ctrl.assoc_control  = assoc_param->assoc_control;
+            assoc_ctrl.validity_period = htons(assoc_param->validity_period);
+            assoc_ctrl.sta_count = assoc_param->sta_count;
+            for (uint8_t i = 0; i < assoc_param->sta_count; i++) {
+                memcpy(&assoc_ctrl.sta_list[i], &assoc_param->sta_list[i], sizeof(mac_address_t));
             }
+            send_client_assoc_ctrl_req_msg(&assoc_ctrl);
+            break;
         }
     }
 
-    set_state(em_state_ctrl_configured);
     return 0;
 }
 
@@ -124,12 +129,9 @@ int em_steering_t::send_client_assoc_ctrl_req_msg(em_client_assoc_ctrl_req_t *as
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_client_assoc_ctrl_req;
 
-    if (assoc_ctrl->count != 1) {
-        em_printfout("assoc_ctrl count=%d unsupported", assoc_ctrl->count);
-        return -1;
-    }
+    size_t tlv_value_len = sizeof(bssid_t) + sizeof(unsigned char) + sizeof(unsigned short) + sizeof(unsigned char) +
+         (static_cast<size_t>(assoc_ctrl->sta_count) * sizeof(mac_address_t));
 
-    size_t tlv_value_len = sizeof(em_client_assoc_ctrl_req_t);
     memcpy(tlv->value, assoc_ctrl, tlv_value_len);
     tlv->len = htons(tlv_value_len);
 
@@ -155,7 +157,8 @@ int em_steering_t::send_client_assoc_ctrl_req_msg(em_client_assoc_ctrl_req_t *as
     }
 
     m_client_assoc_ctrl_req_tx_cnt++;
-    printf("%s:%d: Client Assoc Control Request (%d) Send Successful\n", __func__, __LINE__, m_client_assoc_ctrl_req_tx_cnt);
+    m_client_assoc_ctrl_req_msg_id= ntohs(cmdu->id);
+    em_printfout("Client Assoc Control Request (%d) Send Successful, msg_id:%u\n", m_client_assoc_ctrl_req_tx_cnt, m_client_assoc_ctrl_req_msg_id);
 
     return static_cast<int> (len);
 }
@@ -374,6 +377,95 @@ int em_steering_t::send_1905_ack_message(mac_addr_t sta_mac, unsigned short msg_
     return static_cast<int> (len);
 }
 
+int em_steering_t::send_consolidated_1905_ack_message(const std::vector<const unsigned char*>& sta_list,
+    unsigned short msg_id, unsigned char reason, unsigned char *dst)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned short  msg_type = em_msg_type_1905_ack;
+    size_t len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    short sz = 0;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+    mac_address_t zero_mac = {0};
+
+    if (sta_list.empty()) {
+        em_printfout("%s:%d: Empty STA list provided", __func__, __LINE__);
+        return -1;
+    }
+
+    if (memcmp(dm->get_ctrl_al_interface_mac(), zero_mac, sizeof(mac_address_t)) != 0) {
+        memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    } else if (dst != nullptr) {
+        memcpy(tmp, const_cast<unsigned char *> (dst), sizeof(mac_address_t));
+    } else {
+        em_printfout("%s:%d: no valid destination MAC address available", __func__, __LINE__);
+        return 0;
+    }
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, reinterpret_cast<unsigned char *> (&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *> (tmp);
+
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    // Add Error Code TLVs (only needed when reason != 0)
+    if (reason != 0) {
+        for (const auto *sta_mac : sta_list) {
+            const short err_sz = static_cast<short>(sizeof(unsigned char) + sizeof(mac_address_t));
+            if (len + sizeof(em_tlv_t) + static_cast<size_t>(err_sz) + sizeof(em_tlv_t) > MAX_EM_BUFF_SZ) {
+               em_printfout("%s:%d: Buffer overflow - too many STAs in single message", __func__, __LINE__);
+               return -1;
+            }
+            // 17.2.36 Error Code TLV format
+            tlv = reinterpret_cast<em_tlv_t *>(tmp);
+            tlv->type = em_tlv_type_error_code;
+            sz = create_error_code_tlv(tlv->value, reason, sta_mac);
+            tlv->len = htons(static_cast<short unsigned int>(sz));
+            tmp += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+            len += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+        }
+    }
+
+    // End of message
+    tlv = reinterpret_cast<em_tlv_t *> (tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += (sizeof(em_tlv_t));
+    len += (sizeof(em_tlv_t));
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_3, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
+        em_printfout("%s:%d: Consolidated 1905 ACK validation failed", __func__, __LINE__);
+        return -1;
+    }
+
+    if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
+        em_printfout("%s:%d: Consolidated 1905 ACK send failed, error:%d", __func__, __LINE__, errno);
+        return -1;
+    }
+    em_printfout("%s:%d: Consolidated 1905 ACK send success for %zu STAs", __func__, __LINE__, sta_list.size());
+
+    return static_cast<int> (len);
+}
+
 short em_steering_t::create_btm_request_tlv(unsigned char *buff)
 {
     size_t len = 0;
@@ -432,7 +524,7 @@ short em_steering_t::create_btm_report_tlv(unsigned char *buff)
     return len;
 }
 
-short em_steering_t::create_error_code_tlv(unsigned char *buff, int val, mac_addr_t sta_mac)
+short em_steering_t::create_error_code_tlv(unsigned char *buff, int val, const mac_addr_t sta_mac)
 {
     short len = 0;
     unsigned char *tmp = buff;
@@ -503,13 +595,40 @@ int em_steering_t::handle_client_steering_report(unsigned char *buff, unsigned i
 
 int em_steering_t::handle_ack_msg(unsigned char *buff, unsigned int len)
 {
-    set_state(em_state_ctrl_steer_btm_req_ack_rcvd);
+    std::vector<em_t *> em_radios;
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+    unsigned short response_msg_id = ntohs(cmdu->id);
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+    get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
+
+    for (auto &em : em_radios)
+    {
+        //check for null em pointer in vector
+        if (em == NULL) {
+            em_printfout("Warning: Null em pointer in vector, skipping");
+            continue;
+        }
+
+        if ((em->get_state() == em_state_ctrl_client_assoc_ctrl_req_pending) &&
+            (response_msg_id == em->get_client_assoc_ctrl_req_msg_id())) {
+
+            em->set_state(em_state_ctrl_configured);
+            em->clear_client_assoc_ctrl_req_msg_id();
+            em_printfout("CACR ACK handled for radio %s", util::mac_to_string(em->get_radio_interface_mac()).c_str());
+
+        } else if (em->get_state() == em_state_ctrl_sta_steer_pending) {
+
+            em->set_state(em_state_ctrl_steer_btm_req_ack_rcvd);
+            em_printfout("Steering ACK handled for radio %s", util::mac_to_string(em->get_radio_interface_mac()).c_str());
+       }
+    }
+    em_radios.clear();
     return 0;
 }
 
 int em_steering_t::handle_client_assoc_ctrl_req(unsigned char *buff, unsigned int len)
 {
-    em_printfout("%s:%d: Received Client Assoc Control Request from Controller", __func__, __LINE__);
+    em_printfout("Received Client Assoc Control Request from Controller");
 
     em_tlv_t *tlv;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
@@ -521,27 +640,65 @@ int em_steering_t::handle_client_assoc_ctrl_req(unsigned char *buff, unsigned in
     dm_easy_mesh_t *dm = get_data_model();
 
     if (em_msg_t(em_msg_type_client_assoc_ctrl_req, em_profile_type_3, buff, len).validate(errors) == 0) {
-        em_printfout("%s:%d: Client Association Control Request message validation failed", __func__, __LINE__);
+        em_printfout("Client Association Control Request message validation failed");
         return -1;
     }
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    assoc_ctrl_req = reinterpret_cast<em_client_assoc_ctrl_req_t *> (&tlv->value);
+    assoc_ctrl_req = reinterpret_cast<em_client_assoc_ctrl_req_t *>(tlv->value);
 
-    if (assoc_ctrl_req->assoc_control == 0x00) {  // Block
-        mac_address_t sta_mac;
-        memcpy(sta_mac, assoc_ctrl_req->sta_mac, sizeof(mac_address_t));
-        // Check for associated STAs if blocking
-        if (dm->is_sta_associated(assoc_ctrl_req->bssid, sta_mac)) {
-            // Send Ack with error
-            em_printfout("%s:%d: Sending ack with Error Code TLV", __func__, __LINE__);
-            send_1905_ack_message(sta_mac, msg_id, 1, hdr->src);
-            return 0;
-        }
+    const uint16_t assoc_tlv_len = ntohs(tlv->len);
+    const size_t fixed_len = sizeof(bssid_t) + sizeof(unsigned char) + sizeof(unsigned short) + sizeof(unsigned char);
+    if (assoc_tlv_len < fixed_len) {
+        em_printfout("invalid ClientAssocCtrlRequest TLV (tlv_len=%u expected_min=%zu)", assoc_tlv_len, fixed_len);
+        return -1;
+    }
+    const uint8_t sta_count = assoc_ctrl_req->sta_count;
+    const size_t expected_len = fixed_len + (static_cast<size_t>(sta_count) * sizeof(mac_address_t));
+    if (sta_count == 0 || sta_count > MAX_STA_LIST || assoc_tlv_len < expected_len) {
+        em_printfout("invalid ClientAssocCtrlRequest TLV (sta_count=%u tlv_len=%u expected_min=%zu max=%u)",
+            sta_count, assoc_tlv_len, expected_len, MAX_STA_LIST);
+        return -1;
     }
 
-    send_1905_ack_message(assoc_ctrl_req->sta_mac, msg_id, 0, hdr->src);
+    // Collect indices of associated and unassociated STAs
+    std::vector<uint8_t> associated_sta_indices;
 
+    if (assoc_ctrl_req->assoc_control == ASSOC_CONTROL_BLOCK) {
+
+        for (uint8_t i = 0; i < sta_count; i++) {
+            mac_address_t sta_mac;
+            memcpy(sta_mac, assoc_ctrl_req->sta_list[i], sizeof(mac_address_t));
+
+            if (dm->is_sta_associated(assoc_ctrl_req->bssid, sta_mac)) {
+                associated_sta_indices.push_back(i);
+            }
+        }
+
+        if (!associated_sta_indices.empty()) {
+            std::vector<const unsigned char*> list;
+            for (auto idx : associated_sta_indices) {
+                list.push_back(assoc_ctrl_req->sta_list[idx]);
+            }
+            em_printfout("sending ack with error code tlv");
+            send_consolidated_1905_ack_message(list, msg_id, 1, hdr->src);
+            return 0;
+        } else {
+             // No Error Code TLV needed when all requested STAs are unassociated.
+             send_1905_ack_message(assoc_ctrl_req->sta_list[0], msg_id, 0, hdr->src);
+        }
+    } else if (assoc_ctrl_req->assoc_control == ASSOC_CONTROL_UNBLOCK) {
+        std::vector<const unsigned char*> list;
+        for (uint8_t i = 0; i < sta_count; i++) {
+            list.push_back(assoc_ctrl_req->sta_list[i]);
+        }
+
+        send_consolidated_1905_ack_message(list, msg_id, 0, hdr->src);
+    } else {
+        em_printfout("invalid assoc_control=%u (allowed: 0=Block, 1=Unblock)",
+            assoc_ctrl_req->assoc_control);
+        return -1;
+    }
     // Send the association control request to OneWifi for HAL enforcement
     uint16_t tlv_len = ntohs(tlv->len);
     get_mgr()->io_process(em_bus_event_type_client_assoc_ctrl_req,
@@ -557,10 +714,9 @@ void em_steering_t::process_ctrl_state()
             send_client_steering_req_msg();
             break;
 
-        case em_state_ctrl_sta_disassoc_pending:
+        case em_state_ctrl_client_assoc_ctrl_req_pending:
             send_client_assoc_ctrl_req_msg();
             break;
-
         default:
             break;
     }
@@ -597,6 +753,7 @@ void em_steering_t::process_msg(unsigned char *data, unsigned int len)
 
         case em_msg_type_1905_ack:
             handle_ack_msg(data, len);
+            break;
 
         default:
             break;

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -251,6 +251,12 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
+        case em_cmd_type_client_assoc_ctrl_req:
+            if (em->get_state() == em_state_ctrl_configured) {
+                return true;
+            }
+            break;
+
         case em_cmd_type_sta_disassoc:
             if (em->get_client_assoc_ctrl_req_tx_count() >= EM_MAX_CLIENT_ASSOC_CTRL_REQ_TX_THRESH) {
                 em->set_client_assoc_ctrl_req_tx_count(0);
@@ -367,6 +373,7 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_set_policy:
         case em_cmd_type_bsta_cap:
 	    case em_cmd_type_unassoc_sta_query:
+        case em_cmd_type_client_assoc_ctrl_req:
             if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             }
@@ -566,6 +573,7 @@ bool em_orch_ctrl_t::pre_process_orch_op(em_cmd_t *pcmd)
 
         case dm_orch_type_topo_publish:
         case dm_orch_type_bsta_cap_query:
+        case dm_orch_type_client_assoc:
 			break;
 
         default:
@@ -711,6 +719,19 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
 
             case em_cmd_type_sta_steer:
                 if (em->find_sta(pcmd->m_param.u.steer_params.sta_mac, pcmd->m_param.u.steer_params.source) != NULL) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+                break;
+
+            case em_cmd_type_client_assoc_ctrl_req:
+                if (em->is_al_interface_em() == false) {
+                    em_cmd_client_assoc_params_t *assoc = &pcmd->m_param.u.client_assoc_params;
+
+                    if (em->find_bss(assoc->bssid) == NULL) {
+                        em_printfout("Skipping radio (BSSID not owned by this EM)\n");
+                        break;
+                    }
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
                 }

--- a/src/rdkb-cli/em_cmd_cli.cpp
+++ b/src/rdkb-cli/em_cmd_cli.cpp
@@ -70,6 +70,7 @@ em_cmd_params_t spec_params[] = {
     {.u = {.args = {2, {"", "", "", "", ""}, "MLDReconfig"}}},
     {.u = {.args = {2, {"", "", "", "", ""}, "WifiReset"}}},
     {.u = {.args = {2, {"", "", "", "", ""}, "UnassocSTAQuery.json"}}},
+    {.u = {.args = {2, {"", "", "", "", ""}, "ClientAssocCtrlRequest.json"}}},
 	{.u = {.args = {0, {"", "", "", "", ""}, "max"}}},
 };
 
@@ -105,7 +106,8 @@ em_cmd_t em_cmd_cli_t::m_client_cmd_spec[] = {
     em_cmd_t(em_cmd_type_mld_reconfig, spec_params[27]),
     em_cmd_t(em_cmd_type_get_reset, spec_params[28]),
     em_cmd_t(em_cmd_type_unassoc_sta_query, spec_params[29]),
-    em_cmd_t(em_cmd_type_max, spec_params[30]),
+    em_cmd_t(em_cmd_type_client_assoc_ctrl_req, spec_params[30]),
+    em_cmd_t(em_cmd_type_max, spec_params[31]),
 };
 
 int em_cmd_cli_t::get_edited_node(em_network_node_t *node, const char *header, char *buff)
@@ -470,6 +472,21 @@ int em_cmd_cli_t::execute(char *result)
            }
            break;
 	   
+        case em_cmd_type_client_assoc_ctrl_req:
+            bevt->type = em_bus_event_type_client_assoc_ctrl_req;
+            info = &bevt->u.subdoc;
+            snprintf(info->name, sizeof(info->name), "%s", param->u.args.fixed_args);
+            if (m_cmd.m_param.net_node != NULL) {
+                bevt->data_len = get_edited_node(m_cmd.m_param.net_node, "ClientAssocCtrlRequest", info->buff);
+            } else {
+                bevt->data_len = load_params_file(m_cmd.m_param.u.args.fixed_args, info->buff);
+            }
+            if (bevt->data_len < 0) {
+                printf("%s:%d: failed to load client assoc ctrl req parameters\n", __func__, __LINE__);
+                return -1;
+            }
+            break;
+
         default:
             break;
     }

--- a/src/rdkb-cli/main.go
+++ b/src/rdkb-cli/main.go
@@ -137,6 +137,13 @@ type STA struct {
     SSID        string `json:"-"`
 }
 
+type clientAssocCtrlRequest struct {
+    Bssid          string   `json:"Bssid"`
+    AssocControl   int      `json:"AssocControl"`
+    ValidityPeriod int      `json:"ValidityPeriod"`
+    StaMacList     []string `json:"StaMacList"`
+}
+
 type Device struct {
 	MAC             string         `json:"mac"`
 	Role            string         `json:"role"`
@@ -2907,6 +2914,9 @@ func main() {
 	// Unassoc STA 
 	api.HandleFunc("/unassoc_sta_query", unassocStaQueryHandler).Methods("POST")
 
+	//client assoc ctrl request
+	api.HandleFunc("/client_assoc", clientAssocCtrlRequestHandler).Methods("POST")
+
 	// Enable CORS
 	router.Use(corsMiddleware)
 
@@ -3594,6 +3604,105 @@ func unassocStaQueryHandler(w http.ResponseWriter, r *http.Request) {
     }    
 }
 
+/* func: clientAssocCtrlRequestHandler()
+ * Description:
+ * Handles POST /client_assoc requests. Parses the clientAssocCtrlRequest payload
+ * and triggers a 1905 Client Assoc Ctrl Request.
+ */
+func clientAssocCtrlRequestHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method != http.MethodPost {
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+        return
+    }
+
+    defer r.Body.Close()
+    const maxRequestSize = 64 * 1024 // 64 KB
+    r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
+
+    var req clientAssocCtrlRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "Invalid request payload", http.StatusBadRequest)
+        return
+    }
+
+    if req.Bssid == "" {
+        http.Error(w, "BSSID is required", http.StatusBadRequest)
+        return
+    }
+    if !isValidMac(req.Bssid) {
+        http.Error(w, "BSSID must be a valid MAC address (xx:xx:xx:xx:xx:xx)", http.StatusBadRequest)
+        return
+    }
+
+    if req.AssocControl != 0 && req.AssocControl != 1 {
+        http.Error(w, "AssocControl must be 0 (Block) or 1 (Unblock)", http.StatusBadRequest)
+        return
+    }
+
+    if req.ValidityPeriod < 0 || req.ValidityPeriod > 65535 {
+        http.Error(w, "ValidityPeriod must be in range 0..65535", http.StatusBadRequest)
+        return
+    }
+
+    if len(req.StaMacList) == 0 {
+        http.Error(w, "StaMacList cannot be empty", http.StatusBadRequest)
+        return
+    }
+
+    if len(req.StaMacList) > 20 {
+        http.Error(w, "StaMacList exceeds max supported size (20)", http.StatusBadRequest)
+        return
+    }
+
+    for _, mac := range req.StaMacList {
+        if !isValidMac(mac) {
+            http.Error(w, "StaMacList must contain valid MAC addresses (xx:xx:xx:xx:xx:xx)", http.StatusBadRequest)
+            return
+        }
+    }
+    payload := map[string]interface{}{
+        "Bssid":          req.Bssid,
+        "AssocControl":   req.AssocControl,
+        "ValidityPeriod": req.ValidityPeriod,
+        "StaMacList":     req.StaMacList,
+    }
+    jsonBytes, err := json.Marshal(payload)
+    if err != nil {
+        http.Error(w, "Failed to serialize client assoc parameters", http.StatusInternalServerError)
+        return
+    }
+    log.Printf("Client Assoc Ctrl Request prepared (bssid=%s sta_count=%d)", req.Bssid, len(req.StaMacList))
+    cJsonStr := C.CString(string(jsonBytes))
+    defer C.free(unsafe.Pointer(cJsonStr))
+
+    node := C.get_network_tree(cJsonStr)
+    if node == nil {
+        http.Error(w, "Failed to create network tree for client assoc ctrl request", http.StatusInternalServerError)
+        return
+    }
+    defer C.free_network_tree(node)
+
+    cmd := C.CString("client_assoc OneWifiMesh")
+    defer C.free(unsafe.Pointer(cmd))
+
+    result := C.exec(cmd, C.strlen(cmd), node)
+    if result == nil {
+        http.Error(w, "Client Assoc Ctrl Request command failed", http.StatusInternalServerError)
+        return
+    }
+    defer C.free_network_tree(result)
+
+    log.Printf("Client Assoc Ctrl Request sent: bssid=%s assoc_control=%d validity_period=%d sta_mac_list=%v ",
+        req.Bssid, req.AssocControl, req.ValidityPeriod, req.StaMacList )
+
+    w.Header().Set("Content-Type", "application/json")
+    if err := json.NewEncoder(w).Encode(map[string]interface{}{
+        "success": true,
+        "message": "Client Assoc Ctrl Request sent",
+    }); err != nil {
+        log.Printf("[ERROR][HTTP] Failed to encode response: %v", err)
+    }
+}
 
 //------------------------------------------------------------
 //                    Helper Functions

--- a/src/validation_test.cpp
+++ b/src/validation_test.cpp
@@ -1264,6 +1264,16 @@ int em_testValidation_t::test_bh_steering_req(unsigned char *buff,int i,unsigned
 
 }
 
+static inline uint16_t get_client_assoc_ctrl_req_len(uint8_t sta_count)
+{
+    if (sta_count > MAX_STA_LIST) {
+        sta_count = MAX_STA_LIST;
+    }
+
+    return static_cast<uint16_t>(
+        sizeof(em_client_assoc_ctrl_req_t) -
+        ((MAX_STA_LIST - sta_count) * sizeof(mac_address_t)));
+}
 int em_testValidation_t::test_client_assoc_ctrl_req(unsigned char *buff,int i,unsigned int len)
 {
 
@@ -1271,22 +1281,24 @@ int em_testValidation_t::test_client_assoc_ctrl_req(unsigned char *buff,int i,un
     unsigned short  msg_id = em_msg_type_client_assoc_ctrl_req;
     unsigned char *tmp = (buff+len);
 
-    if(i==0){
-        // Client Association Control Request TLV
-        tlv = (em_tlv_t *)tmp;
-        tlv->type = em_tlv_type_client_assoc_ctrl_req;
-        tlv->len = htons(sizeof(em_client_assoc_ctrl_req_t));
+    if (i == 0) {
+        em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tmp);
 
-        tmp += (sizeof(em_tlv_t) + sizeof(em_client_assoc_ctrl_req_t));
-        len += (sizeof(em_tlv_t) + sizeof(em_client_assoc_ctrl_req_t));
+        const uint8_t sta_count = 1; // test STA count
+        const uint16_t tlv_len = get_client_assoc_ctrl_req_len(sta_count);
+
+        tlv->type = em_tlv_type_client_assoc_ctrl_req;
+        tlv->len  = htons(tlv_len);
+
+        tmp += sizeof(em_tlv_t) + tlv_len;
+        len += sizeof(em_tlv_t) + tlv_len;
     }
 
     // End of message
-    tlv = (em_tlv_t *)tmp;
+    em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tmp);
     tlv->type = em_tlv_type_eom;
     tlv->len = 0;
 
-    tmp += (sizeof (em_tlv_t));
     len += (sizeof (em_tlv_t));
 
     printf("\nTest validation of client_assoc_ctrl_req message\n");

--- a/tests/test_l1_em_cmd_client_assoc_ctrl_req.cpp
+++ b/tests/test_l1_em_cmd_client_assoc_ctrl_req.cpp
@@ -1,0 +1,175 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <stdio.h>
+#include <cstring>
+#include <iostream>
+
+#include "em_cmd_client_assoc_ctrl_req.h"
+
+/* Helper: parse MAC string */
+static void parse_mac(const char *str, unsigned char out[6])
+{
+    unsigned int b[6] = {0};
+    int parsed = sscanf(str, "%02X:%02X:%02X:%02X:%02X:%02X",
+                        &b[0], &b[1], &b[2], &b[3], &b[4], &b[5]);
+
+    EXPECT_EQ(parsed, 6) << "Invalid MAC string: " << (str ? str : "(null)");
+
+    for (int i = 0; i < 6; i++)
+        out[i] = static_cast<unsigned char>(b[i]);
+}
+
+/*
+ * -------------------------------------------------------------
+ * TEST CASE 1: Valid standard parameters
+ * -------------------------------------------------------------
+ */
+TEST(em_cmd_client_assoc_ctrl_req_t, valid_standard_parameters)
+{
+    std::cout << "Entering valid_standard_parameters test" << std::endl;
+
+    em_cmd_client_assoc_params_t params{};
+
+    const char *bssid_str   = "11:22:33:44:55:66";
+    const char *sta_mac_str = "AA:BB:CC:DD:EE:FF";
+
+    unsigned char bssid[6], sta_mac[6];
+
+    parse_mac(bssid_str, bssid);
+    parse_mac(sta_mac_str, sta_mac);
+
+    memcpy(params.bssid, bssid, 6);
+    params.assoc_control = 0;  // block
+    params.validity_period = 30;
+    params.sta_count = 1;
+    memcpy(params.sta_list[0], sta_mac, 6);
+
+    EXPECT_NO_THROW({
+        dm_easy_mesh_t dm;
+        em_cmd_client_assoc_ctrl_req_t obj(params, dm);
+
+        EXPECT_EQ(obj.m_type, em_cmd_type_client_assoc_ctrl_req);
+        EXPECT_STREQ(obj.m_name, "client_assoc");
+        EXPECT_EQ(obj.m_orch_op_idx, 0u);
+        EXPECT_EQ(obj.m_num_orch_desc, 1u);
+        EXPECT_EQ(obj.m_orch_desc[0].op, dm_orch_type_client_assoc);
+        EXPECT_EQ(obj.m_orch_desc[0].submit, true);
+        EXPECT_EQ(obj.m_svc, em_service_type_ctrl);
+
+        EXPECT_EQ(memcmp(obj.m_param.u.client_assoc_params.bssid, bssid, 6), 0);
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.assoc_control, 0);
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.validity_period, 30);
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.sta_count, 1);
+
+        EXPECT_EQ(memcmp(obj.m_param.u.client_assoc_params.sta_list[0], sta_mac, 6), 0);
+
+        obj.deinit();
+    });
+
+    std::cout << "Exiting valid_standard_parameters test" << std::endl;
+}
+
+/*
+ * -------------------------------------------------------------
+ * TEST CASE 2: Zero parameters
+ * -------------------------------------------------------------
+ */
+TEST(em_cmd_client_assoc_ctrl_req_t, constructs_with_zero_parameters)
+{
+    std::cout << "Entering constructs_with_zero_parameters test" << std::endl;
+    em_cmd_client_assoc_params_t params{};
+    memset(&params, 0, sizeof(params));
+
+    EXPECT_NO_THROW({
+        dm_easy_mesh_t dm;
+        em_cmd_client_assoc_ctrl_req_t obj(params, dm);
+
+        EXPECT_EQ(obj.m_type, em_cmd_type_client_assoc_ctrl_req);
+        EXPECT_STREQ(obj.m_name, "client_assoc");
+
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.assoc_control, 0);
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.validity_period, 0);
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.sta_count, 0);
+
+        obj.deinit();
+    });
+
+    std::cout << "Exiting valid_zero_parameters test" << std::endl;
+}
+
+/*
+ * -------------------------------------------------------------
+ * TEST CASE 3: Maximum boundary values
+ * -------------------------------------------------------------
+ */
+TEST(em_cmd_client_assoc_ctrl_req_t, valid_max_boundary_values)
+{
+    std::cout << "Entering valid_max_boundary_values test" << std::endl;
+
+    em_cmd_client_assoc_params_t params{};
+
+    const char *mac_ff = "FF:FF:FF:FF:FF:FF";
+    unsigned char ff[6];
+
+    parse_mac(mac_ff, ff);
+
+    memcpy(params.bssid, ff, 6);
+    params.assoc_control = 1;
+    params.validity_period = 65535; // max for unsigned short
+    params.sta_count = 1;
+    memcpy(params.sta_list[0], ff, 6);
+
+    EXPECT_NO_THROW({
+        dm_easy_mesh_t dm;
+        em_cmd_client_assoc_ctrl_req_t obj(params, dm);
+
+        EXPECT_EQ(obj.m_type, em_cmd_type_client_assoc_ctrl_req);
+        EXPECT_STREQ(obj.m_name, "client_assoc");
+
+        EXPECT_EQ(memcmp(obj.m_param.u.client_assoc_params.bssid, ff, 6), 0);
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.validity_period, 65535);
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.sta_count, 1);
+
+        EXPECT_EQ(memcmp(obj.m_param.u.client_assoc_params.sta_list[0], ff, 6), 0);
+        obj.deinit();
+    });
+
+    std::cout << "Exiting valid_max_boundary_values test" << std::endl;
+}
+
+/*
+ * -------------------------------------------------------------
+ * TEST CASE 4: Multiple STA entries
+ * -------------------------------------------------------------
+ */
+TEST(em_cmd_client_assoc_ctrl_req_t, multiple_sta_entries)
+{
+    std::cout << "Entering multiple_sta_entries test" << std::endl;
+
+    em_cmd_client_assoc_params_t params{};
+
+    const char *sta1 = "00:11:22:33:44:55";
+    const char *sta2 = "66:77:88:99:AA:BB";
+
+    unsigned char mac1[6], mac2[6];
+
+    parse_mac(sta1, mac1);
+    parse_mac(sta2, mac2);
+
+    params.sta_count = 2;
+    memcpy(params.sta_list[0], mac1, 6);
+    memcpy(params.sta_list[1], mac2, 6);
+
+    EXPECT_NO_THROW({
+        dm_easy_mesh_t dm;
+        em_cmd_client_assoc_ctrl_req_t obj(params, dm);
+
+        EXPECT_EQ(obj.m_param.u.client_assoc_params.sta_count, 2);
+
+        EXPECT_EQ(memcmp(obj.m_param.u.client_assoc_params.sta_list[0], mac1, 6), 0);
+        EXPECT_EQ(memcmp(obj.m_param.u.client_assoc_params.sta_list[1], mac2, 6), 0);
+        obj.deinit();
+    });
+
+    std::cout << "Exiting multiple_sta_entries test" << std::endl;
+}


### PR DESCRIPTION
- Added rdkb_cli API support to trigger Client Association Control Request (CACR)
- Refactored implementation to support multiple STA entries per message (spec compliant)