### PR TITLE
RDKBWIFI-420: Add implementation for changing the backhaul SSID.

### DIFF
--- a/build/ctrl/makefile
+++ b/build/ctrl/makefile
@@ -47,7 +47,7 @@ INCLUDEDIRS += -I$(AL_SAP_HOME)/include
 endif
 INDLUDEDIRS += -I$(WIFI_CJSON)
 
-CXX_COMMON_FLAGS = -Wall -Wextra -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Wno-unused-parameter -fsanitize=address -fsanitize=undefined -Werror #-Wconversion -O2 -Weffc++
+CXX_COMMON_FLAGS = -DEM_CTRL_BUILD -Wall -Wextra -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Wno-unused-parameter -fsanitize=address -fsanitize=undefined -Werror #-Wconversion -O2 -Weffc++
 CXX_SPECIFIC_FLAGS = -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -std=c++17
 
 CXXFLAGS += $(INCLUDEDIRS) -g $(CXX_COMMON_FLAGS) $(CXX_SPECIFIC_FLAGS) `mariadb_config --include`

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -2752,7 +2752,10 @@ public:
 	 *
 	 * @note Ensure that all resources are properly released before the object is destroyed.
 	 */
-	virtual ~dm_easy_mesh_t();  
+	virtual ~dm_easy_mesh_t();
+
+	bool m_cfg_renew_in_progress = false;
+	bool m_bsta_reconnect_pending = false;
 };
 
 #endif

--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -154,7 +154,17 @@ public:
 	 * @note Ensure that the event and descriptor are properly initialized before calling this function.
 	 */
 	int analyze_m2ctrl_configuration(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl);
-    
+
+	/**!
+	 * @brief Updates EasymeshCfg.json with new backhaul SSID and passphrase.
+	 *
+	 * Called after M8 decryption provides new backhaul credentials.
+	 *
+	 * @param[in] ssid The new backhaul SSID.
+	 * @param[in] passphrase The new backhaul passphrase.
+	 */
+	void update_easymesh_cfg_backhaul(const char *ssid, const char *passphrase);
+
 	/**!
 	 * @brief Analyzes the channel preference query.
 	 *
@@ -382,7 +392,8 @@ public:
 	 *
 	 * @note Ensure that all dynamically allocated resources are properly released.
 	 */
-	~dm_easy_mesh_agent_t();  
+	~dm_easy_mesh_agent_t();
+
 };
 
 #endif

--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -339,6 +339,22 @@ public:
 	 * @note Ensure that the event and command structures are properly initialized before calling this function.
 	 */
 	int analyze_set_ssid(em_bus_event_t *evt, em_cmd_t *cmd[]);
+
+	/**!
+	 * @brief Analyzes and sets the backhaul configuration based on the provided event and command.
+	 *
+	 * This function processes the event and command to determine the appropriate backhaul configuration settings.
+	 *
+	 * @param[in] evt Pointer to the event structure containing backhaul configuration details.
+	 * @param[out] dm_out Pointer to the dm_easy_mesh_t structure where the backhaul configuration will be updated.
+	 *
+	 * @returns int Status code indicating success or failure of the operation.
+	 * @retval 0 on success.
+	 * @retval -1 on failure.
+	 *
+	 * @note Ensure that the event structure is properly initialized and that dm_out is a valid pointer before calling this function.
+	 */
+	int analyze_set_bh_cfg(em_bus_event_t *evt, dm_easy_mesh_t *dm_out);
     
 	/**!
 	 * @brief Analyzes and sets the radio configuration based on the provided event and command.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2169,6 +2169,7 @@ typedef enum {
     em_cmd_type_get_reset,
     em_cmd_type_bsta_cap,
     em_cmd_type_get_link_quality_report,
+    em_cmd_type_set_bh_cfg,
 
     em_cmd_type_max,
 } em_cmd_type_t;
@@ -2297,6 +2298,7 @@ typedef struct {
     em_small_string_t    primary_device_type;
     em_small_string_t    secondary_device_type;
     ieee_1905_security_t    sec_1905;
+    bool    m8_bsta_reconfiguration;
 } em_device_info_t;
 
 typedef struct {
@@ -2862,6 +2864,7 @@ typedef enum {
     em_bus_event_type_recv_csa_beacon_frame,
     em_bus_event_type_bsta_cap_req,
     em_bus_event_type_link_quality_report,
+    em_bus_event_type_set_bh_cfg,
     em_bus_event_type_client_assoc_ctrl_req,
 
     em_bus_event_type_max
@@ -3004,6 +3007,7 @@ typedef struct{
 	em_haul_type_t haultype[EM_MAX_BSS_PER_RADIO];
 	mac_address_t radio_mac[EM_MAX_BSS_PER_RADIO];
     em_4xlong_string_t dpp_connector[EM_MAX_BSS_PER_RADIO];
+	bool is_bh_reconfig;
 } m2ctrl_radioconfig;
 
 typedef struct{

--- a/inc/em_cmd_set_bh_cfg.h
+++ b/inc/em_cmd_set_bh_cfg.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_SET_BH_CFG_H
+#define EM_CMD_SET_BH_CFG_H
+
+#include "em_cmd.h"
+
+class em_cmd_set_bh_cfg_t : public em_cmd_t {
+
+public:
+    /**!
+     * @brief Constructs a backhaul config command.
+     *
+     * Creates a command with orch descriptors db_cfg + net_ssid_update.
+     * Used for both the initial ioprocess call (with the analyzed dm) and
+     * bus-event re-triggers (with the global m_data_model).
+     *
+     * @param[in] param Command parameters from the bus event.
+     * @param[in] dm    Data model containing the backhaul SSID config.
+     */
+    em_cmd_set_bh_cfg_t(em_cmd_params_t param, dm_easy_mesh_t& dm);
+};
+
+#endif

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -689,7 +689,16 @@ class em_configuration_t {
 	 * @note Ensure the buffer is properly allocated and the length is correct before calling this function.
 	 */
 	int handle_autoconfig_wsc_m2(unsigned char *buff, unsigned int len);
-    
+
+	/**!
+	 * @brief Handles M8 WSC TLVs for backhaul SSID reconfiguration.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the autoconfig WSC message.
+	 * @param[in] len Length of the buffer.
+	 * @returns 0 on success, -1 on failure.
+	 */
+	int handle_autoconfig_wsc_m8(unsigned char *buff, unsigned int len);
+
 	/**!
 	 * @brief Handles the WSC M1 message.
 	 *
@@ -999,7 +1008,28 @@ class em_configuration_t {
 	 * @note Ensure that the buffer is properly allocated and the haul type is valid before calling this function.
 	 */
 	unsigned short create_m2_msg(unsigned char *buff, em_haul_type_t haul_type);
-    
+
+	/**!
+	 * @brief Creates an M8 WSC message for backhaul SSID reconfiguration.
+	 *
+	 * Builds a WSC attribute blob with msg_type=M8 containing encrypted
+	 * backhaul SSID and passphrase. Appended as an additional WSC TLV
+	 * in the autoconfig WSC CMDU only during set_bh_cfg commands.
+	 *
+	 * @param[out] buff Buffer where the M8 message will be written.
+	 * @returns Length of the created M8 message, or 0 if backhaul SSID not found.
+	 */
+	unsigned short create_m8_msg(unsigned char *buff);
+
+	/**!
+	 * @brief Returns the WSC message type from a raw WSC attribute blob.
+	 *
+	 * @param[in] buff Pointer to WSC attribute data (inside a WSC TLV value).
+	 * @param[in] len Length of the WSC attribute data.
+	 * @returns The em_wsc_msg_type_t found, or em_wsc_msg_type_none.
+	 */
+	static em_wsc_msg_type_t get_wsc_blob_msg_type(unsigned char *buff, unsigned int len);
+
 	/**!
 	 * @brief Creates a traffic separation policy.
 	 *
@@ -1665,7 +1695,7 @@ public:
 	 * @note Ensure that the encryption keys are properly initialized
 	 * before calling this function.
 	 */
-	int handle_encrypted_settings(unsigned int wsc_tlv_count);
+	int handle_encrypted_settings(unsigned int wsc_tlv_count, bool is_bh_reconfig = false);
     
 	/**!
 	 * @brief Creates encrypted settings based on the provided buffer and haul type.

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -271,6 +271,7 @@ public:
 	 * @note Ensure that the event structure is properly initialized before calling this function.
 	 */
 	void handle_set_ssid_list(em_bus_event_t *evt);
+	void handle_set_bh_cfg(em_bus_event_t *evt);
     
 	/**!
 	 * @brief Handles the removal of a device from the bus.

--- a/inc/em_network_topo.h
+++ b/inc/em_network_topo.h
@@ -28,6 +28,9 @@ class em_network_topo_t {
 	unsigned int m_num_topologies;	
 	em_network_topo_t	*m_topology[EM_MAX_NETWORKS];
 
+	bool m_bh_processed;
+	bool m_bh_reconfig_active;
+
 public:
 	
 	/**!
@@ -112,6 +115,27 @@ public:
 	 * @note Ensure that the returned pointer is not null before using it.
 	 */
 	dm_easy_mesh_t *get_data_model() { return m_data_model; }
+
+	unsigned int get_num_topologies() { return m_num_topologies; }
+
+
+
+	/**!
+	 * @brief Returns true when all topology nodes have been processed (root included).
+	 *
+	 * @returns true if the root node (this) is marked processed, meaning all
+	 *          layers including the co-located agent have been handled.
+	 */
+	bool is_bh_reconfig_complete();
+
+	bool is_bh_reconfig_active() { return m_bh_reconfig_active; }
+	void set_bh_reconfig_active(bool active) { m_bh_reconfig_active = active; }
+	void set_bh_processed(bool processed) { m_bh_processed = processed; }
+
+	void send_bh_reconfig_event();
+	void reset_bh_reconfig();
+	bool is_bh_reconfig_candidate();
+	void mark_bh_leaves_processed();
 	
 	
 	/**!
@@ -194,6 +218,20 @@ public:
 	 */
 	em_network_topo_t();
     
+	/**!
+	 * @brief Checks if the given data model is a direct child of this topology node.
+	 *
+	 * Used to distinguish gateway/co-located agents (direct children of root)
+	 * from remote extenders deeper in the tree. Direct children of the root
+	 * communicate with the controller without traversing a WiFi backhaul link
+	 * and will not disconnect during backhaul reconfiguration.
+	 *
+	 * @param[in] dm Pointer to the data model to check.
+	 *
+	 * @returns true if dm is a direct child of this node, false otherwise.
+	 */
+	bool is_direct_child(dm_easy_mesh_t *dm);
+
 	/**!
 	 * @brief Destructor for the em_network_topo_t class.
 	 *

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -85,6 +85,7 @@ onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_set_policy.cpp \
      $(top_srcdir)/src/cmd/em_cmd_set_radio.cpp \
      $(top_srcdir)/src/cmd/em_cmd_set_ssid.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_bh_cfg.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_assoc.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_disassoc.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_link_metrics.cpp \

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -194,6 +194,8 @@ int dm_easy_mesh_agent_t::analyze_autoconfig_renew(em_bus_event_t *evt, em_cmd_t
     em_cmd_t *tmp;
     mac_addr_str_t mac_str;
 
+    m_cfg_renew_in_progress = true;
+
     raw = reinterpret_cast<em_bus_event_type_cfg_renew_params_t *>(evt->u.raw_buff);
     memcpy(dm.get_controller_interface_mac(), raw->ctrl_src, sizeof(mac_address_t));
     memcpy(dm.get_radio(index)->get_radio_info()->intf.mac, raw->radio, sizeof(mac_address_t));
@@ -239,6 +241,63 @@ void dm_easy_mesh_agent_t::translate_onewifi_dml_data (char *str)
         
 }
 
+void dm_easy_mesh_agent_t::update_easymesh_cfg_backhaul(const char *ssid, const char *passphrase)
+{
+    FILE *fp = fopen(EM_CFG_FILE, "r");
+    if (fp == NULL) {
+        printf("%s:%d: Failed to open %s for reading\n", __func__, __LINE__, EM_CFG_FILE);
+        return;
+    }
+
+    fseek(fp, 0, SEEK_END);
+    long fsize = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+
+    char *buf = static_cast<char *>(malloc(static_cast<size_t>(fsize) + 1));
+    if (buf == NULL) {
+        fclose(fp);
+        return;
+    }
+    fread(buf, 1, static_cast<size_t>(fsize), fp);
+    buf[fsize] = '\0';
+    fclose(fp);
+
+    cJSON *root = cJSON_Parse(buf);
+    free(buf);
+    if (root == NULL) {
+        printf("%s:%d: Failed to parse %s\n", __func__, __LINE__, EM_CFG_FILE);
+        return;
+    }
+
+    // Update or add Backhaul_SSID and Backhaul_KeyPassphrase
+    if (cJSON_HasObjectItem(root, "Backhaul_SSID")) {
+        cJSON_ReplaceItemInObject(root, "Backhaul_SSID", cJSON_CreateString(ssid));
+    } else {
+        cJSON_AddStringToObject(root, "Backhaul_SSID", ssid);
+    }
+
+    if (cJSON_HasObjectItem(root, "Backhaul_KeyPassphrase")) {
+        cJSON_ReplaceItemInObject(root, "Backhaul_KeyPassphrase", cJSON_CreateString(passphrase));
+    } else {
+        cJSON_AddStringToObject(root, "Backhaul_KeyPassphrase", passphrase);
+    }
+
+    char *json_str = cJSON_Print(root);
+    cJSON_Delete(root);
+
+    fp = fopen(EM_CFG_FILE, "w");
+    if (fp == NULL) {
+        printf("%s:%d: Failed to open %s for writing\n", __func__, __LINE__, EM_CFG_FILE);
+        free(json_str);
+        return;
+    }
+    fprintf(fp, "%s", json_str);
+    fclose(fp);
+
+    printf("%s:%d: Updated %s with Backhaul_SSID=%s\n", __func__, __LINE__, EM_CFG_FILE, ssid);
+    free(json_str);
+}
+
 int dm_easy_mesh_agent_t::analyze_m2ctrl_configuration(em_bus_event_t *evt, wifi_bus_desc_t *desc,bus_handle_t *bus_hdl)
 {
     m2ctrl_radioconfig *radioconfig;
@@ -258,10 +317,42 @@ int dm_easy_mesh_agent_t::analyze_m2ctrl_configuration(em_bus_event_t *evt, wifi
         memcpy(m2ctrl.dpp_connector[i], radioconfig->dpp_connector[i], sizeof(m2ctrl.dpp_connector[i]));
 		dm_easy_mesh_t::macbytes_to_string(radioconfig->radio_mac[i],mac_str);
 		printf("%s:%d New configuration SSID=%s  passphrase=%s haultype=%d radiomac=%s\n",__func__, __LINE__,m2ctrl.ssid[i], m2ctrl.password[i], m2ctrl.haultype[i],mac_str);
+
+		// Update EasymeshCfg.json when backhaul SSID/passphrase changes via M8
+		if (m2ctrl.haultype[i] == em_haul_type_backhaul) {
+			update_easymesh_cfg_backhaul(m2ctrl.ssid[i], m2ctrl.password[i]);
+		}
 	}
 
-    return refresh_onewifi_subdoc(desc, bus_hdl, "Private", get_subdoc_vap_type_for_freq(radioconfig->freq[0]), &m2ctrl, NULL);
-}    
+    // Push Private subdoc to reconfigure AP-side BSSes.
+    int ret = 0;
+    ret = refresh_onewifi_subdoc(desc, bus_hdl, "Private", get_subdoc_vap_type_for_freq(radioconfig->freq[0]), &m2ctrl, NULL);
+
+    // During BH reconfig cfg_renew (M8 present), update bSTA credentials and
+    // defer mesh_backhaul_sta push to cfg_renew completion in em_orch.cpp.
+    if (m_cfg_renew_in_progress && radioconfig->is_bh_reconfig) {
+        em_bss_info_t *bsta_check = get_bsta_bss_info();
+        bool has_active_bsta = (bsta_check != NULL &&
+            bsta_check->connect_status &&
+            memcmp(bsta_check->bssid.mac, ZERO_MAC_ADDR, sizeof(mac_address_t)) != 0);
+
+        if (has_active_bsta) {
+            for (unsigned int i = 0; i < m2ctrl.noofbssconfig; i++) {
+                if (m2ctrl.haultype[i] == em_haul_type_backhaul) {
+                    memset(bsta_check->ssid, 0, sizeof(bsta_check->ssid));
+                    strncpy(bsta_check->ssid, m2ctrl.ssid[i], sizeof(bsta_check->ssid) - 1);
+                    memset(bsta_check->mesh_sta_passphrase, 0, sizeof(bsta_check->mesh_sta_passphrase));
+                    strncpy(bsta_check->mesh_sta_passphrase, m2ctrl.password[i],
+                            sizeof(bsta_check->mesh_sta_passphrase) - 1);
+                    m_bsta_reconnect_pending = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    return ret;
+}
 
 int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1230,6 +1230,7 @@ void em_agent_t::input_listener()
         // This is fine, not a fatal error
     }
 
+    /*
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.APMetricsReport", (void *)&em_agent_t::report_cb, NULL, 0) != 0) {
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
@@ -1239,6 +1240,7 @@ void em_agent_t::input_listener()
         printf("%s:%d bus get failed\n", __func__, __LINE__);
         return;
     }
+        */
 
    if(desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.CSABeaconFrameRecieved", (void *)&em_agent_t::mgmt_csa_beacon_frame_cb, NULL, 0) != 0) {
         printf("%s:%d bus get failed\n",__func__,__LINE__);
@@ -1297,7 +1299,7 @@ int em_agent_t::report_cb(char *event_name, bus_data_prop_t *data, void *userDat
     if (strncmp(event_name, "Device.WiFi.EM.APMetricsReport", sizeof("Device.WiFi.EM.APMetricsReport"))==0) {
         g_agent.io_process(em_bus_event_type_ap_metrics_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
     } else if (strncmp(event_name, WIFI_QUALITY_LINKREPORT, sizeof(WIFI_QUALITY_LINKREPORT))==0) {
-        em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
+        //em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
         cJSON *json = cJSON_Parse((const char *)data->value.raw_data.bytes);
         if (json != NULL) {
             cJSON *link_report_arr;
@@ -1310,11 +1312,12 @@ int em_agent_t::report_cb(char *event_name, bus_data_prop_t *data, void *userDat
                 }
                 if (cJSON_IsArray(link_report_arr) && cJSON_GetArraySize(link_report_arr) == 0) {
                     em_printfout("LinkReport is NULL");
+                    cJSON_Delete(json);
                     return -1;
                 }
             }
         }
-        g_agent.io_process(em_bus_event_type_link_quality_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+        //g_agent.io_process(em_bus_event_type_link_quality_report, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
     }
 
     return 0;
@@ -1446,8 +1449,11 @@ void em_agent_t::onewifi_cb(char *event_name, bus_data_prop_t *data, void *userD
                (strcmp(subdoc_name->valuestring, "mesh backhaul sta") == 0)) {
         g_agent.io_process(em_bus_event_type_onewifi_mesh_sta_cb, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
 
+    } else if (strcmp(subdoc_name->valuestring, "dml") == 0) {
+        g_agent.io_process(em_bus_event_type_dev_init, (unsigned char *)data->value.raw_data.bytes, data->value.raw_data_len);
+
     } else {
-        em_printfout("SubDocName (%s) not matching private, mesh_sta, or radio", subdoc_name->valuestring);
+        em_printfout("SubDocName (%s) not matching private, mesh_sta, radio, or dml", subdoc_name->valuestring);
     }
 
     cJSON_Delete(json);

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -58,6 +58,7 @@ libemcli_la_SOURCES = \
  $(top_srcdir)/src/cmd/em_cmd_set_policy.cpp \
  $(top_srcdir)/src/cmd/em_cmd_set_radio.cpp \
  $(top_srcdir)/src/cmd/em_cmd_set_ssid.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_set_bh_cfg.cpp \
  $(top_srcdir)/src/cmd/em_cmd_sta_assoc.cpp \
  $(top_srcdir)/src/cmd/em_cmd_sta_disassoc.cpp \
  $(top_srcdir)/src/cmd/em_cmd_sta_link_metrics.cpp \

--- a/src/cli/em_cmd_cli.cpp
+++ b/src/cli/em_cmd_cli.cpp
@@ -70,6 +70,7 @@ em_cmd_params_t spec_params[] = {
     {.u = {.args = {2, {"", "", "", "", ""}, "MLDReconfig"}}},
 	{.u = {.args = {2, {"", "", "", "", ""}, "DevTest.json"}}},
 	{.u = {.args = {0, {"", "", "", "", ""}, "max"}}},
+	{.u = {.args = {2, {"", "", "", "", ""}, "BhCfg.json"}}},
 };
 
 em_cmd_t em_cmd_cli_t::m_client_cmd_spec[] = {
@@ -103,6 +104,7 @@ em_cmd_t em_cmd_cli_t::m_client_cmd_spec[] = {
     em_cmd_t(em_cmd_type_get_mld_config, spec_params[26]),
     em_cmd_t(em_cmd_type_mld_reconfig, spec_params[27]),
     em_cmd_t(em_cmd_type_set_dev_test, spec_params[28]),
+    em_cmd_t(em_cmd_type_set_bh_cfg, spec_params[30]),
     em_cmd_t(em_cmd_type_max, spec_params[29]),
 };
 
@@ -312,6 +314,19 @@ int em_cmd_cli_t::execute(char *result)
             info = &bevt->u.subdoc;
             strncpy(info->name, param->u.args.fixed_args, strlen(param->u.args.fixed_args) + 1);
 			if ((bevt->data_len = get_edited_node(node, "SetSSID", info->buff)) < 0) {
+                printf("%s:%d: failed to open file at location:%s error:%d\n", __func__, __LINE__, param->u.args.fixed_args, errno);
+                return -1;
+			}	
+            break;
+
+        case em_cmd_type_set_bh_cfg:
+			if ((node = m_cmd.m_param.net_node) == NULL) {
+				return -1;
+			}
+            bevt->type = em_bus_event_type_set_bh_cfg;
+            info = &bevt->u.subdoc;
+            strncpy(info->name, param->u.args.fixed_args, strlen(param->u.args.fixed_args) + 1);
+			if ((bevt->data_len = get_edited_node(node, "SetBhCfg", info->buff)) < 0) {
                 printf("%s:%d: failed to open file at location:%s error:%d\n", __func__, __LINE__, param->u.args.fixed_args, errno);
                 return -1;
 			}	

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -511,6 +511,7 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_mld_reconfig)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_reset)
         BUS_EVENT_TYPE_2S(em_bus_event_type_link_quality_report)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_set_bh_cfg)
        
         default:
            break;
@@ -644,6 +645,7 @@ const char *em_cmd_t::get_cmd_type_str(em_cmd_type_t type)
         CMD_TYPE_2S(em_cmd_type_ap_metrics_report)
         CMD_TYPE_2S(em_cmd_type_get_reset)
         CMD_TYPE_2S(em_cmd_type_get_link_quality_report)
+        CMD_TYPE_2S(em_cmd_type_set_bh_cfg)
 
         default:
            break;
@@ -790,6 +792,10 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
             type = em_cmd_type_get_link_quality_report;
             break;
 
+        case em_bus_event_type_set_bh_cfg:
+            type = em_cmd_type_set_bh_cfg;
+            break;
+
         default:
             break;
     }
@@ -812,6 +818,10 @@ em_bus_event_type_t em_cmd_t::cmd_2_bus_event_type(em_cmd_type_t ctype)
 
         case em_cmd_type_set_ssid:
             type = em_bus_event_type_set_ssid;;
+            break;
+
+        case em_cmd_type_set_bh_cfg:
+            type = em_bus_event_type_set_bh_cfg;
             break;
 
         case em_cmd_type_em_config:

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -809,6 +809,7 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
 
         case em_bus_event_type_set_bh_cfg:
             type = em_cmd_type_set_bh_cfg;
+            break;
       	case em_bus_event_type_unassoc_sta_query:
             type = em_cmd_type_unassoc_sta_query;
             break;

--- a/src/cmd/em_cmd_set_bh_cfg.cpp
+++ b/src/cmd/em_cmd_set_bh_cfg.cpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <cjson/cJSON.h>
+#include "em_cmd_set_bh_cfg.h"
+
+em_cmd_set_bh_cfg_t::em_cmd_set_bh_cfg_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
+{
+    em_cmd_ctx_t ctx;
+
+    m_type = em_cmd_type_set_bh_cfg;
+    memcpy(&m_param, &param, sizeof(em_cmd_params_t));
+    m_param.u.args.args[0][0] = '\0';
+
+	memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+
+    m_orch_op_idx = 0;
+    m_num_orch_desc = 2;
+    m_orch_desc[0].op = dm_orch_type_db_cfg;
+    m_orch_desc[0].submit = true;
+    m_orch_desc[1].op = dm_orch_type_net_ssid_update;
+
+    strncpy(m_name, "set_bh_cfg", strlen("set_bh_cfg") + 1);
+    m_svc = em_service_type_ctrl;
+    init(dm);
+
+    memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+    ctx.type = m_orch_desc[0].op;
+
+    m_data_model.set_cmd_ctx(&ctx);
+}

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -32,7 +32,7 @@ onewifi_em_ctrl_CPPFLAGS = \
     -I$(top_srcdir)/src/util \
     -I$(top_srcdir)/src/util_crypto
 
-onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fno-omit-frame-pointer #-Wconversion -Werror -O2
+onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -DEM_CTRL_BUILD -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fno-omit-frame-pointer #-Wconversion -Werror -O2
 if EM_ASAN_CTRL
 onewifi_em_ctrl_CXXFLAGS += -fsanitize=address -fsanitize=undefined
 endif
@@ -84,6 +84,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_set_policy.cpp \
      $(top_srcdir)/src/cmd/em_cmd_set_radio.cpp \
      $(top_srcdir)/src/cmd/em_cmd_set_ssid.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_set_bh_cfg.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_assoc.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_disassoc.cpp \
      $(top_srcdir)/src/cmd/em_cmd_sta_link_metrics.cpp \
@@ -207,6 +208,7 @@ onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
 	$(top_srcdir)/tests/test_l1_em_cmd_start_dpp.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_topo_sync.cpp \
 	$(top_srcdir)/tests/test_l1_em_network_topo.cpp \
+	$(top_srcdir)/tests/test_l1_bh_reconfig.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_bsta_cap.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_onewifi_cb.cpp \
 	$(top_srcdir)/tests/test_l1_em_cmd_ap_cap.cpp \

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -43,6 +43,7 @@
 #include "em_cmd_dev_test.h"
 #include "em_cmd_remove_device.h"
 #include "em_cmd_set_ssid.h"
+#include "em_cmd_set_bh_cfg.h"
 #include "em_cmd_set_channel.h"
 #include "em_cmd_scan_channel.h"
 #include "em_cmd_set_radio.h"
@@ -152,7 +153,12 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_
     // Add new JSON as child of root and update subdoc buffer.
     json = new_json;
     new_json = NULL;
-    cJSON_AddItemToObject(root, "wfa-dataelements:SetSSID", json);
+
+    // Determine if this is a backhaul SSID/passphrase change
+    bool is_backhaul_change = (HaulType[0] && strcmp(HaulType, "Backhaul") == 0);
+    em_printfout("Received set_ssid request: SSID=%s AddRemoveChange=%s PassPhrase=%s Band=%s HaulType=%s\n", ssid, addremove, passphrase, band, HaulType);
+    const char *json_key = is_backhaul_change ? "wfa-dataelements:SetBhCfg" : "wfa-dataelements:SetSSID";
+    cJSON_AddItemToObject(root, json_key, json);
 
     ssid_list = cJSON_GetObjectItem(json, "NetworkSSIDList");
     if (!ssid_list || !cJSON_IsArray(ssid_list)) {
@@ -217,6 +223,7 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_
                     if (output_params) *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
                     return bus_error_out_of_resources;
                 }
+
                 cJSON_ReplaceItemInObject(target, "SSID", ssid_item_new);
             }
             if (passphrase[0]) {
@@ -338,7 +345,8 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_
     }
     */
 
-    em_ctrl->io_process(em_bus_event_type_set_ssid, subdoc->buff, json_len);
+    em_ctrl->io_process(is_backhaul_change ? em_bus_event_type_set_bh_cfg : em_bus_event_type_set_ssid,
+                         subdoc->buff, json_len);
     free(updated_json);
     cJSON_Delete(root);
 
@@ -2514,6 +2522,57 @@ int dm_easy_mesh_ctrl_t::analyze_set_ssid(em_bus_event_t *evt, em_cmd_t *pcmd[])
     return num;
 }
 
+int dm_easy_mesh_ctrl_t::analyze_set_bh_cfg(em_bus_event_t *evt, dm_easy_mesh_t *dm_out)
+{
+    int ret;
+    em_subdoc_info_t *subdoc;
+	dm_easy_mesh_t *pdm;
+	dm_network_ssid_t *tgt, *src;
+	int i, j;
+	int bit_mask = 0;
+
+    subdoc = &evt->u.subdoc;
+	if ((ret = dm_out->decode_config(subdoc, "SetBhCfg")) < 0) {
+		return ret;
+	}
+
+	pdm = m_data_model_list.get_first_dm();
+	if (pdm == NULL) {
+		assert(pdm != NULL);
+		return EM_PARSE_ERR_CONFIG;
+	}
+
+	for (i = 0; i < EM_MAX_NET_SSIDS; i++) {
+		tgt = &dm_out->m_network_ssid[i];
+		for (j = 0; j < EM_MAX_NET_SSIDS; j++) {
+			src = &pdm->m_network_ssid[j];
+			if (*tgt == *src) {
+				bit_mask |= (1 << i);
+				break;
+			}
+		}
+	}
+
+	if (bit_mask == (pow(2, EM_MAX_NET_SSIDS) - 1)) {
+		return EM_PARSE_ERR_NO_CHANGE;
+	}
+
+	// Update in-memory network SSIDs in ALL data models so that
+	// subsequent M2 creation uses the new SSID/passphrase.
+	dm_easy_mesh_t *iter_dm = m_data_model_list.get_first_dm();
+	while (iter_dm != NULL) {
+		iter_dm->m_num_net_ssids = dm_out->m_num_net_ssids;
+		for (i = 0; i < EM_MAX_NET_SSIDS; i++) {
+			iter_dm->m_network_ssid[i] = dm_out->m_network_ssid[i];
+		}
+		iter_dm = m_data_model_list.get_next_dm(iter_dm);
+	}
+
+	dm_out->set_db_cfg_param(db_cfg_type_network_ssid_list_update, "");
+
+    return 1;
+}
+
 int dm_easy_mesh_ctrl_t::analyze_remove_device(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     cJSON *obj, *wfa_obj, *net_obj, *dev_list_obj, *id_obj;
@@ -3294,7 +3353,28 @@ void dm_easy_mesh_ctrl_t::init_tables()
 
 int dm_easy_mesh_ctrl_t::load_net_ssid_table()
 {
-	return dm_network_ssid_list_t::load_table(m_db_client);
+	int ret = dm_network_ssid_list_t::load_table(m_db_client);
+
+	// After reloading the global SSID hash map from DB, propagate the updated
+	// network SSIDs to all per-device data models so that create_encrypted_settings
+	// (which reads from em_t::m_data_model) picks up the new SSID/passphrase.
+	dm_network_ssid_t *net_ssid;
+	unsigned int idx;
+	dm_easy_mesh_t *dm;
+
+	for (dm = get_first_dm(); dm != NULL; dm = get_next_dm(dm)) {
+		idx = 0;
+		for (net_ssid = get_first_network_ssid(); net_ssid != NULL;
+				net_ssid = get_next_network_ssid(net_ssid)) {
+			if (idx < EM_MAX_NET_SSIDS) {
+				*(dm->get_network_ssid(idx)) = *net_ssid;
+				idx++;
+			}
+		}
+		dm->set_num_network_ssid(idx);
+	}
+
+	return ret;
 }
 
 int dm_easy_mesh_ctrl_t::load_tables()

--- a/src/ctrl/em_cmd_ctrl.cpp
+++ b/src/ctrl/em_cmd_ctrl.cpp
@@ -86,6 +86,7 @@ int em_cmd_ctrl_t::execute(char *result)
 
         if (SSL_accept(m_ssl) <= 0) {
             SSL_free(m_ssl);
+            m_ssl = NULL;
             close(dsock);
             continue;
         }
@@ -156,6 +157,7 @@ int em_cmd_ctrl_t::send_result(em_cmd_out_status_t status)
 	sd = SSL_get_fd(m_ssl);
 	SSL_shutdown(m_ssl);
 	SSL_free(m_ssl);
+	m_ssl = NULL;
 	close(sd);
 
 	free(str);

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -44,6 +44,8 @@
 #include "em_cmd_ctrl.h"
 #include "dm_easy_mesh.h"
 #include "em_orch_ctrl.h"
+#include "em_cmd_set_bh_cfg.h"
+#include "em_network_topo.h"
 #include "util.h"
 #include "wifi_util.h"
 
@@ -229,9 +231,24 @@ void em_ctrl_t::handle_config_renew(em_bus_event_t *evt)
 
 void em_ctrl_t::handle_m2_tx(em_bus_event_t *evt)
 {
+    // During backhaul reconfig, non-colocated agents (WiFi extenders) will
+    // disconnect after receiving new credentials via M2+M8 and automatically
+    // re-onboard.  Skip the em_config command (topology query) only for those
+    // agents.  The colocated agent stays connected and needs em_config.
+    if (g_network_topology != NULL && g_network_topology->is_bh_reconfig_active()) {
+        em_bus_event_type_m2_tx_params_t *params =
+            reinterpret_cast<em_bus_event_type_m2_tx_params_t *>(evt->u.raw_buff);
+        dm_network_t *net = m_data_model.get_network(GLOBAL_NET_ID);
+        unsigned char *colocated_mac = (net != NULL) ? net->get_colocated_agent_interface_mac() : NULL;
+        if (colocated_mac == NULL || memcmp(params->al, colocated_mac, sizeof(mac_address_t)) != 0) {
+            em_printfout("handle_m2_tx: skipping em_config for non-colocated agent during backhaul reconfig");
+            return;
+        }
+    }
+
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     int num;
-    
+
     if ((num = m_data_model.analyze_m2_tx(evt, pcmd)) > 0) {
         m_orch->submit_commands(pcmd, static_cast<unsigned int> (num));
     }
@@ -282,6 +299,65 @@ void em_ctrl_t::handle_set_ssid_list(em_bus_event_t *evt)
         m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
     } 
 
+}
+
+/**
+ * @brief Handles the em_bus_event_type_set_bh_cfg bus event.
+ *
+ * Two execution paths:
+ *   1. Initial: validates config, checks M8 bSTA capability, submits first command.
+ *   2. Re-trigger: multi-phase reconfig active, submits next leaf layer directly.
+ */
+void em_ctrl_t::handle_set_bh_cfg(em_bus_event_t *evt)
+{
+    int ret;
+    dm_easy_mesh_t dm;
+
+    if (m_orch->is_cmd_type_in_progress(evt) == true) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
+        return;
+    }
+
+    // Re-trigger path: reconfig already active, submit for next phase.
+    if (g_network_topology != NULL && g_network_topology->is_bh_reconfig_active()) {
+        em_cmd_t *cmd = new em_cmd_set_bh_cfg_t(evt->params, dm);
+        m_orch->submit_command(cmd);
+        return;
+    }
+
+    // Validate all agents support M8 bSTA reconfiguration.
+    dm_easy_mesh_t *agent_dm = m_data_model.get_first_dm();
+    while (agent_dm != NULL) {
+        if (agent_dm->is_controller() == false &&
+            agent_dm->m_device.m_device_info.m8_bsta_reconfiguration == false) {
+            em_printfout("SetBhCfg: agent %s lacks M8 bSTA reconfiguration support",
+                util::mac_to_string(agent_dm->m_device.m_device_info.intf.mac).c_str());
+            m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+            return;
+        }
+        agent_dm = m_data_model.get_next_dm(agent_dm);
+    }
+
+    if ((ret = m_data_model.analyze_set_bh_cfg(evt, &dm)) <= 0) {
+        if (ret == EM_PARSE_ERR_NO_CHANGE) {
+            m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+        } else {
+            m_ctrl_cmd->send_result(em_cmd_out_status_invalid_input);
+        }
+        return;
+    }
+
+    if (g_network_topology != NULL) {
+        g_network_topology->reset_bh_reconfig();
+        g_network_topology->set_bh_reconfig_active(true);
+    }
+
+    em_cmd_t *cmd = new em_cmd_set_bh_cfg_t(evt->params, dm);
+    if (m_orch->submit_command(cmd)) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_success);
+    } else {
+        m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+    }
 }
 
 void em_ctrl_t::handle_remove_device(em_bus_event_t *evt)
@@ -561,6 +637,10 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
 
         case em_bus_event_type_set_ssid:
             handle_set_ssid_list(evt);  
+            break;
+
+        case em_bus_event_type_set_bh_cfg:
+            handle_set_bh_cfg(evt);
             break;
 
         case em_bus_event_type_remove_device:
@@ -845,11 +925,8 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
             dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
         
             if ((em = static_cast<em_t *> (hash_map_get(m_em_map, mac_str1))) != NULL) {
-                printf("%s:%d: Found existing radio:%s\n", __func__, __LINE__, mac_str1);
-                if(em->get_state() != em_state_ctrl_wsc_m2_sent)
-                    em->set_state(em_state_ctrl_wsc_m1_pending);
-                else
-                    printf("%s:%d: Autoconf wsc msg sent already. Incorrect state = (%d)\n", __func__, __LINE__, em->get_state());
+                printf("%s:%d: Found existing radio:%s (state=%d)\n", __func__, __LINE__, mac_str1, em->get_state());
+                em->set_state(em_state_ctrl_wsc_m1_pending);
             } else {
                 if ((dm = get_data_model(GLOBAL_NET_ID, const_cast<const unsigned char *> (hdr->src))) == NULL) {
                     printf("%s:%d: Can not find data model\n", __func__, __LINE__);
@@ -899,6 +976,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
 
             if ((dm = get_data_model(GLOBAL_NET_ID, const_cast<const unsigned char *> (hdr->src))) == NULL) {
                 printf("%s:%d: Can not find data model\n", __func__, __LINE__);
+                return NULL;
             }
 
             for (i = 0; i < dm->get_num_radios(); i++) {

--- a/src/ctrl/em_network_topo.cpp
+++ b/src/ctrl/em_network_topo.cpp
@@ -24,10 +24,12 @@
 #include <pthread.h>
 #include <cjson/cJSON.h>
 #include "em_network_topo.h"
+#include "em.h"
 #include "util.h"
 #include "dm_sta_list.h"
 #include "dm_easy_mesh_ctrl.h"
 #include "em_ctrl.h"
+#include "em_cmd_ctrl.h"
 
 extern em_network_topo_t *g_network_topology;
 
@@ -146,6 +148,13 @@ em_network_topo_t *em_network_topo_t::find_topology_by_bh_associated(dm_easy_mes
 	// and return that topology object.
 	mac_address_t bss_mac;
 	memcpy(bss_mac, bss->id.bssid, sizeof(mac_address_t));
+	// If bSTA BSS bssid is zero (e.g. after M1 BSS rebuild during bhreconfig),
+	// fall back to the device's backhaul_mac which was set during M1 processing.
+	if (memcmp(bss_mac, ZERO_MAC_ADDR, sizeof(mac_address_t)) == 0 &&
+		memcmp(dm->m_device.m_device_info.backhaul_mac.mac, ZERO_MAC_ADDR, sizeof(mac_address_t)) != 0) {
+		memcpy(bss_mac, dm->m_device.m_device_info.backhaul_mac.mac, sizeof(mac_address_t));
+		em_printfout("bSTA BSS bssid is zero, using device backhaul_mac: %s", util::mac_to_string(bss_mac).c_str());
+	}
 	if (dm->is_controller() == false) {
 		// Update the backhaul of the dm object with the bss mac address
 		memcpy(dm->m_device.m_device_info.backhaul_mac.mac, bss_mac, sizeof(mac_address_t));
@@ -206,14 +215,8 @@ em_network_topo_t *em_network_topo_t::find_topology(dm_easy_mesh_t *dm)
 {
 	unsigned int i;
 	em_network_topo_t *topo;
-	mac_addr_str_t tgt_dev_mac_str, src_dev_mac_str;
-
-	dm_easy_mesh_t::macbytes_to_string(dm->m_device.m_device_info.intf.mac, tgt_dev_mac_str);
-	dm_easy_mesh_t::macbytes_to_string(m_data_model->m_device.m_device_info.intf.mac, src_dev_mac_str);
-	printf("%s:%d: Trying to find topology: %s in branch: %s\n", __func__, __LINE__, tgt_dev_mac_str, src_dev_mac_str);
 
 	if (m_data_model == dm) {
-		printf("%s:%d: Found topology: %s in branch: %s\n", __func__, __LINE__, tgt_dev_mac_str, src_dev_mac_str);
 		return this;
 	}
 
@@ -319,10 +322,58 @@ bool em_network_topo_t::remove(dm_easy_mesh_t *dm, em_network_topo_t **child_top
 	return false;
 }
 
+bool em_network_topo_t::is_bh_reconfig_complete()
+{
+	return m_bh_processed;
+}
+
+void em_network_topo_t::reset_bh_reconfig()
+{
+	m_bh_processed = false;
+	for (unsigned int i = 0; i < m_num_topologies; i++) {
+		m_topology[i]->reset_bh_reconfig();
+	}
+}
+
+bool em_network_topo_t::is_bh_reconfig_candidate()
+{
+	if (m_bh_processed) {
+		return false;
+	}
+
+	for (unsigned int i = 0; i < m_num_topologies; i++) {
+		if (!m_topology[i]->m_bh_processed) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void em_network_topo_t::mark_bh_leaves_processed()
+{
+	for (unsigned int i = 0; i < m_num_topologies; i++) {
+		m_topology[i]->mark_bh_leaves_processed();
+	}
+	if (is_bh_reconfig_candidate()) {
+		m_bh_processed = true;
+	}
+}
+
+void em_network_topo_t::send_bh_reconfig_event()
+{
+	em_ctrl_t *ctrl = em_ctrl_t::get_em_ctrl_instance();
+	em_cmd_params_t params;
+	memset(&params, 0, sizeof(em_cmd_params_t));
+	ctrl->io_process(em_bus_event_type_set_bh_cfg, static_cast<char *>(NULL), 0, &params);
+}
+
 em_network_topo_t::em_network_topo_t(dm_easy_mesh_t *dm)
 {
 	m_num_topologies  = 0;
 	m_data_model = dm;
+	m_bh_processed = false;
+	m_bh_reconfig_active = false;
 	memset(m_topology, 0, sizeof(m_topology));
 }
 
@@ -330,7 +381,19 @@ em_network_topo_t::em_network_topo_t()
 {
 	m_data_model = NULL;
 	m_num_topologies  = 0;
+	m_bh_processed = false;
+	m_bh_reconfig_active = false;
 	memset(m_topology, 0, sizeof(m_topology));
+}
+
+bool em_network_topo_t::is_direct_child(dm_easy_mesh_t *dm)
+{
+	for (unsigned int i = 0; i < m_num_topologies; i++) {
+		if (m_topology[i]->get_data_model() == dm) {
+			return true;
+		}
+	}
+	return false;
 }
 
 em_network_topo_t::~em_network_topo_t()

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -761,6 +761,9 @@ int dm_easy_mesh_t::decode_config(em_subdoc_info_t *subdoc, const char *str, uns
 	} else if (strncmp(str, "SetSSID", strlen("SetSSID")) == 0) {
         snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
         return decode_config_set_ssid(subdoc, key);
+    } else if (strncmp(str, "SetBhCfg", strlen("SetBhCfg")) == 0) {
+        snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
+        return decode_config_set_ssid(subdoc, key);
     } else if (strncmp(str, "SetAnticipatedChannelPreference", strlen("SetAnticipatedChannelPreference")) == 0) {
         snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
         return decode_config_set_channel(subdoc, key, index, num);
@@ -2615,7 +2618,7 @@ em_bss_info_t* dm_easy_mesh_t::get_bsta_bss_info()
         if (!radio) continue;
         em_printfout("radio_mac:%s backhaul bss_mac:%s radio enabled:%d sta_info enabled:%d",
             util::mac_to_string(bsta_info->ruid.mac).c_str(),
-            util::mac_to_string(bsta_info->id.bssid).c_str(),
+            util::mac_to_string(bsta_info->bssid.mac).c_str(),
             radio->m_radio_info.enabled, bsta_info->enabled);
         if (!radio->m_radio_info.enabled || !bsta_info->enabled) {
             continue;

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1526,7 +1526,7 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 	const em_policy_t	em_policy[] = {
 						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 							em_policy_id_type_ap_metrics_rep}, 0, {}, em_steering_policy_type_unknown, 
-							0, 0, 5, 0, false, false, false, "", false, false, false, {0, 0},
+							0, 0, 0, 0, false, false, false, "", false, false, false, {0, 0},
 							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
 						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
 							em_policy_id_type_radio_metrics_rep}, 0, {}, em_steering_policy_type_unknown, 

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -1234,6 +1234,9 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
             radio_info->unassociated_sta_link_mterics_nonopclass_inclusion_policy = ap_cap->unassociated_client_link_metrics_non_op_channels;
             radio_info->unassociated_sta_link_mterics_opclass_inclusion_policy = ap_cap->unassociated_client_link_metrics_op_channels;
             radio_info->support_rcpi_steering = ap_cap->rcpi_steering;
+
+            // Store M8_bSTA_Reconfiguration capability at device level (Section 5.2.5)
+            dm->m_device.m_device_info.m8_bsta_reconfiguration = ap_cap->m8_bsta_reconfiguration ? true : false;
         } else if (tlv->type == em_tlv_type_ap_radio_basic_cap){
             em_printfout("Received AP Radio Basic Capability TLV");
             handle_ap_radio_basic_cap(tlv->value, htons(tlv->len));

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2281,6 +2281,101 @@ unsigned short em_configuration_t::create_m2_msg(unsigned char *buff, em_haul_ty
     return len;
 }
 
+em_wsc_msg_type_t em_configuration_t::get_wsc_blob_msg_type(unsigned char *buff, unsigned int len)
+{
+    data_elem_attr_t *attr = reinterpret_cast<data_elem_attr_t *>(buff);
+    unsigned int tmp_len = len;
+
+    while (tmp_len > sizeof(data_elem_attr_t)) {
+        if (htons(attr->id) == attr_id_msg_type) {
+            return static_cast<em_wsc_msg_type_t>(attr->val[0]);
+        }
+        unsigned int advance = static_cast<unsigned int>(sizeof(data_elem_attr_t) + htons(attr->len));
+        if (advance > tmp_len) break;
+        tmp_len -= advance;
+        attr = reinterpret_cast<data_elem_attr_t *>(reinterpret_cast<unsigned char *>(attr) + advance);
+    }
+    return em_wsc_msg_type_none;
+}
+
+unsigned short em_configuration_t::create_m8_msg(unsigned char *buff)
+{
+    data_elem_attr_t *attr;
+    unsigned short size, len = 0;
+    unsigned char *tmp = buff;
+    em_network_ssid_info_t *net_ssid_info;
+
+    // M8 only carries backhaul encrypted settings
+    if ((net_ssid_info = get_network_ssid_info_by_haul_type(em_haul_type_backhaul)) == NULL) {
+        em_printfout("M8: Could not find backhaul network ssid information");
+        return 0;
+    }
+
+    if (net_ssid_info->enable == false) {
+        em_printfout("M8: Backhaul SSID is disabled, skipping");
+        return 0;
+    }
+
+    // version
+    attr = reinterpret_cast<data_elem_attr_t *>(tmp);
+    attr->id = htons(attr_id_version);
+    size = 1;
+    attr->len = htons(size);
+    attr->val[0] = 0x10;
+    len += static_cast<unsigned short>(sizeof(data_elem_attr_t) + size);
+    tmp += (sizeof(data_elem_attr_t) + size);
+
+    // message type — M8
+    attr = reinterpret_cast<data_elem_attr_t *>(tmp);
+    attr->id = htons(attr_id_msg_type);
+    size = 1;
+    attr->len = htons(size);
+    attr->val[0] = em_wsc_msg_type_m8;
+    len += static_cast<unsigned short>(sizeof(data_elem_attr_t) + size);
+    tmp += (sizeof(data_elem_attr_t) + size);
+
+    // registrar nonce (EasyMesh Section 5.2.5)
+    attr = reinterpret_cast<data_elem_attr_t *>(tmp);
+    attr->id = htons(attr_id_registrar_nonce);
+    size = sizeof(em_nonce_t);
+    attr->len = htons(size);
+    get_r_nonce(attr->val);
+    len += static_cast<unsigned short>(sizeof(data_elem_attr_t) + size);
+    tmp += (sizeof(data_elem_attr_t) + size);
+
+    // public key — Diffie-Hellman key of Registrar (EasyMesh Section 5.2.5)
+    attr = reinterpret_cast<data_elem_attr_t *>(tmp);
+    attr->id = htons(attr_id_public_key);
+    size = static_cast<unsigned short>(get_r_public_len());
+    attr->len = htons(size);
+    memcpy(attr->val, get_r_public(), size);
+    len += static_cast<unsigned short>(sizeof(data_elem_attr_t) + size);
+    tmp += (sizeof(data_elem_attr_t) + size);
+
+    // encrypted settings (backhaul SSID + passphrase)
+    attr = reinterpret_cast<data_elem_attr_t *>(tmp);
+    attr->id = htons(attr_id_encrypted_settings);
+    size = static_cast<unsigned short>(create_encrypted_settings(attr->val, em_haul_type_backhaul));
+    attr->len = htons(size);
+    len += static_cast<unsigned short>(sizeof(data_elem_attr_t) + size);
+    tmp += (sizeof(data_elem_attr_t) + size);
+
+    // Save M8 as M2 for authenticator computation (reuses m_m2_msg/m_m2_length)
+    m_m2_length = len;
+    memcpy(m_m2_msg, buff, m_m2_length);
+
+    // authenticator
+    attr = reinterpret_cast<data_elem_attr_t *>(tmp);
+    attr->id = htons(attr_id_authenticator);
+    size = static_cast<unsigned short>(create_authenticator(attr->val));
+    attr->len = htons(size);
+    len += static_cast<unsigned short>(sizeof(data_elem_attr_t) + size);
+    tmp += (sizeof(data_elem_attr_t) + size);
+
+    em_printfout("M8 message created, length: %d, backhaul SSID: %s", len, net_ssid_info->ssid);
+    return len;
+}
+
 typedef enum
 {
     wifi_security_mode_wps_none = 0x0001, /**< No security. */
@@ -3320,6 +3415,19 @@ int em_configuration_t::create_autoconfig_wsc_m2_msg(unsigned char *buff, unsign
         return 0;
     }
 
+    // Append M8 WSC TLV for backhaul SSID reconfiguration (bSTA reconfig).
+    em_cmd_t *cur_cmd = get_current_cmd();
+    if (cur_cmd != NULL && cur_cmd->m_type == em_cmd_type_set_bh_cfg) {
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_wsc;
+        sz = create_m8_msg(tlv->value);
+        if (sz > 0) {
+            tlv->len = htons(sz);
+            tmp += (sizeof(em_tlv_t) + sz);
+            len += static_cast<int>(sizeof(em_tlv_t) + sz);
+        }
+    }
+
     // default 8022.1q settings tlv 17.2.49
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_dflt_8021q_settings;
@@ -3645,7 +3753,7 @@ int em_configuration_t::handle_wsc_m2(unsigned char *buff, unsigned int len, uns
     unsigned int tmp_len;
     unsigned short id;
 
-    em_printfout("Parsing m2 message, index: %d, len: %d", index, len);
+    em_printfout("Parsing wsc message, index: %d, len: %d", index, len);
 
     m_m2_length = len - 12;
     memcpy(m_m2_msg, buff, m_m2_length);
@@ -3658,7 +3766,7 @@ int em_configuration_t::handle_wsc_m2(unsigned char *buff, unsigned int len, uns
 
         if (id == attr_id_version) {
         } else if (id == attr_id_msg_type) {
-            if (attr->val[0] != em_wsc_msg_type_m2) {
+            if (attr->val[0] != em_wsc_msg_type_m2 && attr->val[0] != em_wsc_msg_type_m8) {
                 return -1;
             }
         } else if (id == attr_id_registrar_nonce) {
@@ -3807,6 +3915,89 @@ int em_configuration_t::handle_wsc_m1(unsigned char *buff, unsigned int len)
 
 }
 
+int em_configuration_t::handle_autoconfig_wsc_m8(unsigned char *buff, unsigned int len)
+{
+    em_tlv_t *tlv;
+    int tmp_len;
+    unsigned int wsc_tlv_count = 0;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    dm_easy_mesh_t *dm;
+    dm_network_t network;
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+
+    if (em_msg_t(em_msg_type_autoconf_wsc, m_peer_profile, buff, len).validate(errors) == 0) {
+        em_printfout("received wsc m8 msg failed validation");
+        return -1;
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    tmp_len = static_cast<int>(len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
+
+    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+        if (tlv->type == em_tlv_type_wsc) {
+            em_wsc_msg_type_t wsc_type = get_wsc_blob_msg_type(tlv->value, htons(tlv->len));
+
+            if (wsc_type == em_wsc_msg_type_m8) {
+                em_printfout("Found M8 WSC TLV for backhaul SSID reconfiguration");
+
+                set_e_mac(get_radio_interface_mac());
+                handle_wsc_m2(tlv->value, htons(tlv->len), wsc_tlv_count);
+
+                if (compute_keys(get_r_public(), static_cast<unsigned short>(get_r_public_len()),
+                        get_e_private(), static_cast<unsigned short>(get_e_private_len())) != 1) {
+                    em_printfout("M8: Keys computation failed");
+                    return -1;
+                }
+                wsc_tlv_count++;
+            }
+        }
+        tmp_len -= static_cast<int>(sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+    }
+
+    if (wsc_tlv_count == 0) {
+        em_printfout("No M8 WSC TLVs found");
+        return -1;
+    }
+
+    em_printfout("M8 backhaul SSID reconfiguration: processing %d WSC TLV(s)", wsc_tlv_count);
+
+    if (handle_encrypted_settings(wsc_tlv_count, true) == -1) {
+        em_printfout("M8: Error decrypting settings, wsc_tlv_count:%d", wsc_tlv_count);
+        return -1;
+    }
+
+    dm = get_data_model();
+    if ((dm != NULL) && (hdr != NULL)) {
+        memcpy(&network.m_net_info.ctrl_id.mac, &hdr->src, sizeof(mac_address_t));
+        dm->set_network(network);
+    }
+
+    // handle_encrypted_settings() already set the state to owconfig_pending
+    // and queued the m2ctrl_configuration bus event, which will push the new
+    // backhaul credentials to OneWifi (Private subdoc + mesh_backhaul_sta
+    // subdoc for bSTA reconnection).
+    //
+    // For co-located agents the controller is reachable over Ethernet, so
+    // advance to topo_synchronized to answer topology queries immediately.
+    //
+    // For extenders, set to unconfigured so the agent sends autoconfig_search
+    // to re-onboard after bSTA reconnects with new credentials.
+    // The cfg_renew fini check also accepts unconfigured state.
+    em_interface_name_t if_name;
+    bool is_colocated = (hdr != NULL &&
+        dm_easy_mesh_t::name_from_mac_address(&hdr->src, if_name) == 0);
+    if (!is_colocated) {
+        em_printfout("M8: Extender radio set to unconfigured; will send autoconfig_search to re-onboard");
+        set_state(em_state_agent_unconfigured);
+    } else {
+        em_printfout("M8: Collocated radio, setting topo_synchronized");
+        set_state(em_state_agent_topo_synchronized);
+    }
+
+    return 0;
+}
+
 int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned int len)
 {
     em_tlv_t *tlv;
@@ -3817,13 +4008,15 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
     dm_easy_mesh_t *dm;
     dm_network_t network;
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *> (buff);
+    bool has_m8 = false;
 
     if (em_msg_t(em_msg_type_autoconf_wsc, m_peer_profile, buff, len).validate(errors) == 0) {
         printf("%s:%d: received wsc m2 msg failed validation\n", __func__, __LINE__);
-
         return -1;
     }
-   
+
+    // Process all WSC TLVs: M2 TLVs configure AP-side BSSes,
+    // M8 TLVs configure the bSTA (backhaul reconfiguration).
     tlv =  reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tmp_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
 
@@ -3832,8 +4025,21 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
             em_printfout("Found AP MLD details in message");
             handle_ap_mld_config_tlv(tlv->value, htons(tlv->len));
         } else if (tlv->type == em_tlv_type_wsc) {
-            em_printfout("Handle wsc TLV, count: %d", wsc_tlv_count);
-            //Storing m2 address and length in static variable;
+            em_wsc_msg_type_t wsc_type = get_wsc_blob_msg_type(tlv->value, htons(tlv->len));
+            if (wsc_type == em_wsc_msg_type_m8) {
+                has_m8 = true;
+                em_printfout("Found M8 TLV in M2 message, will be handled separately");
+                tmp_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
+                tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+                continue;
+            }
+            em_printfout("Handle wsc M2 TLV, count: %d", wsc_tlv_count);
+            if (wsc_tlv_count >= em_haul_type_max) {
+                em_printfout("wsc_tlv_count:%d exceeds em_haul_type_max:%d, skipping", wsc_tlv_count, em_haul_type_max);
+                tmp_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
+                tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+                continue;
+            }
             set_e_mac(get_radio_interface_mac());
             handle_wsc_m2(tlv->value, htons(tlv->len), wsc_tlv_count);
 
@@ -3865,7 +4071,7 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
         return -1;
     }
 
-    if (handle_encrypted_settings(wsc_tlv_count) == -1) {
+    if (handle_encrypted_settings(wsc_tlv_count, has_m8) == -1) {
         em_printfout("Error in decrypting settings wsc_tlv_count:%d", wsc_tlv_count);
         return -1;
     }
@@ -3886,10 +4092,11 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
 #endif
         }
     }
+
     return 0;
 }
 
-int em_configuration_t::handle_encrypted_settings(unsigned int wsc_tlv_count)
+int em_configuration_t::handle_encrypted_settings(unsigned int wsc_tlv_count, bool is_bh_reconfig)
 {
     data_elem_attr_t    *attr;
     int tmp_len, ret = 0;
@@ -3970,6 +4177,7 @@ int em_configuration_t::handle_encrypted_settings(unsigned int wsc_tlv_count)
     for (unsigned int i = 0; i < radioconfig.noofbssconfig; i++){
         radioconfig.freq[i] = get_band();
     }
+    radioconfig.is_bh_reconfig = is_bh_reconfig;
     get_mgr()->io_process(em_bus_event_type_m2ctrl_configuration, reinterpret_cast<unsigned char *> (&radioconfig), sizeof(radioconfig));
     set_state(em_state_agent_owconfig_pending);
     return ret;
@@ -5160,24 +5368,24 @@ int em_configuration_t::handle_autoconfig_search(unsigned char *buff, unsigned i
     mac_address_t al_mac;
 
     if (em_msg_t(em_msg_type_autoconf_search, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("received autoconfig search msg failed validation\n");
+        em_printfout("Received autoconfig search message failed validation\n");
     
         return -1;
     }
     if (em_msg_t(buff + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
                len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_profile_type(&m_peer_profile) == false) { 
-        printf("%s:%d: Could not get peer profile type\n", __func__, __LINE__);
+        em_printfout("Could not get peer profile type\n");
     } else {
         m_peer_profile = em_profile_type_1;
     }
 
     if (em_msg_t(buff + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)), len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_freq_band(&band) == false) {
-        printf("%s:%d: Could not get freq band\n", __func__, __LINE__);
+        em_printfout("Could not get freq band\n");
         return -1;
     }
 
     if (em_msg_t(buff + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)), len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_al_mac_address(al_mac) == false) {
-        printf("%s:%d: Could not get al mac address\n", __func__, __LINE__);
+        em_printfout("Could not get al mac address\n");
         return -1;
     }
 
@@ -5204,7 +5412,7 @@ int em_configuration_t::handle_autoconfig_search(unsigned char *buff, unsigned i
 
         return -1;
     }
-    printf("%s:%d: autoconfig rsp send success\n", __func__, __LINE__);
+    em_printfout("autoconfig rsp send success, len:%d", sz);
 
     if (!get_is_dpp_onboarding()) {
         set_state(em_state_ctrl_wsc_m1_pending);
@@ -5272,11 +5480,15 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
         case em_msg_type_autoconf_wsc:
             if ((get_wsc_msg_type(tlvs, tlvs_len) == em_wsc_msg_type_m2) &&
                     (get_service_type() == em_service_type_agent) && (get_state() == em_state_agent_wsc_m2_pending)) {
-                        printf("%s:%d: received wsc_m2 len:%d\n", __func__, __LINE__, len);
+                        em_printfout("Received wsc_m2 len:%d\n", len);
                         handle_autoconfig_wsc_m2(data, len);
+            } else if ((get_wsc_msg_type(tlvs, tlvs_len) == em_wsc_msg_type_m8) &&
+                    (get_service_type() == em_service_type_agent) && (get_state() == em_state_agent_owconfig_pending)) {
+                        em_printfout("Received wsc_m8 len:%d\n", len);
+                        handle_autoconfig_wsc_m8(data, len);
             } else if ((get_wsc_msg_type(tlvs, tlvs_len) == em_wsc_msg_type_m1) &&
                     (get_service_type() == em_service_type_ctrl) && (get_state() == em_state_ctrl_wsc_m1_pending))  {
-                        printf("%s:%d: received wsc_m1 len:%d\n", __func__, __LINE__, len);
+                        em_printfout("Received wsc_m1 len:%d\n", len);
                         handle_autoconfig_wsc_m1(data, len);
             }
 
@@ -5284,6 +5496,7 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
 
         case em_msg_type_autoconf_renew:
             if (get_service_type() == em_service_type_agent) {
+                em_printfout("Received autoconf renew message, len:%d\n", len);
                 handle_autoconfig_renew(data, len);
             }
             break;
@@ -5294,8 +5507,8 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
                 std::vector<em_t*> em_radios;
                 get_mgr()->get_all_em_for_al_mac(hdr->dst, em_radios);
                 for (auto &em : em_radios) {
-                    if ((em->get_service_type() == em_service_type_agent) && (em->get_state() < em_state_agent_onewifi_bssconfig_ind)) {
-                        em_printfout("radio %s is not configured, ignoring", util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                    if ((em->get_service_type() == em_service_type_agent) && (em->get_state() < em_state_agent_owconfig_pending)) {
+                        em_printfout("radio %s is not configured (state %d), ignoring", util::mac_to_string(em->get_radio_interface_mac()).c_str(), em->get_state());
                         em_radios.clear();
                         return;
                     }
@@ -5324,9 +5537,14 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
                         util::mac_to_string(hdr->src).c_str());
                     get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
                     for (auto &em : em_radios) {
-                        em->set_state(em_state_ctrl_topo_synchronized);
-                        em->set_ssid_mismatch(false);
-                        printf("%s:%d em_msg_type_topo_resp handle success, state: %s\n", __func__, __LINE__, em_t::state_2_str(em->get_state()));
+                        // Only advance radios that are actually in topo_sync_pending;
+                        // radios in other states (misconfigured, configured) should
+                        // not be blindly transitioned.
+                        if (em->get_state() == em_state_ctrl_topo_sync_pending) {
+                            em->set_state(em_state_ctrl_topo_synchronized);
+                            em->set_ssid_mismatch(false);
+                            printf("%s:%d em_msg_type_topo_resp handle success, state: %s\n", __func__, __LINE__, em_t::state_2_str(em->get_state()));
+                        }
                     }
                     em_radios.clear();
                     //Reset the mismatch and topo_query_last sent values
@@ -5475,6 +5693,9 @@ void em_configuration_t::handle_state_wsc_m1_pending()
 void em_configuration_t::handle_state_wsc_m2_pending()
 {
     assert(get_service_type() == em_service_type_agent);
+    // M1 may have been lost in transit. Retry by re-sending autoconfig_search
+    // which restarts the autoconfig_resp → M1 → M2 sequence.
+    handle_state_config_none();
 }
 
 void em_configuration_t::fill_media_data(em_media_spec_data_t *spec, dm_bss_t *bss)
@@ -5570,10 +5791,14 @@ void em_configuration_t::process_ctrl_state()
 
             if (ssid_mismatch_present == false)
             {
+                // Only wait for radios still transitioning (wsc_m2_sent means
+                // M2 was sent but orch hasn't moved it to topo_sync_pending yet).
+                // Radios in stable states (misconfigured, configured, etc.)
+                // should not block topology query for the other radios.
                 for (auto &em : em_radios) {
-                    if (em->get_state() != em_state_ctrl_topo_sync_pending) {
-                        em_printfout("radio %s is in state:%d, not in topo sync pending state, ignoring",
-                            util::mac_to_string(em->get_radio_interface_mac()).c_str(), em->get_state());
+                    if (em->get_state() == em_state_ctrl_wsc_m2_sent) {
+                        em_printfout("radio %s is in state wsc_m2_sent, waiting for topo_sync_pending",
+                            util::mac_to_string(em->get_radio_interface_mac()).c_str());
                         em_radios.clear();
                         return;
                     }
@@ -5581,9 +5806,12 @@ void em_configuration_t::process_ctrl_state()
                 // Reset the mismatch and topo_query_last sent values before sending topo query
                 dm->set_ssid_mismatch_check_time(0);
                 dm->set_last_topo_query_sent_time(0);
-                // If all radios are in topo sync pending state, send topo query on one of them, 
-                // ignore sending topo query on other radios
-                if (this == em_radios.front()){
+                // Send topo query on the first radio in topo_sync_pending state;
+                // ignore radios in other states (misconfigured, configured, etc.)
+                auto topo_it = std::find_if(em_radios.begin(), em_radios.end(), [](em_t *em) {
+                    return em->get_state() == em_state_ctrl_topo_sync_pending;
+                });
+                if (topo_it != em_radios.end() && this == *topo_it){
                     em_printfout("Sending the Topology query message to agent al_mac:%s on radio: %s",
                         util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
                         util::mac_to_string(get_radio_interface_mac()).c_str());

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -98,6 +98,7 @@ void em_t::orch_execute(em_cmd_t *pcmd)
 			break;
 
         case em_cmd_type_set_ssid:
+        case em_cmd_type_set_bh_cfg:
         case em_cmd_type_set_radio:
 	    if (m_service_type == em_service_type_ctrl) {
 	        set_renew_tx_count(0);
@@ -479,6 +480,7 @@ void em_t::handle_ctrl_state()
     cmd_type = m_cmd->m_type;
     switch (cmd_type) {
         case em_cmd_type_set_ssid:
+        case em_cmd_type_set_bh_cfg:
         case em_cmd_type_set_radio:
         case em_cmd_type_cfg_renew:
             em_configuration_t::process_ctrl_state();
@@ -1025,7 +1027,7 @@ short em_t::create_ap_cap_tlv(unsigned char *buff)
     ap_cap->unassociated_client_link_metrics_non_op_channels = radio_info->unassociated_sta_link_mterics_nonopclass_inclusion_policy;
     ap_cap->unassociated_client_link_metrics_op_channels =  radio_info->unassociated_sta_link_mterics_opclass_inclusion_policy;
     ap_cap->rcpi_steering = radio_info->support_rcpi_steering;
-    // ap_cap->reserved - Future implementation
+    ap_cap->m8_bsta_reconfiguration = 1;
     len = sizeof(em_ap_capability_t);
     return len;
 }

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -1735,7 +1735,7 @@ void em_metrics_t::process_msg(unsigned char *data, unsigned int len)
             break;
 
         case em_msg_type_ap_metrics_rsp:
-            handle_ap_metrics_response(data, len);
+            //handle_ap_metrics_response(data, len);
             break;
         case em_msg_type_topo_vendor:
             handle_vendor_msg(data, len);

--- a/src/orch/em_orch.cpp
+++ b/src/orch/em_orch.cpp
@@ -36,8 +36,25 @@
 #include "em_base.h"
 #include "em_cmd.h"
 #include "em_orch.h"
+#include "em_mgr.h"
+#include "em_network_topo.h"
 #include "util.h"
 #define MAX_CMD_DEV_TEST 2
+
+// Weak definition: overridden by the strong definition in em_ctrl.cpp when
+// linking the ctrl binary. For the agent binary (which doesn't link
+// em_network_topo.o or em_ctrl.o), this provides a NULL pointer so that all
+// the runtime g_network_topology != NULL checks safely skip topology code.
+__attribute__((weak)) em_network_topo_t *g_network_topology = nullptr;
+
+// Weak stubs for em_network_topo_t member functions referenced below.
+// In the ctrl binary, the real implementations from em_network_topo.cpp
+// (strong symbols) override these. In the agent binary these satisfy the
+// linker; they are never called because g_network_topology stays NULL.
+__attribute__((weak)) void em_network_topo_t::reset_bh_reconfig() {}
+__attribute__((weak)) void em_network_topo_t::send_bh_reconfig_event() {}
+__attribute__((weak)) void em_network_topo_t::mark_bh_leaves_processed() {}
+__attribute__((weak)) em_network_topo_t *em_network_topo_t::find_topology(dm_easy_mesh_t *) { return nullptr; }
 
 unsigned int em_orch_t::submit_commands(em_cmd_t *pcmd[], unsigned int num)
 {
@@ -134,9 +151,33 @@ bool em_orch_t::submit_command(em_cmd_t *pcmd)
 {
     bool submitted = false;
 
+    // Pre-process the submit orch op (e.g. update DB with new SSIDs)
+    // before building candidates, so the data model is up-to-date when
+    // create_encrypted_settings reads network SSID info for M8.
+    if (pre_process_orch_op(pcmd) == false) {
+        destroy_command(pcmd);
+        return false;
+    }
+
+    // Also process any remaining non-submit orch ops (e.g. net_ssid_update)
+    // that would otherwise never execute in the single-command path.
+    {
+        unsigned int saved_idx = pcmd->get_orch_op_index();
+        for (unsigned int i = saved_idx + 1; i < pcmd->m_num_orch_desc; i++) {
+            pcmd->m_orch_op_idx = i;
+            if (pcmd->get_orch_submit() == false) {
+                pre_process_orch_op(pcmd);
+            }
+        }
+        pcmd->m_orch_op_idx = saved_idx;
+    }
+
     // build em candidates in cmd;
     if (build_candidates(pcmd) == 0) {
-        // if there are no candidates, complete the command
+        if (pcmd->get_type() == em_cmd_type_set_bh_cfg && g_network_topology != NULL) {
+            g_network_topology->set_bh_reconfig_active(false);
+            g_network_topology->reset_bh_reconfig();
+        }
         destroy_command(pcmd);
     } else {
         queue_push(m_pending, pcmd);
@@ -391,6 +432,7 @@ bool em_orch_t::is_cmd_in_progress_by_radio(em_bus_event_t *evt)
 				for (j = static_cast<int>(queue_count(pcmd->m_em_candidates)) - 1; j >= 0; j--) {
 					em = static_cast<em_t *>(queue_peek(pcmd->m_em_candidates, static_cast<unsigned int>(j)));
 					dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+
 					if (memcmp(mac, em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
 						dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
                         em_printfout("Command of type: %s and cmd: %s actively executing for %s",
@@ -551,23 +593,53 @@ void em_orch_t::handle_timeout()
         pcmd = static_cast<em_cmd_t *>(queue_peek(m_active, static_cast<unsigned int>(i)));
 		//printf("%s:%d: Cmd: %s, em candidates: %d\n", __func__, __LINE__, 
 					//em_cmd_t::get_cmd_type_str(pcmd->m_type), queue_count(pcmd->m_em_candidates));
+        ret = true;
         for (j = static_cast<int>(queue_count(pcmd->m_em_candidates)) - 1; j >= 0; j--) {
             em = static_cast<em_t *>(queue_peek(pcmd->m_em_candidates, static_cast<unsigned int>(j)));
             ret &= orchestrate(pcmd, em);
         }
 
         if (ret == true) {
-            // means the command is in fini sate 
-            //printf("%s:%d: Removing and destroying Command type: %s Orchestration: %s because command is in fini state\n", 
-                   // __func__, __LINE__, pcmd->get_cmd_name(), em_cmd_t::get_orch_op_str(pcmd->get_orch_op()));
+            bool bh_reconfig_next = (pcmd->m_type == em_cmd_type_set_bh_cfg);
+
             queue_remove(m_active, static_cast<unsigned int>(i));
             pop_stats(pcmd);
             for (j = static_cast<int>(queue_count(pcmd->m_em_candidates)) - 1; j >= 0; j--) {
                 em = static_cast<em_t *>(queue_peek(pcmd->m_em_candidates, static_cast<unsigned int>(j)));
                 em->set_orch_state(em_orch_state_idle);
+                if (bh_reconfig_next && g_network_topology != NULL) {
+                    em_network_topo_t *topo = g_network_topology->find_topology(em->get_data_model());
+                    if (topo != NULL) {
+                        topo->set_bh_processed(true);
+                    }
+                }
             }
+
+            // When cfg_renew completes on agent, handle bSTA reconnect if pending.
+            // Push mesh STA subdoc to trigger bSTA reconnection with new credentials.
+            // After bSTA reconnects, OneWifi fires dev_init which triggers
+            // normal reonboarding through orchestration.
+            if (pcmd->m_type == em_cmd_type_cfg_renew) {
+                em_t *first_em = static_cast<em_t *>(queue_peek(pcmd->m_em_candidates, 0));
+                if (first_em != NULL && first_em->get_data_model() != NULL) {
+                    first_em->get_data_model()->m_cfg_renew_in_progress = false;
+                    
+                    if (first_em->get_data_model()->m_bsta_reconnect_pending) {
+                        first_em->get_data_model()->m_bsta_reconnect_pending = false;
+                        if (first_em->get_mgr() != NULL) {
+                            first_em->get_mgr()->refresh_onewifi_subdoc(
+                                "MESH STA CONFIG", webconfig_subdoc_type_mesh_backhaul_sta);
+                            }
+                        }
+                    }
+                }
+
             destroy_command(pcmd);
-            //em->set_state(em_state_agent_config_complete);
+
+            if (bh_reconfig_next && g_network_topology != NULL) {
+                g_network_topology->send_bh_reconfig_event();
+            }
+
             break;
         }
 

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -62,6 +62,45 @@ void em_orch_agent_t::orch_transient(em_cmd_t *pcmd, em_t *em)
     }
 
     if (stats->time > EM_MAX_CMD_GEN_TTL) {
+        // For cfg_renew on a non-colocated agent (extender): after M8 backhaul
+        // reconfig the bSTA disconnects and reconnects with new credentials.
+        // While disconnected the radio cycles through unconfigured →
+        // autoconfig_rsp_pending → wsc_m2_pending.  Allow extra time for the
+        // bSTA to come back up before canceling.
+        if (pcmd->get_type() == em_cmd_type_cfg_renew &&
+            em->get_state() < em_state_agent_topo_synchronized) {
+            dm_easy_mesh_t *dm = em->get_data_model();
+            if (dm != NULL) {
+                // Detect colocation: if the controller's AL MAC is a local
+                // interface, this is the collocated agent (no extended wait).
+                unsigned char *ctrl_mac = dm->get_ctrl_al_interface_mac();
+                em_interface_name_t if_name;
+                bool is_colocated = (ctrl_mac != NULL &&
+                    dm_easy_mesh_t::name_from_mac_address(
+                        reinterpret_cast<const mac_address_t*>(ctrl_mac), if_name) == 0);
+                if (!is_colocated && stats->time <= EM_SSID_MISMATCH_TTL) {
+                    return; // keep sending autoconfig_search
+                }
+            }
+        }
+         // For dev_init on a non-colocated agent (extender): after cfg_renew
+        // completes, the "dml" subdoc triggers dev_init while the bSTA is still
+        // reconnecting to the new SSID.  Allow extended time for the bSTA to
+        // come back up so autoconfig_search can reach the controller.
+        if (pcmd->get_type() == em_cmd_type_dev_init &&
+            em->get_state() == em_state_agent_owconfig_pending) {
+            dm_easy_mesh_t *dm = em->get_data_model();
+            if (dm != NULL) {
+                unsigned char *ctrl_mac = dm->get_ctrl_al_interface_mac();
+                em_interface_name_t if_name;
+                bool is_colocated = (ctrl_mac != NULL &&
+                    dm_easy_mesh_t::name_from_mac_address(
+                        reinterpret_cast<const mac_address_t*>(ctrl_mac), if_name) == 0);
+                if (!is_colocated && stats->time <= EM_SSID_MISMATCH_TTL) {
+                    return; // keep sending autoconfig_search until bSTA reconnects
+                }
+            }
+        }
         em_printfout("Canceling cmd: %s because time limit exceeded\n", pcmd->get_cmd_name());
         cancel_command(pcmd->get_type());
     	if (em->get_state() < em_state_agent_topo_synchronized) {
@@ -88,7 +127,8 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
         case em_cmd_type_cfg_renew:
-            if (em->get_state() == em_state_agent_owconfig_pending) {
+            if (em->get_state() == em_state_agent_owconfig_pending ||
+                em->get_state() == em_state_agent_topo_synchronized) {
                 return true;
             }
             break;
@@ -361,9 +401,9 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
 				}
 				break;
             case em_cmd_type_cfg_renew:
-		dm_easy_mesh_t::macbytes_to_string(pcmd->get_data_model()->get_radio(num)->get_radio_info()->intf.mac, src_mac_str);
-                if ((memcmp(pcmd->get_data_model()->get_radio(num)->get_radio_info()->intf.mac, em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) && (!(em->is_al_interface_em()))) {
-		    printf("%s:%d Renew %s added\n", __func__, __LINE__,src_mac_str);
+                if (!(em->is_al_interface_em())) {
+                    dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), src_mac_str);
+                    printf("%s:%d Renew %s added\n", __func__, __LINE__, src_mac_str);
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
                 }

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -40,6 +40,9 @@
 #include "em_configuration.h"
 #include "em_orch_ctrl.h"
 #include "em_cmd_ctrl.h"
+#include "em_network_topo.h"
+
+extern em_network_topo_t *g_network_topology;
 
 void em_orch_ctrl_t::orch_transient(em_cmd_t *pcmd, em_t *em)
 {
@@ -134,19 +137,28 @@ void em_orch_ctrl_t::orch_transient(em_cmd_t *pcmd, em_t *em)
                     }
                 }
             } else if (stats->time > (EM_MAX_CMD_GEN_TTL + EM_MAX_CMD_EXT_TTL)) {
-                em_printfout("Canceling cmd: %s because time limit exceeded",pcmd->get_cmd_name());
+                em_printfout("Canceling cmd: %s for agent %s because time limit exceeded",
+                    pcmd->get_cmd_name(),
+                    util::mac_to_string(dm->get_agent_al_interface_mac()).c_str());
                 // Reset the mismatch and topo_query_last sent values before canceling
                 dm->set_ssid_mismatch_check_time(0);
                 dm->set_last_topo_query_sent_time(0);
-                cancel_command(pcmd->get_type());
+                // Cancel only this agent's radios, not all em_config commands
+                cancel_command(pcmd->get_type(), all_em_radios);
             }
             break;
         }
 
+        case em_cmd_type_set_bh_cfg:
+            if (stats->time > (EM_MAX_CMD_GEN_TTL + EM_MAX_CMD_EXT_TTL)) {
+                cancel_command(pcmd->get_type());
+            }
+            break;
+
         default:
         if (stats->time > EM_MAX_CMD_GEN_TTL)
         {
-            em_printfout("Canceling cmd: %s because time limit exceeded",pcmd->get_cmd_name());
+            em_printfout("Canceling cmd: %s because time limit exceeded (stats->time=%u)",pcmd->get_cmd_name(), stats->time);
             cancel_command(pcmd->get_type());
         }
         break;
@@ -155,8 +167,9 @@ void em_orch_ctrl_t::orch_transient(em_cmd_t *pcmd, em_t *em)
 
 bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
 {
-    // if the command is SetSSID and 5 renews have been sent transition to fini
+    
     switch (pcmd->m_type) {
+        // if the command is SetSSID and 5 renews have been sent transition to fini
         case em_cmd_type_set_ssid:
         case em_cmd_type_cfg_renew:
 		case em_cmd_type_set_radio:
@@ -167,6 +180,15 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             } else if (em->get_state() == em_state_ctrl_wsc_m2_sent) {
                 return true;
 			}
+            break;
+   
+        case em_cmd_type_set_bh_cfg:
+            if (em->get_state() == em_state_ctrl_wsc_m2_sent) {
+                return true;
+            } else if (em->get_renew_tx_count() >= EM_MAX_RENEW_TX_THRESH) {
+                em->set_renew_tx_count(0);
+                return true;
+            }
             break;
 
         case em_cmd_type_em_config:
@@ -284,6 +306,7 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
 {
     switch (pcmd->m_type) {
         case em_cmd_type_set_ssid:
+        case em_cmd_type_set_bh_cfg:
         case em_cmd_type_set_radio:
         case em_cmd_type_mld_reconfig:
         case em_cmd_type_start_dpp:
@@ -530,6 +553,16 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                     //em_printfout("Set SSID: %s push to queue", mac_str);
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
+                }
+                break;
+
+            case em_cmd_type_set_bh_cfg:
+                if (em->is_al_interface_em() == false && g_network_topology != NULL) {
+                    em_network_topo_t *topo = g_network_topology->find_topology(em->get_data_model());
+                    if (topo != NULL && topo->is_bh_reconfig_candidate()) {
+                        queue_push(pcmd->m_em_candidates, em);
+                        count++;
+                    }
                 }
                 break;
 


### PR DESCRIPTION
Reason for change: Add a new feature so that backhaul credentials can be changed across all agents in postorder, while agents are onboarded in preorder.
Risks: High
Priority: P1
Test procedure: Flash the image and verify that the backhaul credentials are changed across all agents. The RBUS CLI method below can be used for testing.

Command : method_values Device.WiFi.DataElements.Network.SetSSID SSID string "COMCAST_BACK" HaulType string "Backhaul" AddRemoveChange string "Change"