### PR TITLE
RDKBWIFI-464: EasyMesh - Client Assoc/Disassoc notification.

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -1738,6 +1738,8 @@ public:
 	void update_assoc_sta_mld_info(em_assoc_sta_mld_info_t *assoc_sta_mld_info);
 	static void update_assoc_sta_mld_info(void *dm, em_assoc_sta_mld_info_t *assoc_sta_mld_info) { (static_cast<dm_easy_mesh_t *>(dm))->update_assoc_sta_mld_info(assoc_sta_mld_info); }
 
+	void remove_assoc_sta_mld_info(mac_address_t sta_mld_mac);
+
 	em_radio_cap_info_t *get_radio_cap_info(int index);
 	static em_radio_cap_info_t *get_radio_cap_info(void *dm, int index) { return (static_cast<dm_easy_mesh_t *>(dm))->get_radio_cap_info(index); }
 

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -210,7 +210,14 @@ class em_agent_t : public em_mgr_t {
 	 * @param event The event containing the `rdk_sta_data_t` info which includes the association status along with other information
 	 */
 	void handle_recv_assoc_status(em_bus_event_t *event);
-    
+
+	/**
+	 * @brief Handles the reception of connection status event of a STA
+	 *
+	 * @param event The event containing the `em_connection_status_evt_data_t` payload
+	 */
+	void handle_recv_connection_status(em_bus_event_t *event);
+
 	/**!
 	 * @brief Handles the BTM response action frame.
 	 *
@@ -991,6 +998,16 @@ public:
 	 * @return int 1 on success, otherwise -1
 	 */
 	static int association_status_cb(char *event_name, bus_data_prop_t *data, void *userData);
+
+	/**
+	 * @brief Callback for connection-status event
+	 *
+	 * @param event_name The name of the event
+	 * @param data The raw event data
+	 * @param userData Optional user-provided callback data
+	 * @return int 1 on success, otherwise -1
+	 */
+	static int connection_status_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**
 	 * @brief Callback for BSS scan events

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -699,6 +699,7 @@ typedef enum {
     em_tlv_type_ap_mld_config = 0xe0,
     em_tlv_type_bsta_mld_config = 0xe1,
     em_tlv_type_assoc_sta_mld_conf_rep = 0xe2,
+    em_tlv_type_affiliated_sta_metrics = 0xe4,
     em_tlv_type_tid_to_link_map_policy = 0xe6,
     em_tlv_eht_operations = 0xe7,
     em_tlv_type_avail_spectrum_inquiry_reg = 0xe8,
@@ -1453,6 +1454,16 @@ typedef struct {
 typedef struct {
     unsigned short reason_code;
 } __attribute__((__packed__)) em_reason_code_t;
+
+typedef struct
+{
+    mac_address_t sta_mac_addr;
+    unsigned int bytes_sent;
+    unsigned int bytes_recv;
+    unsigned int packets_sent;
+    unsigned int packets_recv;
+    unsigned int tx_packets_errors;
+} __attribute__((__packed__)) em_affiliated_sta_metrics_t;
 
 typedef struct {
     unsigned char *dpp_config_obj;
@@ -2463,6 +2474,7 @@ typedef struct {
 
     wifi_BeaconReport_t beacon_reports[EM_MAX_BEACON_REPORTS_PER_SCAN];
     em_link_report_t link_stats_report;
+    unsigned short  reason_code;
 } em_sta_info_t;
 
 typedef enum {
@@ -2887,6 +2899,7 @@ typedef enum {
     em_bus_event_type_recv_gas_frame,
     em_bus_event_type_get_sta_client_type,
     em_bus_event_type_assoc_status,
+    em_bus_event_type_connection_status,
     em_bus_event_type_ap_metrics_report,
     em_bus_event_type_bss_info,
     em_bus_event_type_get_reset,
@@ -3224,9 +3237,19 @@ typedef struct {
  */
 typedef enum {
     em_cmd_event_type_ap_metrics_report,
+    em_cmd_event_type_failed_connection,
 
     em_cmd_event_type_max
 } em_cmd_event_type_t;
+
+typedef struct {
+    int             ap_index;
+    mac_address_t   sta_mac;
+    mac_address_t   bssid;
+    unsigned short  status_code;
+    unsigned short  reason_code;
+    bool            reason_code_present;
+} em_connection_status_evt_data_t;
 
 typedef struct {
     em_cmd_event_type_t type;

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -474,7 +474,44 @@ class em_configuration_t {
 	 * @note Ensure that the MAC address and BSSID are valid before calling this function.
 	 */
 	int send_topology_notification_by_client(mac_address_t sta, bssid_t bssid, bool assoc);
-    
+
+	/**!
+	 * @brief Sends a Client Disassociation Stats message as required by EasyMesh spec (17.1.41).
+	 *
+	 * When a client disassociates, this message shall be sent to the Multi-AP Controller
+	 * including STA MAC Address Type TLV, Reason Code TLV, Associated STA Traffic Stats TLV,
+	 * and zero or more Affiliated STA Metrics TLVs (for MLD clients).
+	 *
+	 * @param[in] sta  The MAC address of the disassociated station (MLD MAC if MLD client).
+	 * @param[in] bssid The BSSID from which the station disassociated.
+	 *
+	 * @returns int
+	 * @retval message length on success
+	 * @retval -1 on failure
+	 */
+	int send_client_disassoc_stats_msg(mac_address_t sta, bssid_t bssid);
+
+	/**!
+	 * @brief Sends a Failed Connection message
+	 *
+	 * Message content:
+	 * - One BSSID TLV
+	 * - One STA MAC Address Type TLV
+	 * - One Status Code TLV
+	 * - Zero or one Reason Code TLV
+	 *
+	 * @param[in] sta MAC address of the STA that attempted to connect.
+	 * @param[in] bssid BSSID to which the connection attempt was made.
+	 * @param[in] status_code IEEE 802.11 status code. If non-zero, reason TLV is omitted.
+	 * @param[in] reason_code IEEE 802.11 reason code used when status_code is zero.
+	 *
+	 * @returns int
+	 * @retval message length on success
+	 * @retval -1 on failure
+	 */
+	int send_failed_connection_msg(mac_address_t sta, bssid_t bssid,
+								   unsigned short status_code, unsigned short reason_code);
+
 	/**!
 	 * @brief Sends a BSTA MLD configuration request message.
 	 *
@@ -804,6 +841,7 @@ class em_configuration_t {
 	 */
 	int handle_topology_notification(unsigned char *buff, unsigned int len);
 	int handle_bsta_radio_cap(unsigned char *buff, unsigned int len);
+	int handle_assoc_sta_mld_conf_rep_tlv(unsigned char *buff, unsigned int len);
 
 	/**!
 	 * @brief Handles the operational BSS for the access point.
@@ -1578,7 +1616,21 @@ public:
 	bool send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN], unsigned short msg_id);
 
 	bool send_bss_config_req_msg(uint8_t dest_al_mac[ETH_ALEN]);
-    
+
+	/**!
+	 * @brief Evaluates Unsuccessful Association Policy and sends a Failed Connection message if permitted.
+	 *
+	 * Checks report_unsuccess_assocs and rate-limiting before calling send_failed_connection_msg.
+	 *
+	 * @param[in] sta MAC address of the STA that attempted to connect.
+	 * @param[in] bssid BSSID to which the connection attempt was made.
+	 * @param[in] status_code IEEE 802.11 status code.
+	 * @param[in] reason_code IEEE 802.11 reason code.
+	 * @param[in] reason_code_present Indicates whether reason_code is valid in the event payload.
+	 */
+	void handle_failed_connection_event(const mac_address_t sta, const bssid_t bssid,
+									 unsigned short status_code, unsigned short reason_code,
+									 bool reason_code_present);
 	/**!
 	 * @brief Processes a message with the given data and length.
 	 *

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -523,7 +523,7 @@ class em_metrics_t {
 	 *
 	 * @note Ensure that the buffer is large enough to hold the TLV data.
 	 */
-	short create_assoc_sta_traffic_stats_tlv(unsigned char *buff, const dm_sta_t *const sta);
+	virtual short create_assoc_sta_traffic_stats_tlv(unsigned char *buff, const dm_sta_t *const sta);
     
 	/**!
 	 * @brief Creates an association report TLV for a WiFi 6 station.

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -109,10 +109,19 @@ int dm_easy_mesh_agent_t::analyze_dev_init(em_bus_event_t *evt, em_cmd_t *pcmd[]
 int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     unsigned int num = 0, i = 0, num_radios = 0;
+    unsigned int idx = 0, j = 0, k = 0;
     dm_easy_mesh_agent_t  dm;
     dm_sta_t *sta = NULL;
     em_cmd_t *tmp = NULL;
+    mac_address_t sta_mld_mac;
+    mac_address_t *candidate = NULL;
     em_long_string_t key;
+    mac_address_t assoc_sta_mld_tracked_macs[EM_MAX_ASSOC_STA_MLD] = {{0}};
+    mac_address_t disassoc_sta_mld_tracked_macs[EM_MAX_ASSOC_STA_MLD] = {{0}};
+    unsigned int assoc_sta_mld_tracked_count = 0;
+    unsigned int disassoc_sta_mld_tracked_count = 0;
+    bool disassoc_only_update = false;
+    bool is_tracked_sta_mld = false;
     mac_addr_str_t radio_str;
     mac_addr_str_t  sta_mac_str, bss_mac_str, radio_mac_str;
 
@@ -132,6 +141,36 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
     dm.translate_and_decode_onewifi_subdoc(reinterpret_cast<char *>(evt->u.raw_buff),
         webconfig_subdoc_type_associated_clients, "Assoc clients");
 
+    // Refresh global STA-MLD entries from the latest decoded snapshot.
+    for (idx = 0; idx < dm.m_num_assoc_sta_mld; idx++) {
+        memcpy(sta_mld_mac, dm.m_assoc_sta_mld[idx].m_assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
+        remove_assoc_sta_mld_info(sta_mld_mac);
+        update_assoc_sta_mld_info(&dm.m_assoc_sta_mld[idx].m_assoc_sta_mld_info);
+    }
+
+    // Purge stale global STA-MLD entries.
+    // Skip purge for disassoc-only updates to retain AP-MLD mapping for disconnect handling.
+    disassoc_only_update = ((dm.m_num_assoc_sta_mld == 0) &&
+                            (hash_map_count(dm.m_sta_dassoc_map) > 0));
+    if (!disassoc_only_update) {
+        for (idx = m_num_assoc_sta_mld; idx-- > 0;) {
+            candidate = &m_assoc_sta_mld[idx].m_assoc_sta_mld_info.mac_addr;
+            bool still_present = false;
+            for (j = 0; j < dm.m_num_assoc_sta_mld; j++) {
+                if (memcmp(dm.m_assoc_sta_mld[j].m_assoc_sta_mld_info.mac_addr, *candidate,
+                           sizeof(mac_address_t)) == 0) {
+                    still_present = true;
+                    break;
+                }
+            }
+            if (!still_present) {
+                em_printfout("Purge stale assoc STA MLD: %s",
+                             util::mac_to_string(*candidate).c_str());
+                remove_assoc_sta_mld_info(*candidate);
+            }
+        }
+    }
+
     for ( i = 0; i < num_radios; i++) {
         evt->params.u.args.num_args = 1;
         dm_easy_mesh_t::macbytes_to_string(get_radio_by_ref(i).get_radio_interface_mac(), radio_str);
@@ -147,8 +186,24 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
             }
 
             dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
-            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
             dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
+            is_tracked_sta_mld = false;
+            for (k = 0; k < assoc_sta_mld_tracked_count; k++) {
+                if (memcmp(assoc_sta_mld_tracked_macs[k], sta->m_sta_info.id, sizeof(mac_address_t)) == 0) {
+                    is_tracked_sta_mld = true;
+                    break;
+                }
+            }
+            if (is_tracked_sta_mld) {
+                sta = static_cast<dm_sta_t *>(hash_map_get_next(dm.m_sta_assoc_map, sta));
+                continue;
+            }
+            if (assoc_sta_mld_tracked_count < EM_MAX_ASSOC_STA_MLD) {
+                memcpy(assoc_sta_mld_tracked_macs[assoc_sta_mld_tracked_count], sta->m_sta_info.id, sizeof(mac_address_t));
+                assoc_sta_mld_tracked_count++;
+            }
+
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
             snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
             hash_map_put(pcmd[num]->m_data_model.m_sta_assoc_map, strdup(key), new dm_sta_t(*sta));
             sta = static_cast<dm_sta_t *> (hash_map_get_next(dm.m_sta_assoc_map, sta));
@@ -162,8 +217,24 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
              }
 
             dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
-            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
             dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
+            is_tracked_sta_mld = false;
+            for (k = 0; k < disassoc_sta_mld_tracked_count; k++) {
+                if (memcmp(disassoc_sta_mld_tracked_macs[k], sta->m_sta_info.id, sizeof(mac_address_t)) == 0) {
+                    is_tracked_sta_mld = true;
+                    break;
+                }
+            }
+            if (is_tracked_sta_mld) {
+                sta = static_cast<dm_sta_t *>(hash_map_get_next(dm.m_sta_dassoc_map, sta));
+                continue;
+            }
+            if (disassoc_sta_mld_tracked_count < EM_MAX_ASSOC_STA_MLD) {
+                memcpy(disassoc_sta_mld_tracked_macs[disassoc_sta_mld_tracked_count], sta->m_sta_info.id, sizeof(mac_address_t));
+                disassoc_sta_mld_tracked_count++;
+            }
+
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
             snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
             hash_map_put(pcmd[num]->m_data_model.m_sta_dassoc_map, strdup(key), new dm_sta_t(*sta));
             sta = static_cast<dm_sta_t *> (hash_map_get_next(dm.m_sta_dassoc_map, sta));

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -55,6 +55,71 @@ AlServiceAccessPoint* g_sap;
 MacAddress g_al_mac_sap;
 #endif
 
+static bool is_known_failure_status_code(unsigned short status_code)
+{
+    switch (status_code) {
+        case 1:  // Unspecified failure
+        case 5:  // Association denied; AP unable to handle BSS
+        case 10: // Cannot support all requested capabilities
+        case 11: // Reassociation denied; previous association unknown
+        case 12: // Association denied; reason outside scope
+        case 13: // Auth algorithm not supported
+        case 15: // Challenge failure (authentication denied)
+        case 16: // Association failure due to timeout
+        case 17: // Auth sequence timeout; STA did not respond
+        case 30: // Association rejected temporarily; try again later
+        case 31: // Robust management frame policy violation
+        case 43: // Invalid AKMP
+        case 44: // IEEE 802.1X authentication failed
+        case 45: // PMK not available/cached
+        case 53: // Invalid PMKID
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool is_known_failure_reason_code(unsigned short reason_code)
+{
+    switch (reason_code) {
+        case 2:  // Previous authentication not valid
+        case 3:  // Deauthenticated; STA is leaving
+        case 6:  // Class 2 frame from nonauthenticated STA
+        case 7:  // Class 3 frame from nonassociated STA
+        case 9:  // STA requested (re)assoc without authentication
+        case 13: // Invalid IE in frame
+        case 14: // Michael MIC failure
+        case 15: // 4-way handshake timeout
+        case 16: // Group key update timeout
+        case 17: // IE in 4-way handshake differs from (re)assoc request
+        case 18: // Group cipher suite not valid
+        case 19: // Pairwise cipher suite not valid
+        case 20: // AKMP not valid
+        case 21: // Unsupported RSN IE version
+        case 22: // Invalid RSN IE capabilities
+        case 23: // IEEE 802.1X authentication failed
+        case 24: // Cipher suite rejected by security policy
+        case 39: // Requested from peer STA (wrong password / MIC failure)
+        case 49: // Invalid PMKID
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool is_failed_connection_message(const em_connection_status_evt_data_t *conn_status_evt)
+{
+    if (conn_status_evt == nullptr) {
+        return false;
+    }
+
+    if (conn_status_evt->reason_code_present) {
+        return is_known_failure_reason_code(conn_status_evt->reason_code);
+    }
+
+    return is_known_failure_status_code(conn_status_evt->status_code);
+}
+
 void em_agent_t::handle_sta_list(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -407,6 +472,80 @@ void em_agent_t::handle_recv_assoc_status(em_bus_event_t *event)
         em_printfout("EC managed failed to handle association status event!");
         return;
     }
+}
+
+void em_agent_t::handle_recv_connection_status(em_bus_event_t *event)
+{
+    const em_connection_status_evt_data_t *conn_status_evt = nullptr;
+    em_bss_info_t *target_bss = nullptr;
+    mac_address_t bssid = {0};
+    em_t *em = nullptr;
+    em_event_t *qevt = nullptr;
+    em_connection_status_evt_data_t *evt_copy = nullptr;
+    std::string ruid_str;
+
+    if (event == nullptr) {
+        em_printfout("NULL event!");
+        return;
+    }
+
+    if (event->u.raw_buff == nullptr || event->data_len != sizeof(em_connection_status_evt_data_t)) {
+        em_printfout("Invalid connection status payload: expected %zu, got %u",
+                     sizeof(em_connection_status_evt_data_t), event->data_len);
+        return;
+    }
+
+    conn_status_evt = reinterpret_cast<const em_connection_status_evt_data_t *>(event->u.raw_buff);
+
+    if (!is_failed_connection_message(conn_status_evt)) {
+        /*em_printfout("Skip: sta=%s bssid=%s status=%u not in failed-connection filter",
+                     util::mac_to_string(conn_status_evt->sta_mac).c_str(),
+                     util::mac_to_string(conn_status_evt->bssid).c_str(),
+                     conn_status_evt->status_code);*/
+        return;
+    }
+
+    memcpy(bssid, conn_status_evt->bssid, sizeof(mac_address_t));
+    target_bss = m_data_model.get_bss_info_with_mac(bssid);
+    if (target_bss == nullptr) {
+        em_printfout("No BSS for bssid=%s, drop",
+                     util::mac_to_string(conn_status_evt->bssid).c_str());
+        return;
+    }
+
+    ruid_str = util::mac_to_string(target_bss->ruid.mac);
+    em = static_cast<em_t *>(hash_map_get(g_agent.m_em_map, ruid_str.c_str()));
+    if (em == nullptr) {
+        em_printfout("No radio EM for bssid=%s, drop",
+                     util::mac_to_string(conn_status_evt->bssid).c_str());
+        return;
+    }
+
+    qevt = static_cast<em_event_t *>(calloc(1, sizeof(em_event_t)));
+    if (qevt == nullptr) {
+        em_printfout("Failed to alloc failed connection event");
+        return;
+    }
+
+    evt_copy = static_cast<em_connection_status_evt_data_t *>(malloc(sizeof(em_connection_status_evt_data_t)));
+    if (evt_copy == nullptr) {
+        em_printfout("Failed to alloc connection status payload");
+        free(qevt);
+        return;
+    }
+
+    memcpy(evt_copy, conn_status_evt, sizeof(em_connection_status_evt_data_t));
+
+    qevt->type = em_event_type_cmd;
+    qevt->u.cevt.type = em_cmd_event_type_failed_connection;
+    qevt->u.cevt.cmd_ptr = evt_copy;
+
+    em_printfout("Queue failed connection: sta=%s bssid=%s status=%u",
+                 util::mac_to_string(evt_copy->sta_mac).c_str(),
+                 util::mac_to_string(evt_copy->bssid).c_str(),
+                 evt_copy->status_code);
+
+    em->push_to_queue(qevt);
 }
 
 void em_agent_t::handle_bss_info(em_bus_event_t *event)
@@ -950,6 +1089,10 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
             handle_recv_assoc_status(evt);
             break;
 
+        case em_bus_event_type_connection_status:
+            handle_recv_connection_status(evt);
+            break;
+
         case em_bus_event_type_ap_metrics_report:
             handle_ap_metrics_report(evt);
             break;
@@ -1219,6 +1362,11 @@ void em_agent_t::input_listener()
         return;
     }
 
+    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.ReportConnectionStatus", reinterpret_cast<void *>(&em_agent_t::connection_status_cb), nullptr, 0) != 0) {
+        em_printfout("Error: Failed to subscribe to 'Device.WiFi.EM.ReportConnectionStatus'");
+        return;
+    }
+
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EC.BSSInfo", reinterpret_cast<void *>(&em_agent_t::bss_info_cb), nullptr, 0) != 0) {
         em_printfout("Error: Failed to subscribe to 'Device.WiFi.EC.BSSInfo', dynamic DPP channel list for Reconfiguration Announcement is not available");
         // This is fine, not a fatal error
@@ -1259,6 +1407,22 @@ int em_agent_t::association_status_cb(char *event_name, bus_data_prop_t *data, v
         return -1;
     }
     g_agent.io_process(em_bus_event_type_assoc_status, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
+    return 1;
+}
+
+int em_agent_t::connection_status_cb(char *event_name, bus_data_prop_t *data, void *userData)
+{
+    (void)event_name;
+    (void)userData;
+
+    if (data == nullptr) {
+        em_printfout("NULL data from OneWiFi callback!");
+        return -1;
+    }
+
+    g_agent.io_process(em_bus_event_type_connection_status,
+                       reinterpret_cast<unsigned char *>(data->value.raw_data.bytes),
+                       data->value.raw_data_len);
     return 1;
 }
 
@@ -1501,6 +1665,9 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
     bool found = false;
     em_string_t al_mac_str;
     em_bss_info_t *em_bss = NULL;
+    em_t *tmp_em = NULL;
+    em_ap_mld_info_t *ap_mld_info = NULL;
+    unsigned int i = 0, j = 0;
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
     if (len < ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)))) {
@@ -1659,12 +1826,50 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             while (em != NULL) {
                 dm = em->get_data_model();
                 em_bss = dm->get_bss_info_with_mac(bss_mac);
-                if (memcmp(em_bss->ruid.mac, em->get_radio_interface_mac(), sizeof(bssid_t)) == 0) {
+                if ((em_bss != NULL) &&
+                    (memcmp(em_bss->ruid.mac, em->get_radio_interface_mac(), sizeof(bssid_t)) == 0)) {
                     printf("%s:%d: Received client cap query: found radio for bss:%s\n", __func__, __LINE__, mac_str1);
                     break;
                 }
                 em = static_cast<em_t *> (hash_map_get_next(m_em_map, em));
             }
+
+            if (em == NULL) {
+                // AP MLD MAC fallback: resolve affiliated link radio EM.
+                tmp_em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+                while (tmp_em != NULL) {
+                    dm = tmp_em->get_data_model();
+                    if ((dm != NULL) && (tmp_em->is_al_interface_em() == false)) {
+                        for (i = 0; i < dm->get_num_ap_mld(); i++) {
+                            ap_mld_info = &dm->m_ap_mld[i].m_ap_mld_info;
+                            if (memcmp(ap_mld_info->mac_addr, bss_mac, sizeof(mac_address_t)) != 0) {
+                                continue;
+                            }
+
+                            for (j = 0; j < ap_mld_info->num_affiliated_ap; j++) {
+                                if (memcmp(ap_mld_info->affiliated_ap[j].ruid.mac,
+                                           tmp_em->get_radio_interface_mac(),
+                                           sizeof(mac_address_t)) == 0) {
+                                    em = tmp_em;
+                                    em_printfout("Client cap: AP-MLD bssid=%s mapped to radio=%s",
+                                           util::mac_to_string(bss_mac).c_str(),
+                                           util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                                    break;
+                                }
+                            }
+                            if (em != NULL) {
+                                break;
+                            }
+                        }
+                    }
+
+                    if (em != NULL) {
+                        break;
+                    }
+                    tmp_em = static_cast<em_t *>(hash_map_get_next(m_em_map, tmp_em));
+                }
+            }
+
             if(em == NULL){
                 dm_easy_mesh_t::macbytes_to_string(bss_mac, mac_str2);
                 printf("%s:%d: Received client cap query: Could not find radio:%s of bss:%s\n", __func__, __LINE__, mac_str1, mac_str2);

--- a/src/cmd/em_cmd_sta_assoc.cpp
+++ b/src/cmd/em_cmd_sta_assoc.cpp
@@ -45,11 +45,13 @@ em_cmd_sta_assoc_t::em_cmd_sta_assoc_t(em_cmd_params_t param, dm_easy_mesh_t& dm
 	memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
 
     m_orch_op_idx = 0;
-    m_num_orch_desc = 2;
-    m_orch_desc[0].op = dm_orch_type_sta_cap;
+    m_num_orch_desc = 3;
+    m_orch_desc[0].op = dm_orch_type_topo_sync;
     m_orch_desc[0].submit = true;
-    m_orch_desc[1].op = dm_orch_type_topo_publish;
+    m_orch_desc[1].op = dm_orch_type_sta_cap;
     m_orch_desc[1].submit = true;
+    m_orch_desc[2].op = dm_orch_type_topo_publish;
+    m_orch_desc[2].submit = true;
 
     strncpy(m_name, "sta_assoc", strlen("sta_assoc") + 1);
     m_svc = em_service_type_ctrl;

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -1651,8 +1651,7 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     dm_easy_mesh_t  dm, *pdm;
     em_cmd_t *tmp;
     dm_bss_t *pbss;
-    bool radio_matched = false, found;
-    em_sta_info_t sta_info;
+    bool radio_matched = false, found = false;
     em_orch_desc_t desc;
     em_2xlong_string_t	key;
 
@@ -1693,38 +1692,46 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
         break;
     }
     if (found == false) {
-        printf("%s:%d: Could not find bss: %s\n", __func__, __LINE__, bss_mac_str);
-        return -1;
-    }
+        // For MLO notifications, BSSID may be AP MLD MAC and not directly resolvable
+        // to a per-link BSS yet. Continue orchestration (topology sync/query path) and
+        // defer exact link resolution to topology response processing
+        em_printfout("BSS not found bssid=%s, using fallback radio",
+            util::mac_to_string(params->assoc.bssid).c_str());
+        if (pdm->m_num_radios == 0) {
+            return -1;
+        }
+        dm_easy_mesh_t::macbytes_to_string(pdm->m_radio[0].m_radio_info.intf.mac, radio_mac_str);
+        radio_matched = true;
+    } else {
+        dm_easy_mesh_t::macbytes_to_string(pbss->m_bss_info.ruid.mac, radio_mac_str);
 
-    dm_easy_mesh_t::macbytes_to_string(pbss->m_bss_info.ruid.mac, radio_mac_str);
+        // confirm that the radio is on this device
+        for (i = 0; i < pdm->m_num_radios; i++) {
+            if (memcmp(pbss->m_bss_info.ruid.mac, pdm->m_radio[i].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                radio_matched = true;
+                break;
+            }
+        }
 
-    // confirm that the radio is on this device
-    for (i = 0; i < pdm->m_num_radios; i++) {
-        if (memcmp(pbss->m_bss_info.ruid.mac, pdm->m_radio[i].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
-            radio_matched = true;
-            break;
+        if (radio_matched == false) {
+            printf("%s:%d: Could not find bss: %s on radio: %s\n", __func__, __LINE__, bss_mac_str, radio_mac_str);
+            return -1;
         }
     }
-
-    if (radio_matched == false) {
-        printf("%s:%d: Could not find bss: %s on radio: %s\n", __func__, __LINE__, bss_mac_str, radio_mac_str);
-        return -1;
-    }
-
-    memcpy(sta_info.id, params->assoc.cli_mac_address, sizeof(mac_address_t));
-    memcpy(sta_info.bssid, params->assoc.bssid, sizeof(mac_address_t));
-    memcpy(sta_info.radiomac, pbss->m_bss_info.ruid.mac, sizeof(mac_address_t));
 
     pcmd[num] = new em_cmd_sta_assoc_t(evt->params, dm);
     tmp = pcmd[num];
     num++;
 
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
-    if ((get_sta(key) != NULL) && (params->assoc.assoc_event == false)){
+    if ((params->assoc.assoc_event == false) && ((get_sta(key) != NULL) || (found == false))) {
         desc.op = dm_orch_type_topo_update;
         desc.submit = false;
         pcmd[num - 1]->override_op(0, &desc);
+        desc.op = dm_orch_type_topo_publish;
+        desc.submit = true;
+        pcmd[num - 1]->override_op(1, &desc);
+        pcmd[num - 1]->m_num_orch_desc = 2;
     }
 
     while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
@@ -3519,6 +3526,15 @@ int dm_easy_mesh_ctrl_t::update_tables(dm_easy_mesh_t *dm)
             sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_assoc_map, sta));
         }
 
+        sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_dassoc_map));
+        while (sta != NULL) {
+            criteria = dm->db_cfg_type_get_criteria(db_cfg_type_sta_list_update);
+            if (dm_sta_list_t::set_config(m_db_client, *sta, NULL) == 0) {
+                dm->reset_db_cfg_type(db_cfg_type_sta_list_update);
+            }
+            sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_dassoc_map, sta));
+        }
+
         sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_assoc_map));
         while (sta != NULL) {
             tmp = sta;
@@ -3536,6 +3552,21 @@ int dm_easy_mesh_ctrl_t::update_tables(dm_easy_mesh_t *dm)
             delete tmp;
         }
             
+        sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_dassoc_map));
+        while (sta != NULL) {
+            tmp = sta;
+            criteria = dm->db_cfg_type_get_criteria(db_cfg_type_sta_list_update);
+            if (dm_sta_list_t::set_config(m_db_client, *sta, NULL) == 0) {
+                dm->reset_db_cfg_type(db_cfg_type_sta_list_update);
+            }
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bssid_str);
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
+            snprintf(key, sizeof(em_2xlong_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
+            sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_dassoc_map, sta));
+            hash_map_remove(dm->m_sta_dassoc_map, key);
+            delete tmp;
+        } 
 		dm->reset_db_cfg_type(db_cfg_type_sta_list_update);
     }
 

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -792,7 +792,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
     em_2xlong_string_t key;
     unsigned int i;
     bool found;
-    mac_addr_str_t mac_str1, mac_str2, dev_mac_str, radio_mac_str;
+    mac_addr_str_t mac_str1 = {0}, mac_str2 = {0}, dev_mac_str = {0}, radio_mac_str = {0};
     em_commit_info_t dm_commit;
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
@@ -891,6 +891,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
         case em_msg_type_topo_notif:
         case em_msg_type_client_cap_rprt:
         case em_msg_type_ap_metrics_rsp:
+        case em_msg_type_failed_conn:
            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
                     len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_bss_id(&bssid) == false) {
                 printf("%s:%d: Could not find bss id in msg:0x%04x\n", __func__, __LINE__, htons(cmdu->type));
@@ -899,7 +900,10 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
 
             if ((dm = get_data_model(GLOBAL_NET_ID, const_cast<const unsigned char *> (hdr->src))) == NULL) {
                 printf("%s:%d: Can not find data model\n", __func__, __LINE__);
+                return NULL;
             }
+
+            found = false;
 
             for (i = 0; i < dm->get_num_radios(); i++) {
                 found = true;
@@ -917,19 +921,28 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
 
             if (found == false) {
                 printf("%s:%d: Could not find bss:%s from data model, for radio: %s\n", __func__, __LINE__, mac_str1, radio_mac_str);
-                return NULL;
-            }
-              
-            dm_easy_mesh_t::macbytes_to_string(bss->m_bss_info.ruid.mac, mac_str1);
-            if ((em = static_cast<em_t *> (hash_map_get(m_em_map, mac_str1))) == NULL) {
-                printf("%s:%d: Could not find radio:%s\n", __func__, __LINE__, mac_str1);
-                return NULL;
+                if ((htons(cmdu->type) == em_msg_type_topo_notif) ||
+                    (htons(cmdu->type) == em_msg_type_client_cap_rprt)) {
+                    // BSSID may be AP MLD MAC. Use any radio EM for this device.
+                    for (i = 0; i < dm->get_num_radios(); i++) {
+                        dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(dm->get_radio_info(i)->id.ruid), mac_str1);
+                        if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) != NULL) {
+                            break;
+                        }
+                    }
+                    if (em == NULL) {
+                        em_printfout("fallback em not found for msg 0x%04x", htons(cmdu->type));
+                        return NULL;
+                    }
+                } else {
+                    return NULL;
+                }
             } else {
-                dm_easy_mesh_t::macbytes_to_string(bssid, mac_str1);
-                mac_addr_str_t mac;
-                dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac);
-                //printf("%s:%d: Em radio id: %s\n", __func__, __LINE__, mac);
-                //printf("%s:%d: Found em for msg type: %d, key for bss[%s]: %s\n", __func__, __LINE__, htons(cmdu->type), mac_str1, key);
+                dm_easy_mesh_t::macbytes_to_string(bss->m_bss_info.ruid.mac, mac_str1);
+                if ((em = static_cast<em_t *> (hash_map_get(m_em_map, mac_str1))) == NULL) {
+                    printf("%s:%d: Could not find radio:%s\n", __func__, __LINE__, mac_str1);
+                    return NULL;
+                }
             }
 
             break;

--- a/src/dm/dm_bss.cpp
+++ b/src/dm/dm_bss.cpp
@@ -50,6 +50,11 @@ int dm_bss_t::decode(const cJSON *obj, void *parent_id)
         dm_easy_mesh_t::name_from_mac_address(&m_bss_info.bssid.mac, m_bss_info.bssid.name);
     }
 
+    if ((tmp = cJSON_GetObjectItem(obj, "MLDAddr")) != NULL) {
+        snprintf(mac_str, sizeof(mac_str), "%s", cJSON_GetStringValue(tmp));
+        dm_easy_mesh_t::string_to_macbytes(mac_str, m_bss_info.mld_mac);
+    }
+    
     if ((tmp = cJSON_GetObjectItem(obj, "UnicastBytesSent")) != NULL) {
         m_bss_info.unicast_bytes_sent = static_cast<unsigned int> (tmp->valuedouble);
     }

--- a/src/dm/dm_bsta_mld.cpp
+++ b/src/dm/dm_bsta_mld.cpp
@@ -58,7 +58,13 @@ void dm_bsta_mld_t::operator = (const dm_bsta_mld_t& obj)
     this->m_bsta_mld_info.emlsr = obj.m_bsta_mld_info.emlsr;
     this->m_bsta_mld_info.emlmr = obj.m_bsta_mld_info.emlmr;
     this->m_bsta_mld_info.num_affiliated_bsta = obj.m_bsta_mld_info.num_affiliated_bsta;
-    memcpy(&this->m_bsta_mld_info.affiliated_bsta,&obj.m_bsta_mld_info.affiliated_bsta,sizeof(em_affiliated_bsta_info_t));
+    for (unsigned int i = 0; i < this->m_bsta_mld_info.num_affiliated_bsta; i++) {
+        this->m_bsta_mld_info.affiliated_bsta[i].mac_addr_valid = obj.m_bsta_mld_info.affiliated_bsta[i].mac_addr_valid;
+        memcpy(&this->m_bsta_mld_info.affiliated_bsta[i].ruid.mac,
+            &obj.m_bsta_mld_info.affiliated_bsta[i].ruid.mac, sizeof(mac_address_t));
+        memcpy(&this->m_bsta_mld_info.affiliated_bsta[i].mac_addr,
+            &obj.m_bsta_mld_info.affiliated_bsta[i].mac_addr, sizeof(mac_address_t));
+    }
 }
 
 
@@ -75,7 +81,13 @@ bool dm_bsta_mld_t::operator == (const dm_bsta_mld_t& obj)
     ret += !(this->m_bsta_mld_info.emlsr == obj.m_bsta_mld_info.emlsr);
     ret += !(this->m_bsta_mld_info.emlmr == obj.m_bsta_mld_info.emlmr);
     ret += !(this->m_bsta_mld_info.num_affiliated_bsta == obj.m_bsta_mld_info.num_affiliated_bsta);
-    ret += (memcmp(&this->m_bsta_mld_info.affiliated_bsta,&obj.m_bsta_mld_info.affiliated_bsta,sizeof(em_affiliated_ap_info_t)) != 0);
+    for (unsigned int i = 0; i < this->m_bsta_mld_info.num_affiliated_bsta; i++) {
+        ret += !(this->m_bsta_mld_info.affiliated_bsta[i].mac_addr_valid == obj.m_bsta_mld_info.affiliated_bsta[i].mac_addr_valid);
+        ret += (memcmp(&this->m_bsta_mld_info.affiliated_bsta[i].ruid.mac,
+            &obj.m_bsta_mld_info.affiliated_bsta[i].ruid.mac, sizeof(mac_address_t)) != 0);
+        ret += (memcmp(&this->m_bsta_mld_info.affiliated_bsta[i].mac_addr,
+            &obj.m_bsta_mld_info.affiliated_bsta[i].mac_addr, sizeof(mac_address_t)) != 0);
+    }
 
     if (ret > 0)
         return false;
@@ -85,6 +97,10 @@ bool dm_bsta_mld_t::operator == (const dm_bsta_mld_t& obj)
 
 dm_bsta_mld_t::dm_bsta_mld_t(em_bsta_mld_info_t *bsta_mld_info)
 {
+    memset(&m_bsta_mld_info, 0, sizeof(em_bsta_mld_info_t));
+    if (bsta_mld_info == nullptr) {
+        return;
+    }
     memcpy(&m_bsta_mld_info, bsta_mld_info, sizeof(em_bsta_mld_info_t));
 }
 

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -105,6 +105,11 @@ dm_easy_mesh_t& dm_easy_mesh_t::operator = (dm_easy_mesh_t const& obj)
         m_ap_mld[i] = obj.m_ap_mld[i];
     }
 
+    m_num_assoc_sta_mld = obj.m_num_assoc_sta_mld;
+    for (unsigned int i = 0; i < EM_MAX_ASSOC_STA_MLD; i++) {
+        m_assoc_sta_mld[i] = obj.m_assoc_sta_mld[i];
+    }
+
     sta = static_cast<dm_sta_t *> (hash_map_get_first(obj.m_sta_map));
     while (sta != NULL) {
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
@@ -3353,8 +3358,99 @@ void dm_easy_mesh_t::update_bsta_mld_info(em_bsta_mld_info_t *bsta_mld_info)
 
 void dm_easy_mesh_t::update_assoc_sta_mld_info(em_assoc_sta_mld_info_t *assoc_sta_mld_info)
 {
-    // TODO: Implement ASSOC MLD info update logic
-    em_printfout("Enter");
+    em_assoc_sta_mld_info_t *target_mld = NULL;
+    em_affiliated_sta_info_t *input_sta = NULL;                             
+    em_affiliated_sta_info_t *target_aff_sta = NULL;                        
+    unsigned int i, j, k;
+
+    // Find existing assoc STA MLD entry by STA MLD MAC address
+    for (i = 0; i < m_num_assoc_sta_mld; i++) {
+        if (memcmp(m_assoc_sta_mld[i].m_assoc_sta_mld_info.mac_addr, assoc_sta_mld_info->mac_addr,
+                sizeof(mac_address_t)) == 0) {
+            target_mld = &m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+            break;
+        }
+    }
+
+    // If not found, create a new entry
+    if (!target_mld) {
+        if (m_num_assoc_sta_mld >= EM_MAX_ASSOC_STA_MLD) {
+            em_printfout("Max assoc STA MLD entries reached");
+            return;
+        }
+
+        target_mld = &m_assoc_sta_mld[m_num_assoc_sta_mld].m_assoc_sta_mld_info;
+        memset(target_mld, 0, sizeof(em_assoc_sta_mld_info_t));
+        m_num_assoc_sta_mld++;
+    }
+
+    // Update top-level MLD fields
+    memcpy(target_mld->mac_addr, assoc_sta_mld_info->mac_addr, sizeof(mac_address_t));
+    memcpy(target_mld->ap_mld_mac_addr, assoc_sta_mld_info->ap_mld_mac_addr, sizeof(mac_address_t));
+    target_mld->str   = assoc_sta_mld_info->str;
+    target_mld->nstr  = assoc_sta_mld_info->nstr;
+    target_mld->emlsr = assoc_sta_mld_info->emlsr;
+    target_mld->emlmr = assoc_sta_mld_info->emlmr;
+
+    // Update affiliated STA entries, keyed by BSSID.
+    // Keep this incremental because some callers may feed one affiliated link per update.
+    for (j = 0; j < assoc_sta_mld_info->num_affiliated_sta; j++) {
+        input_sta = &assoc_sta_mld_info->affiliated_sta[j];
+        target_aff_sta = NULL;
+        bool aff_sta_found = false;
+
+        for (k = 0; k < target_mld->num_affiliated_sta; k++) {
+            if (memcmp(target_mld->affiliated_sta[k].bssid, input_sta->bssid,
+                    sizeof(mac_address_t)) == 0) {
+                target_aff_sta = &target_mld->affiliated_sta[k];
+                aff_sta_found = true;
+                break;
+            }
+        }
+
+        if (!aff_sta_found) {
+            if (target_mld->num_affiliated_sta >= EM_MAX_AP_MLD) {
+                em_printfout("Max affiliated STAs reached for assoc STA MLD");
+                continue;
+            }
+
+            target_aff_sta = &target_mld->affiliated_sta[target_mld->num_affiliated_sta];
+            memset(target_aff_sta, 0, sizeof(em_affiliated_sta_info_t));
+            target_mld->num_affiliated_sta++;
+        }
+
+        memcpy(target_aff_sta->bssid, input_sta->bssid, sizeof(mac_address_t));
+        memcpy(target_aff_sta->mac_addr, input_sta->mac_addr, sizeof(mac_address_t));
+    }
+
+}
+
+void dm_easy_mesh_t::remove_assoc_sta_mld_info(mac_address_t sta_mld_mac)
+{
+    unsigned int found_idx = m_num_assoc_sta_mld; // sentinel: not found
+    unsigned int i;
+
+    for (i = 0; i < m_num_assoc_sta_mld; i++) {
+        if (memcmp(m_assoc_sta_mld[i].m_assoc_sta_mld_info.mac_addr, sta_mld_mac,
+                sizeof(mac_address_t)) == 0) {
+            found_idx = i;
+            break;
+        }
+    }
+
+    if (found_idx == m_num_assoc_sta_mld) {
+        return; // not found
+    }
+
+    // Compact the array: shift entries after found_idx one position left.
+    for (unsigned int i = found_idx; i < m_num_assoc_sta_mld - 1; i++) {
+        m_assoc_sta_mld[i] = m_assoc_sta_mld[i + 1];
+    }
+
+    // Zero out the vacated last slot and decrement count.
+    //memset(&m_assoc_sta_mld[m_num_assoc_sta_mld - 1], 0, sizeof(dm_assoc_sta_mld_t));
+    m_assoc_sta_mld[m_num_assoc_sta_mld - 1].init();
+    m_num_assoc_sta_mld--;
 }
 
 void dm_easy_mesh_t::reset_db_cfg_type(db_cfg_type_t type) 

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -403,6 +403,13 @@ void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
 
     sta->m_sta_info.num_vendor_infos = 0;
 
+    /* The frame_body stores the full 802.11 (Re)Association Request frame body:
+     * capab_info (2B) + listen_interval (2B) + IEs. Skip the fixed fields. */
+    if (sta->m_sta_info.frame_body_len < 4) {
+        return;
+    }
+    offset = 4;
+
     while (offset < sta->m_sta_info.frame_body_len) {
         if (offset + 2 > sta->m_sta_info.frame_body_len) {
             printf("%s:%d: Insufficient data for tag header\n", __func__, __LINE__);

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -334,18 +334,53 @@ short em_capability_t::create_client_cap_tlv(unsigned char *buff, mac_address_t 
     unsigned char res = 0;
     dm_easy_mesh_t *dm;
     dm_sta_t *dm_sta;
+    em_assoc_sta_mld_info_t *assoc_info = NULL;
+    unsigned int i, j;
+    mac_address_t lookup_sta;
 
     dm = get_data_model();
+    memcpy(lookup_sta, sta, sizeof(mac_address_t));
 
     dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
     while(dm_sta != NULL) {
-        if (memcmp(dm_sta->get_sta_info()->id, sta, sizeof(mac_address_t)) == 0) {
+        if (memcmp(dm_sta->get_sta_info()->id, lookup_sta, sizeof(mac_address_t)) == 0) {
             break;
         }
-        dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+        dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, dm_sta));
     }
 
-    //TODO; if dm_sta is null break; fill result 0?
+    // Client Capability Query for MLO may carry STA MLD MAC while local sta_map may hold
+    // affiliated link STA MACs. Resolve STA MLD -> affiliated STA and retry lookup.
+    if (dm_sta == NULL) {
+        for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+            assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+            if (memcmp(assoc_info->mac_addr, sta, sizeof(mac_address_t)) != 0) {
+                continue;
+            }
+
+            for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+                memcpy(lookup_sta, assoc_info->affiliated_sta[j].mac_addr, sizeof(mac_address_t));
+                dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
+                while (dm_sta != NULL) {
+                    if (memcmp(dm_sta->get_sta_info()->id, lookup_sta, sizeof(mac_address_t)) == 0) {
+                        break;
+                    }
+                    dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, dm_sta));
+                }
+
+                if (dm_sta != NULL) {
+                    em_printfout("Client cap: mapped MLD %s to link STA %s",
+                            util::mac_to_string(sta).c_str(), util::mac_to_string(lookup_sta).c_str());
+                    break;
+                }
+            }
+
+            if (dm_sta != NULL) {
+                break;
+            }
+        }
+    }
+
     if(dm_sta == NULL) {
         return 0;
     }
@@ -390,7 +425,7 @@ short em_capability_t::create_error_code_tlv(unsigned char *buff, mac_address_t 
 
     memcpy(tmp, sta, sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
-    len += static_cast<short> (sizeof(unsigned char));
+    len += static_cast<short> (sizeof(mac_address_t));
 
     return len;
 }
@@ -736,10 +771,21 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     em_tlv_t *tlv;
     em_sta_info_t sta_info;
     mac_addr_str_t sta_mac_str, bssid_str, radio_mac_str;
+    mac_addr_str_t link_bssid_str, link_radio_str;
     em_long_string_t	key;
     dm_easy_mesh_t  *dm;
+    em_assoc_sta_mld_info_t *assoc_info = NULL;
+    dm_bss_t *aff_bss = NULL;
+    dm_sta_t *existing_link_sta = NULL;
+    dm_sta_t *existing_sta = NULL;
+    em_sta_info_t link_sta_info;
+    em_long_string_t link_key;
+    bool remapped_bssid = false;
     bool found_client_info = false;
     bool found_cap_report = false;
+    bool sta_match = false;
+    bool updated_any = false;
+    unsigned int i, j, k;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
 
     dm = get_data_model();
@@ -768,6 +814,41 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     if (found_client_info == false) {
         em_printfout("Error: Could not find client info");
         return -1;
+    }
+
+    // Remap AP MLD BSSID to a local link BSSID when needed.
+    if (dm->get_bss(get_radio_interface_mac(), sta_info.bssid) == NULL) {
+        for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+            assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+            sta_match = (memcmp(assoc_info->mac_addr, sta_info.id, sizeof(mac_address_t)) == 0);
+
+            if (sta_match == false) {
+                for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+                    if (memcmp(assoc_info->affiliated_sta[j].mac_addr, sta_info.id, sizeof(mac_address_t)) == 0) {
+                        sta_match = true;
+                        break;
+                    }
+                }
+            }
+
+            if (sta_match == false) {
+                continue;
+            }
+
+            for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+                if (dm->get_bss(get_radio_interface_mac(), assoc_info->affiliated_sta[j].bssid) != NULL) {
+                    memcpy(sta_info.bssid, assoc_info->affiliated_sta[j].bssid, sizeof(mac_address_t));
+                    em_printfout("Client cap: remapped BSSID for STA %s -> %s",
+                        util::mac_to_string(sta_info.id).c_str(), util::mac_to_string(sta_info.bssid).c_str());
+                    remapped_bssid = true;
+                    break;
+                }
+            }
+
+            if (remapped_bssid == true) {
+                break;
+            }
+        }
     }
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
@@ -802,11 +883,58 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     dm_easy_mesh_t::macbytes_to_string(get_radio_interface_mac(), radio_mac_str);
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
 
-    if (hash_map_get(dm->m_sta_assoc_map, key) == NULL) {
-        hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
-        dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
-        em_printfout("New client updated to db: %s", key);
+    // For MLO STA, update all affiliated link rows.
+    for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+        assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+        if (memcmp(assoc_info->mac_addr, sta_info.id, sizeof(mac_address_t)) != 0) {
+            continue;
+        }
+
+        for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+            aff_bss = NULL;
+            link_sta_info = sta_info;
+            memcpy(link_sta_info.bssid, assoc_info->affiliated_sta[j].bssid, sizeof(mac_address_t));
+            for (k = 0; k < dm->get_num_radios(); k++) {
+                aff_bss = dm->get_bss(dm->get_radio_info(k)->id.ruid, link_sta_info.bssid);
+                if (aff_bss != NULL) {
+                    memcpy(link_sta_info.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+                    break;
+                }
+            }
+
+            dm_easy_mesh_t::macbytes_to_string(link_sta_info.bssid, link_bssid_str);
+            dm_easy_mesh_t::macbytes_to_string(link_sta_info.radiomac, link_radio_str);
+            snprintf(link_key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, link_bssid_str, link_radio_str);
+
+            existing_link_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, link_key));
+            if (existing_link_sta == NULL) {
+                hash_map_put(dm->m_sta_assoc_map, strdup(link_key), new dm_sta_t(&link_sta_info));
+                em_printfout("Client cap DB new link: %s len=%u assoc=%d",
+                        link_key, link_sta_info.frame_body_len, link_sta_info.associated);
+            } else {
+                memcpy(&existing_link_sta->m_sta_info, &link_sta_info, sizeof(em_sta_info_t));
+                em_printfout("Client cap DB update link: %s len=%u assoc=%d",
+                        link_key, link_sta_info.frame_body_len, link_sta_info.associated);
+            }
+            updated_any = true;
+        }
+        break;
     }
+
+    if (updated_any == false) {
+        existing_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, key));
+        if (existing_sta == NULL) {
+            hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
+            em_printfout("Client cap DB new: %s len=%u assoc=%d",
+                    key, sta_info.frame_body_len, sta_info.associated);
+        } else {
+            memcpy(&existing_sta->m_sta_info, &sta_info, sizeof(em_sta_info_t));
+            em_printfout("Client cap DB update: %s len=%u assoc=%d",
+                    key, sta_info.frame_body_len, sta_info.associated);
+        }
+    }
+
+    dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
     return 0;
 }
 
@@ -815,20 +943,61 @@ void em_capability_t::handle_client_cap_query(unsigned char *buff, unsigned int 
     mac_address_t sta;
     bssid_t bss;
     em_tlv_t *tlv;
+    em_cmdu_t *cmdu;
+    unsigned int tmp_len;
+    unsigned int tlv_sz;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    if (buff == NULL) {
+        em_printfout("Client cap query: null buffer");
+        return;
+    }
+
+    if (len < (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t) + sizeof(em_tlv_t))) {
+        em_printfout("Client cap query: short frame len=%u", len);
+        return;
+    }
+
+    cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
 
     if (em_msg_t(em_msg_type_client_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
         em_printfout("Error: Client Capability Query msg validation failed");
         return;
     }
 
-    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    tmp_len = len - static_cast<unsigned int>(sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+        if (tlv->type == em_tlv_type_client_info) {
+            break;
+        }
+        tlv_sz = static_cast<unsigned int>(sizeof(em_tlv_t) + htons(tlv->len));
+        if (tmp_len < tlv_sz) {
+            em_printfout("Client cap query: malformed tlv chain");
+            return;
+        }
+        tmp_len -= tlv_sz;
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + tlv_sz);
+    }
+
+    if (tlv->type != em_tlv_type_client_info) {
+        em_printfout("Client cap query: client_info tlv not found");
+        return;
+    }
+
+    if (htons(tlv->len) < (2 * sizeof(mac_address_t))) {
+        em_printfout("Client cap query: invalid client_info tlv len=%u", htons(tlv->len));
+        return;
+    }
 
     memcpy(bss, tlv->value, sizeof(bssid_t));
     memcpy(sta, tlv->value + sizeof(mac_address_t), sizeof(bssid_t));
 
-    send_client_cap_report_msg(sta, bss, ntohs(cmdu->id));
+    if (send_client_cap_report_msg(sta, bss, ntohs(cmdu->id)) < 0) {
+        em_printfout("Client cap report send failed for sta=%s",
+                util::mac_to_string(sta).c_str());
+    }
     set_state(em_state_agent_configured);
 }
 

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -39,6 +39,10 @@
 #include <openssl/rand.h>
 #include <assert.h>
 #include <string>
+#include <set>
+#include <deque>
+#include <mutex>
+#include <ctime>
 #include <vector>
 #include <algorithm>
 #include "em_configuration.h"
@@ -58,6 +62,277 @@
 unsigned short em_configuration_t::msg_id = 0;
 // OUI value of Comcast
 static const unsigned char em_vendor_oui[EM_VENDOR_OUI_SIZE] = {0xd8, 0x9c, 0x8e};
+
+std::deque<time_t> g_failed_conn_report_timestamps;
+static std::mutex g_failed_conn_report_mutex;
+
+static bool allow_failed_conn_report(unsigned short max_reports_per_min)
+{
+    if (max_reports_per_min == 0) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(g_failed_conn_report_mutex);
+
+    time_t now = time(NULL);
+    while (!g_failed_conn_report_timestamps.empty() &&
+           (now - g_failed_conn_report_timestamps.front()) >= 60) {
+        g_failed_conn_report_timestamps.pop_front();
+    }
+
+    if (g_failed_conn_report_timestamps.size() >= max_reports_per_min) {
+        return false;
+    }
+
+    g_failed_conn_report_timestamps.push_back(now);
+    return true;
+}
+
+static bool em_cfg_update_sta_assoc_row(hash_map_t *sta_assoc_map,
+                                        em_sta_info_t *row,
+                                        const char *new_log_prefix,
+                                        const char *update_log_prefix)
+{
+    mac_addr_str_t row_sta_str, row_bssid_str, row_radio_str;
+    em_long_string_t row_key;
+    dm_sta_t *existing_row;
+
+    dm_easy_mesh_t::macbytes_to_string(row->id, row_sta_str);
+    dm_easy_mesh_t::macbytes_to_string(row->bssid, row_bssid_str);
+    dm_easy_mesh_t::macbytes_to_string(row->radiomac, row_radio_str);
+    snprintf(row_key, sizeof(em_long_string_t), "%s@%s@%s", row_sta_str, row_bssid_str, row_radio_str);
+
+    existing_row = static_cast<dm_sta_t *>(hash_map_get(sta_assoc_map, row_key));
+    if (existing_row == NULL) {
+        hash_map_put(sta_assoc_map, strdup(row_key), new dm_sta_t(row));
+        em_printfout("%s%s", new_log_prefix, row_key);
+    } else {
+        existing_row->m_sta_info.associated = row->associated;
+        em_printfout("%s%s", update_log_prefix, row_key);
+    }
+
+    return true;
+}
+
+static dm_sta_t *em_cfg_find_dassoc_sta(dm_easy_mesh_t *dm,
+                                        const mac_address_t sta_mac,
+                                        const bssid_t bssid,
+                                        bool match_bssid)
+{
+    dm_sta_t *dassoc_sta;
+
+    dassoc_sta = static_cast<dm_sta_t *>(hash_map_get_first(dm->m_sta_dassoc_map));
+    while (dassoc_sta != NULL) {
+        if ((memcmp(dassoc_sta->m_sta_info.id, sta_mac, sizeof(mac_address_t)) == 0) &&
+            ((match_bssid == false) ||
+             (memcmp(dassoc_sta->m_sta_info.bssid, bssid, sizeof(bssid_t)) == 0))) {
+            return dassoc_sta;
+        }
+        dassoc_sta = static_cast<dm_sta_t *>(hash_map_get_next(dm->m_sta_dassoc_map, dassoc_sta));
+    }
+
+    return NULL;
+}
+
+static unsigned short em_cfg_create_assoc_sta_traffic_stats_tlv(em_tlv_t *tlv,
+                                                                const mac_address_t logical_sta,
+                                                                dm_easy_mesh_t *dm,
+                                                                const em_assoc_sta_mld_info_t *mld_info,
+                                                                dm_sta_t *dassoc_sta)
+{
+    em_assoc_sta_traffic_sts_t *stats;
+    dm_sta_t *aff_sta;
+    unsigned short sz;
+    unsigned int j;
+    uint32_t bytes_sent = 0, bytes_recv = 0;
+    uint32_t packets_sent = 0, packets_recv = 0;
+    uint32_t tx_errors = 0, rx_errors = 0;
+    uint32_t retrans = 0;
+
+    tlv->type = em_tlv_type_assoc_sta_traffic_sts;
+    stats = reinterpret_cast<em_assoc_sta_traffic_sts_t *>(tlv->value);
+    memset(stats, 0, sizeof(*stats));
+    memcpy(stats->sta_mac_addr, logical_sta, sizeof(mac_address_t));
+
+    if (mld_info != NULL) {
+
+        for (j = 0; j < mld_info->num_affiliated_sta; j++) {
+            aff_sta = em_cfg_find_dassoc_sta(dm,
+                                             mld_info->affiliated_sta[j].mac_addr,
+                                             mld_info->affiliated_sta[j].bssid,
+                                             false);
+            if (aff_sta == NULL) {
+                continue;
+            }
+            bytes_sent    += aff_sta->m_sta_info.bytes_tx;
+            bytes_recv    += aff_sta->m_sta_info.bytes_rx;
+            packets_sent  += aff_sta->m_sta_info.pkts_tx;
+            packets_recv  += aff_sta->m_sta_info.pkts_rx;
+            tx_errors     += aff_sta->m_sta_info.errors_tx;
+            rx_errors     += aff_sta->m_sta_info.errors_rx;
+            retrans       += aff_sta->m_sta_info.retrans_count;
+            if (dassoc_sta == NULL) {
+                dassoc_sta = aff_sta;
+            }
+        }
+        stats->bytes_sent        = htonl(bytes_sent);
+        stats->bytes_recv        = htonl(bytes_recv);
+        stats->packets_sent      = htonl(packets_sent);
+        stats->packets_recv      = htonl(packets_recv);
+        stats->tx_packets_errors = htonl(tx_errors);
+        stats->rx_packets_errors = htonl(rx_errors);
+        stats->retrans_count     = htonl(retrans);
+    } else if (dassoc_sta != NULL) {
+        stats->bytes_sent = htonl(dassoc_sta->m_sta_info.bytes_tx);
+        stats->bytes_recv = htonl(dassoc_sta->m_sta_info.bytes_rx);
+        stats->packets_sent = htonl(dassoc_sta->m_sta_info.pkts_tx);
+        stats->packets_recv = htonl(dassoc_sta->m_sta_info.pkts_rx);
+        stats->tx_packets_errors = htonl(dassoc_sta->m_sta_info.errors_tx);
+        stats->rx_packets_errors = htonl(dassoc_sta->m_sta_info.errors_rx);
+        stats->retrans_count = htonl(dassoc_sta->m_sta_info.retrans_count);
+    }
+
+    sz = static_cast<unsigned short>(sizeof(em_assoc_sta_traffic_sts_t));
+    tlv->len = htons(sz);
+
+    return static_cast<unsigned short>(sizeof(em_tlv_t) + sz);
+}
+
+static unsigned short em_cfg_create_affiliated_sta_metrics_tlvs(unsigned char *buff,
+                                                                dm_easy_mesh_t *dm,
+                                                                const em_assoc_sta_mld_info_t *mld_info)
+{
+    em_tlv_t *tlv;
+    em_affiliated_sta_metrics_t *metrics;
+    dm_sta_t *aff_dassoc_sta;
+    const em_affiliated_sta_info_t *aff_sta;
+    unsigned short sz;
+    unsigned short total_len = 0;
+    unsigned int j;
+
+    if (mld_info == NULL) {
+        return 0;
+    }
+
+    for (j = 0; j < mld_info->num_affiliated_sta; j++) {
+        aff_sta = &mld_info->affiliated_sta[j];
+        aff_dassoc_sta = em_cfg_find_dassoc_sta(dm, aff_sta->mac_addr, aff_sta->bssid, false);
+
+        tlv = reinterpret_cast<em_tlv_t *>(buff + total_len);
+        tlv->type = em_tlv_type_affiliated_sta_metrics;
+        metrics = reinterpret_cast<em_affiliated_sta_metrics_t *>(tlv->value);
+        memset(metrics, 0, sizeof(*metrics));
+        memcpy(metrics->sta_mac_addr, aff_sta->mac_addr, sizeof(mac_address_t));
+
+        if (aff_dassoc_sta != NULL) {
+            metrics->bytes_sent = htonl(aff_dassoc_sta->m_sta_info.bytes_tx);
+            metrics->bytes_recv = htonl(aff_dassoc_sta->m_sta_info.bytes_rx);
+            metrics->packets_sent = htonl(aff_dassoc_sta->m_sta_info.pkts_tx);
+            metrics->packets_recv = htonl(aff_dassoc_sta->m_sta_info.pkts_rx);
+            metrics->tx_packets_errors = htonl(aff_dassoc_sta->m_sta_info.errors_tx);
+        }
+
+        sz = static_cast<unsigned short>(sizeof(em_affiliated_sta_metrics_t));
+        tlv->len = htons(sz);
+        total_len += static_cast<unsigned short>(sizeof(em_tlv_t) + sz);
+    }
+
+    return total_len;
+}
+
+static bool em_cfg_handle_assoc_sta_mld_topology_updates(dm_easy_mesh_t *dm)
+{
+    bool sta_db_update_needed;
+    bool in_new_set;
+    unsigned int i, j, r;
+    em_assoc_sta_mld_info_t *assoc_info;
+    dm_bss_t *aff_bss;
+    em_sta_info_t sta_info;
+    dm_sta_t *db_sta;
+    em_sta_info_t disassoc_info;
+    dm_sta_t *queued_sta;
+    mac_addr_str_t check_sta_str, check_bssid_str, check_radio_str;
+    em_long_string_t check_key;
+
+    sta_db_update_needed = false;
+    assoc_info = NULL;
+    aff_bss = NULL;
+    db_sta = NULL;
+    queued_sta = NULL;
+
+    for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+        assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+        for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+            aff_bss = NULL;
+            for (r = 0; r < dm->get_num_radios(); r++) {
+                aff_bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, assoc_info->affiliated_sta[j].bssid);
+                if (aff_bss != NULL) {
+                    break;
+                }
+            }
+
+            if (aff_bss == NULL) {
+                continue;
+            }
+
+            memset(&sta_info, 0, sizeof(em_sta_info_t));
+            memcpy(sta_info.id, assoc_info->mac_addr, sizeof(mac_address_t));
+            memcpy(sta_info.bssid, assoc_info->affiliated_sta[j].bssid, sizeof(mac_address_t));
+            memcpy(sta_info.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+            sta_info.associated = true;
+
+            if (em_cfg_update_sta_assoc_row(dm->m_sta_assoc_map, &sta_info,
+                        "Topo resp add link: ",
+                        "Topo resp update link: ") == true) {
+                sta_db_update_needed = true;
+            }
+        }
+    }
+
+    for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+        assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+        db_sta = static_cast<dm_sta_t *>(hash_map_get_first(dm->m_sta_map));
+        while (db_sta != NULL) {
+            if (memcmp(db_sta->m_sta_info.id, assoc_info->mac_addr, sizeof(mac_address_t)) == 0
+                    && db_sta->m_sta_info.associated) {
+                in_new_set = false;
+                for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+                    if (memcmp(db_sta->m_sta_info.bssid, assoc_info->affiliated_sta[j].bssid,
+                            sizeof(mac_address_t)) == 0) {
+                        in_new_set = true;
+                        break;
+                    }
+                }
+                if (!in_new_set) {
+                    disassoc_info = db_sta->m_sta_info;
+                    disassoc_info.associated = false;
+                    disassoc_info.frame_body_len = 0;
+                    dm_easy_mesh_t::macbytes_to_string(disassoc_info.id, check_sta_str);
+                    dm_easy_mesh_t::macbytes_to_string(disassoc_info.bssid, check_bssid_str);
+                    dm_easy_mesh_t::macbytes_to_string(disassoc_info.radiomac, check_radio_str);
+                    snprintf(check_key, sizeof(em_long_string_t), "%s@%s@%s",
+                            check_sta_str, check_bssid_str, check_radio_str);
+
+                    queued_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, check_key));
+                    if (queued_sta != NULL) {
+                        queued_sta->m_sta_info.associated = false;
+                        queued_sta->m_sta_info.frame_body_len = 0;
+                        memset(queued_sta->m_sta_info.frame_body, 0, sizeof(queued_sta->m_sta_info.frame_body));
+                        sta_db_update_needed = true;
+                        em_printfout("Topo resp stale link queued disassoc: %s", check_key);
+                    } else {
+                        hash_map_put(dm->m_sta_assoc_map, strdup(check_key), new dm_sta_t(&disassoc_info));
+                        sta_db_update_needed = true;
+                        em_printfout("Topo resp stale link disassoc: %s", check_key);
+                    }
+                }
+            }
+            db_sta = static_cast<dm_sta_t *>(hash_map_get_next(dm->m_sta_map, db_sta));
+        }
+    }
+
+    return sta_db_update_needed;
+}
 
 /* Extract N bytes (ignore endianess) */
 static inline void _EnB(uint8_t **packet_ppointer, void *memory_pointer, uint32_t n)
@@ -107,10 +382,11 @@ unsigned short em_configuration_t::create_client_assoc_event_tlv(unsigned char *
 
     for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
         em_assoc_sta_mld_info_t& assoc_sta_mld_info = dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
-        if (memcmp(assoc_sta_mld_info.mac_addr, sta, sizeof(mac_address_t) == 0)) {
+        if (memcmp(assoc_sta_mld_info.mac_addr, sta, sizeof(mac_address_t)) == 0) {
             found_assoc_sta_mld = true;
             memcpy(tmp, assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
             memcpy(tmp + sizeof(mac_address_t), assoc_sta_mld_info.ap_mld_mac_addr, sizeof(mac_address_t));
+            break;        
         }
     }
 
@@ -123,6 +399,300 @@ unsigned short em_configuration_t::create_client_assoc_event_tlv(unsigned char *
     len = 2*sizeof(mac_address_t) + sizeof(unsigned char);
 
     return len;
+}
+
+
+int em_configuration_t::send_client_disassoc_stats_msg(mac_address_t sta, bssid_t bssid)
+{
+    unsigned short  msg_type = em_msg_type_client_disassoc_stats;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int len = 0;
+    unsigned short sz;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm;
+    dm_sta_t *dassoc_sta = NULL;
+    em_assoc_sta_mld_info_t *mld_info = NULL;
+    unsigned int i, j;
+    mac_address_t logical_sta = {0};
+    unsigned short tlv_total_len;
+
+    dm = get_data_model();
+    memcpy(logical_sta, sta, sizeof(mac_address_t));
+
+    // Ethernet header: dst (controller AL MAC), src (agent AL MAC), EtherType
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int>(sizeof(mac_address_t));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int>(sizeof(mac_address_t));
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += static_cast<unsigned int>(sizeof(unsigned short));
+
+    // CMDU header
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    cmdu->last_frag_ind = 1;
+
+    tmp += sizeof(em_cmdu_t);
+    len += static_cast<unsigned int>(sizeof(em_cmdu_t));
+
+    // Resolve whether this STA belongs to an MLD client.
+    for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+        em_assoc_sta_mld_info_t &assoc_sta_mld_info = dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+        if (memcmp(assoc_sta_mld_info.mac_addr, sta, sizeof(mac_address_t)) == 0) {
+            mld_info = &assoc_sta_mld_info;
+            memcpy(logical_sta, assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
+            break;
+        }
+        for (j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
+            if (memcmp(assoc_sta_mld_info.affiliated_sta[j].mac_addr, sta, sizeof(mac_address_t)) == 0) {
+                mld_info = &assoc_sta_mld_info;
+                memcpy(logical_sta, assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
+                break;
+            }
+        }
+        if (mld_info != NULL) {
+            break;
+        }
+    }
+
+    // Use BSSID for non-MLD lookup to avoid ambiguous STA matches.
+    dassoc_sta = em_cfg_find_dassoc_sta(dm, logical_sta, bssid, (mld_info == NULL));
+
+    // STA MAC Address Type TLV (17.2.23)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_sta_mac_addr;
+    memcpy(tlv->value, logical_sta, sizeof(mac_address_t));
+    tlv->len = htons(sizeof(mac_address_t));
+
+    tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sizeof(mac_address_t));
+
+    // Reason Code TLV (17.2.64)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_reason_code;
+    {
+        em_reason_code_t *rc = reinterpret_cast<em_reason_code_t *>(tlv->value);
+        unsigned short reason = (dassoc_sta != NULL) ? dassoc_sta->m_sta_info.reason_code : 1;
+        rc->reason_code = htons(reason);
+    }
+    sz = static_cast<unsigned short>(sizeof(em_reason_code_t));
+    tlv->len = htons(sz);
+
+    tmp += (sizeof(em_tlv_t) + sz);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sz);
+
+    // Associated STA Traffic Stats TLV (17.2.35)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv_total_len = em_cfg_create_assoc_sta_traffic_stats_tlv(tlv, logical_sta, dm, mld_info, dassoc_sta);
+    tmp += tlv_total_len;
+    len += static_cast<unsigned int>(tlv_total_len);
+
+    // Affiliated STA Metrics TLVs (17.2.100)
+    tlv_total_len = em_cfg_create_affiliated_sta_metrics_tlvs(tmp, dm, mld_info);
+    tmp += tlv_total_len;
+    len += static_cast<unsigned int>(tlv_total_len);
+
+    // End of message TLV
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += sizeof(em_tlv_t);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t));
+
+    em_printfout("Client disassoc stats msg built, len=%u", len);
+
+    if (em_msg_t(em_msg_type_client_disassoc_stats, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("Client disassoc stats msg validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        em_printfout("Client disassoc stats send failed, err=%d", errno);
+        return -1;
+    }
+
+    em_printfout("Client disassoc stats sent");
+
+    return static_cast<int>(len);
+}
+
+int em_configuration_t::send_failed_connection_msg(mac_address_t sta, bssid_t bssid,
+                                                   unsigned short status_code,
+                                                   unsigned short reason_code)
+{
+    unsigned short msg_type = em_msg_type_failed_conn;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int len = 0;
+    unsigned short sz;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (dm == NULL) {
+        em_printfout("%s:%d: Data model is NULL", __func__, __LINE__);
+        return -1;
+    }
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int>(sizeof(mac_address_t));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int>(sizeof(mac_address_t));
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += static_cast<unsigned int>(sizeof(unsigned short));
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    cmdu->last_frag_ind = 1;
+
+    tmp += sizeof(em_cmdu_t);
+    len += static_cast<unsigned int>(sizeof(em_cmdu_t));
+
+    // BSSID TLV (17.2.74)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_bssid;
+    tlv->len = htons(sizeof(mac_address_t));
+    memcpy(tlv->value, bssid, sizeof(mac_address_t));
+
+    tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sizeof(mac_address_t));
+
+    // STA MAC Address Type TLV (17.2.23)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_sta_mac_addr;
+    tlv->len = htons(sizeof(mac_address_t));
+    memcpy(tlv->value, sta, sizeof(mac_address_t));
+
+    tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sizeof(mac_address_t));
+
+    // Status Code TLV (17.2.63)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_status_code;
+    {
+        em_status_code_t *status = reinterpret_cast<em_status_code_t *>(tlv->value);
+        status->status_code = htons(status_code);
+    }
+    sz = static_cast<unsigned short>(sizeof(em_status_code_t));
+    tlv->len = htons(sz);
+
+    tmp += (sizeof(em_tlv_t) + sz);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sz);
+
+    // Reason Code TLV (17.2.64) is included only when Status Code is zero.
+    if (status_code == 0) {
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_reason_code;
+        {
+            em_reason_code_t *reason = reinterpret_cast<em_reason_code_t *>(tlv->value);
+            reason->reason_code = htons(reason_code);
+        }
+        sz = static_cast<unsigned short>(sizeof(em_reason_code_t));
+        tlv->len = htons(sz);
+
+        tmp += (sizeof(em_tlv_t) + sz);
+        len += static_cast<unsigned int>(sizeof(em_tlv_t) + sz);
+    }
+
+    // End of message TLV
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += sizeof(em_tlv_t);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t));
+
+    if (em_msg_t(em_msg_type_failed_conn, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("%s:%d: Failed Connection msg validation failed", __func__, __LINE__);
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        em_printfout("%s:%d: Failed Connection msg send failed, error:%d", __func__, __LINE__, errno);
+        return -1;
+    }
+
+    em_printfout("%s:%d: Failed Connection msg send success", __func__, __LINE__);
+    return static_cast<int>(len);
+}
+
+void em_configuration_t::handle_failed_connection_event(const mac_address_t sta,
+                                                       const bssid_t bssid,
+                                                       unsigned short status_code,
+                                                       unsigned short reason_code,
+                                                       bool reason_code_present)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    unsigned short max_rate;
+    unsigned short final_reason_code;
+    bssid_t bssid_copy = {0};
+    mac_address_t sta_copy = {0};
+    std::string sta_str;
+    std::string bssid_str;
+
+    if (dm == NULL) {
+        em_printfout("FailedConn: data model is NULL, skipping");
+        return;
+    }
+
+    em_device_info_t *device_info = dm->get_device_info();
+    if (device_info == NULL) {
+        em_printfout("FailedConn: device_info is NULL, skipping");
+        return;
+    }
+
+    if (device_info->report_unsuccess_assocs == false) {
+        //em_printfout("FailedConn: report_unsuccess_assocs=false, skipping");
+        return;
+    }
+
+    max_rate = device_info->max_unsuccessful_assoc_report_rate;
+    if (max_rate == 0) {
+        max_rate = device_info->max_reporting_rate;
+    }
+    em_printfout("FailedConn: max_rate=%u", max_rate);
+
+    if (!allow_failed_conn_report(max_rate)) {
+        em_printfout("FailedConn: rate limit reached (max_rate=%u per min), skipping", max_rate);
+        return;
+    }
+
+    final_reason_code = 1;
+    if ((status_code == 0) && reason_code_present && (reason_code != 0)) {
+        final_reason_code = reason_code;
+    }
+
+    sta_str = util::mac_to_string(sta);
+    bssid_str = util::mac_to_string(bssid);
+    em_printfout("FailedConn: send sta=%s bssid=%s status=%u reason=%u has_reason=%d",
+                 sta_str.c_str(), bssid_str.c_str(), status_code,
+                 final_reason_code, static_cast<int>(reason_code_present));
+
+    memcpy(sta_copy, sta, sizeof(mac_address_t));
+    memcpy(bssid_copy, bssid, sizeof(bssid_t));
+
+    send_failed_connection_msg(sta_copy, bssid_copy, status_code, final_reason_code);
 }
 
 int em_configuration_t::send_topology_notification_by_client(mac_address_t sta, bssid_t bssid, bool assoc)
@@ -213,6 +783,9 @@ void em_configuration_t::handle_state_topology_notify()
 {
     dm_easy_mesh_t *dm;
     dm_sta_t *sta;
+    int notif_ret;
+    int disassoc_stats_ret;
+    std::string sta_str;
 
     dm = get_current_cmd()->get_data_model();
 
@@ -224,7 +797,19 @@ void em_configuration_t::handle_state_topology_notify()
 
     sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_dassoc_map));
     while (sta != NULL) {
-        send_topology_notification_by_client(sta->m_sta_info.id, sta->m_sta_info.bssid, false);
+            sta_str = util::mac_to_string(sta->m_sta_info.id);
+            notif_ret = send_topology_notification_by_client(sta->m_sta_info.id, sta->m_sta_info.bssid, false);
+            if (notif_ret >= 0) {
+                disassoc_stats_ret = send_client_disassoc_stats_msg(sta->m_sta_info.id, sta->m_sta_info.bssid);
+
+                if (disassoc_stats_ret >= 0) {
+                    dm->remove_assoc_sta_mld_info(sta->m_sta_info.id);
+                } else {
+                    em_printfout("topo notification: stats send failed for sta=%s", sta_str.c_str());
+                }
+            } else {
+                em_printfout("topo notification: disassoc notif failed for sta=%s", sta_str.c_str());
+            }
         sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_dassoc_map, sta));
     }
     set_state(em_state_agent_configured);
@@ -725,6 +1310,7 @@ int em_configuration_t::create_assoc_sta_mld_config_report_tlv(unsigned char *bu
         tlv->type = em_tlv_type_assoc_sta_mld_conf_rep;
 
         assoc_sta_mld = reinterpret_cast<em_assoc_sta_mld_t *>(tlv->value);
+        memset(assoc_sta_mld, 0, sizeof(em_assoc_sta_mld_t));
 
         em_assoc_sta_mld_info_t &assoc_sta_mld_info = dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
         memcpy(assoc_sta_mld->sta_mld_mac_addr, assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
@@ -739,6 +1325,7 @@ int em_configuration_t::create_assoc_sta_mld_config_report_tlv(unsigned char *bu
 
         for (j = 0; j < assoc_sta_mld->num_affiliated_sta; j++) {
             em_affiliated_sta_info_t &affiliated_sta_info = assoc_sta_mld_info.affiliated_sta[j];
+            memset(affiliated_sta_mld, 0, sizeof(em_affiliated_sta_mld_t));
             memcpy(affiliated_sta_mld->bssid, affiliated_sta_info.bssid, sizeof(mac_address_t));
             memcpy(affiliated_sta_mld->affiliated_sta_mac_addr, affiliated_sta_info.mac_addr, sizeof(mac_address_t));
 
@@ -775,6 +1362,8 @@ int em_configuration_t::create_vendor_operational_bss_tlv(unsigned char *buff)
 	printf("first tlv_len in em_configuration_t::create_custom_operational_bss_tlv = %d\n",tlv_len);
 	ap = reinterpret_cast<em_ap_vendor_op_bss_t *> (tlv->value);
 	ap->radios_num = dm->get_num_radios();
+    /* Include em_ap_vendor_op_bss_t header (radios_num) in TLV payload length. */
+    tlv_len = static_cast<unsigned short>(sizeof(em_ap_vendor_op_bss_t));
 	radio = ap->radios;
     for (radio_index = 0; radio_index < dm->get_num_radios(); radio_index++) {
         memcpy(radio->ruid, dm->get_radio_by_ref(radio_index).get_radio_interface_mac(), sizeof(mac_address_t));
@@ -1520,6 +2109,16 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
     em_client_assoc_event_t *assoc_evt_tlv;
     em_sta_info_t sta_info;
     em_bus_event_type_client_assoc_params_t    raw;
+    bool updated_any = false;
+    bool assoc_event;
+    unsigned int mld_i, aff_j, r;
+    em_assoc_sta_mld_info_t *assoc_info = NULL;
+    em_sta_info_t link_sta;
+    dm_bss_t *aff_bss = NULL;
+    mac_addr_str_t b_str, r_str;
+    em_long_string_t link_key;
+    dm_sta_t *assoc_row = NULL;
+    dm_sta_t *sta_row = NULL;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
 
 	dm = get_data_model();
@@ -1557,24 +2156,99 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
             dm_easy_mesh_t::macbytes_to_string(assoc_evt_tlv->bssid, bssid_str);
             dm_easy_mesh_t::macbytes_to_string(get_radio_interface_mac(), radio_mac_str);
             snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
+            assoc_event = assoc_evt_tlv->assoc_event;
 
             //em_printfout("Client Device:%s %s to BSSID: %s\n", sta_mac_str,
             //        (assoc_evt_tlv->assoc_event == 1)?"associated":"disassociated", bssid_str);
-            if ((assoc_evt_tlv->assoc_event == false)) {
-                //if disassoc, update db with thi sta_info info
-                memset(&sta_info, 0, sizeof(em_sta_info_t));
-                memcpy(sta_info.id, assoc_evt_tlv->cli_mac_address, sizeof(mac_address_t));
-                memcpy(sta_info.bssid, assoc_evt_tlv->bssid, sizeof(mac_address_t));
-                memcpy(sta_info.radiomac, get_radio_interface_mac(), sizeof(mac_address_t));
-                sta_info.associated = assoc_evt_tlv->assoc_event;
-
-                hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
-
-                dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
-                //em_printfout("Client updated to db: %s", key);
+            if (assoc_event == false) {
+                em_printfout("topo notification disassoc: sta=%s bssid=%s key=%s",
+                        util::mac_to_string(assoc_evt_tlv->cli_mac_address).c_str(),
+                        util::mac_to_string(assoc_evt_tlv->bssid).c_str(), key);
             }
+            memset(&sta_info, 0, sizeof(em_sta_info_t));
+            memcpy(sta_info.id, assoc_evt_tlv->cli_mac_address, sizeof(mac_address_t));
+            memcpy(sta_info.bssid, assoc_evt_tlv->bssid, sizeof(mac_address_t));
+            memcpy(sta_info.radiomac, get_radio_interface_mac(), sizeof(mac_address_t));
+            sta_info.associated = assoc_event;
+
+            if (assoc_event == false) {
+                updated_any = false;
+
+                for (mld_i = 0; mld_i < dm->get_num_assoc_sta_mld(); mld_i++) {
+                    assoc_info = &dm->m_assoc_sta_mld[mld_i].m_assoc_sta_mld_info;
+                    if (memcmp(assoc_info->mac_addr, sta_info.id, sizeof(mac_address_t)) != 0) {
+                        continue;
+                    }
+                    for (aff_j = 0; aff_j < assoc_info->num_affiliated_sta; aff_j++) {
+                        bool link_radio_resolved = false;
+                        memset(&link_sta, 0, sizeof(em_sta_info_t));
+                        memcpy(link_sta.id, sta_info.id, sizeof(mac_address_t));
+                        memcpy(link_sta.bssid, assoc_info->affiliated_sta[aff_j].bssid, sizeof(mac_address_t));
+                        link_sta.associated = false;
+
+                        aff_bss = NULL;
+                        for (r = 0; r < dm->get_num_radios(); r++) {
+                            aff_bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, link_sta.bssid);
+                            if (aff_bss != NULL) {
+                                memcpy(link_sta.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+                                link_radio_resolved = true;
+                                break;
+                            }
+                        }
+
+                        if (link_radio_resolved == false) {
+                            em_printfout("TOPO_NOTIF_DISASSOC: skipping unresolved affiliated link sta=%s bssid=%s",
+                                    util::mac_to_string(link_sta.id).c_str(),
+                                    util::mac_to_string(link_sta.bssid).c_str());
+                            continue;
+                        }
+
+                        dm_easy_mesh_t::macbytes_to_string(link_sta.bssid, b_str);
+                        dm_easy_mesh_t::macbytes_to_string(link_sta.radiomac, r_str);
+                        snprintf(link_key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, b_str, r_str);
+
+                        assoc_row = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, link_key));
+                        if (assoc_row != NULL) {
+                            assoc_row->m_sta_info.associated = false;
+                            assoc_row->m_sta_info.frame_body_len = 0;
+                            memset(assoc_row->m_sta_info.frame_body, 0, sizeof(assoc_row->m_sta_info.frame_body));
+                        } else {
+                            hash_map_put(dm->m_sta_assoc_map, strdup(link_key), new dm_sta_t(&link_sta));
+                        }
+
+                        sta_row = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_map, link_key));
+                        if (sta_row != NULL) {
+                            sta_row->m_sta_info.associated = false;
+                            sta_row->m_sta_info.frame_body_len = 0;
+                            memset(sta_row->m_sta_info.frame_body, 0, sizeof(sta_row->m_sta_info.frame_body));
+                        }
+
+                        em_printfout("topo notification disassoc key=%s", link_key);
+                        updated_any = true;
+                    }
+                    break;
+                }
+
+                if (updated_any) {
+                    dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
+                } else {
+                    em_printfout("topo notification disassoc: no MLD info for sta=%s",
+                            util::mac_to_string(sta_info.id).c_str());
+                }
+            } else {
+                em_printfout("topo notification assoc defer: sta=%s bssid=%s",
+                        util::mac_to_string(sta_info.id).c_str(),
+                        util::mac_to_string(sta_info.bssid).c_str());
+            }
+
             memcpy(raw.dev, dev_mac, sizeof(mac_address_t));
             memcpy(reinterpret_cast<unsigned char *> (&raw.assoc), reinterpret_cast<unsigned char *> (assoc_evt_tlv), sizeof(em_client_assoc_event_t));
+            if (assoc_event == false) {
+                em_printfout("topo notification disassoc: dispatch dev=%s sta=%s bssid=%s assoc=%d",
+                        util::mac_to_string(dev_mac).c_str(),
+                        util::mac_to_string(assoc_evt_tlv->cli_mac_address).c_str(),
+                        util::mac_to_string(assoc_evt_tlv->bssid).c_str(), assoc_evt_tlv->assoc_event);
+            }
             get_mgr()->io_process(em_bus_event_type_sta_assoc, reinterpret_cast<unsigned char *> (&raw), sizeof(em_bus_event_type_client_assoc_params_t));
             break;
         }
@@ -1595,6 +2269,8 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
     bool found_op_bss = false;
     bool found_profile = false;
     bool found_bss_config_rprt = false;
+    bool found_ap_mld = false;
+    unsigned int assoc_sta_mld_count = 0;
     em_profile_type_t profile = em_profile_type_reserved;
 	dm_easy_mesh_t *dm;
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
@@ -1712,8 +2388,6 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
         }
     }
 
-
-    bool found_ap_mld = false;
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type != em_tlv_type_ap_mld_config) {
             tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
@@ -1732,6 +2406,26 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
         handle_ap_mld_config_tlv(tlv->value, htons(tlv->len));
     }
     em_printfout("No of AP MLDs: %d", dm->m_num_ap_mld);
+
+    // Parse Associated STA MLD Configuration Report TLVs.
+    tlv = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    tmp_len = len - static_cast<unsigned int>(sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    assoc_sta_mld_count = 0;
+    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+        if (tlv->type == em_tlv_type_assoc_sta_mld_conf_rep) {
+            em_printfout("Found Assoc STA MLD Configuration Report TLV #%u", assoc_sta_mld_count);
+            handle_assoc_sta_mld_conf_rep_tlv(tlv->value, htons(tlv->len));
+            assoc_sta_mld_count++;
+        }
+        tmp_len -= static_cast<unsigned int>(sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+    }
+    em_printfout("Total Assoc STA MLD TLVs parsed: %u, m_num_assoc_sta_mld=%u",
+        assoc_sta_mld_count, dm->m_num_assoc_sta_mld);
+
+    if (em_cfg_handle_assoc_sta_mld_topology_updates(dm) == true) {
+        dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
+    }
 
     em_printfout("Src al mac: " MACSTRFMT, MAC2STR(src_al_mac));
 
@@ -1777,6 +2471,81 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
 int em_configuration_t::handle_ack_msg(unsigned char *buff, unsigned int len)
 {
     set_state(em_state_ctrl_ap_mld_req_ack_rcvd);
+    return 0;
+}
+
+
+int em_configuration_t::handle_assoc_sta_mld_conf_rep_tlv(unsigned char *buff, unsigned int len)
+{
+    em_assoc_sta_mld_t *assoc_sta_mld;
+    em_affiliated_sta_mld_t *affiliated_sta_mld;
+    em_assoc_sta_mld_info_t assoc_sta_mld_info;
+    dm_easy_mesh_t *dm;
+    unsigned int j;
+    unsigned int affiliated_payload_len;
+    unsigned int max_affiliated_in_tlv;
+    unsigned int reported_affiliated_count;
+
+    dm = get_data_model();
+
+    if (buff == NULL || len < sizeof(em_assoc_sta_mld_t)) {
+        em_printfout("Invalid assoc STA MLD TLV: buff=%p len=%u", buff, len);
+        return -1;
+    }
+
+    assoc_sta_mld = reinterpret_cast<em_assoc_sta_mld_t *>(buff);
+
+    memset(&assoc_sta_mld_info, 0, sizeof(em_assoc_sta_mld_info_t));
+
+    memcpy(assoc_sta_mld_info.mac_addr, assoc_sta_mld->sta_mld_mac_addr, sizeof(mac_address_t));
+    memcpy(assoc_sta_mld_info.ap_mld_mac_addr, assoc_sta_mld->ap_mld_mac_addr, sizeof(mac_address_t));
+    assoc_sta_mld_info.str   = assoc_sta_mld->str;
+    assoc_sta_mld_info.nstr  = assoc_sta_mld->nstr;
+    assoc_sta_mld_info.emlsr = assoc_sta_mld->emlsr;
+    assoc_sta_mld_info.emlmr = assoc_sta_mld->emlmr;
+
+    affiliated_payload_len = len - static_cast<unsigned int>(sizeof(em_assoc_sta_mld_t));
+    max_affiliated_in_tlv = affiliated_payload_len /
+        static_cast<unsigned int>(sizeof(em_affiliated_sta_mld_t));
+    reported_affiliated_count = assoc_sta_mld->num_affiliated_sta;
+
+    if (reported_affiliated_count > max_affiliated_in_tlv) {
+        em_printfout("Malformed assoc STA MLD TLV: num_affiliated_sta=%u exceeds payload capacity=%u (len=%u)",
+            reported_affiliated_count, max_affiliated_in_tlv, len);
+    }
+
+    assoc_sta_mld_info.num_affiliated_sta = static_cast<unsigned char>(
+        std::min(static_cast<unsigned int>(EM_MAX_AP_MLD),
+                 std::min(reported_affiliated_count, max_affiliated_in_tlv)));
+
+    affiliated_sta_mld = assoc_sta_mld->affiliated_sta_mld;
+    for (j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
+        memcpy(assoc_sta_mld_info.affiliated_sta[j].bssid,
+               affiliated_sta_mld->bssid, sizeof(mac_address_t));
+        memcpy(assoc_sta_mld_info.affiliated_sta[j].mac_addr,
+               affiliated_sta_mld->affiliated_sta_mac_addr, sizeof(mac_address_t));
+        affiliated_sta_mld = reinterpret_cast<em_affiliated_sta_mld_t *>(
+            reinterpret_cast<unsigned char *>(affiliated_sta_mld) + sizeof(em_affiliated_sta_mld_t));
+    }
+
+    em_printfout("Parsed assoc STA MLD: sta_mld_mac=%s ap_mld_mac=%s str=%d nstr=%d emlsr=%d emlmr=%d num_affiliated_sta=%u",
+        util::mac_to_string(assoc_sta_mld_info.mac_addr).c_str(),
+        util::mac_to_string(assoc_sta_mld_info.ap_mld_mac_addr).c_str(),
+        assoc_sta_mld_info.str, assoc_sta_mld_info.nstr,
+        assoc_sta_mld_info.emlsr, assoc_sta_mld_info.emlmr,
+        assoc_sta_mld_info.num_affiliated_sta);
+
+    for (j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
+        em_printfout("affiliated_sta[%u]: bssid=%s mac_addr=%s", j,
+            util::mac_to_string(assoc_sta_mld_info.affiliated_sta[j].bssid).c_str(),
+            util::mac_to_string(assoc_sta_mld_info.affiliated_sta[j].mac_addr).c_str());
+    }
+
+    // Replace existing STA-MLD row to avoid stale affiliated links.
+    dm->remove_assoc_sta_mld_info(assoc_sta_mld_info.mac_addr);
+    dm->update_assoc_sta_mld_info(&assoc_sta_mld_info);
+
+    em_printfout("Updated controller DM assoc STA MLD, m_num_assoc_sta_mld=%u", dm->m_num_assoc_sta_mld);
     return 0;
 }
 
@@ -5274,6 +6043,12 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
         case em_msg_type_topo_notif:
             if ((get_service_type() == em_service_type_ctrl) && (get_state() >= em_state_ctrl_topo_synchronized)) {
                 handle_topology_notification(data, len);
+            }
+            break;
+
+        case em_msg_type_failed_conn:
+            if (get_service_type() == em_service_type_ctrl) {
+                em_printfout("Received failed connection message from agent src_al_mac:%s", util::mac_to_string(src_al_mac).c_str());
             }
             break;
         

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -175,7 +175,11 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_agent_onewifi_bssconfig_ind);
             break;
         case em_cmd_type_sta_assoc:
-            if ((pcmd->get_orch_op() == dm_orch_type_topo_publish) && (m_sm.get_state() == em_state_ctrl_configured)) {
+            if ((pcmd->get_orch_op() == dm_orch_type_topo_sync) && (m_sm.get_state() == em_state_ctrl_configured)) {
+                m_sm.set_state(em_state_ctrl_topo_sync_pending);
+            } else if ((pcmd->get_orch_op() == dm_orch_type_sta_cap) && (m_sm.get_state() == em_state_ctrl_configured)) {
+                m_sm.set_state(em_state_ctrl_sta_cap_pending);
+            } else if (pcmd->get_orch_op() == dm_orch_type_topo_publish) {
                 m_sm.set_state(em_state_ctrl_topo_publish_pending);
             } else {
                 m_sm.set_state(em_state_ctrl_sta_cap_pending);
@@ -287,6 +291,7 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_topo_resp:
         case em_msg_type_topo_query:
         case em_msg_type_topo_notif:
+        case em_msg_type_failed_conn:
         case em_msg_type_ap_mld_config_req:
         case em_msg_type_ap_mld_config_resp:
         case em_msg_type_bss_config_req:
@@ -378,6 +383,21 @@ void em_t::proto_process(em_cmd_event_t *cevt)
             em_metrics_t::process_agent_state(em_cmd_event_type_ap_metrics_report);
             delete ap_cmd;
             m_cmd = saved_cmd;
+            break;
+        }
+        case em_cmd_event_type_failed_connection:
+        {
+            em_connection_status_evt_data_t *failed_conn_evt =
+                static_cast<em_connection_status_evt_data_t *>(cevt->cmd_ptr);
+
+            if (failed_conn_evt != NULL) {
+                handle_failed_connection_event(failed_conn_evt->sta_mac, failed_conn_evt->bssid,
+                                               failed_conn_evt->status_code,
+                                               failed_conn_evt->reason_code,
+                                               failed_conn_evt->reason_code_present);
+                free(failed_conn_evt);
+                cevt->cmd_ptr = NULL;
+            }
             break;
         }
         default:

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -124,6 +124,9 @@ bool em_msg_t::get_bss_id(mac_address_t *mac)
         } else if (tlv->type == em_tlv_type_ap_metrics) {
             memcpy(mac, tlv->value, sizeof(mac_address_t));
             return true;
+        } else if (tlv->type == em_tlv_type_bssid) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
         }
 
         len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
@@ -837,6 +840,7 @@ void em_msg_t::client_disassoc_stats()
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_sta_mac_addr, mandatory, "17.2.23 of Wi-Fi Easy Mesh 5.0", 9);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_reason_code, mandatory, "17.2.64 of Wi-Fi Easy Mesh 5.0", 5);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_assoc_sta_traffic_sts, mandatory, "17.2.35 of Wi-Fi Easy Mesh 5.0", 37);
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_affiliated_sta_metrics, optional, "17.2.100 of Wi-Fi Easy Mesh 6.0", 26);
 }
 void em_msg_t::svc_prio_req()
 {

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -217,6 +217,8 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             } else if (em->get_state() == em_state_ctrl_sta_cap_confirmed) {
                 em->set_state(em_state_ctrl_configured);
                 return true;
+            } else if (em->get_state() == em_state_ctrl_topo_synchronized) {
+                return true;
             } else if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             }
@@ -503,8 +505,9 @@ bool em_orch_ctrl_t::pre_process_orch_op(em_cmd_t *pcmd)
 unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
 {
     em_t *em;
+    std::vector<em_t *> sta_assoc_fallback_ems;
     dm_easy_mesh_t *dm;
-    mac_address_t	bss_mac, rad_mac;
+    mac_address_t	bss_mac, rad_mac, dev_mac;
     unsigned int count = 0, i;
     em_disassoc_params_t *disassoc_param;
     dm_sta_t *sta;
@@ -568,6 +571,7 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
 
             case em_cmd_type_sta_assoc:
                 dm = em->get_data_model();
+                dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[0], dev_mac);
                 dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[1], bss_mac);
                 //em_printfout("BSS for this STA %s is %s", pcmd->m_param.u.args.args[2], pcmd->m_param.u.args.args[1]);
                 for (i = 0; i < dm->m_num_bss; i++) {
@@ -578,6 +582,11 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                         //em_printfout("Found em this STA, candidate count: %d", count);
                         break;
                     }
+                }
+
+                if ((em->is_al_interface_em() == false) &&
+                    (memcmp(dm->get_agent_al_interface_mac(), dev_mac, sizeof(mac_address_t)) == 0)) {
+                    sta_assoc_fallback_ems.push_back(em);
                 }
                 break;
 
@@ -693,6 +702,16 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
         }
         em = static_cast<em_t *>(hash_map_get_next(m_mgr->m_em_map, em));
     }
+
+    if ((pcmd->m_type == em_cmd_type_sta_assoc) && (count == 0) && (!sta_assoc_fallback_ems.empty())) {
+        em_printfout("No per-link BSS match for %s, using %zu fallback radios",
+                pcmd->m_param.u.args.args[1], sta_assoc_fallback_ems.size());
+        for (auto *fallback_em : sta_assoc_fallback_ems) {
+            queue_push(pcmd->m_em_candidates, fallback_em);
+            count++;
+        }
+    }
+
     pthread_mutex_unlock(&m_mgr->m_mutex);
 
     return count;


### PR DESCRIPTION
Reason for change: Added changes to support Client Assoc/Disassoc notification in EasyMesh 
Test Procedure: Ensure Client Assoc/Disassoc notification works properly. 
Risks:Medium
Priority:P1