### PR TITLE
RDKBWIFI-408: X_AIRTIES_BeaconMetricsQuery method for TR-181 added

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -783,6 +783,24 @@ public:
          int analyze_unassoc_sta_metrics_query(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 
 	/**!
+	 * @brief Analyzes the beacon metrics query command.
+	 *
+	 * This function processes the beacon metrics query command provided in the
+	 * em_cmd_t structure array.
+	 *
+	 * @param[in] evt Pointer to the event structure containing event details.
+	 * @param[in] pcmd Array of command structures to be analyzed.
+	 *
+	 * @returns int Number of commands generated into pcmd[]
+	 * @retval 0 No command generated / parse failure
+	 * @retval >0 Number of generated commands
+	 *
+	 * @note Ensure that the pcmd array is properly initialized before calling
+	 * this function.
+	 */
+	int analyze_beacon_metrics_query(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
+	/**!
 	 * @brief Resets the configuration to its default state.
 	 *
 	 * This function is responsible for resetting all configuration settings

--- a/inc/em.h
+++ b/inc/em.h
@@ -769,7 +769,21 @@ public:
 	 */
 	dm_sta_t *find_sta(mac_address_t sta_mac, bssid_t bssid);
 
-    
+    	/**!
+	 * @brief Finds a station based on its MAC address.
+	 *
+	 * This function searches for a station in the network using the provided
+	 * MAC address, and returns a pointer to the station information if found.
+	 *
+	 * @param[in] sta_mac The MAC address of the station to find.
+	 *
+	 * @returns A pointer to the station information (dm_sta_t) if the station
+	 * is found, or NULL if the station is not found.
+	 *
+	 * @note Ensure that the MAC address is valid.
+	 */
+	dm_sta_t *find_sta(mac_address_t sta_mac);
+
 	/**!
 	 * @brief Pushes an event to the queue.
 	 *

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -92,6 +92,7 @@ extern "C"
 #define EM_MAX_NEIGHBORS	16
 #define EM_MAX_CHANNEL_SCAN_RPRT_MSG_LEN		166
 #define EM_MAX_CLIENT_MARKER    5
+#define EM_MAX_ELEMENT_IDS      32
 
 #define   EM_MAX_EVENT_DATA_LEN   4096*100
 #define EM_MAX_CHANNELS_IN_LIST  64
@@ -1172,7 +1173,7 @@ typedef struct {
 
 typedef struct {
     unsigned char num_element_id;
-    unsigned char element_list[6];
+    unsigned char element_list[EM_MAX_ELEMENT_IDS];
 }__attribute__((__packed__)) em_beacon_element_list_t;
 
 typedef struct {
@@ -2340,6 +2341,7 @@ typedef enum {
     em_state_ctrl_bsta_cap_pending,
     em_state_ctrl_topo_publish_pending,
     em_state_ctrl_unassoc_sta_link_metrics_pending, 
+    em_state_ctrl_beacon_query_pending,
 
     em_state_max,
 } em_state_t;
@@ -2387,6 +2389,7 @@ typedef enum {
     em_cmd_type_avail_spectrum_inquiry,
     em_cmd_type_get_mld_config,
     em_cmd_type_mld_reconfig,
+    em_cmd_type_beacon_query,
     em_cmd_type_beacon_report,
     em_cmd_type_ap_metrics_report,
     em_cmd_type_get_reset,
@@ -3081,6 +3084,7 @@ typedef enum {
 	em_bus_event_type_channel_scan_params,
     em_bus_event_type_get_mld_config,
     em_bus_event_type_mld_reconfig,
+    em_bus_event_type_beacon_query,
     em_bus_event_type_beacon_report,
     em_bus_event_type_recv_wfa_action_frame,
     em_bus_event_type_recv_gas_frame,
@@ -3185,6 +3189,7 @@ typedef enum {
     dm_orch_type_sta_disassoc,
     dm_orch_type_policy_cfg,
     dm_orch_type_mld_reconfig,
+    dm_orch_type_beacon_query,
     dm_orch_type_beacon_report,
     dm_orch_type_bsta_cap_query,
     dm_orch_type_link_quality_report,
@@ -3371,6 +3376,8 @@ typedef struct {
 } em_cmd_unassoc_sta_query_params_t;
 
 typedef em_scan_params_t em_cmd_scan_params_t;
+typedef em_beacon_metrics_query_t em_cmd_beacon_metrics_param_t;
+
 typedef struct {
     union {
         em_cmd_args_t	args;
@@ -3380,6 +3387,7 @@ typedef struct {
 		em_cmd_scan_params_t	scan_params;
         em_cmd_ap_metrics_rprt_params_t ap_metrics_params;
         em_cmd_unassoc_sta_query_params_t unassoc_sta_query_params;
+        em_cmd_beacon_metrics_param_t   beacon_metrics_params;
     } u;
 	em_network_node_t *net_node;
 } em_cmd_params_t;

--- a/inc/em_cmd_beacon_query.h
+++ b/inc/em_cmd_beacon_query.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_BEACON_QUERY_H
+#define EM_CMD_BEACON_QUERY_H
+
+#include "em_cmd.h"
+
+class em_cmd_beacon_query_t : public em_cmd_t {
+
+public:
+    
+	/**!
+	 * @brief 
+	 *
+	 * This function handles the beacon metrics query command.
+	 *
+	 * @param[in] param The command parameters for the beacon query.
+	 * @param[in,out] dm The easy mesh data structure to be updated.
+	 *
+	 * @returns em_cmd_beacon_query_t
+	 *
+	 * @note Ensure that the dm structure is properly initialized before calling this function.
+	 */
+	em_cmd_beacon_query_t(em_cmd_params_t param, dm_easy_mesh_t& dm);
+};
+
+#endif
+

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -487,6 +487,17 @@ public:
         void handle_unassoc_sta_metrics_query(em_bus_event_t *evt);
 
 	/**!
+	 * @brief Handles the beacon metrics query event.
+	 *
+	 * This function processes the beacon metrics query event received on the bus.
+	 *
+	 * @param[in] evt Pointer to the event structure containing beacon metrics query details.
+	 *
+	 * @note Ensure that the event structure is properly initialized before calling this function.
+	 */
+	void handle_beacon_metrics_query(em_bus_event_t *evt);
+
+	/**!
 	 * @brief 
 	 * This function handles input/output operations.
 	 *
@@ -797,6 +808,25 @@ public:
 	 * @note Input property ownership remains with the caller; this function does not free them.
 	 */
 	static bus_error_t cmd_clientsteer (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+
+	/**!
+	 * @brief Handles the bus X_AIRTIES_BeaconMetricsQuery method request.
+	 *
+	 * Validates X_AIRTIES_BeaconMetricsQuery input properties, dispatches the request to
+	 * the EasyMesh controller, and optionally populates response properties for the caller.
+	 *
+	 * @param[in] method_name Bus method name (...Radio.{i}.BSS.{i}.STA.{i}.X_AIRTIES_BeaconMetricsQuery).
+	 * @param[in] input_params Linked list of input properties carrying the request payload.
+	 * @param[out] output_params Populated with response properties when provided.
+	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
+	 *
+	 * @returns bus_error_t
+	 * @retval bus_error_none on successful X_AIRTIES_BeaconMetricsQuery handling.
+	 * @retval bus_error_failed on validation or controller execution failure.
+	 *
+	 * @note Input property ownership remains with the caller; this function does not free them.
+	 */
+	static bus_error_t cmd_beaconmetricsquery (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
 
 	/**!
 	 * @brief Handles the bus Disassociate method request.

--- a/inc/em_msg.h
+++ b/inc/em_msg.h
@@ -254,6 +254,19 @@ public:
 	bool get_bss_id(mac_address_t *mac);
     
 	/**!
+	 * @brief Retrieves the STA MAC address.
+	 *
+	 * This function fetches the STA MAC address and stores it in the provided MAC address structure.
+	 *
+	 * @param[out] mac Pointer to a mac_address_t structure where the STA MAC address will be stored.
+	 *
+	 * @returns true if the STA MAC address was successfully retrieved, false otherwise.
+	 *
+	 * @note Ensure that the mac pointer is valid and points to a properly allocated mac_address_t structure.
+	 */
+	bool get_sta_mac(mac_address_t *mac);
+
+	/**!
 	* @brief Retrieves the profile information.
 	*
 	* This function fetches the profile details based on the provided profile type.

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -96,6 +96,8 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define TR181_REQMODE_MAX_LEN      24
 #define TR181_CHITEM_MAX_CNT       8
 #define TR181_STAMAC_MAX_CNT       16
+#define TR181_CHANREP_MAX_CNT      6
+#define TR181_ELEMLIST_MAX_LEN     128
 
 #define MAX_INSTANCE_LEN        32
 #define MAX_CAPS_STR_LEN        32
@@ -112,6 +114,11 @@ typedef struct {
     unsigned int sta_cnt;
     mac_addr_str_t sta_macs[TR181_STAMAC_MAX_CNT];
 } tr181_unassoc_ch_item_t;
+
+typedef struct {
+    int op_class;
+    char ch_list[EM_MAX_CHANNELS_IN_LIST];
+} tr181_bmq_ch_rep_item_t;
 
 /* Device.WiFi.DataElements.Network */
 #define DE_NETWORK_ID           DATAELEMS_NETWORK       "ID"
@@ -395,6 +402,7 @@ typedef struct {
 #define DE_STA_PAIRWSCIPHER     DE_BSS_STA              "PairwiseCipher"
 #define DE_STA_RSNCAPS          DE_BSS_STA              "RSNCapabilities"
 #define DE_STA_CLIENTSTEER      DE_BSS_STA              "ClientSteer()"
+#define DE_STA_BEACONMETRICSQ   DE_BSS_STA              "X_AIRTIES_BeaconMetricsQuery()"
 /* Device.WiFi.DataElements.Network.Device.Radio.BSS.STA.WiFi6Capabilities */
 #define DE_STA_WIFI6CAPS        DE_BSS_STA              "WiFi6Capabilities."
 #define DE_STAWF6CAPS_HE160     DE_STA_WIFI6CAPS        "HE160"
@@ -717,6 +725,27 @@ public:
         bus_data_prop_t *output_data, void *async_handle);
 
     /**!
+     * @brief Handles the RBUS X_AIRTIES_BeaconMetricsQuery method invocation.
+     *
+     * This function extracts X_AIRTIES_BeaconMetricsQuery properties from the raw input
+     * payload, forwards them to the EasyMesh controller, and optionally writes response
+     * properties to the output raw buffer for RBUS callers.
+     *
+     * @param method_name RBUS method name, expected to match X_AIRTIES_BeaconMetricsQuery.
+     * @param input_data Input containing a chained list of bus_data_prop_t entries.
+     * @param output_data Output populated with response properties when provided.
+     * @param async_handle RBUS async handle when the call is asynchronous (may be null).
+     *
+     * @returns bus_error_t
+     * @retval bus_error_none on successful X_AIRTIES_BeaconMetricsQuery handling.
+     * @retval bus_error_failed on validation or controller execution failure.
+     *
+     * @note Ownership of input and output buffers remains with the caller.
+     */
+    static bus_error_t beaconmetricsquery_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
+
+    /**!
      * @brief Handles the RBUS Disassociate method invocation.
      *
      * This function extracts Disassociate properties from the raw input payload, forwards them
@@ -831,6 +860,18 @@ public:
      * @note Returns false on invalid input.
      */
     static bool parse_unassoc_ch_obj(const bus_data_prop_t *prop, tr181_unassoc_ch_item_t *ch_item);
+
+    /**!
+     * @brief Parse the AP channel report object of beacon metrics query from property.
+     *
+     * @param prop Input, property expected to contain a valid name and value pair.
+     * @param ch_rep_item Output, AP channel report object of beacon metrics query.
+     *
+     * @returns bool Result of the operation.
+     *
+     * @note Returns false on invalid input.
+     */
+    static bool parse_bmq_ch_rep_obj(const bus_data_prop_t *prop, tr181_bmq_ch_rep_item_t *ch_rep_item);
 
      /**!
      * @brief Allocate a bus_data_prop_t with a string value.

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -456,9 +456,14 @@ void em_cmd_t::init()
             m_svc = em_service_type_ctrl;
             break;
 
+        case em_cmd_type_beacon_query:
+            snprintf(m_name, sizeof(m_name), "%s", "beacon_query");
+            m_svc = em_service_type_ctrl;
+            break;
+
         case em_cmd_type_beacon_report:
             snprintf(m_name, sizeof(m_name), "%s", "beacon_report");
-            m_svc = em_service_type_ctrl;
+            m_svc = em_service_type_agent;
             break;
 
         case em_cmd_type_get_reset:
@@ -529,6 +534,7 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_link_metrics_query)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_result)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_failed_conn)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_beacon_query)
        
         default:
            break;
@@ -608,6 +614,7 @@ const char *em_cmd_t::get_orch_op_str(dm_orch_type_t type)
         ORCH_TYPE_2S(dm_orch_type_topo_publish)
         ORCH_TYPE_2S(dm_orch_type_unassoc_sta_link_req_query)
 	ORCH_TYPE_2S(dm_orch_type_unassoc_sta_result)
+        ORCH_TYPE_2S(dm_orch_type_beacon_query)
 
         default:
            break;
@@ -660,6 +667,7 @@ const char *em_cmd_t::get_cmd_type_str(em_cmd_type_t type)
         CMD_TYPE_2S(em_cmd_type_set_policy)
         CMD_TYPE_2S(em_cmd_type_get_mld_config)
         CMD_TYPE_2S(em_cmd_type_mld_reconfig)
+        CMD_TYPE_2S(em_cmd_type_beacon_query)
         CMD_TYPE_2S(em_cmd_type_beacon_report)
         CMD_TYPE_2S(em_cmd_type_ap_metrics_report)
         CMD_TYPE_2S(em_cmd_type_get_reset)
@@ -794,6 +802,10 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
 
         case em_bus_event_type_mld_reconfig:
             type = em_cmd_type_mld_reconfig;
+            break;
+
+        case em_bus_event_type_beacon_query:
+            type = em_cmd_type_beacon_query;
             break;
 
         case em_bus_event_type_beacon_report:

--- a/src/cmd/em_cmd_beacon_query.cpp
+++ b/src/cmd/em_cmd_beacon_query.cpp
@@ -33,24 +33,24 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <cjson/cJSON.h>
-#include "em_cmd_beacon_report.h"
+#include "em_cmd_beacon_query.h"
 
-em_cmd_beacon_report_t::em_cmd_beacon_report_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
+em_cmd_beacon_query_t::em_cmd_beacon_query_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
 {
     em_cmd_ctx_t ctx;
 
-    m_type = em_cmd_type_beacon_report;
+    m_type = em_cmd_type_beacon_query;
     memcpy(&m_param, &param, sizeof(em_cmd_params_t));
     
     memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
 
     m_orch_op_idx = 0;
     m_num_orch_desc = 1;
-    m_orch_desc[0].op = dm_orch_type_beacon_report;
+    m_orch_desc[0].op = dm_orch_type_beacon_query;
     m_orch_desc[0].submit = true;
 
-    strncpy(m_name, "beacon_report", strlen("beacon_report") + 1);
-    m_svc = em_service_type_agent;
+    strncpy(m_name, "beacon_query", strlen("beacon_query") + 1);
+    m_svc = em_service_type_ctrl;
     init(dm);
 
     memset(&ctx, 0, sizeof(em_cmd_ctx_t));

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -91,7 +91,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_start_dpp.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_steer.cpp \
      $(top_srcdir)/src/cmd/em_cmd_topo_sync.cpp \
-     $(top_srcdir)/src/cmd/em_cmd_beacon_report.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_beacon_query.cpp \
      $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
      $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
      $(top_srcdir)/src/cmd/em_cmd_bsta_cap.cpp \
@@ -190,7 +190,7 @@ onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
 	$(top_srcdir)/tests/test_l1_em_cmd_get_ssid.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_mld_reconfig.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_sta_link_metrics.cpp	\
-	$(top_srcdir)/tests/test_l1_em_cmd_beacon_report.cpp \
+	$(top_srcdir)/tests/test_l1_em_cmd_beacon_query.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_cfg_renew.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_client_cap.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_get_device.cpp \

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -64,6 +64,7 @@
 #include "em_cmd_mld_reconfig.h"
 #include "em_cmd_bsta_cap.h"
 #include "em_cmd_unassoc_sta_query.h"
+#include "em_cmd_beacon_query.h"
 
 extern em_network_topo_t *g_network_topology;
 
@@ -982,7 +983,7 @@ invalid:
             return bus_error_invalid_input;
         }
     }
-    /* Mandatory parameters: OpClass and ChannelList is any one of them is provided */
+    /* Mandatory parameters: OpClass and ChannelList if any one of them is provided */
     if ((op_class > 0 && !ch_list[0]) || (ch_list[0] && op_class < 0)) {
         em_printfout("Mandatory parameters missing");
         if (output_params) {
@@ -2094,6 +2095,479 @@ invalid:
     */
 
     em_ctrl->io_process(em_bus_event_type_steer_sta, subdoc->buff, json_len);
+    free(json_buff);
+    cJSON_Delete(root);
+
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Success");
+    }
+
+    return bus_error_success;
+
+cleanup:
+    cJSON_Delete(root);
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+    }
+    return rc;
+}
+
+bus_error_t em_ctrl_t::cmd_beaconmetricsquery(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+{
+    (void)async_handle;
+    const char *name = method_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    const bus_data_prop_t *prop = NULL;
+    int op_class = -1;
+    int channel_num = -1;
+    int rep_detail = -1;
+    int ch_rep_idx;
+    unsigned int ch_rep_cnt = 0;
+    const char *wildcard_mac = "FF:FF:FF:FF:FF:FF";
+    char bssid[TR181_BSSID_MAX_LEN + 1] = { 0 };
+    char ssid[TR181_SSID_MAX_LEN + 1] = { 0 };
+    char elem_list[TR181_ELEMLIST_MAX_LEN + 1] = { 0 };
+    tr181_bmq_ch_rep_item_t ch_rep_items[TR181_CHANREP_MAX_CNT] = { 0, 0, 0 };
+    em_subdoc_info_t *subdoc = NULL;
+    alignas(em_subdoc_info_t) unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
+    cJSON *root = NULL, *json = NULL, *net_obj = NULL;
+    cJSON *dev_arr = NULL, *dev_obj = NULL;
+    cJSON *radio_arr = NULL, *radio_obj = NULL;
+    cJSON *bss_arr = NULL, *bss_obj = NULL;
+    cJSON *sta_arr = NULL, *sta_obj = NULL;
+    cJSON *bmquery_obj = NULL;
+    cJSON *chrep_arr = NULL, *chrep_obj = NULL;
+    cJSON *chlist_arr = NULL, *chlist_obj = NULL;
+    cJSON *elemlist_arr = NULL, *elemlist_obj = NULL;
+    mac_addr_str_t mac_str;
+    char *json_buff = NULL;
+    size_t json_len = 0;
+    bus_error_t rc;
+
+    param = (name ? strrchr(name, '.') : NULL);
+    if (param == NULL) {
+        em_printfout("Invalid method name");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+    ++param;
+    if (strcmp("X_AIRTIES_BeaconMetricsQuery()", param) != 0) {
+        em_printfout("Invalid method");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_method;
+    }
+
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!em_ctrl) {
+        em_printfout("Controller not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_general;
+    }
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        em_printfout("Device not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_device_info_t *di = dm->get_device()->get_device_info();
+
+    /* Extract radio instance (numeric or alias), find the radio dm object
+     * for that instance, and finally get info struct for radio dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_radio_t *radio = dm_ctrl->get_dm_radio(dm, instance, is_num);
+    if (radio == NULL) {
+        em_printfout("Radio not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_radio_info_t *ri = radio->get_radio_info();
+
+    /* Extract bss instance (numeric or alias), find the bss dm object
+     * for that instance, and finally get info struct for bss dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_bss_t *bss = dm_ctrl->get_dm_bss(dm, ri, instance, is_num);
+    if (bss == NULL) {
+        em_printfout("BSS not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_bss_info_t *bi = bss->get_bss_info();
+
+    /* Extract sta instance (numeric or alias), find the sta dm object
+     * for that instance, and finally get info struct for sta dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_sta_t *sta = dm_ctrl->get_dm_sta(dm, bi, instance, is_num);
+    if (sta == NULL) {
+        em_printfout("STA not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_sta_info_t *si = sta->get_sta_info();
+
+    /* Most of the parameters are mandatory, parse them */
+    for (prop = input_params; prop; prop = prop->next_data) {
+        if (strcmp(prop->name, "OperatingClass") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &op_class)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "Channel") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &channel_num)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "BSSID") == 0) {
+            if (!tr_181_t::tr181_copy_prop_string(prop, bssid, sizeof(bssid))) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "ReportingDetail") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &rep_detail)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "SSID") == 0) {
+            if (!tr_181_t::tr181_copy_prop_string(prop, ssid, sizeof(ssid))) {
+                goto invalid;
+            }
+        } else if (strncmp(prop->name, "APChannelReport.", sizeof("APChannelReport.") - 1) == 0) {
+            if (!tr_181_t::parse_object_index(prop->name, &ch_rep_idx)) {
+                em_printfout("Parse channel report index failed");
+                goto invalid;
+            }
+            if (ch_rep_idx < 1 || ch_rep_idx > TR181_CHANREP_MAX_CNT) {
+                em_printfout("Invalid channel report index: %d", ch_rep_idx);
+                goto invalid;
+            }
+            if (ch_rep_idx > static_cast<int> (ch_rep_cnt)) {
+                ch_rep_cnt = static_cast<unsigned int> (ch_rep_idx);
+            }
+            --ch_rep_idx;
+            if (!tr_181_t::parse_bmq_ch_rep_obj(prop, &ch_rep_items[ch_rep_idx])) {
+                em_printfout("Parse channel report object failed");
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "ElementIDList") == 0) {
+            if (!tr_181_t::tr181_copy_prop_string(prop, elem_list, sizeof(elem_list))) {
+                goto invalid;
+            }
+        } else {
+invalid:
+            em_printfout("Invalid parameter: %s", prop->name);
+            if (output_params) {
+                *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+            }
+            return bus_error_invalid_input;
+        }
+    }
+    /* Mandatory parameters: OperatingClass, Channel, SSID,
+     *                       APChannelReport if Channel is 255 and
+     *                       ElementIDList if ReportingDetail is 1
+     * Note: Wi-Fi EasyMesh Specification allows SSID to be omitted via setting SSID Length
+     *       field in 17.2.27 to zero (10.3.3), but this implementation mandates SSID to be
+     *       specified. */
+    if (op_class < 0 || channel_num < 0 || !ssid[0] ||
+        (channel_num == 255 && !ch_rep_cnt) || (rep_detail == 1 && !elem_list[0])) {
+        em_printfout("Mandatory parameters missing");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+    for (unsigned int c = 0; c < ch_rep_cnt; c++) {
+        tr181_bmq_ch_rep_item_t *ch_rep_item = &ch_rep_items[c];
+        if (ch_rep_item->op_class <= 0 || !ch_rep_item->ch_list[0]) {
+            em_printfout("Invalid APChannelReport[%d] parameter", c);
+            if (output_params) {
+                *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+            }
+            return bus_error_invalid_input;
+        }
+    }
+    if (!bssid[0]) {
+        /* If BSSID is not provided, use wildcard BBSID */
+        strncpy(bssid, wildcard_mac, sizeof(bssid) - 1);
+    }
+    if (rep_detail < 0 || rep_detail > 2) {
+        /* If reporting detail is not provided or invalid, then it's not needed */
+        rep_detail = 0;
+    }
+
+    /* Prepare subdoc to be processed with command */
+    subdoc = reinterpret_cast<em_subdoc_info_t *>(buff);
+    memset(subdoc, 0, sizeof(em_subdoc_info_t));
+    strncpy(subdoc->name, "BeaconMetricsQuery", sizeof(subdoc->name) - 1);
+
+    /* Create json with root "wfa-dataelements:BeaconMetricsQuery" and fill
+     * with necessary parameters we extract from path */
+    rc = bus_error_out_of_resources;
+    root = cJSON_CreateObject();
+    json = cJSON_CreateObject();
+    if (!root || !json) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(root, "wfa-dataelements:BeaconMetricsQuery", json)) {
+        em_printfout("Add item failed");
+        cJSON_Delete(json);
+        goto cleanup;
+    }
+    /* Add Network parameters */
+    net_obj = cJSON_AddObjectToObject(json, "Network");
+    if (!net_obj) {
+        em_printfout("Add Network failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddStringToObject(net_obj, "ID", GLOBAL_NET_ID)) {
+        em_printfout("Add Network ID failed");
+        goto cleanup;
+    }
+    /* Add Device parameters */
+    dev_arr = cJSON_AddArrayToObject(net_obj, "DeviceList");
+    if (!dev_arr) {
+        em_printfout("Add DeviceList failed");
+        goto cleanup;
+    }
+    dev_obj = cJSON_CreateObject();
+    if (!dev_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(dev_arr, dev_obj)) {
+        em_printfout("Add Device failed");
+        cJSON_Delete(dev_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(di->intf.mac, mac_str);
+    if (!cJSON_AddStringToObject(dev_obj, "ID", mac_str)) {
+        em_printfout("Add Device ID failed");
+        goto cleanup;
+    }
+    /* Add Radio parameters */
+    radio_arr = cJSON_AddArrayToObject(dev_obj, "RadioList");
+    if (!radio_arr) {
+        em_printfout("Add RadioList failed");
+        goto cleanup;
+    }
+    radio_obj = cJSON_CreateObject();
+    if (!radio_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(radio_arr, radio_obj)) {
+        em_printfout("Add Radio failed");
+        cJSON_Delete(radio_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(ri->id.ruid, mac_str);
+    if (!cJSON_AddStringToObject(radio_obj, "ID", mac_str)) {
+        em_printfout("Add Radio ID failed");
+        goto cleanup;
+    }
+    /* Add BSS parameters */
+    bss_arr = cJSON_AddArrayToObject(radio_obj, "BSSList");
+    if (!bss_arr) {
+        em_printfout("Add BSSList failed");
+        goto cleanup;
+    }
+    bss_obj = cJSON_CreateObject();
+    if (!bss_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(bss_arr, bss_obj)) {
+        em_printfout("Add BSS failed");
+        cJSON_Delete(bss_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(bi->bssid.mac, mac_str);
+    if (!cJSON_AddStringToObject(bss_obj, "BSSID", mac_str)) {
+        em_printfout("Add BSSID failed");
+        goto cleanup;
+    }
+    /* Add STA parameters */
+    sta_arr = cJSON_AddArrayToObject(bss_obj, "STAList");
+    if (!sta_arr) {
+        em_printfout("Add STAList failed");
+        goto cleanup;
+    }
+    sta_obj = cJSON_CreateObject();
+    if (!sta_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(sta_arr, sta_obj)) {
+        em_printfout("Add STA failed");
+        cJSON_Delete(sta_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(si->id, mac_str);
+    if (!cJSON_AddStringToObject(sta_obj, "MACAddress", mac_str)) {
+        em_printfout("Add MACAddress failed");
+        goto cleanup;
+    }
+    /* Add method parameters */
+    bmquery_obj = cJSON_CreateObject();
+    if (!bmquery_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(sta_obj, "BeaconMetricsQuery", bmquery_obj)) {
+        em_printfout("Add BeaconMetricsQuery failed");
+        cJSON_Delete(bmquery_obj);
+        goto cleanup;
+    }
+    /* TODO: Validity check of parameters? */
+    if (!cJSON_AddNumberToObject(bmquery_obj, "OperatingClass", op_class)) {
+        em_printfout("Add OperatingClass failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddNumberToObject(bmquery_obj, "Channel", channel_num)) {
+        em_printfout("Add Channel failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddNumberToObject(bmquery_obj, "ReportingDetail", rep_detail)) {
+        em_printfout("Add ReportingDetail failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddStringToObject(bmquery_obj, "BSSID", bssid)) {
+        em_printfout("Add BSSID failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddStringToObject(bmquery_obj, "SSID", ssid)) {
+        em_printfout("Add SSID failed");
+        goto cleanup;
+    }
+    if (channel_num == 255) {
+        chrep_arr = cJSON_AddArrayToObject(bmquery_obj, "APChReportList");
+        if (!chrep_arr) {
+            em_printfout("Add APChReportList array failed");
+            goto cleanup;
+        }
+        for (unsigned int c = 0; c < ch_rep_cnt; c++) {
+            tr181_bmq_ch_rep_item_t *ch_rep_item = &ch_rep_items[c];
+            chrep_obj = cJSON_CreateObject();
+            if (!chrep_obj) {
+                em_printfout("Create object failed");
+                goto cleanup;
+            }
+            if (!cJSON_AddItemToArray(chrep_arr, chrep_obj)) {
+                em_printfout("Add APChReport failed");
+                cJSON_Delete(chrep_obj);
+                goto cleanup;
+            }
+            if (!cJSON_AddNumberToObject(chrep_obj, "OpClass", ch_rep_item->op_class)) {
+                em_printfout("Add OpClass failed");
+                goto cleanup;
+            }
+            chlist_arr = cJSON_AddArrayToObject(chrep_obj, "ChannelList");
+            if (!chlist_arr) {
+                em_printfout("Add ChannelList array failed");
+                goto cleanup;
+            }
+            std::string chlist_str = ch_rep_item->ch_list;
+            std::vector<std::string> channels = util::split_by_delim(chlist_str, ',');
+            for (unsigned int i = 0; i < channels.size(); i++) {
+                char *ep = NULL;
+                int channel = static_cast<int> (std::strtol(channels[i].c_str(), &ep, 10));
+                if (ep == channels[i].c_str() || *ep != '\0') {
+                    em_printfout("Invalid channel");
+                    rc = bus_error_invalid_input;
+                    goto cleanup;
+                }
+                chlist_obj = cJSON_CreateNumber(channel);
+                if (!chlist_obj) {
+                    em_printfout("Create number failed");
+                    goto cleanup;
+                }
+                if (!cJSON_AddItemToArray(chlist_arr, chlist_obj)) {
+                    em_printfout("Add item failed");
+                    cJSON_Delete(chlist_obj);
+                    goto cleanup;
+                }
+            }
+        }
+    }
+    if (rep_detail == 1) {
+        elemlist_arr = cJSON_AddArrayToObject(bmquery_obj, "ElementList");
+        if (!elemlist_arr) {
+            em_printfout("Add ElementList array failed");
+            goto cleanup;
+        }
+        std::string elemlist_str = elem_list;
+        std::vector<std::string> elements = util::split_by_delim(elemlist_str, ',');
+        for (unsigned int i = 0; i < elements.size(); i++) {
+            char *ep = NULL;
+            int element = static_cast<int> (std::strtol(elements[i].c_str(), &ep, 10));
+            if (ep == elements[i].c_str() || *ep != '\0') {
+                em_printfout("Invalid element");
+                rc = bus_error_invalid_input;
+                goto cleanup;
+            }
+            elemlist_obj = cJSON_CreateNumber(element);
+            if (!elemlist_obj) {
+                em_printfout("Create number failed");
+                goto cleanup;
+            }
+            if (!cJSON_AddItemToArray(elemlist_arr, elemlist_obj)) {
+                em_printfout("Add item failed");
+                cJSON_Delete(elemlist_obj);
+                goto cleanup;
+            }
+        }
+    }
+
+    /* Convert JSON back to string and store in subdoc buffer. */
+    json_buff = cJSON_PrintUnformatted(root);
+    if (!json_buff) {
+        em_printfout("Create output buffer failed");
+        rc = bus_error_out_of_resources;
+        goto cleanup;
+    }
+    /* Ensure updated JSON fits in buffer. */
+    json_len = strlen(json_buff);
+    if (json_len >= EM_IO_BUFF_SZ) {
+        em_printfout("Buffer too big for subdoc");
+        free(json_buff);
+        rc = bus_error_invalid_input;
+        goto cleanup;
+    }
+    memcpy(subdoc->buff, json_buff, json_len);
+    subdoc->buff[json_len] = '\0';
+
+    // uncomment below lines to log the updated JSON before sending to DM; can be helpful for debugging.
+    /*
+    cJSON *json_obj;
+    json_obj = cJSON_Parse(subdoc->buff);
+    if (json_obj) {
+        char *new_json = cJSON_Print(json_obj);
+        em_printfout("Updated and formatted JSON:\n%s", new_json);
+        free(new_json);
+        cJSON_Delete(json_obj);
+    } else {
+        em_printfout("Invalid JSON in subdoc->buff");
+    }
+    */
+
+    em_ctrl->io_process(em_bus_event_type_beacon_query, subdoc->buff, static_cast<unsigned int>(json_len + 1U));
     free(json_buff);
     cJSON_Delete(root);
 
@@ -3875,6 +4349,224 @@ int dm_easy_mesh_ctrl_t::analyze_bsta_cap_req(em_bus_event_t *evt, em_cmd_t *pcm
 
     pcmd[num] = new em_cmd_bsta_cap_t(evt->params, dm);
     num++;
+
+    return num;
+}
+
+int dm_easy_mesh_ctrl_t::analyze_beacon_metrics_query(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    dm_easy_mesh_t dm = *this;
+    em_subdoc_info_t *subdoc;
+    cJSON *root, *wfa_obj, *net_obj;
+    cJSON *dev_arr, *dev_obj;
+    cJSON *radio_arr, *radio_obj;
+    cJSON *bss_arr, *bss_obj;
+    cJSON *sta_arr, *sta_obj;
+    cJSON *bmquery_obj, *mac_obj, *op_class_obj, *channel_obj, *bssid_obj, *rprt_obj, *ssid_obj;
+    cJSON *chrep_arr, *chrep_obj, *chlist_arr, *chlist_obj, *elemlist_arr, *elemlist_obj;
+    int num = 0;
+    em_cmd_t *tmp;
+
+    subdoc = &evt->u.subdoc;
+    root = cJSON_Parse(subdoc->buff);
+    if (root == NULL) {
+        return 0;
+    }
+
+    if ((wfa_obj = cJSON_GetObjectItem(root, "wfa-dataelements:BeaconMetricsQuery")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    if ((net_obj = cJSON_GetObjectItem(wfa_obj, "Network")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+
+    if ((dev_arr = cJSON_GetObjectItem(net_obj, "DeviceList")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    if (cJSON_GetArraySize(dev_arr) == 0 || (dev_obj = cJSON_GetArrayItem(dev_arr, 0)) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+
+    if ((radio_arr = cJSON_GetObjectItem(dev_obj, "RadioList")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    if (cJSON_GetArraySize(radio_arr) == 0 || (radio_obj = cJSON_GetArrayItem(radio_arr, 0)) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+
+    if ((bss_arr = cJSON_GetObjectItem(radio_obj, "BSSList")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    if (cJSON_GetArraySize(bss_arr) == 0 || (bss_obj = cJSON_GetArrayItem(bss_arr, 0)) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    if ((sta_arr = cJSON_GetObjectItem(bss_obj, "STAList")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    if (cJSON_GetArraySize(sta_arr) == 0 || (sta_obj = cJSON_GetArrayItem(sta_arr, 0)) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+
+    em_cmd_beacon_metrics_param_t *beacon_params = &evt->params.u.beacon_metrics_params;
+
+    if ((mac_obj = cJSON_GetObjectItem(sta_obj, "MACAddress")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    char *sta_mac_str = cJSON_GetStringValue(mac_obj);
+    if (!sta_mac_str) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    dm_easy_mesh_t::string_to_macbytes(sta_mac_str, beacon_params->sta_mac_addr);
+
+    if ((bmquery_obj = cJSON_GetObjectItem(sta_obj, "BeaconMetricsQuery")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    if ((op_class_obj = cJSON_GetObjectItem(bmquery_obj, "OperatingClass")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    beacon_params->op_class = static_cast<unsigned char> (cJSON_GetNumberValue(op_class_obj));
+
+    if ((channel_obj = cJSON_GetObjectItem(bmquery_obj, "Channel")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    beacon_params->channel_num = static_cast<unsigned char> (cJSON_GetNumberValue(channel_obj));
+
+    if ((bssid_obj = cJSON_GetObjectItem(bmquery_obj, "BSSID")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    char *bssid_str = cJSON_GetStringValue(bssid_obj);
+    if (!bssid_str) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    dm_easy_mesh_t::string_to_macbytes(bssid_str, beacon_params->bssid);
+
+    if ((rprt_obj = cJSON_GetObjectItem(bmquery_obj, "ReportingDetail")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    beacon_params->rprt_detail = static_cast<unsigned char> (cJSON_GetNumberValue(rprt_obj));
+    if (beacon_params->rprt_detail > 2) {
+        cJSON_Delete(root);
+        return 0;
+    }
+
+    if ((ssid_obj = cJSON_GetObjectItem(bmquery_obj, "SSID")) == NULL) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    const char *ssid_str = cJSON_GetStringValue(ssid_obj);
+    if (!ssid_str) {
+        cJSON_Delete(root);
+        return 0;
+    }
+    size_t ssid_len = strnlen(ssid_str, sizeof(beacon_params->ssid) - 1U);
+    beacon_params->ssid_len = static_cast<unsigned char> (ssid_len);
+    memcpy(beacon_params->ssid, ssid_str, ssid_len);
+    beacon_params->ssid[ssid_len] = '\0';
+
+
+    if (beacon_params->channel_num == 255) {
+        if ((chrep_arr = cJSON_GetObjectItem(bmquery_obj, "APChReportList")) == NULL) {
+            cJSON_Delete(root);
+            return 0;
+        }
+        beacon_params->num_ap_channel_rprt = static_cast<unsigned char> (cJSON_GetArraySize(chrep_arr));
+        if (!beacon_params->num_ap_channel_rprt ||
+            (beacon_params->num_ap_channel_rprt > ARRAY_SIZE(beacon_params->ap_channel_rprt))) {
+            cJSON_Delete(root);
+            return 0;
+        }
+
+        for (int i = 0; i < beacon_params->num_ap_channel_rprt; i++) {
+            if ((chrep_obj = cJSON_GetArrayItem(chrep_arr, i)) == NULL) {
+                cJSON_Delete(root);
+                return 0;
+            }
+            if ((op_class_obj = cJSON_GetObjectItem(chrep_obj, "OpClass")) == NULL) {
+                cJSON_Delete(root);
+                return 0;
+            }
+            beacon_params->ap_channel_rprt[i].ap_channel_op_class =
+                static_cast<unsigned char> (cJSON_GetNumberValue(op_class_obj));
+
+            if ((chlist_arr = cJSON_GetObjectItem(chrep_obj, "ChannelList")) == NULL) {
+                cJSON_Delete(root);
+                return 0;
+            }
+            beacon_params->ap_channel_rprt[i].ap_channel_rprt_len =
+                static_cast<unsigned char> (cJSON_GetArraySize(chlist_arr));
+            if (!beacon_params->ap_channel_rprt[i].ap_channel_rprt_len ||
+                (beacon_params->ap_channel_rprt[i].ap_channel_rprt_len >
+                ARRAY_SIZE(beacon_params->ap_channel_rprt[i].ap_channel_list))) {
+                cJSON_Delete(root);
+                return 0;
+            }
+
+            for (int j = 0; j < beacon_params->ap_channel_rprt[i].ap_channel_rprt_len; j++) {
+                if ((chlist_obj = cJSON_GetArrayItem(chlist_arr, j)) == NULL) {
+                    cJSON_Delete(root);
+                    return 0;
+                }
+                beacon_params->ap_channel_rprt[i].ap_channel_list[j] =
+                    static_cast<unsigned char> (cJSON_GetNumberValue(chlist_obj));
+            }
+        }
+    } else {
+        beacon_params->num_ap_channel_rprt = 0;
+        memset(beacon_params->ap_channel_rprt, 0, sizeof(beacon_params->ap_channel_rprt));
+    }
+
+    if (beacon_params->rprt_detail == 1) {
+        if ((elemlist_arr = cJSON_GetObjectItem(bmquery_obj, "ElementList")) == NULL) {
+            cJSON_Delete(root);
+            return 0;
+        }
+        beacon_params->element_list.num_element_id = static_cast<unsigned char> (cJSON_GetArraySize(elemlist_arr));
+        if (!beacon_params->element_list.num_element_id ||
+            (beacon_params->element_list.num_element_id > ARRAY_SIZE(beacon_params->element_list.element_list))) {
+            cJSON_Delete(root);
+            return 0;
+        }
+
+        for (int i = 0; i < beacon_params->element_list.num_element_id; i++) {
+            if ((elemlist_obj = cJSON_GetArrayItem(elemlist_arr, i)) == NULL) {
+                cJSON_Delete(root);
+                return 0;
+            }
+            beacon_params->element_list.element_list[i] = static_cast<unsigned char> (cJSON_GetNumberValue(elemlist_obj));
+        }
+    } else {
+        beacon_params->element_list.num_element_id = 0;
+        memset(&beacon_params->element_list, 0, sizeof(beacon_params->element_list));
+    }
+
+    cJSON_Delete(root);
+
+    pcmd[num] = new em_cmd_beacon_query_t(evt->params, dm);
+    tmp = pcmd[num];
+    num++;
+
+    while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
+        tmp = pcmd[num];
+        num++;
+    }
 
     return num;
 }

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -630,6 +630,22 @@ void em_ctrl_t::handle_failed_conn_msg(unsigned char *data, unsigned int len)
 }
 
 
+void em_ctrl_t::handle_beacon_metrics_query(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    int num;
+
+    if (m_orch->is_cmd_type_in_progress(evt) == true) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
+    } else if ((num = m_data_model.analyze_beacon_metrics_query(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
+    } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_success);
+    } else {
+        m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+    }
+}
+
 void em_ctrl_t::handle_dirty_dm()
 {
 	m_data_model.handle_dirty_dm();
@@ -800,6 +816,10 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
 
 	case em_bus_event_type_unassoc_sta_query:
            handle_unassoc_sta_metrics_query(evt);
+           break;
+	
+        case em_bus_event_type_beacon_query:
+           handle_beacon_metrics_query(evt);
            break;
 
         default:
@@ -1366,6 +1386,9 @@ void em_ctrl_t::start_complete()
             { bus_data_type_property, false, 0, 0, 0, NULL } },
         { const_cast<char*>(DE_STA_CLIENTSTEER), bus_element_type_method,
             { NULL, NULL , NULL, NULL, NULL, tr_181_t::clientsteer_handler}, slow_speed, ZERO_TABLE,
+            { bus_data_type_property, false, 0, 0, 0, NULL } },
+        { const_cast<char*>(DE_STA_BEACONMETRICSQ), bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, tr_181_t::beaconmetricsquery_handler}, slow_speed, ZERO_TABLE,
             { bus_data_type_property, false, 0, 0, 0, NULL } },
         { const_cast<char*>(DE_STAMAP_DISASSOC), bus_element_type_method,
             { NULL, NULL , NULL, NULL, NULL, tr_181_t::disassociate_handler}, slow_speed, ZERO_TABLE,

--- a/src/ctrl/tr_181/wfa_data_model/tr_181_helper.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181_helper.cpp
@@ -396,3 +396,34 @@ bool tr_181_t::parse_unassoc_ch_obj(const bus_data_prop_t *prop, tr181_unassoc_c
     return true;
 }
 
+bool tr_181_t::parse_bmq_ch_rep_obj(const bus_data_prop_t *prop, tr181_bmq_ch_rep_item_t *ch_rep_item)
+{
+     if (!prop || !prop->name || !ch_rep_item) {
+         return false;
+     }
+
+    const char *name = prop->name;
+
+    /* APChannelReport.{i}.OperatingClass or APChannelReport.{i}.ChannelList */
+    name += sizeof("APChannelReport");
+    name  = strstr(name, ".");
+    if (!name) {
+        return false;
+    }
+
+    ++name;
+    if (strcmp(name, "OperatingClass") == 0) {
+        if (!tr_181_t::tr181_get_prop_int(prop, &ch_rep_item->op_class)) {
+            return false;
+        }
+    } else if (strcmp(name, "ChannelList") == 0) {
+        if (!tr_181_t::tr181_copy_prop_string(prop, ch_rep_item->ch_list, sizeof(ch_rep_item->ch_list))) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    return true;
+}
+

--- a/src/ctrl/tr_181/wfa_data_model/tr_181_method.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181_method.cpp
@@ -333,6 +333,58 @@ bus_error_t tr_181_t::clientsteer_handler(const char *method_name, bus_data_prop
     return rc;
 }
 
+bus_error_t tr_181_t::beaconmetricsquery_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
+{
+    // Standardize input pointer checks
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
+        em_printfout("Invalid input_data or missing input_props");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_data_prop_t *input_props = input_data;
+    bus_data_prop_t *output_props = NULL;
+
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
+    // Log all chained input properties
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
+    }
+
+    em_ctrl_t *ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!ctrl) {
+        em_printfout("Controller unavailable");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: controller unavailable");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_error_t rc = ctrl->cmd_beaconmetricsquery(method_name, input_props, output_data ? &output_props : NULL, async_handle);
+
+    if (output_data && output_props) {
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
+    }
+
+    return rc;
+}
+
 bus_error_t tr_181_t::disassociate_handler(const char *method_name, bus_data_prop_t *input_data,
     bus_data_prop_t *output_data, void *async_handle)
 {

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -239,6 +239,10 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_ctrl_ap_mld_config_pending);
             break;
 
+        case em_cmd_type_beacon_query:
+            m_sm.set_state(em_state_ctrl_beacon_query_pending);
+            break;
+
         case em_cmd_type_beacon_report:
             m_sm.set_state(em_state_agent_beacon_report_pending);
             break;
@@ -576,6 +580,10 @@ void em_t::handle_ctrl_state()
             break;
 
         case em_cmd_type_unassoc_sta_query:
+            em_metrics_t::process_ctrl_state();
+            break;
+
+        case em_cmd_type_beacon_query:
             em_metrics_t::process_ctrl_state();
             break;
 
@@ -965,6 +973,23 @@ dm_sta_t *em_t::find_sta(mac_address_t sta_mac, bssid_t bssid)
     dm_sta_t *sta;
 
     sta = get_data_model()->find_sta(sta_mac, bssid);
+    if (sta == NULL) {
+        return NULL;
+    }
+
+    // the sta can be from a different radio
+    if (memcmp(sta->m_sta_info.radiomac, get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
+        return sta;
+    }
+
+    return NULL;
+}
+
+dm_sta_t *em_t::find_sta(mac_address_t sta_mac)
+{
+    dm_sta_t *sta;
+
+    sta = get_data_model()->find_sta(sta_mac);
     if (sta == NULL) {
         return NULL;
     }
@@ -2879,6 +2904,7 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_ctrl_bsta_cap_pending)
         EM_STATE_2S(em_state_ctrl_topo_publish_pending)
 	EM_STATE_2S(em_state_ctrl_unassoc_sta_link_metrics_pending)
+	EM_STATE_2S(em_state_ctrl_beacon_query_pending)
         EM_STATE_2S(em_state_agent_unconfigured)
         EM_STATE_2S(em_state_agent_autoconfig_rsp_pending)
         EM_STATE_2S(em_state_agent_wsc_m2_pending)

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -168,6 +168,51 @@ bool em_msg_t::get_profile(em_profile_type_t *profile)
     return false;
 }
 
+bool em_msg_t::get_sta_mac(mac_address_t *mac)
+{
+    em_tlv_t    *tlv;
+    unsigned int len;
+
+    if (mac == nullptr) {
+        em_printfout("Error: NULL mac");
+        return false;
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *> (m_buff);
+    len = m_len;
+
+    while ((len >= sizeof(em_tlv_t)) && (tlv->type != em_tlv_type_eom)) {
+        const uint16_t value_len = ntohs(tlv->len);
+        if (len < (sizeof(em_tlv_t) + value_len)) {
+            em_printfout("Error: length mismatch");
+            return false;
+        }
+
+        if (tlv->type == em_tlv_type_client_info) {
+            if (value_len < (2U * sizeof(mac_address_t))) {
+                em_printfout("Error: tlv data too small");
+                return false;
+            }
+            memcpy(mac, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
+            return true;
+        } else if ((tlv->type == em_tlv_type_client_assoc_event) ||
+                   (tlv->type == em_tlv_type_bcon_metric_query) ||
+                   (tlv->type == em_tlv_type_assoc_sta_link_metric)) {
+            if (value_len < sizeof(mac_address_t)) {
+                em_printfout("Error: tlv data too small");
+                return false;
+            }
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
+        }
+
+        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + value_len);
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + value_len);
+    }
+
+    return false;
+}
+
 bool em_msg_t::get_bss_id(mac_address_t *mac)
 {
     em_tlv_t    *tlv;
@@ -179,9 +224,6 @@ bool em_msg_t::get_bss_id(mac_address_t *mac)
             memcpy(mac, tlv->value, sizeof(mac_address_t));
             return true;
         } else if (tlv->type == em_tlv_type_client_assoc_event) {
-            memcpy(mac, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
-            return true;
-        } else if (tlv->type == em_tlv_type_client_info) {
             memcpy(mac, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
             return true;
         } else if (tlv->type == em_tlv_type_ap_metrics) {

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -2581,7 +2581,10 @@ void em_metrics_t::process_ctrl_state()
         case em_state_ctrl_unassoc_sta_link_metrics_pending:
             send_unassoc_sta_link_metrics_query_msg();
             break;
-	    
+
+        case em_state_ctrl_beacon_query_pending:
+            break;
+
         default:
             printf("%s:%d: unhandled case %s\n", __func__, __LINE__, em_t::state_2_str(get_state()));
             break;

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -302,6 +302,12 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
+        case em_cmd_type_beacon_query:
+            if (em->get_state() == em_state_ctrl_configured) {
+                return true;
+            }
+            break;
+
         default:
             break;
     }
@@ -361,6 +367,7 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_set_policy:
         case em_cmd_type_bsta_cap:
 	case em_cmd_type_unassoc_sta_query:
+        case em_cmd_type_beacon_query:
             if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             }
@@ -554,6 +561,7 @@ bool em_orch_ctrl_t::pre_process_orch_op(em_cmd_t *pcmd)
 
         case dm_orch_type_topo_publish:
         case dm_orch_type_bsta_cap_query:
+        case dm_orch_type_beacon_query:
 			break;
 
         default:
@@ -772,9 +780,17 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
 		    count++;
 		}		
 		break;
-	    default:
-		break;
-	}
+
+            case em_cmd_type_beacon_query:
+                if (em->find_sta(pcmd->m_param.u.beacon_metrics_params.sta_mac_addr) != NULL) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+                break;
+
+            default:
+                break;
+        }
         em = static_cast<em_t *>(hash_map_get_next(m_mgr->m_em_map, em));
     }
 

--- a/tests/test_l1_em_cmd_beacon_query.cpp
+++ b/tests/test_l1_em_cmd_beacon_query.cpp
@@ -1,0 +1,246 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <stdio.h>
+#include "em_cmd_beacon_query.h"
+
+
+
+/**
+ * @brief Verify that em_cmd_beacon_query_t is created correctly with valid parameters.
+ *
+ * This test verifies that the em_cmd_beacon_query_t API initializes all members with the expected valid parameter values. 
+ * It checks that the fixed argument, the first argument value, the number of arguments, and various object properties 
+ * (such as command type, operation index, descriptor, name, and service type) are correctly set upon construction. 
+ * @n
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 001@n
+ * **Priority:** High@n
+ * @n
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ * @n
+ * **Test Procedure:**@n
+ * | Variation / Step | Description | Test Data | Expected Result | Notes |
+ * | :----: | --------- | ---------- |-------------- | ----- |
+ * | 01 | Log the entering test message | None | "Entering em_cmd_beacon_query_t_create_valid_parameters test" printed | Should be successful |
+ * | 02 | Initialize the fixed_args field with a valid string | param.u.args.fixed_args = "ValidFixedArguments" | fixed_args is set correctly with a null terminator | Should be successful |
+ * | 03 | Initialize the first argument in args array with a valid string | param.u.args.args[0] = "Argument1" | args[0] is set correctly with a null terminator | Should be successful |
+ * | 04 | Set the number of arguments | param.u.args.num_args = 1 | num_args equals 1 | Should be successful |
+ * | 05 | Log the API invocation details with fixed_args and argument value | Printed message with param.u.args.fixed_args and param.u.args.args[0] values | Correct invocation message is printed | Should be successful |
+ * | 06 | Create the em_cmd_beacon_query_t object with valid parameters | Invocation using: fixed_args = "ValidFixedArguments", args[0] = "Argument1", num_args = 1, dm instance | Object is instantiated with proper member initialization | Should Pass |
+ * | 07 | Validate object member values using assertions | Expected: fixed_args = "ValidFixedArguments", num_args = 1, args[0] = "Argument1", m_type = em_cmd_type_beacon_query, m_orch_op_idx = 0, m_num_orch_desc = 1, m_orch_desc[0].submit = true, m_name = "beacon_query", m_orch_desc[0].op = dm_orch_type_beacon_query, m_svc = em_service_type_ctrl, m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_query | All assertions pass confirming correct values | Should Pass |
+ * | 08 | Deinitialize the command object | Call cmd.deinit() | Resources are released and object is deinitialized properly | Should be successful |
+ * | 09 | Log the exiting test message | None | "Exiting em_cmd_beacon_query_t_create_valid_parameters test" printed | Should be successful |
+ */
+TEST(em_cmd_beacon_query_t, em_cmd_beacon_query_t_create_valid_parameters) {
+    std::cout << "Entering em_cmd_beacon_query_t_create_valid_parameters test" << std::endl;
+    em_cmd_params_t param{};
+    const char *fixedStr = "ValidFixedArguments";
+    strncpy(param.u.args.fixed_args, fixedStr, sizeof(param.u.args.fixed_args) - 1);
+    param.u.args.fixed_args[sizeof(param.u.args.fixed_args) - 1] = '\0';
+    const char *arg0 = "Argument1";
+    strncpy(param.u.args.args[0], arg0, sizeof(param.u.args.args[0]) - 1);
+    param.u.args.args[0][sizeof(param.u.args.args[0]) - 1] = '\0';
+    param.u.args.num_args = 1;
+    dm_easy_mesh_t dm;
+    std::cout << "Invoking em_cmd_beacon_query_t with fixed_args: " << param.u.args.fixed_args << " and argument[0]: " << param.u.args.args[0] << std::endl;
+    em_cmd_beacon_query_t cmd(param, dm);
+    EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "ValidFixedArguments");
+    EXPECT_EQ(cmd.m_param.u.args.num_args, 1);
+    EXPECT_STREQ(cmd.m_param.u.args.args[0], "Argument1");
+    EXPECT_EQ(cmd.m_type, em_cmd_type_beacon_query);
+    EXPECT_EQ(cmd.m_orch_op_idx, 0);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
+    EXPECT_TRUE(cmd.m_orch_desc[0].submit);
+    EXPECT_STREQ(cmd.m_name, "beacon_query");
+    EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_beacon_query);
+    EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
+    EXPECT_EQ(cmd.m_data_model.m_cmd_ctx.type, dm_orch_type_beacon_query);
+    cmd.deinit();
+    std::cout << "Exiting em_cmd_beacon_query_t_create_valid_parameters test" << std::endl;
+}
+/**
+ * @brief Test the creation of a beacon_query command with edge case parameter lengths
+ *
+ * This test confirms that the em_cmd_beacon_query_t command is properly initialized when provided with edge-case parameter lengths.
+ * Specifically, it verifies that the fixed argument string and each argument in the args array are correctly set to their maximum edge-case values,
+ * and that all member fields of the beacon query command match the expected values after initialization.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 002@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description | Test Data | Expected Result | Notes |
+ * | :----: | --------- | ---------- |-------------- | ----- |
+ * | 01 | Initialize test parameters by filling fixed_args with 'X' and each argument in args with 'Y', and setting num_args to EM_CLI_MAX_ARGS | fixed_args = 'X' repeated (sizeof(fixed_args)-1), args = 'Y' repeated (sizeof(each args element)-1), num_args = EM_CLI_MAX_ARGS | All parameters are correctly initialized with edge-case lengths | Should be successful |
+ * | 02 | Invoke the em_cmd_beacon_query_t constructor with the initialized param and dm instance | Input: param (with fixed_args and args as set above), dm instance | beaconQuery instance is created with proper initialization of its internal fields | Should Pass |
+ * | 03 | Validate beaconQuery fields using assertions (m_type, m_orch_op_idx, m_num_orch_desc, m_name, m_orch_desc, m_svc, m_data_model, and parameter consistency) | Expected: m_type = em_cmd_type_beacon_query, m_orch_op_idx = 0, m_num_orch_desc = 1, m_name = "beacon_query", m_orch_desc[0].submit = true, m_orch_desc[0].op = dm_orch_type_beacon_query, m_svc = em_service_type_ctrl, m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_query, and parameters match input | All member fields satisfy the expected conditions and assertions pass | Should Pass |
+ * | 04 | Deinitialize the beaconQuery instance by calling deinit() | N/A | Resources are properly released without error | Should be successful |
+ */
+TEST(em_cmd_beacon_query_t, em_cmd_beacon_query_t_create_edge_case_parameter_lengths) {
+    std::cout << "Entering em_cmd_beacon_query_t_create_edge_case_parameter_lengths test" << std::endl;
+    em_cmd_params_t param{};
+    memset(param.u.args.fixed_args, 'X', sizeof(param.u.args.fixed_args) - 1);
+    param.u.args.fixed_args[sizeof(param.u.args.fixed_args) - 1] = '\0';
+    const int maxArgs = EM_CLI_MAX_ARGS;
+    for (int i = 0; i < maxArgs; i++) {
+        memset(param.u.args.args[i], 'Y', sizeof(param.u.args.args[i]) - 1);
+        param.u.args.args[i][sizeof(param.u.args.args[i]) - 1] = '\0';
+    }
+    param.u.args.num_args = maxArgs;
+    dm_easy_mesh_t dm;
+    std::cout << "Invoking em_cmd_beacon_query_t with fixed_args (first 20 chars): "  << std::string(param.u.args.fixed_args, 20) << "..." << std::endl;
+    em_cmd_beacon_query_t beaconQuery(param, dm);
+    EXPECT_EQ(beaconQuery.m_type, em_cmd_type_beacon_query);
+    EXPECT_EQ(beaconQuery.m_orch_op_idx, 0);
+    EXPECT_EQ(beaconQuery.m_num_orch_desc, 1);
+    EXPECT_TRUE(beaconQuery.m_orch_desc[0].submit);
+    EXPECT_STREQ(beaconQuery.m_name, "beacon_query");
+    EXPECT_EQ(beaconQuery.m_orch_desc[0].op, dm_orch_type_beacon_query);
+    EXPECT_EQ(beaconQuery.m_svc, em_service_type_ctrl);
+    EXPECT_EQ(beaconQuery.m_data_model.m_cmd_ctx.type, dm_orch_type_beacon_query);
+    EXPECT_EQ(memcmp(beaconQuery.m_param.u.args.fixed_args, param.u.args.fixed_args, sizeof(param.u.args.fixed_args)), 0);
+    EXPECT_EQ(beaconQuery.m_param.u.args.num_args, maxArgs);
+    for (int i = 0; i < maxArgs; i++) {
+        EXPECT_EQ(
+            memcmp(beaconQuery.m_param.u.args.args[i],
+                   param.u.args.args[i],
+                   sizeof(param.u.args.args[i])),
+            0
+        );
+    }
+    beaconQuery.deinit();
+    std::cout << "Exiting em_cmd_beacon_query_t_create_edge_case_parameter_lengths test" << std::endl;
+}
+/**
+ * @brief Validates that the em_cmd_beacon_query_t object initializes correctly with minimal valid parameters.
+ *
+ * This test verifies that when the minimal valid fixed arguments ("a") and a minimal command argument ("b") are provided,
+ * the em_cmd_beacon_query_t constructor correctly initializes the associated member variables. It ensures all fields are set as expected,
+ * matching the provided inputs and default values, and that the proper command type and service are assigned.
+ *
+ * **Test Group ID:** Basic: 01
+ * **Test Case ID:** 003
+ * **Priority:** High
+ *
+ * **Pre-Conditions:** None
+ * **Dependencies:** None
+ * **User Interaction:** None
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description | Test Data | Expected Result | Notes |
+ * | :----: | --------- | ---------- |-------------- | ----- |
+ * | 01 | Initialize minimal fixed_args and argument values; assign num_args. | fixed_args = "a", args[0] = "b", num_args = 1 | The parameters structure is populated with minimal valid values. | Should be successful |
+ * | 02 | Instantiate the dm_easy_mesh_t object required by the command. | dm instance created with default initialization | dm_easy_mesh_t object created successfully. | Should be successful |
+ * | 03 | Invoke the em_cmd_beacon_query_t constructor with the minimal valid parameters and dm instance. | param (with fixed_args "a", args[0] "b", num_args = 1), dm | A beaconQuery object is created with member variables set based on the input parameters and default configurations. | Should Pass |
+ * | 04 | Validate that fixed_args in beaconQuery matches the minimal fixed_args "a". | input: m_param.u.args.fixed_args = "a" | EXPECT_STREQ confirms "a" equals the stored fixed_args. | Should Pass |
+ * | 05 | Validate that the number of arguments is set to 1. | input: m_param.u.args.num_args = 1 | EXPECT_EQ confirms num_args equals 1. | Should Pass |
+ * | 06 | Validate that the argument passed (args[0]) matches the minimal argument "b". | input: m_param.u.args.args[0] = "b" | EXPECT_STREQ confirms "b" equals the stored argument. | Should Pass |
+ * | 07 | Validate that the command type is correctly set to em_cmd_type_beacon_query. | input: m_type = em_cmd_type_beacon_query | EXPECT_EQ confirms m_type matches em_cmd_type_beacon_query. | Should Pass |
+ * | 08 | Validate that the operational index is set to 0. | input: m_orch_op_idx = 0 | EXPECT_EQ confirms m_orch_op_idx equals 0. | Should Pass |
+ * | 09 | Validate that the number of orchestrator descriptors is set to 1. | input: m_num_orch_desc = 1 | EXPECT_EQ confirms m_num_orch_desc equals 1. | Should Pass |
+ * | 10 | Validate that the first orchestrator descriptor is marked for submission. | input: m_orch_desc[0].submit = true | EXPECT_TRUE confirms m_orch_desc[0].submit is true. | Should Pass |
+ * | 11 | Validate that the command name is set to "beacon_query". | input: m_name = "beacon_query" | EXPECT_STREQ confirms m_name equals "beacon_query". | Should Pass |
+ * | 12 | Validate that the orchestrator operation type is set to dm_orch_type_beacon_query. | input: m_orch_desc[0].op = dm_orch_type_beacon_query | EXPECT_EQ confirms m_orch_desc[0].op matches dm_orch_type_beacon_query. | Should Pass |
+ * | 13 | Validate that the service type is set to em_service_type_ctrl. | input: m_svc = em_service_type_ctrl | EXPECT_EQ confirms m_svc equals em_service_type_ctrl. | Should Pass |
+ * | 14 | Validate that the command context type in the data model matches dm_orch_type_beacon_query. | input: m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_query | EXPECT_EQ confirms the type is dm_orch_type_beacon_query. | Should Pass |
+ */
+TEST(em_cmd_beacon_query_t, em_cmd_beacon_query_t_create_minimal_valid_parameters) {
+    std::cout << "Entering em_cmd_beacon_query_t_create_minimal_valid_parameters test" << std::endl;
+    em_cmd_params_t param{};
+    const char *minFixed = "a";
+    strncpy(param.u.args.fixed_args, minFixed, sizeof(param.u.args.fixed_args) - 1);
+    param.u.args.fixed_args[sizeof(param.u.args.fixed_args)-1] = '\0';
+    const char *minArg = "b";
+    strncpy(param.u.args.args[0], minArg, sizeof(param.u.args.args[0]) - 1);
+    param.u.args.args[0][sizeof(param.u.args.args[0])-1] = '\0';
+    param.u.args.num_args = 1;
+    dm_easy_mesh_t dm;
+    std::cout << "Invoking em_cmd_beacon_query_t with minimal fixed_args: " << param.u.args.fixed_args << " and minimal argument: " << param.u.args.args[0] << std::endl;
+    em_cmd_beacon_query_t beaconQuery(param, dm);
+    EXPECT_STREQ(beaconQuery.m_param.u.args.fixed_args, minFixed);
+    EXPECT_EQ(beaconQuery.m_param.u.args.num_args, 1);
+    EXPECT_STREQ(beaconQuery.m_param.u.args.args[0], minArg);
+    EXPECT_EQ(beaconQuery.m_type, em_cmd_type_beacon_query);
+    EXPECT_EQ(beaconQuery.m_orch_op_idx, 0);
+    EXPECT_EQ(beaconQuery.m_num_orch_desc, 1);
+    EXPECT_TRUE(beaconQuery.m_orch_desc[0].submit);
+    EXPECT_STREQ(beaconQuery.m_name, "beacon_query");
+    EXPECT_EQ(beaconQuery.m_orch_desc[0].op, dm_orch_type_beacon_query);
+    EXPECT_EQ(beaconQuery.m_svc, em_service_type_ctrl);
+    EXPECT_EQ(beaconQuery.m_data_model.m_cmd_ctx.type, dm_orch_type_beacon_query);
+    beaconQuery.deinit();
+    std::cout << "Exiting em_cmd_beacon_query_t_create_minimal_valid_parameters test" << std::endl;
+}
+/**
+ * @brief Verify the construction of em_cmd_beacon_query_t object with empty fixed_args
+ *
+ * This test validates that when the input fixed_args is an empty string and num_args is set to 0,
+ * the em_cmd_beacon_query_t API correctly initializes the internal parameters of the command object.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 004@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description | Test Data | Expected Result | Notes |
+ * | :----: | --------- | ---------- |-------------- | ----- |
+ * | 01 | Set num_args to 0 and copy an empty string into fixed_args of params. | params.u.args.num_args = 0, params.u.args.fixed_args = "" | params.u.args.fixed_args is empty and num_args is 0 | Should Pass |
+ * | 02 | Create a dm_easy_mesh_t object. | dm_easy_mesh_t dm instantiated | dm object is created successfully | Should be successful |
+ * | 03 | Construct an em_cmd_beacon_query_t object using params and dm. | params (num_args = 0, fixed_args = ""), dm | em_cmd_beacon_query_t object is constructed and its internal parameters are initialized | Should Pass |
+ * | 04 | Validate the internal member values of the constructed object using assertions. | cmd.m_param.u.args.fixed_args = "", cmd.m_param.u.args.num_args = 0, cmd.m_type = em_cmd_type_beacon_query, cmd.m_orch_op_idx = 0, cmd.m_num_orch_desc = 1, cmd.m_orch_desc[0].submit = true, cmd.m_name = "beacon_query", cmd.m_orch_desc[0].op = dm_orch_type_beacon_query, cmd.m_svc = em_service_type_ctrl, cmd.m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_query | All internal members are set as expected | Should Pass |
+ * | 05 | Call deinit to release any allocated resources. | cmd.deinit() | Resources are released without error | Should be successful |
+ */
+TEST(em_cmd_beacon_query_t, em_cmd_beacon_query_t_empty_fixed_args) {
+    std::cout << "Entering em_cmd_beacon_query_t_empty_fixed_args test" << std::endl;
+    em_cmd_params_t params{};
+    params.u.args.num_args = 0;
+    const char *emptyStr = "";
+    strncpy(params.u.args.fixed_args, emptyStr, sizeof(params.u.args.fixed_args));
+    std::cout << "Passed fixed_args (expected empty): '" << params.u.args.fixed_args << "'" << std::endl;
+    dm_easy_mesh_t dm;
+    std::cout << "dm_easy_mesh_t object created" << std::endl;
+    em_cmd_beacon_query_t cmd(params, dm);
+    std::cout << "em_cmd_beacon_query_t object constructed successfully with empty fixed_args" << std::endl;
+    EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "");
+    EXPECT_EQ(cmd.m_param.u.args.num_args, 0);
+    EXPECT_EQ(cmd.m_type, em_cmd_type_beacon_query);
+    EXPECT_EQ(cmd.m_orch_op_idx, 0);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
+    EXPECT_TRUE(cmd.m_orch_desc[0].submit);
+    EXPECT_STREQ(cmd.m_name,  "beacon_query");
+    EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_beacon_query);
+    EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
+    EXPECT_EQ(cmd.m_data_model.m_cmd_ctx.type, dm_orch_type_beacon_query);
+    cmd.deinit();
+    std::cout << "Exiting em_cmd_beacon_query_t_empty_fixed_args test" << std::endl;
+}

--- a/tests/test_l1_em_cmd_beacon_report.cpp
+++ b/tests/test_l1_em_cmd_beacon_report.cpp
@@ -48,7 +48,7 @@
  * | 04 | Set the number of arguments | param.u.args.num_args = 1 | num_args equals 1 | Should be successful |
  * | 05 | Log the API invocation details with fixed_args and argument value | Printed message with param.u.args.fixed_args and param.u.args.args[0] values | Correct invocation message is printed | Should be successful |
  * | 06 | Create the em_cmd_beacon_report_t object with valid parameters | Invocation using: fixed_args = "ValidFixedArguments", args[0] = "Argument1", num_args = 1, dm instance | Object is instantiated with proper member initialization | Should Pass |
- * | 07 | Validate object member values using assertions | Expected: fixed_args = "ValidFixedArguments", num_args = 1, args[0] = "Argument1", m_type = em_cmd_type_beacon_report, m_orch_op_idx = 0, m_num_orch_desc = 1, m_orch_desc[0].submit = true, m_name = "beacon_report", m_orch_desc[0].op = dm_orch_type_beacon_report, m_svc = em_service_type_ctrl, m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_report | All assertions pass confirming correct values | Should Pass |
+ * | 07 | Validate object member values using assertions | Expected: fixed_args = "ValidFixedArguments", num_args = 1, args[0] = "Argument1", m_type = em_cmd_type_beacon_report, m_orch_op_idx = 0, m_num_orch_desc = 1, m_orch_desc[0].submit = true, m_name = "beacon_report", m_orch_desc[0].op = dm_orch_type_beacon_report, m_svc = em_service_type_agent, m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_report | All assertions pass confirming correct values | Should Pass |
  * | 08 | Deinitialize the command object | Call cmd.deinit() | Resources are released and object is deinitialized properly | Should be successful |
  * | 09 | Log the exiting test message | None | "Exiting em_cmd_beacon_report_t_create_valid_parameters test" printed | Should be successful |
  */
@@ -74,7 +74,7 @@ TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_create_valid_parameters) {
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     EXPECT_STREQ(cmd.m_name, "beacon_report");
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_beacon_report);
-    EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
+    EXPECT_EQ(cmd.m_svc, em_service_type_agent);
     EXPECT_EQ(cmd.m_data_model.m_cmd_ctx.type, dm_orch_type_beacon_report);
     cmd.deinit();
     std::cout << "Exiting em_cmd_beacon_report_t_create_valid_parameters test" << std::endl;
@@ -99,7 +99,7 @@ TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_create_valid_parameters) {
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Initialize test parameters by filling fixed_args with 'X' and each argument in args with 'Y', and setting num_args to EM_CLI_MAX_ARGS | fixed_args = 'X' repeated (sizeof(fixed_args)-1), args = 'Y' repeated (sizeof(each args element)-1), num_args = EM_CLI_MAX_ARGS | All parameters are correctly initialized with edge-case lengths | Should be successful |
  * | 02 | Invoke the em_cmd_beacon_report_t constructor with the initialized param and dm instance | Input: param (with fixed_args and args as set above), dm instance | beaconReport instance is created with proper initialization of its internal fields | Should Pass |
- * | 03 | Validate beaconReport fields using assertions (m_type, m_orch_op_idx, m_num_orch_desc, m_name, m_orch_desc, m_svc, m_data_model, and parameter consistency) | Expected: m_type = em_cmd_type_beacon_report, m_orch_op_idx = 0, m_num_orch_desc = 1, m_name = "beacon_report", m_orch_desc[0].submit = true, m_orch_desc[0].op = dm_orch_type_beacon_report, m_svc = em_service_type_ctrl, m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_report, and parameters match input | All member fields satisfy the expected conditions and assertions pass | Should Pass |
+ * | 03 | Validate beaconReport fields using assertions (m_type, m_orch_op_idx, m_num_orch_desc, m_name, m_orch_desc, m_svc, m_data_model, and parameter consistency) | Expected: m_type = em_cmd_type_beacon_report, m_orch_op_idx = 0, m_num_orch_desc = 1, m_name = "beacon_report", m_orch_desc[0].submit = true, m_orch_desc[0].op = dm_orch_type_beacon_report, m_svc = em_service_type_agent, m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_report, and parameters match input | All member fields satisfy the expected conditions and assertions pass | Should Pass |
  * | 04 | Deinitialize the beaconReport instance by calling deinit() | N/A | Resources are properly released without error | Should be successful |
  */
 TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_create_edge_case_parameter_lengths) {
@@ -122,7 +122,7 @@ TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_create_edge_case_parameter_l
     EXPECT_TRUE(beaconReport.m_orch_desc[0].submit);
     EXPECT_STREQ(beaconReport.m_name, "beacon_report");
     EXPECT_EQ(beaconReport.m_orch_desc[0].op, dm_orch_type_beacon_report);
-    EXPECT_EQ(beaconReport.m_svc, em_service_type_ctrl);
+    EXPECT_EQ(beaconReport.m_svc, em_service_type_agent);
     EXPECT_EQ(beaconReport.m_data_model.m_cmd_ctx.type, dm_orch_type_beacon_report);
     EXPECT_EQ(memcmp(beaconReport.m_param.u.args.fixed_args, param.u.args.fixed_args, sizeof(param.u.args.fixed_args)), 0);
     EXPECT_EQ(beaconReport.m_param.u.args.num_args, maxArgs);
@@ -167,7 +167,7 @@ TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_create_edge_case_parameter_l
  * | 10 | Validate that the first orchestrator descriptor is marked for submission. | input: m_orch_desc[0].submit = true | EXPECT_TRUE confirms m_orch_desc[0].submit is true. | Should Pass |
  * | 11 | Validate that the command name is set to "beacon_report". | input: m_name = "beacon_report" | EXPECT_STREQ confirms m_name equals "beacon_report". | Should Pass |
  * | 12 | Validate that the orchestrator operation type is set to dm_orch_type_beacon_report. | input: m_orch_desc[0].op = dm_orch_type_beacon_report | EXPECT_EQ confirms m_orch_desc[0].op matches dm_orch_type_beacon_report. | Should Pass |
- * | 13 | Validate that the service type is set to em_service_type_ctrl. | input: m_svc = em_service_type_ctrl | EXPECT_EQ confirms m_svc equals em_service_type_ctrl. | Should Pass |
+ * | 13 | Validate that the service type is set to em_service_type_agent. | input: m_svc = em_service_type_agent | EXPECT_EQ confirms m_svc equals em_service_type_agent. | Should Pass |
  * | 14 | Validate that the command context type in the data model matches dm_orch_type_beacon_report. | input: m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_report | EXPECT_EQ confirms the type is dm_orch_type_beacon_report. | Should Pass |
  */
 TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_create_minimal_valid_parameters) {
@@ -192,7 +192,7 @@ TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_create_minimal_valid_paramet
     EXPECT_TRUE(beaconReport.m_orch_desc[0].submit);
     EXPECT_STREQ(beaconReport.m_name, "beacon_report");
     EXPECT_EQ(beaconReport.m_orch_desc[0].op, dm_orch_type_beacon_report);
-    EXPECT_EQ(beaconReport.m_svc, em_service_type_ctrl);
+    EXPECT_EQ(beaconReport.m_svc, em_service_type_agent);
     EXPECT_EQ(beaconReport.m_data_model.m_cmd_ctx.type, dm_orch_type_beacon_report);
     beaconReport.deinit();
     std::cout << "Exiting em_cmd_beacon_report_t_create_minimal_valid_parameters test" << std::endl;
@@ -217,7 +217,7 @@ TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_create_minimal_valid_paramet
  * | 01 | Set num_args to 0 and copy an empty string into fixed_args of params. | params.u.args.num_args = 0, params.u.args.fixed_args = "" | params.u.args.fixed_args is empty and num_args is 0 | Should Pass |
  * | 02 | Create a dm_easy_mesh_t object. | dm_easy_mesh_t dm instantiated | dm object is created successfully | Should be successful |
  * | 03 | Construct an em_cmd_beacon_report_t object using params and dm. | params (num_args = 0, fixed_args = ""), dm | em_cmd_beacon_report_t object is constructed and its internal parameters are initialized | Should Pass |
- * | 04 | Validate the internal member values of the constructed object using assertions. | cmd.m_param.u.args.fixed_args = "", cmd.m_param.u.args.num_args = 0, cmd.m_type = em_cmd_type_beacon_report, cmd.m_orch_op_idx = 0, cmd.m_num_orch_desc = 1, cmd.m_orch_desc[0].submit = true, cmd.m_name = "beacon_report", cmd.m_orch_desc[0].op = dm_orch_type_beacon_report, cmd.m_svc = em_service_type_ctrl, cmd.m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_report | All internal members are set as expected | Should Pass |
+ * | 04 | Validate the internal member values of the constructed object using assertions. | cmd.m_param.u.args.fixed_args = "", cmd.m_param.u.args.num_args = 0, cmd.m_type = em_cmd_type_beacon_report, cmd.m_orch_op_idx = 0, cmd.m_num_orch_desc = 1, cmd.m_orch_desc[0].submit = true, cmd.m_name = "beacon_report", cmd.m_orch_desc[0].op = dm_orch_type_beacon_report, cmd.m_svc = em_service_type_agent, cmd.m_data_model.m_cmd_ctx.type = dm_orch_type_beacon_report | All internal members are set as expected | Should Pass |
  * | 05 | Call deinit to release any allocated resources. | cmd.deinit() | Resources are released without error | Should be successful |
  */
 TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_empty_fixed_args) {
@@ -239,7 +239,7 @@ TEST(em_cmd_beacon_report_t, em_cmd_beacon_report_t_empty_fixed_args) {
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     EXPECT_STREQ(cmd.m_name,  "beacon_report");
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_beacon_report);
-    EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
+    EXPECT_EQ(cmd.m_svc, em_service_type_agent);
     EXPECT_EQ(cmd.m_data_model.m_cmd_ctx.type, dm_orch_type_beacon_report);
     cmd.deinit();
     std::cout << "Exiting em_cmd_beacon_report_t_empty_fixed_args test" << std::endl;


### PR DESCRIPTION
Reason for change: Getters, setters and methods of WFA datamodel parameters are needed for TR-181.
  em_metrics.h and em_metrics.cpp changes not included, too many conflicts with ongoing PR-679
Test Procedure: (RDKB) rbuscli may be used to call this method. Some examples:
  rbuscli method_values 'Device.WiFi.DataElements.Network.Device.1.Radio.1.BSS.1.STA.1.X_AIRTIES_BeaconMetricsQuery()' OperatingClass uint32 81 Channel uint32 6 SSID string "private_ssid"
  rbuscli method_values 'Device.WiFi.DataElements.Network.Device.1.Radio.1.BSS.1.STA.1.X_AIRTIES_BeaconMetricsQuery()' OperatingClass uint32 81 Channel uint32 6 BSSID string "02:02:20:67:4c:e1" SSID string "private_ssid"
  rbuscli method_values 'Device.WiFi.DataElements.Network.Device.1.Radio.1.BSS.1.STA.1.X_AIRTIES_BeaconMetricsQuery()' OperatingClass uint32 81 Channel uint32 6 BSSID string "02:02:20:67:4c:e1" SSID string "private_ssid" ReportingDetail uint32 2
  rbuscli method_values 'Device.WiFi.DataElements.Network.Device.1.Radio.1.BSS.1.STA.1.X_AIRTIES_BeaconMetricsQuery()' OperatingClass uint32 81 Channel uint32 255 BSSID string "02:02:20:67:4c:e1" SSID string "private_ssid" APChannelReport.1.OperatingClass uint32 115 APChannelReport.1.ChannelList string "3,5,8" APChannelReport.2.OperatingClass uint32 128 APChannelReport.2.ChannelList string "36,42"
  rbuscli method_values 'Device.WiFi.DataElements.Network.Device.1.Radio.1.BSS.1.STA.1.X_AIRTIES_BeaconMetricsQuery()' OperatingClass uint32 81 Channel uint32 255 BSSID string "02:02:20:67:4c:e1" SSID string "private_ssid" ReportingDetail uint32 1 APChannelReport.1.OperatingClass uint32 115 APChannelReport.1.ChannelList string "3,5,8" APChannelReport.2.OperatingClass uint32 128 APChannelReport.2.ChannelList string "36,42"  ElementIDList string "11,32,63"
Risks: Low