### PR TITLE
Add TR-181 ChannelSelectionRequest support and fix RDKB CLI channel selection

### DIFF
--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -367,6 +367,23 @@ public:
 	int analyze_set_radio(em_bus_event_t *evt, em_cmd_t *cmd[]);
     
 	/**!
+	 * @brief Analyzes the channel selection based on the provided event and command.
+	 *
+	 * This function processes the event and command to determine the appropriate channel selection.
+	 *
+	 * @param[in] evt Pointer to the event structure containing channel selection data.
+	 * @param[in] cmd Array of pointers to command structures for processing.
+	 *
+	 * @returns int Number of generated commands (>0) on success.
+	 * @retval 0 No-op (nothing to do).
+	 * @retval EM_PARSE_ERR_NO_CHANGE No config changes detected.
+	 * @retval <0 Negative parse/validation error code.
+	 * @note Ensure that the event and command structures are properly initialized
+	 * before calling this function.
+	 */
+	int analyze_channel_select(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
+	/**!
 	 * @brief Analyzes and sets the channel based on the provided event and command.
 	 *
 	 * This function processes the event and command to determine the appropriate channel settings.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2538,6 +2538,7 @@ typedef enum {
     em_op_class_type_preference,
     em_op_class_type_anticipated,
     em_op_class_type_scan_param,
+    em_op_class_type_selection,
 } em_op_class_type_t;
 
 typedef struct {
@@ -3012,6 +3013,7 @@ typedef enum {
     em_bus_event_type_set_channel,
     em_bus_event_type_scan_channel,
     em_bus_event_type_scan_result,
+    em_bus_event_type_channel_select,
     em_bus_event_type_get_bss,
     em_bus_event_type_get_sta,
     em_bus_event_type_steer_sta,

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -266,6 +266,17 @@ public:
 	void handle_set_ssid_list(em_bus_event_t *evt);
     
 	/**!
+	 * @brief Handles channel selection events.
+	 *
+	 * This function processes channel selection events and schedules channel selection commands.
+	 *
+	 * @param[in] evt Pointer to the event structure containing channel select information.
+	 *
+	 * @note Ensure that the event structure is properly initialized before calling this function.
+	 */
+	void handle_channel_select(em_bus_event_t *evt);
+
+	/**!
 	 * @brief Handles the removal of a device from the bus.
 	 *
 	 * This function processes the event associated with the removal of a device.
@@ -723,6 +734,29 @@ public:
 	 * @note Input property ownership remains with the caller; this function does not free them.
 	 */
 	static bus_error_t cmd_channelscan (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+
+	// Constants for channel selection request parsing
+	static const int MAX_CHANSEL_CLASSES = 32;
+	static const int MAX_CHANSEL_CHANNELS = 64;
+
+	/**!
+	 * @brief Handles the bus ChannelSelectionRequest method request.
+	 *
+	 * Validates ChannelSelectionRequest input properties, dispatches the request to the EasyMesh
+	 * controller, and optionally populates response properties for the caller.
+	 *
+	 * @param[in] method_name Bus method name (...Network.Device.{i}.Radio.{i}.ChannelSelectionRequest()).
+	 * @param[in] input_params Linked list of input properties carrying the request payload.
+	 * @param[out] output_params Populated with response properties when provided.
+	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
+	 *
+	 * @returns bus_error_t
+	 * @retval bus_error_success on successful ChannelSelectionRequest handling.
+	 * @retval bus_error_invalid_input on validation failure.
+	 * @retval other non-zero bus_error_t values on error.
+	 * @note Input property ownership remains with the caller; this function does not free them.
+	 */
+	static bus_error_t cmd_channelselect(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
 
 	/**!
 	 * @brief Handles the bus ClientSteer method request.

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -217,6 +217,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_RADIO_BSSNOE         DE_DEVICE_RADIO         "BSSNumberOfEntries"
 #define DE_RADIO_NOUNASSCSTA    DE_DEVICE_RADIO         "UnassociatedSTANumberOfEntries"
 #define DE_RADIO_CHSCANREQ      DE_DEVICE_RADIO         "ChannelScanRequest()"
+#define DE_RADIO_CHSELREQ       DE_DEVICE_RADIO         "ChannelSelectionRequest()"
 #define DE_RADIO_XAIRTIES_OPERSTANDARDS DE_DEVICE_RADIO "X_AIRTIES_OperatingStandards"
 /* Device.WiFi.DataElements.Network.Device.Radio.BackhaulSta */
 #define DE_RADIO_BHSTA          DE_DEVICE_RADIO         "BackhaulSta."
@@ -613,6 +614,27 @@ public:
      * @note Ownership of input and output buffers remains with the caller.
      */
     static bus_error_t channelscan_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
+
+    /**!
+     * @brief Handles the RBUS ChannelSelectionRequest method invocation.
+     *
+     * This function extracts ChannelSelectionRequest properties from the raw input payload, forwards
+     * them to the EasyMesh controller, and optionally writes response properties to the output
+     * raw buffer for RBUS callers.
+     *
+     * @param method_name RBUS method name, expected to match ChannelSelectionRequest().
+     * @param input_data Input containing a chained list of bus_data_prop_t entries.
+     * @param output_data Output populated with response properties when provided.
+     * @param async_handle RBUS async handle when the call is asynchronous (may be null).
+     *
+     * @returns bus_error_t
+     * @retval bus_error_success on successful ChannelSelectionRequest handling.
+     * @retval bus_error_invalid_input on validation failure.
+     * @retval other non-zero bus_error_t values on error.
+     * @note Ownership of input and output buffers remains with the caller.
+     */
+    static bus_error_t channelselect_handler(const char *method_name, bus_data_prop_t *input_data,
         bus_data_prop_t *output_data, void *async_handle);
 
     /**!

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -497,6 +497,7 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_set_ssid)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_channel)
         BUS_EVENT_TYPE_2S(em_bus_event_type_set_channel)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_channel_select)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_bss)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_sta)
         BUS_EVENT_TYPE_2S(em_bus_event_type_steer_sta)
@@ -811,6 +812,10 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
 
       	case em_bus_event_type_unassoc_sta_result:
             type = em_cmd_type_unassoc_sta_result;
+            break;
+
+        case em_bus_event_type_channel_select:
+            type = em_cmd_type_set_channel;
             break;
 
         default:

--- a/src/cmd/em_cmd_exec.cpp
+++ b/src/cmd/em_cmd_exec.cpp
@@ -411,7 +411,8 @@ int em_cmd_exec_t::init()
 
 em_cmd_exec_t::em_cmd_exec_t()
 {
-
+    m_ssl = NULL;
+    m_ssl_ctx = NULL;
 }
 
 em_cmd_exec_t::~em_cmd_exec_t()

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -33,10 +33,12 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
+#include <stdlib.h>
 #include "dm_easy_mesh_ctrl.h"
 #include "dm_easy_mesh.h"
 #include "em_ctrl.h"
 #include "tr_181.h"
+#include "util.h"
 #include <cjson/cJSON.h>
 #include "em_cmd_exec.h"
 #include "em_cmd_reset.h"
@@ -844,6 +846,399 @@ cleanup:
     if (output_params) {
         *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
     }
+    return rc;
+}
+
+bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+{
+    (void)async_handle;
+    const char *name = method_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    const bus_data_prop_t *prop = NULL;
+    em_subdoc_info_t *subdoc = NULL;
+    unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
+    cJSON *root = NULL, *json = NULL, *net_obj = NULL;
+    cJSON *dev_list = NULL, *dev_obj = NULL, *radio_list = NULL, *radio_obj = NULL;
+    cJSON *class_arr = NULL, *class_obj = NULL;
+    cJSON *channel_list_obj = NULL, *channel_pref_obj = NULL;
+    mac_addr_str_t mac_str;
+    char *json_buff = NULL;
+    size_t json_len = 0;
+    bus_error_t rc = bus_error_success;
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        em_printfout("Invalid method name");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+    ++param;
+    if (strcmp("ChannelSelectionRequest()", param) != 0) {
+        em_printfout("Invalid method");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_method;
+    }
+
+    // Lookup controller and get the DM instance for this device/radio path
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!em_ctrl) {
+        em_printfout("Controller not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_general;
+    }
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl->get_dm_ctrl();
+
+    // Skip the static network prefix and parse the device instance from the TR-181 path
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        em_printfout("Device not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_radio_t *radio = dm_ctrl->get_dm_radio(dm, instance, is_num);
+    if (radio == NULL) {
+        em_printfout("Radio not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+
+    em_device_info_t *di = dm->get_device()->get_device_info();
+    em_radio_info_t *ri = radio->get_radio_info();
+
+    // Data structures used to collect nested Class.N.* channel preference input
+    struct channel_info {
+        bool have_channel;
+        bool have_pref;
+        int channel;
+        int preference;
+    };
+
+    struct class_info {
+        int instance_index;
+        bool have_op_class;
+        int op_class;
+        int max_channel_index;
+        channel_info channels[MAX_CHANSEL_CHANNELS];
+    };
+
+    class_info classes[MAX_CHANSEL_CLASSES];
+    int num_classes = 0;
+
+    // Initialize or reset a class_info slot
+    auto clear_class = [&](class_info &cls) {
+        cls.instance_index = -1;
+        cls.have_op_class = false;
+        cls.op_class = -1;
+        cls.max_channel_index = -1;
+        for (int i = 0; i < MAX_CHANSEL_CHANNELS; i++) {
+            cls.channels[i].have_channel = false;
+            cls.channels[i].have_pref = false;
+            cls.channels[i].channel = -1;
+            cls.channels[i].preference = -1;
+        }
+    };
+
+    // Find an existing class_info by instance index, or allocate a new one
+    auto find_or_create_class_by_instance = [&](int instance_index) -> class_info* {
+        for (int i = 0; i < num_classes; i++) {
+            if (classes[i].instance_index == instance_index) {
+                return &classes[i];
+            }
+        }
+        if (num_classes >= MAX_CHANSEL_CLASSES) {
+            return NULL;
+        }
+        clear_class(classes[num_classes]);
+        classes[num_classes].instance_index = instance_index;
+        classes[num_classes].have_op_class = false;
+        classes[num_classes].max_channel_index = -1;
+        num_classes++;
+        return &classes[num_classes - 1];
+    };
+
+    // Parse incoming TR-181 parameters and populate class/channel structures
+    for (prop = input_params; prop; prop = prop->next_data) {
+        char prop_name[BUS_MAX_NAME_LENGTH];
+        snprintf(prop_name, sizeof(prop_name), "%s", prop->name);
+
+        char *tokens[6] = { NULL };
+        char *saveptr = NULL;
+        int token_count = 0;
+        char *tok = strtok_r(prop_name, ".", &saveptr);
+        while (tok != NULL && token_count < 6) {
+            tokens[token_count++] = tok;
+            tok = strtok_r(NULL, ".", &saveptr);
+        }
+
+        // Only nested Class.N.* properties are valid for ChannelSelectionRequest()
+        if (token_count >= 2 && strcmp(tokens[0], "Class") == 0) {
+            char *end = NULL;
+            long class_index_l = strtol(tokens[1], &end, 10);
+            if (end == tokens[1] || *end != '\0' || class_index_l < 0 || class_index_l >= MAX_CHANSEL_CLASSES) {
+                em_printfout("Invalid class index in '%s'", prop->name);
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+            int class_index = static_cast<int>(class_index_l);
+            class_info *cls = find_or_create_class_by_instance(class_index);
+            if (!cls) {
+                em_printfout("Too many classes");
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+
+            if (token_count == 3 && strcmp(tokens[2], "OpClass") == 0) {
+                // Parse Class.N.OpClass
+                if (!tr_181_t::tr181_get_prop_int(prop, &cls->op_class)) {
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+                cls->have_op_class = true;
+            } else if (token_count == 5 && strcmp(tokens[2], "Channel") == 0) {
+                // Parse Class.N.Channel.M.Channel or Class.N.Channel.M.Preference
+                char *end = NULL;
+                long channel_idx_l = strtol(tokens[3], &end, 10);
+                if (end == tokens[3] || *end != '\0' || channel_idx_l < 0 || channel_idx_l >= MAX_CHANSEL_CHANNELS) {
+                    em_printfout("Invalid channel index in '%s'", prop->name);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+                int channel_idx = static_cast<int>(channel_idx_l);
+                if (strcmp(tokens[4], "Channel") == 0) {
+                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_idx].channel)) {
+                        rc = bus_error_invalid_input;
+                        goto finish;
+                    }
+                    cls->channels[channel_idx].have_channel = true;
+                    if (channel_idx > cls->max_channel_index) {
+                        cls->max_channel_index = channel_idx;
+                    }
+                } else if (strcmp(tokens[4], "Preference") == 0) {
+                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_idx].preference)) {
+                        rc = bus_error_invalid_input;
+                        goto finish;
+                    }
+                    cls->channels[channel_idx].have_pref = true;
+                } else {
+                    em_printfout("Invalid parameter: %s", prop->name);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+            } else {
+                em_printfout("Invalid parameter: %s", prop->name);
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+        } else {
+            em_printfout("Invalid parameter: %s", prop->name);
+            rc = bus_error_invalid_input;
+            goto finish;
+        }
+    }
+
+    // Fail if there were no nested class definitions in the request
+    if (num_classes == 0) {
+        em_printfout("Mandatory parameters missing: expected nested Class.N.* entries");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+
+    // Build the EM control subdocument and JSON payload for ChannelSelectionRequest
+    subdoc = reinterpret_cast<em_subdoc_info_t *>(buff);
+    memset(subdoc, 0, sizeof(em_subdoc_info_t));
+    strncpy(subdoc->name, "ChannelSelectionRequest", sizeof(subdoc->name) - 1);
+
+    root = cJSON_CreateObject();
+    json = cJSON_CreateObject();
+    if (!root || !json) {
+        em_printfout("Create object failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    if (!cJSON_AddItemToObject(root, "wfa-dataelements:ChannelSelectionRequest", json)) {
+        em_printfout("Add item failed");
+        cJSON_Delete(json);
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    // Create the Network/Device/Radio container structure for the payload
+    net_obj = cJSON_AddObjectToObject(json, "Network");
+    if (!net_obj) {
+        em_printfout("Add Network failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    if (!cJSON_AddStringToObject(net_obj, "ID", GLOBAL_NET_ID)) {
+        em_printfout("Add Network ID failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    dev_list = cJSON_AddArrayToObject(net_obj, "DeviceList");
+    if (!dev_list) {
+        em_printfout("Add DeviceList failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    dev_obj = cJSON_CreateObject();
+    if (!dev_obj) {
+        em_printfout("Create device object failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    if (!cJSON_AddItemToArray(dev_list, dev_obj)) {
+        em_printfout("Add Device failed");
+        cJSON_Delete(dev_obj);
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    dm_easy_mesh_t::macbytes_to_string(di->intf.mac, mac_str);
+    if (!cJSON_AddStringToObject(dev_obj, "ID", mac_str)) {
+        em_printfout("Add Device ID failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    radio_list = cJSON_AddArrayToObject(dev_obj, "RadioList");
+    if (!radio_list) {
+        em_printfout("Add RadioList failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    radio_obj = cJSON_CreateObject();
+    if (!radio_obj) {
+        em_printfout("Create radio object failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    if (!cJSON_AddItemToArray(radio_list, radio_obj)) {
+        em_printfout("Add Radio failed");
+        cJSON_Delete(radio_obj);
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    dm_easy_mesh_t::macbytes_to_string(ri->id.ruid, mac_str);
+    if (!cJSON_AddStringToObject(radio_obj, "ID", mac_str)) {
+        em_printfout("Add Radio ID failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    // Add the radio-level ChannelSelectionRequest array
+    class_arr = cJSON_AddArrayToObject(radio_obj, "ChannelSelectionRequest");
+    if (!class_arr) {
+        em_printfout("Add ChannelSelectionRequest failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    if (num_classes > 0) {
+        // Convert each parsed class entry into JSON with ChannelList and ChannelPrefList
+        for (int i = 0; i < num_classes; i++) {
+            class_info &cls = classes[i];
+            if (!cls.have_op_class || cls.max_channel_index < 0) {
+                em_printfout("Incomplete class entry");
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+
+            class_obj = cJSON_CreateObject();
+            if (!class_obj) {
+                em_printfout("Create class object failed");
+                rc = bus_error_out_of_resources;
+                goto finish;
+            }
+            if (!cJSON_AddItemToArray(class_arr, class_obj)) {
+                em_printfout("Add class object failed");
+                cJSON_Delete(class_obj);
+                rc = bus_error_out_of_resources;
+                goto finish;
+            }
+            if (!cJSON_AddNumberToObject(class_obj, "Class", cls.op_class)) {
+                em_printfout("Add Class failed");
+                rc = bus_error_out_of_resources;
+                goto finish;
+            }
+
+            channel_list_obj = cJSON_AddArrayToObject(class_obj, "ChannelList");
+            channel_pref_obj = cJSON_AddArrayToObject(class_obj, "ChannelPrefList");
+            if (!channel_list_obj || !channel_pref_obj) {
+                em_printfout("Add ChannelList or ChannelPrefList failed");
+                rc = bus_error_out_of_resources;
+                goto finish;
+            }
+
+            for (int idx = 0; idx <= cls.max_channel_index; idx++) {
+                if (!cls.channels[idx].have_channel) {
+                    continue;
+                }
+                if (!cls.channels[idx].have_pref) {
+                    em_printfout("Missing Preference for channel index %d", idx);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+                cJSON_AddItemToArray(channel_list_obj, cJSON_CreateNumber(cls.channels[idx].channel));
+                cJSON_AddItemToArray(channel_pref_obj, cJSON_CreateNumber(cls.channels[idx].preference));
+            }
+        }
+    }
+
+    // Serialize the final JSON payload and send it to the EM control bus
+    json_buff = cJSON_PrintUnformatted(root);
+    if (!json_buff) {
+        em_printfout("Print JSON failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    json_len = strlen(json_buff) + 1;
+    if (json_len > EM_IO_BUFF_SZ) {
+        em_printfout("JSON payload too large");
+        rc = bus_error_invalid_input;
+        goto finish;
+    }
+    memcpy(subdoc->buff, json_buff, json_len);
+
+    em_printfout("Sending ChannelSelectionRequest with JSON payload len %zu:\n", json_len - 1);
+    em_ctrl->io_process(em_bus_event_type_channel_select, subdoc->buff, json_len);
+    free(json_buff);
+    cJSON_Delete(root);
+
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Success");
+    }
+
+    // Request processed successfully
+    return bus_error_success;
+
+finish:
+    // Common cleanup for failure paths
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+    }
+    if (json_buff) free(json_buff);
+    if (root) cJSON_Delete(root);
     return rc;
 }
 
@@ -2503,6 +2898,102 @@ int dm_easy_mesh_ctrl_t::analyze_scan_channel(em_bus_event_t *evt, em_cmd_t *pcm
     return static_cast<int> (num);
 }
 
+int dm_easy_mesh_ctrl_t::analyze_channel_select(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    int ret;
+    em_subdoc_info_t *subdoc;
+    dm_easy_mesh_t dm, *pdm;
+    em_cmd_t *tmp;
+    unsigned int num = 0, num_devices = 0, i = 0, j = 0;
+    dm_op_class_t *updated_oclass, *current_oclass;
+    mac_addr_str_t mac_str;
+    std::vector<std::string> delete_invalid_opclass_ids;
+
+    subdoc = &evt->u.subdoc;
+    em_printfout("Received tr181 Channel Selection event");
+
+    if ((ret = dm.decode_config(subdoc, "ChannelSelectionRequest", i, &num_devices)) < 0) {
+        em_printfout("Decode config for set channel select failed");
+        return ret;
+    }
+
+    // Lets process radio channel preference report and schedule channel selection request
+    // print all opclasses and channels received in the event for debugging purpose
+    em_printfout("Number of opclasses received in the event: %d", dm.get_num_op_class());
+    for (i = 0; i < dm.get_num_op_class(); i++) {
+        updated_oclass = &dm.m_op_class[i];
+        dm_easy_mesh_t::macbytes_to_string(updated_oclass->m_op_class_info.id.ruid, mac_str);
+        em_printfout("Radio: %s, OpClass: %d, Type: %d, NumChannels: %d", mac_str,
+                     updated_oclass->m_op_class_info.id.op_class, updated_oclass->m_op_class_info.id.type, updated_oclass->m_op_class_info.num_channels);
+        for (j = 0; j < updated_oclass->m_op_class_info.num_channels; j++)
+        {
+            // Update preference values to Easymesh Standard
+            updated_oclass->m_op_class_info.channel_pref[j] = static_cast<unsigned char>(updated_oclass->m_op_class_info.channel_pref[j] << EM_CH_PREF_SHIFT);
+            em_printfout("Channel: %d, Preference: %d", updated_oclass->m_op_class_info.channels[j], updated_oclass->m_op_class_info.channel_pref[j]);
+
+        }
+    }
+
+    pdm = m_data_model_list.get_first_dm();
+    while (pdm != NULL) {
+        if (memcmp(dm.m_device.m_device_info.intf.mac, pdm->get_device_info()->intf.mac, sizeof(mac_address_t)) != 0) {
+            pdm = m_data_model_list.get_next_dm(pdm);
+            continue;
+        }
+        break;
+    }
+
+    if (pdm == NULL) {
+        em_printfout("No matching DM found for device MAC in ChannelSelectionRequest event");
+        return 0;
+    }
+
+    // Assuming that the opclass list received in the event is only for one radio,
+    // invalidating the opclasses for that radio based on RUID match
+    // Create list of invalid opclasses id's to delete it from DB
+    {
+        updated_oclass = &dm.m_op_class[0];
+        for (j = 0; j < pdm->get_num_op_class(); j++)
+        {
+            current_oclass = &pdm->m_op_class[j];
+            if (current_oclass->m_op_class_info.id.type == em_op_class_type_anticipated &&
+                memcmp(current_oclass->m_op_class_info.id.ruid, updated_oclass->m_op_class_info.id.ruid, sizeof(mac_address_t)) == 0)
+            {
+                current_oclass->m_op_class_info.pref_valid = EM_CH_PREF_ENTRY_INVALID;
+                std::string opclass_id = util::mac_to_string(current_oclass->m_op_class_info.id.ruid) + "@" +
+                                         std::to_string(static_cast<unsigned int>(current_oclass->m_op_class_info.id.type)) + "@" +
+                                         std::to_string(static_cast<unsigned int>(current_oclass->m_op_class_info.id.op_class));
+                em_printfout("Marking opclass with id: %s for deletion from DB", opclass_id.c_str());
+                delete_invalid_opclass_ids.push_back(opclass_id);
+            }
+        }
+    }
+    // Invalidated all the OPCLASSES belonging to the particular radio
+    // Update data model and db with new opclass info received in the event
+    pdm->set_channels_list(dm.m_op_class, dm.get_num_op_class());
+
+    // Delete invalid row of anticipated type from db
+    for (const auto &del_id : delete_invalid_opclass_ids) {
+        dm_op_class_list_t::delete_row(m_db_client, del_id.c_str());
+    }
+
+    // Update db with new opclasses received in the event
+    pdm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
+
+    // Queue the channel selection command to trigger the channel selection
+    // Explicitly set num_args to 0 to make sure command is handled properly in build_candidates()
+    evt->params.u.args.num_args = 0;
+    pcmd[num] = new em_cmd_set_channel_t(evt->params, dm);
+    tmp = pcmd[num];
+    num++;
+    while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
+        tmp = pcmd[num];
+        num++;
+    }
+
+    return static_cast<int> (num);
+}
+
 int dm_easy_mesh_ctrl_t::analyze_set_channel(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     int ret;
@@ -2635,8 +3126,11 @@ int dm_easy_mesh_ctrl_t::analyze_set_channel(em_bus_event_t *evt, em_cmd_t *pcmd
 		pdm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
 		pdm = m_data_model_list.get_next_dm(pdm);
 	}
-	
 
+	if (evt->params.u.args.num_args == 0) {
+        em_printfout("No change detected in channel or preference, skipping command generation");
+        return 0;
+    }
    	pcmd[num] = new em_cmd_set_channel_t(evt->params, dm);
    	tmp = pcmd[num];
    	num++;
@@ -3285,7 +3779,7 @@ int dm_easy_mesh_ctrl_t::get_channel_config(cJSON *parent, char *key, em_get_cha
             if (reason == em_get_channel_list_reason_set_anticipated) {
                 channel_list_obj = cJSON_AddArrayToObject(radio_obj, "AnticipatedChannelPreference");
                 snprintf(op_key, sizeof(op_key), "%s@%d@%d", tmp, em_op_class_type_anticipated, 0);
-                dm_op_class_list_t::get_config(op_class_list_obj, op_key);
+                dm_op_class_list_t::get_config(channel_list_obj, op_key);
             }
             op_class_list_obj = cJSON_AddArrayToObject(radio_obj, "CurrentOperatingClasses");
             snprintf(op_key, sizeof(op_key), "%s@%d@%d", tmp, em_op_class_type_current, 0);

--- a/src/ctrl/em_cmd_ctrl.cpp
+++ b/src/ctrl/em_cmd_ctrl.cpp
@@ -86,6 +86,7 @@ int em_cmd_ctrl_t::execute(char *result)
 
         if (SSL_accept(m_ssl) <= 0) {
             SSL_free(m_ssl);
+            m_ssl = NULL;
             close(dsock);
             continue;
         }
@@ -156,6 +157,7 @@ int em_cmd_ctrl_t::send_result(em_cmd_out_status_t status)
 	sd = SSL_get_fd(m_ssl);
 	SSL_shutdown(m_ssl);
 	SSL_free(m_ssl);
+	m_ssl = NULL;
 	close(sd);
 
 	free(str);

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -174,6 +174,22 @@ void em_ctrl_t::handle_start_dpp(em_bus_event_t *evt)
 
 }
 
+void em_ctrl_t::handle_channel_select(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    int num;
+
+    if (m_orch->is_cmd_type_in_progress(evt) == true) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
+    } else if ((num = m_data_model.analyze_channel_select(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
+    } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_success);
+    } else {
+        m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+    }
+}
+
 void em_ctrl_t::handle_set_channel_list(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -592,6 +608,10 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
         
         case em_bus_event_type_set_channel:
             handle_set_channel_list(evt);
+            break;
+
+        case em_bus_event_type_channel_select:
+            handle_channel_select(evt);
             break;
 
         case em_bus_event_type_scan_channel:
@@ -1149,6 +1169,9 @@ void em_ctrl_t::start_complete()
             { bus_data_type_property, false, 0, 0, 0, NULL } },
         { const_cast<char*>(DE_RADIO_CHSCANREQ), bus_element_type_method,
             { NULL, NULL , NULL, NULL, NULL, tr_181_t::channelscan_handler}, slow_speed, ZERO_TABLE,
+            { bus_data_type_property, false, 0, 0, 0, NULL } },
+        { const_cast<char*>(DE_RADIO_CHSELREQ), bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, tr_181_t::channelselect_handler}, slow_speed, ZERO_TABLE,
             { bus_data_type_property, false, 0, 0, 0, NULL } },
         { const_cast<char*>(DE_STA_CLIENTSTEER), bus_element_type_method,
             { NULL, NULL , NULL, NULL, NULL, tr_181_t::clientsteer_handler}, slow_speed, ZERO_TABLE,

--- a/src/ctrl/tr_181/wfa_data_model/tr_181_method.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181_method.cpp
@@ -175,6 +175,60 @@ bus_error_t tr_181_t::channelscan_handler(const char *method_name, bus_data_prop
     return rc;
 }
 
+bus_error_t tr_181_t::channelselect_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
+{
+    // Standardize input pointer checks
+    em_printfout("Entered channelselect_handler");
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
+        em_printfout("Invalid input_data or missing input_props");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_data_prop_t *input_props = input_data;
+    bus_data_prop_t *output_props = NULL;
+
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
+    // Log all chained input properties
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
+    }
+
+    em_ctrl_t *ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!ctrl) {
+        em_printfout("Controller unavailable");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: controller unavailable");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_error_t rc = ctrl->cmd_channelselect(method_name, input_props, output_data ? &output_props : NULL, async_handle);
+
+    if (output_data && output_props) {
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
+    }
+    em_printfout("Exiting channelselect_handler with rc=%d", rc);
+
+    return rc;
+}
+
 bus_error_t tr_181_t::clientsteer_handler(const char *method_name, bus_data_prop_t *input_data,
     bus_data_prop_t *output_data, void *async_handle)
 {

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -775,6 +775,9 @@ int dm_easy_mesh_t::decode_config(em_subdoc_info_t *subdoc, const char *str, uns
     } else if (strncmp(str, "SetAnticipatedChannelPreference", strlen("SetAnticipatedChannelPreference")) == 0) {
         snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
         return decode_config_set_channel(subdoc, key, index, num);
+    } else if (strncmp(str, "ChannelSelectionRequest", strlen("ChannelSelectionRequest")) == 0) {
+        snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
+        return decode_config_set_channel(subdoc, key, index, num);
     } else if (strncmp(str, "ChannelScanRequest", strlen("ChannelScanRequest")) == 0) {
         snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
         return decode_config_set_channel(subdoc, key, index, num);
@@ -1218,6 +1221,7 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
 {
 #define KEY_CHANNEL_ANTICIPATED "wfa-dataelements:SetAnticipatedChannelPreference"
 #define KEY_CHANNEL_SCANREQUEST "wfa-dataelements:ChannelScanRequest"
+#define KEY_CHANNEL_SELECTION "wfa-dataelements:ChannelSelectionRequest"
     cJSON *parent_obj = NULL;
     cJSON *wrapper_obj, *net_obj, *net_id_obj;
     cJSON *dev_arr_obj, *dev_obj, *dev_id_obj;
@@ -1246,6 +1250,9 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
     } else if (strncmp(key, KEY_CHANNEL_SCANREQUEST, strlen(KEY_CHANNEL_SCANREQUEST)) == 0) {
         snprintf(target_key, sizeof(em_long_string_t), "ChannelScanParameters");
         type = em_op_class_type_scan_param;
+    } else if (strncmp(key, KEY_CHANNEL_SELECTION, strlen(KEY_CHANNEL_SELECTION)) == 0) {
+        snprintf(target_key, sizeof(em_long_string_t), "ChannelSelectionRequest");
+        type = em_op_class_type_selection;
     } else {
         em_printfout("Invalid wrapper key: '%s'", key);
         return EM_PARSE_ERR_GEN;
@@ -1311,7 +1318,7 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
 
     /* "Channel Scan" is for radio, so is "Set Channel". "Set Anticipated Channel Preference"
      * is for device. There is also a clash here. */
-    if (type == em_op_class_type_scan_param) {
+    if (type == em_op_class_type_scan_param || type == em_op_class_type_selection) {
         /* Get 'RadioList' under 'Device' and extract Radio ID (MAC) */
         if ((radio_arr_obj = cJSON_GetObjectItem(dev_obj, "RadioList")) == NULL) {
             em_printfout("'RadioList' not found in Device: %s", subdoc->buff);
@@ -1363,9 +1370,21 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
 
         memset(&m_op_class[m_num_opclass].m_op_class_info, 0, sizeof(em_op_class_info_t));
 
-        m_op_class[m_num_opclass].m_op_class_info.id.type = type;
-        m_op_class[m_num_opclass].m_op_class_info.op_class = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetObjectItem(target_obj, "Class")));
-        m_op_class[m_num_opclass].m_op_class_info.id.op_class = m_op_class[m_num_opclass].m_op_class_info.op_class;
+        // Presently only Anticipated opclass is being used as valid.
+        // Support of type selection will be used in upcoming updates
+        m_op_class[m_num_opclass].m_op_class_info.id.type =
+            (type == em_op_class_type_selection) ? em_op_class_type_anticipated : type;
+
+        cJSON *class_num_obj = cJSON_GetObjectItem(target_obj, "Class");
+        if (!cJSON_IsNumber(class_num_obj)) {
+            em_printfout("Class not present");
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
+        m_op_class[m_num_opclass].m_op_class_info.op_class =
+            static_cast<unsigned int>(cJSON_GetNumberValue(class_num_obj));
+        m_op_class[m_num_opclass].m_op_class_info.id.op_class =
+            m_op_class[m_num_opclass].m_op_class_info.op_class;
 
         if ((channel_arr_obj = cJSON_GetObjectItem(target_obj, "ChannelList")) == NULL) {
             em_printfout("ChannelList not present");
@@ -1375,6 +1394,12 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
 
         m_op_class[m_num_opclass].m_op_class_info.num_channels = 0;
         if (type != em_op_class_type_scan_param) {
+
+            // For TR181 request belongs to only one radio, so copying same for all opclass entries as ID
+            if (type == em_op_class_type_selection) {
+                memcpy(m_op_class[m_num_opclass].m_op_class_info.id.ruid, m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t));
+            }
+
             if ((channel_pref_arry_obj = cJSON_GetObjectItem(target_obj, "ChannelPrefList")) == NULL) {
                 em_printfout("ChannelPrefList not present");
                 cJSON_Delete(parent_obj);
@@ -1402,7 +1427,7 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
         m_num_opclass++;
     }
 
-    if (type == em_op_class_type_anticipated && m_num_opclass == 0) {
+    if ((type == em_op_class_type_anticipated || type == em_op_class_type_selection) && m_num_opclass == 0) {
         em_printfout("OpClass list is empty");
         cJSON_Delete(parent_obj);
         return EM_PARSE_ERR_NO_CHANGE;

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1063,8 +1063,12 @@ dm_op_class_t *dm_easy_mesh_list_t::get_first_pre_set_op_class_by_type(em_op_cla
 
 	for (i = 0; i < dm->get_num_op_class(); i++) {
 		op_class = &dm->m_op_class[i];
-		if (op_class->m_op_class_info.id.type == type) {
-			return op_class;
+        // Make sure PRESET opclasses should not include the radio level anticipated opclasses
+		if (op_class->m_op_class_info.id.type == type ) {
+                if (type != em_op_class_type_anticipated ||
+                    memcmp(op_class->m_op_class_info.id.ruid, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                    return op_class;
+                }
 		}
 	}	
 
@@ -1087,7 +1091,10 @@ dm_op_class_t *dm_easy_mesh_list_t::get_next_pre_set_op_class_by_type(em_op_clas
 		pop_class = &dm->m_op_class[i];
 
 		if ((return_next == true) && (pop_class->m_op_class_info.id.type == type)) {
-			return pop_class;
+            if (type != em_op_class_type_anticipated ||
+                memcmp(pop_class->m_op_class_info.id.ruid, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                return pop_class;
+            }
 		}
 
 		if ((pop_class->m_op_class_info.id.type == type) &&

--- a/src/dm/dm_op_class_list.cpp
+++ b/src/dm/dm_op_class_list.cpp
@@ -43,7 +43,7 @@
 int dm_op_class_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
 {
     dm_op_class_t *pop_class;
-    cJSON *obj, *non_op_arr, *anticipated_arr, *channel_arr;
+    cJSON *obj, *non_op_arr, *anticipated_arr, *anticipated_pref_list, *channel_arr;
     unsigned int i;
     em_op_class_id_t id;
     em_op_class_info_t *info;
@@ -86,7 +86,16 @@ int dm_op_class_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
 			anticipated_arr = cJSON_AddArrayToObject(obj, "ChannelList");
 			for (i = 0; i < pop_class->m_op_class_info.num_channels; i++) {
             	cJSON_AddItemToArray(anticipated_arr, cJSON_CreateNumber(pop_class->m_op_class_info.channels[i]));
-        	}
+            }
+            if (id.type == em_op_class_type_anticipated) {
+                if (pop_class->m_op_class_info.pref_valid) {
+                    anticipated_pref_list = cJSON_AddArrayToObject(obj, "ChannelPrefList");
+                    for (i = 0; i < pop_class->m_op_class_info.num_channels; i++) {
+                        cJSON_AddItemToArray(anticipated_pref_list, cJSON_CreateNumber(pop_class->m_op_class_info.channel_pref[i]));
+                    }
+                }
+
+            }
     	}
 		cJSON_AddItemToArray(obj_arr, obj);
 		pop_class = get_next_op_class(pop_class);

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -660,9 +660,14 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                     count++;
                 }
                 break;
-            
             case em_cmd_type_set_channel:
-                if (em->is_al_interface_em() == false) {
+                if ((em->is_al_interface_em() == false) && (!pcmd->m_param.u.args.num_args)) {
+                    dm = pcmd->get_data_model();
+                    if (memcmp(em->get_radio_interface_mac(), dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                        queue_push(pcmd->m_em_candidates, em);
+                        count++;
+                    }
+                } else if (em->is_al_interface_em() == false) {
                     for (i = 0; i < pcmd->m_param.u.args.num_args; i++) {
                         if (atoi(pcmd->m_param.u.args.args[i]) == em->get_band()) {
                             //mac_addr_str_t mac_str;

--- a/tests/test_l1_dm_easy_mesh.cpp
+++ b/tests/test_l1_dm_easy_mesh.cpp
@@ -3441,6 +3441,119 @@ TEST(dm_easy_mesh_t, decode_config_set_channel_valid_anticipated)
     std::cout << "Exiting decode_config_set_channel_valid_anticipated\n";
 }
 
+TEST(dm_easy_mesh_t, decode_config_set_channel_valid_selection_request)
+{
+    std::cout << "Entering decode_config_set_channel_valid_selection_request\n";
+    dm_easy_mesh_t obj;
+    char subdoc_buf[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ]{};
+    em_subdoc_info_t *subdoc = reinterpret_cast<em_subdoc_info_t*>(subdoc_buf);
+    const char json[] =
+        "{"
+        "  \"wfa-dataelements:ChannelSelectionRequest\": {"
+        "    \"Network\": {"
+        "      \"ID\": \"TestNet\","
+        "      \"DeviceList\": [{"
+        "        \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "        \"RadioList\": [{"
+        "          \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "          \"ChannelSelectionRequest\": [{"
+        "            \"Class\": 81,"
+        "            \"ChannelList\": [1, 6, 11],"
+        "            \"ChannelPrefList\": [0, 0, 0]"
+        "          }]"
+        "        }]"
+        "      }]"
+        "    }"
+        "  }"
+        "}";
+    snprintf(subdoc->buff, EM_IO_BUFF_SZ, "%s", json);
+    unsigned int num = 0;
+    std::cout << "Invoking decode_config_set_channel with valid ChannelSelectionRequest\n";
+    int ret = obj.decode_config_set_channel(
+        subdoc,
+        "wfa-dataelements:ChannelSelectionRequest",
+        0,
+        &num
+    );
+    EXPECT_EQ(ret, 0);
+    EXPECT_EQ(num, 1);
+    std::cout << "Exiting decode_config_set_channel_valid_selection_request\n";
+}
+
+TEST(dm_easy_mesh_t, decode_config_set_channel_missing_class_in_selection_request)
+{
+    std::cout << "Entering decode_config_set_channel_missing_class_in_selection_request\n";
+    dm_easy_mesh_t obj;
+    char subdoc_buf[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ]{};
+    em_subdoc_info_t *subdoc = reinterpret_cast<em_subdoc_info_t*>(subdoc_buf);
+    const char json[] =
+        "{"
+        "  \"wfa-dataelements:ChannelSelectionRequest\": {"
+        "    \"Network\": {"
+        "      \"ID\": \"TestNet\","
+        "      \"DeviceList\": [{"
+        "        \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "        \"RadioList\": [{"
+        "          \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "          \"ChannelSelectionRequest\": [{"
+        "            \"ChannelList\": [1, 6, 11],"
+        "            \"ChannelPrefList\": [0, 0, 0]"
+        "          }]"
+        "        }]"
+        "      }]"
+        "    }"
+        "  }"
+        "}";
+    snprintf(subdoc->buff, EM_IO_BUFF_SZ, "%s", json);
+    unsigned int num = 0;
+    std::cout << "Invoking decode_config_set_channel with missing Class\n";
+    int ret = obj.decode_config_set_channel(
+        subdoc,
+        "wfa-dataelements:ChannelSelectionRequest",
+        0,
+        &num
+    );
+    EXPECT_EQ(ret, EM_PARSE_ERR_GEN);
+    std::cout << "Exiting decode_config_set_channel_missing_class_in_selection_request\n";
+}
+
+TEST(dm_easy_mesh_t, decode_config_set_channel_missing_channel_pref_list_in_selection_request)
+{
+    std::cout << "Entering decode_config_set_channel_missing_channel_pref_list_in_selection_request\n";
+    dm_easy_mesh_t obj;
+    char subdoc_buf[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ]{};
+    em_subdoc_info_t *subdoc = reinterpret_cast<em_subdoc_info_t*>(subdoc_buf);
+    const char json[] =
+        "{"
+        "  \"wfa-dataelements:ChannelSelectionRequest\": {"
+        "    \"Network\": {"
+        "      \"ID\": \"TestNet\","
+        "      \"DeviceList\": [{"
+        "        \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "        \"RadioList\": [{"
+        "          \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "          \"ChannelSelectionRequest\": [{"
+        "            \"Class\": 81,"
+        "            \"ChannelList\": [1, 6, 11]"
+        "          }]"
+        "        }]"
+        "      }]"
+        "    }"
+        "  }"
+        "}";
+    snprintf(subdoc->buff, EM_IO_BUFF_SZ, "%s", json);
+    unsigned int num = 0;
+    std::cout << "Invoking decode_config_set_channel with missing ChannelPrefList\n";
+    int ret = obj.decode_config_set_channel(
+        subdoc,
+        "wfa-dataelements:ChannelSelectionRequest",
+        0,
+        &num
+    );
+    EXPECT_EQ(ret, EM_PARSE_ERR_GEN);
+    std::cout << "Exiting decode_config_set_channel_missing_channel_pref_list_in_selection_request\n";
+}
+
 /**
  * @brief Verify that decode_config_set_channel handles empty key input properly
  *


### PR DESCRIPTION

- Introduce TR-181 ChannelSelectionRequest/ChannelSelect support in tr_181 layer
- Add channelselect_handler and cmd_channelselect to route TR-181 method calls into em_ctrl
- Implement controller-side parsing, device/radio resolution, JSON payload construction, and channel selection command enqueue
- Add handle_channel_select and analyze_channel_select support in DM controller
- Update TR-181 method registration and constants for ChannelSelectionRequest
- Fix RDKB CLI channel selection flow so ChannelSelect requests are handled correctly