### PR TITLE
RDKBWIFI-464:  Fix issue with clients DB data override and empty stats  value.

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -1756,6 +1756,8 @@ public:
 	static void update_assoc_sta_mld_info(void *dm, em_assoc_sta_mld_info_t *assoc_sta_mld_info) { (static_cast<dm_easy_mesh_t *>(dm))->update_assoc_sta_mld_info(assoc_sta_mld_info); }
 
 	void remove_assoc_sta_mld_info(mac_address_t sta_mld_mac);
+	bool is_ap_mld_mac(const mac_address_t mac);
+	bool resolve_ap_mld_to_fallback_ruid(const mac_address_t ap_mld_mac, mac_address_t fallback_ruid);
 
 	em_radio_cap_info_t *get_radio_cap_info(unsigned int index);
 	static em_radio_cap_info_t *get_radio_cap_info(void *dm, unsigned int index) { return (static_cast<dm_easy_mesh_t *>(dm))->get_radio_cap_info(index); }

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -484,14 +484,13 @@ class em_configuration_t {
 	 * including STA MAC Address Type TLV, Reason Code TLV, Associated STA Traffic Stats TLV,
 	 * and zero or more Affiliated STA Metrics TLVs (for MLD clients).
 	 *
-	 * @param[in] sta  The MAC address of the disassociated station (MLD MAC if MLD client).
-	 * @param[in] bssid The BSSID from which the station disassociated.
+	 * @param[in] dassoc_sta Pointer to the disassociated sta
 	 *
 	 * @returns int
 	 * @retval message length on success
 	 * @retval -1 on failure
 	 */
-	int send_client_disassoc_stats_msg(mac_address_t sta, bssid_t bssid);
+	int send_client_disassoc_stats_msg(const dm_sta_t *dassoc_sta);
 
 	/**!
 	 * @brief Sends a Failed Connection message

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -492,22 +492,7 @@ class em_metrics_t {
 	 * @note Ensure that the buffer is large enough to hold the TLV.
 	 */
 	short create_radio_metrics_tlv(unsigned char *buff, int index);
-    
-	/**!
-	 * @brief Creates an associated station traffic statistics TLV.
-	 *
-	 * This function generates a TLV (Type-Length-Value) structure for the traffic statistics
-	 * of an associated station and stores it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
-	 * @param[in] sta Constant pointer to the station data structure containing the statistics.
-	 *
-	 * @returns short The length of the TLV created.
-	 *
-	 * @note Ensure that the buffer is large enough to hold the TLV data.
-	 */
-	virtual short create_assoc_sta_traffic_stats_tlv(unsigned char *buff, const dm_sta_t *const sta);
-    
+
 	/**!
 	 * @brief Creates an association report TLV for a WiFi 6 station.
 	 *
@@ -671,6 +656,21 @@ class em_metrics_t {
         void clear_unassoc_sta_query_msg_id() { m_unassoc_sta_query_msg_id = 0; }	
 
 public:
+
+	/**!
+	 * @brief Creates an associated station traffic statistics TLV.
+	 *
+	 * This function generates a TLV (Type-Length-Value) structure for the traffic statistics
+	 * of an associated station and stores it in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
+	 * @param[in] sta Constant pointer to the station data structure containing the statistics.
+	 *
+	 * @returns short The length of the TLV created.
+	 *
+	 * @note Ensure that the buffer is large enough to hold the TLV data.
+	 */
+	virtual short create_assoc_sta_traffic_stats_tlv(unsigned char *buff, const dm_sta_t *const sta);
 
 	/**!
 	 * @brief Retrieves the manager instance.

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -110,23 +110,20 @@ int dm_easy_mesh_agent_t::analyze_dev_init(em_bus_event_t *evt, em_cmd_t *pcmd[]
 int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     unsigned int num = 0, i = 0, num_radios = 0;
-    unsigned int idx = 0, j = 0, k = 0;
+    unsigned int idx = 0, k = 0;
     dm_easy_mesh_agent_t  dm;
     dm_sta_t *sta = NULL;
     em_cmd_t *tmp = NULL;
     mac_address_t sta_mld_mac;
-    mac_address_t *candidate = NULL;
     em_long_string_t key;
     mac_address_t assoc_sta_mld_tracked_macs[EM_MAX_ASSOC_STA_MLD] = {{0}};
     mac_address_t disassoc_sta_mld_tracked_macs[EM_MAX_ASSOC_STA_MLD] = {{0}};
     unsigned int assoc_sta_mld_tracked_count = 0;
     unsigned int disassoc_sta_mld_tracked_count = 0;
-    bool disassoc_only_update = false;
     bool is_tracked_sta_mld = false;
     mac_addr_str_t radio_str;
     mac_addr_str_t  sta_mac_str, bss_mac_str, radio_mac_str;
 
-    num_radios = get_num_radios();
     dm.init();
 
     num_radios = m_num_radios;
@@ -141,7 +138,6 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
 
     dm.translate_and_decode_onewifi_subdoc(reinterpret_cast<char *>(evt->u.raw_buff),
         webconfig_subdoc_type_associated_clients, "Assoc clients");
-
     // Refresh global STA-MLD entries from the latest decoded snapshot.
     for (idx = 0; idx < dm.m_num_assoc_sta_mld; idx++) {
         memcpy(sta_mld_mac, dm.m_assoc_sta_mld[idx].m_assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
@@ -149,28 +145,6 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
         update_assoc_sta_mld_info(&dm.m_assoc_sta_mld[idx].m_assoc_sta_mld_info);
     }
 
-    // Purge stale global STA-MLD entries.
-    // Skip purge for disassoc-only updates to retain AP-MLD mapping for disconnect handling.
-    disassoc_only_update = ((dm.m_num_assoc_sta_mld == 0) &&
-                            (hash_map_count(dm.m_sta_dassoc_map) > 0));
-    if (!disassoc_only_update) {
-        for (idx = m_num_assoc_sta_mld; idx-- > 0;) {
-            candidate = &m_assoc_sta_mld[idx].m_assoc_sta_mld_info.mac_addr;
-            bool still_present = false;
-            for (j = 0; j < dm.m_num_assoc_sta_mld; j++) {
-                if (memcmp(dm.m_assoc_sta_mld[j].m_assoc_sta_mld_info.mac_addr, *candidate,
-                           sizeof(mac_address_t)) == 0) {
-                    still_present = true;
-                    break;
-                }
-            }
-            if (!still_present) {
-                em_printfout("Purge stale assoc STA MLD: %s",
-                             util::mac_to_string(*candidate).c_str());
-                remove_assoc_sta_mld_info(*candidate);
-            }
-        }
-    }
 
     for ( i = 0; i < num_radios; i++) {
         evt->params.u.args.num_args = 1;

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -498,10 +498,6 @@ void em_agent_t::handle_recv_connection_status(em_bus_event_t *event)
     conn_status_evt = reinterpret_cast<const em_connection_status_evt_data_t *>(event->u.raw_buff);
 
     if (!is_failed_connection_message(conn_status_evt)) {
-        /*em_printfout("Skip: sta=%s bssid=%s status=%u not in failed-connection filter",
-                     util::mac_to_string(conn_status_evt->sta_mac).c_str(),
-                     util::mac_to_string(conn_status_evt->bssid).c_str(),
-                     conn_status_evt->status_code);*/
         return;
     }
 
@@ -540,10 +536,11 @@ void em_agent_t::handle_recv_connection_status(em_bus_event_t *event)
     qevt->u.cevt.type = em_cmd_event_type_failed_connection;
     qevt->u.cevt.cmd_ptr = evt_copy;
 
-    em_printfout("Queue failed connection: sta=%s bssid=%s status=%u",
+    em_printfout("Queue failed connection: sta=%s bssid=%s status=%u reason=%u",
                  util::mac_to_string(evt_copy->sta_mac).c_str(),
                  util::mac_to_string(evt_copy->bssid).c_str(),
-                 evt_copy->status_code);
+                 evt_copy->status_code,
+                 evt_copy->reason_code);
 
     em->push_to_queue(qevt);
 }
@@ -1928,8 +1925,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
     bool found = false;
     em_string_t al_mac_str;
     em_bss_info_t *em_bss = NULL;
-    em_t *tmp_em = NULL;
-    em_ap_mld_info_t *ap_mld_info = NULL;
+    mac_address_t fallback_ruid = {0};
     unsigned int i = 0, j = 0;
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
@@ -2084,58 +2080,32 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             }
 
             dm_easy_mesh_t::macbytes_to_string(bss_mac, mac_str1);
-
-            em = static_cast<em_t *> (hash_map_get_first(m_em_map));
-            while (em != NULL) {
-                dm = em->get_data_model();
-                em_bss = dm->get_bss_info_with_mac(bss_mac);
-                if ((em_bss != NULL) &&
-                    (memcmp(em_bss->ruid.mac, em->get_radio_interface_mac(), sizeof(bssid_t)) == 0)) {
-                    printf("%s:%d: Received client cap query: found radio for bss:%s\n", __func__, __LINE__, mac_str1);
-                    break;
-                }
-                em = static_cast<em_t *> (hash_map_get_next(m_em_map, em));
-            }
-
-            if (em == NULL) {
-                // AP MLD MAC fallback: resolve affiliated link radio EM.
-                tmp_em = static_cast<em_t *>(hash_map_get_first(m_em_map));
-                while (tmp_em != NULL) {
-                    dm = tmp_em->get_data_model();
-                    if ((dm != NULL) && (tmp_em->is_al_interface_em() == false)) {
-                        for (i = 0; i < dm->get_num_ap_mld(); i++) {
-                            ap_mld_info = &dm->m_ap_mld[i].m_ap_mld_info;
-                            if (memcmp(ap_mld_info->mac_addr, bss_mac, sizeof(mac_address_t)) != 0) {
-                                continue;
-                            }
-
-                            for (j = 0; j < ap_mld_info->num_affiliated_ap; j++) {
-                                if (memcmp(ap_mld_info->affiliated_ap[j].ruid.mac,
-                                           tmp_em->get_radio_interface_mac(),
-                                           sizeof(mac_address_t)) == 0) {
-                                    em = tmp_em;
-                                    em_printfout("Client cap: AP-MLD bssid=%s mapped to radio=%s",
-                                           util::mac_to_string(bss_mac).c_str(),
-                                           util::mac_to_string(em->get_radio_interface_mac()).c_str());
-                                    break;
-                                }
-                            }
-                            if (em != NULL) {
-                                break;
-                            }
-                        }
-                    }
-
-                    if (em != NULL) {
+            if (m_data_model.is_ap_mld_mac(bss_mac) == false) {
+                em_printfout("Client cap query bss=%s is not AP-MLD MAC, using direct BSS lookup", mac_str1);
+                em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+                while (em != NULL) {
+                    dm = em->get_data_model();
+                    em_bss = dm->get_bss_info_with_mac(bss_mac);
+                    if ((em_bss != NULL) &&
+                        (memcmp(em_bss->ruid.mac, em->get_radio_interface_mac(), sizeof(bssid_t)) == 0)) {
+                        em_printfout("Received client cap query: found radio for bss:%s", mac_str1);
                         break;
                     }
-                    tmp_em = static_cast<em_t *>(hash_map_get_next(m_em_map, tmp_em));
+                    em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
+                }
+            } else {
+                em_printfout("Client cap query bss=%s is AP-MLD MAC, resolving to affiliated radio", mac_str1);
+                if (m_data_model.resolve_ap_mld_to_fallback_ruid(bss_mac, fallback_ruid)) {
+                    dm_easy_mesh_t::macbytes_to_string(fallback_ruid, mac_str2);
+                    em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str2));
+                    if (em != NULL) {
+                        em_printfout("Client cap query AP-MLD bss=%s resolved to radio=%s", mac_str1, mac_str2);
+                    }
                 }
             }
-
             if(em == NULL){
                 dm_easy_mesh_t::macbytes_to_string(bss_mac, mac_str2);
-                printf("%s:%d: Received client cap query: Could not find radio:%s of bss:%s\n", __func__, __LINE__, mac_str1, mac_str2);
+                em_printfout("Received client cap query: Could not find radio:%s of bss:%s", mac_str1, mac_str2);
             }
             break;
 

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -1817,10 +1817,10 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     dm_bss_t *pbss;
     bool radio_matched = false, found = false;
     em_orch_desc_t desc;
-    em_2xlong_string_t	key;
+    mac_address_t fallback_ruid = {0};
 
     if (evt == NULL) {
-        printf("%s:%d: NULL event\n", __func__, __LINE__);
+        em_printfout("NULL event");
         return -1;
     }
 
@@ -1846,40 +1846,41 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
 
     pdm->set_topo_state(true);
 
-    for (i = 0; i < pdm->get_num_radios(); i++) {
-        found = true;
-        pbss = pdm->get_bss(pdm->get_radio_info(i)->id.ruid, params->assoc.bssid);
-        if (pbss == NULL) {
-            found = false;
-            continue;
-        }
-        break;
-    }
-    if (found == false) {
-        // For MLO notifications, BSSID may be AP MLD MAC and not directly resolvable
-        // to a per-link BSS yet. Continue orchestration (topology sync/query path) and
-        // defer exact link resolution to topology response processing
-        em_printfout("BSS not found bssid=%s, using fallback radio",
-            util::mac_to_string(params->assoc.bssid).c_str());
-        if (pdm->m_num_radios == 0) {
-            return -1;
-        }
-        dm_easy_mesh_t::macbytes_to_string(pdm->m_radio[0].m_radio_info.intf.mac, radio_mac_str);
-        radio_matched = true;
-    } else {
-        dm_easy_mesh_t::macbytes_to_string(pbss->m_bss_info.ruid.mac, radio_mac_str);
-
-        // confirm that the radio is on this device
-        for (i = 0; i < pdm->m_num_radios; i++) {
-            if (memcmp(pbss->m_bss_info.ruid.mac, pdm->m_radio[i].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
-                radio_matched = true;
+    if (pdm->is_ap_mld_mac(params->assoc.bssid) == false) {
+        em_printfout("bssid=%s is not AP-MLD MAC, using direct BSS lookup for STA assoc event", bss_mac_str);
+        found = false;
+        for (i = 0; i < pdm->get_num_radios(); i++) {
+            pbss = pdm->get_bss(pdm->get_radio_info(i)->id.ruid, params->assoc.bssid);
+            if (pbss != NULL) {
+                found = true;
                 break;
             }
         }
 
-        if (radio_matched == false) {
-            printf("%s:%d: Could not find bss: %s on radio: %s\n", __func__, __LINE__, bss_mac_str, radio_mac_str);
-            return -1;
+        if (found == true) {
+            dm_easy_mesh_t::macbytes_to_string(pbss->m_bss_info.ruid.mac, radio_mac_str);
+
+            // confirm that the radio is on this device
+            for (i = 0; i < pdm->m_num_radios; i++) {
+                    if (memcmp(pbss->m_bss_info.ruid.mac, pdm->m_radio[i].m_radio_info.intf.mac,
+                           sizeof(mac_address_t)) == 0) {
+                    radio_matched = true;
+                    break;
+                }
+            }
+
+            if (radio_matched == false) {
+                em_printfout("Could not find bss: %s on radio: %s", bss_mac_str, radio_mac_str);
+                return -1;
+            }
+        }
+    } else {
+        em_printfout("bssid=%s is AP-MLD MAC, resolving to affiliated radio for STA assoc event", bss_mac_str);
+        if (pdm->resolve_ap_mld_to_fallback_ruid(params->assoc.bssid, fallback_ruid)) {
+            dm_easy_mesh_t::macbytes_to_string(fallback_ruid, radio_mac_str);
+            em_printfout("Resolved AP-MLD bssid=%s to radio=%s for STA assoc event",
+                bss_mac_str, radio_mac_str);
+            found = true;
         }
     }
 
@@ -1887,10 +1888,20 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     tmp = pcmd[num];
     num++;
 
-    snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
-    if ((params->assoc.assoc_event == false) && ((get_sta(key) != NULL) || (found == false))) {
+    if (params->assoc.assoc_event == false) {
         desc.op = dm_orch_type_topo_update;
         desc.submit = false;
+        pcmd[num - 1]->override_op(0, &desc);
+        desc.op = dm_orch_type_topo_publish;
+        desc.submit = true;
+        pcmd[num - 1]->override_op(1, &desc);
+        pcmd[num - 1]->m_num_orch_desc = 2;
+    } else if ((params->assoc.assoc_event == true) && (found == true) &&
+               (pdm->is_ap_mld_mac(params->assoc.bssid) == false)) {
+        // BSS is directly resolvable for a non-MLO client — topology query not needed;
+        // skip dm_orch_type_topo_sync and go straight to client capability query + publish.
+        desc.op = dm_orch_type_sta_cap;
+        desc.submit = true;
         pcmd[num - 1]->override_op(0, &desc);
         desc.op = dm_orch_type_topo_publish;
         desc.submit = true;
@@ -3775,15 +3786,6 @@ int dm_easy_mesh_ctrl_t::update_tables(dm_easy_mesh_t *dm)
             sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_assoc_map, sta));
         }
 
-        sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_dassoc_map));
-        while (sta != NULL) {
-            criteria = dm->db_cfg_type_get_criteria(db_cfg_type_sta_list_update);
-            if (dm_sta_list_t::set_config(m_db_client, *sta, NULL) == 0) {
-                dm->reset_db_cfg_type(db_cfg_type_sta_list_update);
-            }
-            sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_dassoc_map, sta));
-        }
-
         sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_assoc_map));
         while (sta != NULL) {
             tmp = sta;
@@ -3800,22 +3802,7 @@ int dm_easy_mesh_ctrl_t::update_tables(dm_easy_mesh_t *dm)
             hash_map_remove(dm->m_sta_assoc_map, key);
             delete tmp;
         }
-            
-        sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_dassoc_map));
-        while (sta != NULL) {
-            tmp = sta;
-            criteria = dm->db_cfg_type_get_criteria(db_cfg_type_sta_list_update);
-            if (dm_sta_list_t::set_config(m_db_client, *sta, NULL) == 0) {
-                dm->reset_db_cfg_type(db_cfg_type_sta_list_update);
-            }
-            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
-            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bssid_str);
-            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
-            snprintf(key, sizeof(em_2xlong_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
-            sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_dassoc_map, sta));
-            hash_map_remove(dm->m_sta_dassoc_map, key);
-            delete tmp;
-        } 
+
 		dm->reset_db_cfg_type(db_cfg_type_sta_list_update);
     }
 

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -809,11 +809,10 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
     bssid_t	bssid;
     dm_bss_t *bss;
     em_profile_type_t profile;
-    em_2xlong_string_t key;
     unsigned int i;
-    bool found;
-    mac_addr_str_t mac_str1 = {0}, mac_str2 = {0}, dev_mac_str = {0}, radio_mac_str = {0};
+    mac_addr_str_t mac_str1 = {0}, mac_str2 = {0};
     em_commit_info_t dm_commit;
+    mac_address_t fallback_ruid = {0};
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
     if (len < ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)))) {
@@ -923,31 +922,37 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
                 return NULL;
             }
 
-            found = false;
-
-            for (i = 0; i < dm->get_num_radios(); i++) {
-                found = true;
-                dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (dm->get_radio_info(i)->id.dev_mac), dev_mac_str);
-                dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (dm->get_radio_info(i)->id.ruid), radio_mac_str);
-                dm_easy_mesh_t::macbytes_to_string(bssid, mac_str1);
-                snprintf(key, sizeof (em_2xlong_string_t), "%s@%s@%s@%s@", dm->get_radio_info(i)->id.net_id, dev_mac_str, radio_mac_str, mac_str1);
-
-                if ((bss = dm->get_bss(dm->get_radio_info(i)->id.ruid, bssid)) == NULL) {
-                    found = false;
-                    continue;
+            if (dm->is_ap_mld_mac(bssid) == false) {
+                bss = NULL;
+                for (i = 0; i < dm->get_num_radios(); i++) {
+                    bss = dm->get_bss(dm->get_radio_info(i)->id.ruid, bssid);
+                    if (bss != NULL) {
+                        break;
+                    }
                 }
-                break;
-            }
 
-            if (found == false) {
-                printf("%s:%d: Could not find bss:%s from data model, for radio: %s\n", __func__, __LINE__, mac_str1, radio_mac_str);
+                if (bss == NULL) {
+                    em_printfout("Could not find bss=%s from data model",
+                        util::mac_to_string(bssid).c_str());
+                    return NULL;
+                }
+
+                dm_easy_mesh_t::macbytes_to_string(bss->m_bss_info.ruid.mac, mac_str1);
+                if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) == NULL) {
+                    em_printfout("Could not find radio:%s", mac_str1);
+                    return NULL;
+                }
+            } else {
                 if ((htons(cmdu->type) == em_msg_type_topo_notif) ||
                     (htons(cmdu->type) == em_msg_type_client_cap_rprt)) {
-                    // BSSID may be AP MLD MAC. Use any radio EM for this device.
-                    for (i = 0; i < dm->get_num_radios(); i++) {
-                        dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *>(dm->get_radio_info(i)->id.ruid), mac_str1);
-                        if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) != NULL) {
-                            break;
+                    if (dm->resolve_ap_mld_to_fallback_ruid(bssid, fallback_ruid)) {
+                        dm_easy_mesh_t::macbytes_to_string(fallback_ruid, mac_str1);
+                        em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1));
+                        if (em != NULL) {
+                            em_printfout("Resolved AP-MLD bssid=%s to radio=%s for msg=0x%04x",
+                                util::mac_to_string(bssid).c_str(),
+                                util::mac_to_string(fallback_ruid).c_str(),
+                                htons(cmdu->type));
                         }
                     }
                     if (em == NULL) {
@@ -955,12 +960,8 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
                         return NULL;
                     }
                 } else {
-                    return NULL;
-                }
-            } else {
-                dm_easy_mesh_t::macbytes_to_string(bss->m_bss_info.ruid.mac, mac_str1);
-                if ((em = static_cast<em_t *> (hash_map_get(m_em_map, mac_str1))) == NULL) {
-                    printf("%s:%d: Could not find radio:%s\n", __func__, __LINE__, mac_str1);
+                    em_printfout("Could not find bss=%s from data model",
+                        util::mac_to_string(bssid).c_str());
                     return NULL;
                 }
             }

--- a/src/dm/dm_assoc_sta_mld.cpp
+++ b/src/dm/dm_assoc_sta_mld.cpp
@@ -57,7 +57,12 @@ void dm_assoc_sta_mld_t::operator = (const dm_assoc_sta_mld_t& obj)
     this->m_assoc_sta_mld_info.emlsr = obj.m_assoc_sta_mld_info.emlsr;
     this->m_assoc_sta_mld_info.emlmr = obj.m_assoc_sta_mld_info.emlmr;
     this->m_assoc_sta_mld_info.num_affiliated_sta = obj.m_assoc_sta_mld_info.num_affiliated_sta;
-    memcpy(&this->m_assoc_sta_mld_info.affiliated_sta,&obj.m_assoc_sta_mld_info.affiliated_sta,sizeof(em_affiliated_sta_info_t));
+    for (unsigned int i = 0; i < this->m_assoc_sta_mld_info.num_affiliated_sta; i++) {
+        memcpy(&this->m_assoc_sta_mld_info.affiliated_sta[i].bssid,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].bssid, sizeof(mac_address_t));
+        memcpy(&this->m_assoc_sta_mld_info.affiliated_sta[i].mac_addr,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].mac_addr, sizeof(mac_address_t));
+    }
 }
 
 bool dm_assoc_sta_mld_t::operator == (const dm_assoc_sta_mld_t& obj)
@@ -71,7 +76,12 @@ bool dm_assoc_sta_mld_t::operator == (const dm_assoc_sta_mld_t& obj)
     ret += !(this->m_assoc_sta_mld_info.emlsr == obj.m_assoc_sta_mld_info.emlsr);
     ret += !(this->m_assoc_sta_mld_info.emlmr == obj.m_assoc_sta_mld_info.emlmr);
     ret += !(this->m_assoc_sta_mld_info.num_affiliated_sta == obj.m_assoc_sta_mld_info.num_affiliated_sta);
-    ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta,&obj.m_assoc_sta_mld_info.affiliated_sta,sizeof(em_affiliated_ap_info_t)) != 0);
+    for (unsigned int i = 0; i < this->m_assoc_sta_mld_info.num_affiliated_sta; i++) {
+        ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].bssid,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].bssid, sizeof(mac_address_t)) != 0);
+        ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].mac_addr,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].mac_addr, sizeof(mac_address_t)) != 0);
+    }
 
     if (ret > 0)
         return false;

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -3339,6 +3339,59 @@ em_ap_mld_info_t *dm_easy_mesh_t::get_ap_mld_frm_bssid(mac_address_t bss_id)
     return NULL;
 }
 
+bool dm_easy_mesh_t::is_ap_mld_mac(const mac_address_t mac)
+{
+    const em_ap_mld_info_t *ap_mld_info = NULL;
+
+    if (mac == NULL) {
+        return false;
+    }
+
+    for (unsigned int i = 0; i < m_num_ap_mld; i++) {
+        ap_mld_info = &m_ap_mld[i].m_ap_mld_info;
+        if (!ap_mld_info->mac_addr_valid) {
+            continue;
+        }
+        if (memcmp(ap_mld_info->mac_addr, mac, sizeof(mac_address_t)) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool dm_easy_mesh_t::resolve_ap_mld_to_fallback_ruid(const mac_address_t ap_mld_mac, mac_address_t fallback_ruid)
+{
+    em_ap_mld_info_t *ap_mld_info = NULL;
+    unsigned int i, j;
+
+    if ((ap_mld_mac == NULL) || (fallback_ruid == NULL)) {
+        return false;
+    }
+
+    for (i = 0; i < m_num_ap_mld; i++) {
+        ap_mld_info = &m_ap_mld[i].m_ap_mld_info;
+        if (!ap_mld_info->mac_addr_valid) {
+            continue;
+        }
+        if (memcmp(ap_mld_info->mac_addr, ap_mld_mac, sizeof(mac_address_t)) != 0) {
+            continue;
+        }
+
+        // Use the first valid affiliated AP's RUID as fallback.
+        for (j = 0; j < ap_mld_info->num_affiliated_ap; j++) {
+            if (!ap_mld_info->affiliated_ap[j].mac_addr_valid) {
+                continue;
+            }
+            memcpy(fallback_ruid, ap_mld_info->affiliated_ap[j].ruid.mac, sizeof(mac_address_t));
+            return true;
+        }
+        return false;
+    }
+
+    return false;
+}
+
 void dm_easy_mesh_t::update_ap_mld_info(em_ap_mld_info_t *ap_mld_info)
 {
 

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -342,51 +342,15 @@ short em_capability_t::create_client_cap_tlv(unsigned char *buff, mac_address_t 
     unsigned char res = 0;
     dm_easy_mesh_t *dm;
     dm_sta_t *dm_sta;
-    em_assoc_sta_mld_info_t *assoc_info = NULL;
-    unsigned int i, j;
-    mac_address_t lookup_sta;
 
     dm = get_data_model();
-    memcpy(lookup_sta, sta, sizeof(mac_address_t));
 
     dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
     while(dm_sta != NULL) {
-        if (memcmp(dm_sta->get_sta_info()->id, lookup_sta, sizeof(mac_address_t)) == 0) {
+        if (memcmp(dm_sta->get_sta_info()->id, sta, sizeof(mac_address_t)) == 0) {
             break;
         }
         dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, dm_sta));
-    }
-
-    // Client Capability Query for MLO may carry STA MLD MAC while local sta_map may hold
-    // affiliated link STA MACs. Resolve STA MLD -> affiliated STA and retry lookup.
-    if (dm_sta == NULL) {
-        for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
-            assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
-            if (memcmp(assoc_info->mac_addr, sta, sizeof(mac_address_t)) != 0) {
-                continue;
-            }
-
-            for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
-                memcpy(lookup_sta, assoc_info->affiliated_sta[j].mac_addr, sizeof(mac_address_t));
-                dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
-                while (dm_sta != NULL) {
-                    if (memcmp(dm_sta->get_sta_info()->id, lookup_sta, sizeof(mac_address_t)) == 0) {
-                        break;
-                    }
-                    dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, dm_sta));
-                }
-
-                if (dm_sta != NULL) {
-                    em_printfout("Client cap: mapped MLD %s to link STA %s",
-                            util::mac_to_string(sta).c_str(), util::mac_to_string(lookup_sta).c_str());
-                    break;
-                }
-            }
-
-            if (dm_sta != NULL) {
-                break;
-            }
-        }
     }
 
     if(dm_sta == NULL) {
@@ -788,10 +752,8 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     dm_sta_t *existing_sta = NULL;
     em_sta_info_t link_sta_info;
     em_long_string_t link_key;
-    bool remapped_bssid = false;
     bool found_client_info = false;
     bool found_cap_report = false;
-    bool sta_match = false;
     bool updated_any = false;
     unsigned int i, j, k;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
@@ -824,37 +786,27 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
         return -1;
     }
 
-    // Remap AP MLD BSSID to a local link BSSID when needed.
-    if (dm->get_bss(get_radio_interface_mac(), sta_info.bssid) == NULL) {
+    if ((dm->get_bss(get_radio_interface_mac(), sta_info.bssid) == NULL) && dm->is_ap_mld_mac(sta_info.bssid)) {
+        em_printfout("Client cap: STA %s is affiliated with MLD BSSID %s, remapping to affiliated link BSSID",
+            util::mac_to_string(sta_info.id).c_str(), util::mac_to_string(sta_info.bssid).c_str());
+        assoc_info = NULL;
         for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
-            assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
-            sta_match = (memcmp(assoc_info->mac_addr, sta_info.id, sizeof(mac_address_t)) == 0);
-
-            if (sta_match == false) {
-                for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
-                    if (memcmp(assoc_info->affiliated_sta[j].mac_addr, sta_info.id, sizeof(mac_address_t)) == 0) {
-                        sta_match = true;
-                        break;
-                    }
-                }
+            if (memcmp(dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info.mac_addr,
+                       sta_info.id,
+                       sizeof(mac_address_t)) == 0) {
+                assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+                break;
             }
+        }
 
-            if (sta_match == false) {
-                continue;
-            }
-
+        if (assoc_info != NULL) {
             for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
                 if (dm->get_bss(get_radio_interface_mac(), assoc_info->affiliated_sta[j].bssid) != NULL) {
                     memcpy(sta_info.bssid, assoc_info->affiliated_sta[j].bssid, sizeof(mac_address_t));
                     em_printfout("Client cap: remapped BSSID for STA %s -> %s",
                         util::mac_to_string(sta_info.id).c_str(), util::mac_to_string(sta_info.bssid).c_str());
-                    remapped_bssid = true;
                     break;
                 }
-            }
-
-            if (remapped_bssid == true) {
-                break;
             }
         }
     }
@@ -908,6 +860,13 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
                     memcpy(link_sta_info.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
                     break;
                 }
+            }
+
+            if (aff_bss == NULL) {
+                em_printfout("Client cap DB skip link: unresolved BSSID %s for STA %s",
+                    util::mac_to_string(link_sta_info.bssid).c_str(),
+                    util::mac_to_string(link_sta_info.id).c_str());
+                continue;
             }
 
             dm_easy_mesh_t::macbytes_to_string(link_sta_info.bssid, link_bssid_str);

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -88,10 +88,7 @@ static bool allow_failed_conn_report(unsigned short max_reports_per_min)
     return true;
 }
 
-static bool em_cfg_update_sta_assoc_row(hash_map_t *sta_assoc_map,
-                                        em_sta_info_t *row,
-                                        const char *new_log_prefix,
-                                        const char *update_log_prefix)
+static bool update_sta_map_assoc_row(hash_map_t *sta_assoc_map, em_sta_info_t *row)
 {
     mac_addr_str_t row_sta_str, row_bssid_str, row_radio_str;
     em_long_string_t row_key;
@@ -105,131 +102,68 @@ static bool em_cfg_update_sta_assoc_row(hash_map_t *sta_assoc_map,
     existing_row = static_cast<dm_sta_t *>(hash_map_get(sta_assoc_map, row_key));
     if (existing_row == NULL) {
         hash_map_put(sta_assoc_map, strdup(row_key), new dm_sta_t(row));
-        em_printfout("%s%s", new_log_prefix, row_key);
+        em_printfout("sta_map add: %s", row_key);
     } else {
-        existing_row->m_sta_info.associated = row->associated;
-        em_printfout("%s%s", update_log_prefix, row_key);
+        memcpy(&existing_row->m_sta_info, row, sizeof(em_sta_info_t));
+        em_printfout("sta_map update: %s", row_key);
     }
 
     return true;
 }
 
-static dm_sta_t *em_cfg_find_dassoc_sta(dm_easy_mesh_t *dm,
-                                        const mac_address_t sta_mac,
-                                        const bssid_t bssid,
-                                        bool match_bssid)
-{
-    dm_sta_t *dassoc_sta;
-
-    dassoc_sta = static_cast<dm_sta_t *>(hash_map_get_first(dm->m_sta_dassoc_map));
-    while (dassoc_sta != NULL) {
-        if ((memcmp(dassoc_sta->m_sta_info.id, sta_mac, sizeof(mac_address_t)) == 0) &&
-            ((match_bssid == false) ||
-             (memcmp(dassoc_sta->m_sta_info.bssid, bssid, sizeof(bssid_t)) == 0))) {
-            return dassoc_sta;
-        }
-        dassoc_sta = static_cast<dm_sta_t *>(hash_map_get_next(dm->m_sta_dassoc_map, dassoc_sta));
-    }
-
-    return NULL;
-}
-
-static unsigned short em_cfg_create_assoc_sta_traffic_stats_tlv(em_tlv_t *tlv,
-                                                                const mac_address_t logical_sta,
-                                                                dm_easy_mesh_t *dm,
-                                                                const em_assoc_sta_mld_info_t *mld_info,
-                                                                dm_sta_t *dassoc_sta)
-{
-    em_assoc_sta_traffic_sts_t *stats;
-    dm_sta_t *aff_sta;
-    unsigned short sz;
-    unsigned int j;
-    uint32_t bytes_sent = 0, bytes_recv = 0;
-    uint32_t packets_sent = 0, packets_recv = 0;
-    uint32_t tx_errors = 0, rx_errors = 0;
-    uint32_t retrans = 0;
-
-    tlv->type = em_tlv_type_assoc_sta_traffic_sts;
-    stats = reinterpret_cast<em_assoc_sta_traffic_sts_t *>(tlv->value);
-    memset(stats, 0, sizeof(*stats));
-    memcpy(stats->sta_mac_addr, logical_sta, sizeof(mac_address_t));
-
-    if (mld_info != NULL) {
-
-        for (j = 0; j < mld_info->num_affiliated_sta; j++) {
-            aff_sta = em_cfg_find_dassoc_sta(dm,
-                                             mld_info->affiliated_sta[j].mac_addr,
-                                             mld_info->affiliated_sta[j].bssid,
-                                             false);
-            if (aff_sta == NULL) {
-                continue;
-            }
-            bytes_sent    += aff_sta->m_sta_info.bytes_tx;
-            bytes_recv    += aff_sta->m_sta_info.bytes_rx;
-            packets_sent  += aff_sta->m_sta_info.pkts_tx;
-            packets_recv  += aff_sta->m_sta_info.pkts_rx;
-            tx_errors     += aff_sta->m_sta_info.errors_tx;
-            rx_errors     += aff_sta->m_sta_info.errors_rx;
-            retrans       += aff_sta->m_sta_info.retrans_count;
-            if (dassoc_sta == NULL) {
-                dassoc_sta = aff_sta;
-            }
-        }
-        stats->bytes_sent        = htonl(bytes_sent);
-        stats->bytes_recv        = htonl(bytes_recv);
-        stats->packets_sent      = htonl(packets_sent);
-        stats->packets_recv      = htonl(packets_recv);
-        stats->tx_packets_errors = htonl(tx_errors);
-        stats->rx_packets_errors = htonl(rx_errors);
-        stats->retrans_count     = htonl(retrans);
-    } else if (dassoc_sta != NULL) {
-        stats->bytes_sent = htonl(dassoc_sta->m_sta_info.bytes_tx);
-        stats->bytes_recv = htonl(dassoc_sta->m_sta_info.bytes_rx);
-        stats->packets_sent = htonl(dassoc_sta->m_sta_info.pkts_tx);
-        stats->packets_recv = htonl(dassoc_sta->m_sta_info.pkts_rx);
-        stats->tx_packets_errors = htonl(dassoc_sta->m_sta_info.errors_tx);
-        stats->rx_packets_errors = htonl(dassoc_sta->m_sta_info.errors_rx);
-        stats->retrans_count = htonl(dassoc_sta->m_sta_info.retrans_count);
-    }
-
-    sz = static_cast<unsigned short>(sizeof(em_assoc_sta_traffic_sts_t));
-    tlv->len = htons(sz);
-
-    return static_cast<unsigned short>(sizeof(em_tlv_t) + sz);
-}
-
-static unsigned short em_cfg_create_affiliated_sta_metrics_tlvs(unsigned char *buff,
-                                                                dm_easy_mesh_t *dm,
-                                                                const em_assoc_sta_mld_info_t *mld_info)
+static unsigned short create_affiliated_sta_metrics_tlvs(unsigned char *buff,
+                                                         dm_easy_mesh_t *dm,
+                                                         const em_assoc_sta_mld_info_t *mld_info,
+                                                         em_target_sta_map_t target_map)
 {
     em_tlv_t *tlv;
     em_affiliated_sta_metrics_t *metrics;
-    dm_sta_t *aff_dassoc_sta;
     const em_affiliated_sta_info_t *aff_sta;
+    em_sta_info_t *aff_sta_info;
+    dm_bss_t *aff_bss;
     unsigned short sz;
     unsigned short total_len = 0;
-    unsigned int j;
+    unsigned int j, r;
+    mac_address_t aff_sta_mac = {0};
+    bssid_t aff_bssid = {0};
+    mac_address_t aff_radio_mac = {0};
 
-    if (mld_info == NULL) {
+    if ((dm == NULL) || (mld_info == NULL)) {
         return 0;
     }
 
     for (j = 0; j < mld_info->num_affiliated_sta; j++) {
         aff_sta = &mld_info->affiliated_sta[j];
-        aff_dassoc_sta = em_cfg_find_dassoc_sta(dm, aff_sta->mac_addr, aff_sta->bssid, false);
 
         tlv = reinterpret_cast<em_tlv_t *>(buff + total_len);
         tlv->type = em_tlv_type_affiliated_sta_metrics;
         metrics = reinterpret_cast<em_affiliated_sta_metrics_t *>(tlv->value);
         memset(metrics, 0, sizeof(*metrics));
         memcpy(metrics->sta_mac_addr, aff_sta->mac_addr, sizeof(mac_address_t));
+        memcpy(aff_bssid, aff_sta->bssid, sizeof(bssid_t));
 
-        if (aff_dassoc_sta != NULL) {
-            metrics->bytes_sent = htonl(aff_dassoc_sta->m_sta_info.bytes_tx);
-            metrics->bytes_recv = htonl(aff_dassoc_sta->m_sta_info.bytes_rx);
-            metrics->packets_sent = htonl(aff_dassoc_sta->m_sta_info.pkts_tx);
-            metrics->packets_recv = htonl(aff_dassoc_sta->m_sta_info.pkts_rx);
-            metrics->tx_packets_errors = htonl(aff_dassoc_sta->m_sta_info.errors_tx);
+        aff_bss = NULL;
+        for (r = 0; r < dm->get_num_radios(); r++) {
+            aff_bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, aff_bssid);
+            if (aff_bss != NULL) {
+                break;
+            }
+        }
+
+        aff_sta_info = NULL;
+        if (aff_bss != NULL) {
+            memcpy(aff_sta_mac, aff_sta->mac_addr, sizeof(mac_address_t));
+            memcpy(aff_radio_mac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+
+            aff_sta_info = dm->get_sta_info(aff_sta_mac, aff_bssid, aff_radio_mac, target_map);
+        }
+
+        if (aff_sta_info != NULL) {
+            metrics->bytes_sent = htonl(aff_sta_info->bytes_tx);
+            metrics->bytes_recv = htonl(aff_sta_info->bytes_rx);
+            metrics->packets_sent = htonl(aff_sta_info->pkts_tx);
+            metrics->packets_recv = htonl(aff_sta_info->pkts_rx);
+            metrics->tx_packets_errors = htonl(aff_sta_info->errors_tx);
         }
 
         sz = static_cast<unsigned short>(sizeof(em_affiliated_sta_metrics_t));
@@ -240,25 +174,20 @@ static unsigned short em_cfg_create_affiliated_sta_metrics_tlvs(unsigned char *b
     return total_len;
 }
 
-static bool em_cfg_handle_assoc_sta_mld_topology_updates(dm_easy_mesh_t *dm)
+static bool handle_assoc_sta_mld_topology_update(dm_easy_mesh_t *dm)
 {
     bool sta_db_update_needed;
-    bool in_new_set;
     unsigned int i, j, r;
     em_assoc_sta_mld_info_t *assoc_info;
     dm_bss_t *aff_bss;
     em_sta_info_t sta_info;
-    dm_sta_t *db_sta;
-    em_sta_info_t disassoc_info;
-    dm_sta_t *queued_sta;
-    mac_addr_str_t check_sta_str, check_bssid_str, check_radio_str;
-    em_long_string_t check_key;
+    mac_addr_str_t s_str, b_str_tmp, r_str_tmp;
+    em_long_string_t exist_key;
+    dm_sta_t *existing_sta;
 
     sta_db_update_needed = false;
     assoc_info = NULL;
     aff_bss = NULL;
-    db_sta = NULL;
-    queued_sta = NULL;
 
     for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
         assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
@@ -281,53 +210,20 @@ static bool em_cfg_handle_assoc_sta_mld_topology_updates(dm_easy_mesh_t *dm)
             memcpy(sta_info.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
             sta_info.associated = true;
 
-            if (em_cfg_update_sta_assoc_row(dm->m_sta_assoc_map, &sta_info,
-                        "Topo resp add link: ",
-                        "Topo resp update link: ") == true) {
+            dm_easy_mesh_t::macbytes_to_string(sta_info.id, s_str);
+            dm_easy_mesh_t::macbytes_to_string(sta_info.bssid, b_str_tmp);
+            dm_easy_mesh_t::macbytes_to_string(sta_info.radiomac, r_str_tmp);
+            snprintf(exist_key, sizeof(em_long_string_t), "%s@%s@%s", s_str, b_str_tmp, r_str_tmp);
+            existing_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_map, exist_key));
+            if (existing_sta != NULL) {
+                em_printfout("Existing sta row found for %s, preserving stats", exist_key);
+                memcpy(&sta_info, &existing_sta->m_sta_info, sizeof(em_sta_info_t));
+                sta_info.associated = true;
+            }
+
+            if (update_sta_map_assoc_row(dm->m_sta_assoc_map, &sta_info)) {
                 sta_db_update_needed = true;
             }
-        }
-    }
-
-    for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
-        assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
-        db_sta = static_cast<dm_sta_t *>(hash_map_get_first(dm->m_sta_map));
-        while (db_sta != NULL) {
-            if (memcmp(db_sta->m_sta_info.id, assoc_info->mac_addr, sizeof(mac_address_t)) == 0
-                    && db_sta->m_sta_info.associated) {
-                in_new_set = false;
-                for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
-                    if (memcmp(db_sta->m_sta_info.bssid, assoc_info->affiliated_sta[j].bssid,
-                            sizeof(mac_address_t)) == 0) {
-                        in_new_set = true;
-                        break;
-                    }
-                }
-                if (!in_new_set) {
-                    disassoc_info = db_sta->m_sta_info;
-                    disassoc_info.associated = false;
-                    disassoc_info.frame_body_len = 0;
-                    dm_easy_mesh_t::macbytes_to_string(disassoc_info.id, check_sta_str);
-                    dm_easy_mesh_t::macbytes_to_string(disassoc_info.bssid, check_bssid_str);
-                    dm_easy_mesh_t::macbytes_to_string(disassoc_info.radiomac, check_radio_str);
-                    snprintf(check_key, sizeof(em_long_string_t), "%s@%s@%s",
-                            check_sta_str, check_bssid_str, check_radio_str);
-
-                    queued_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, check_key));
-                    if (queued_sta != NULL) {
-                        queued_sta->m_sta_info.associated = false;
-                        queued_sta->m_sta_info.frame_body_len = 0;
-                        memset(queued_sta->m_sta_info.frame_body, 0, sizeof(queued_sta->m_sta_info.frame_body));
-                        sta_db_update_needed = true;
-                        em_printfout("Topo resp stale link queued disassoc: %s", check_key);
-                    } else {
-                        hash_map_put(dm->m_sta_assoc_map, strdup(check_key), new dm_sta_t(&disassoc_info));
-                        sta_db_update_needed = true;
-                        em_printfout("Topo resp stale link disassoc: %s", check_key);
-                    }
-                }
-            }
-            db_sta = static_cast<dm_sta_t *>(hash_map_get_next(dm->m_sta_map, db_sta));
         }
     }
 
@@ -402,26 +298,44 @@ unsigned short em_configuration_t::create_client_assoc_event_tlv(unsigned char *
 }
 
 
-int em_configuration_t::send_client_disassoc_stats_msg(mac_address_t sta, bssid_t bssid)
+int em_configuration_t::send_client_disassoc_stats_msg(const dm_sta_t *dassoc_sta)
 {
     unsigned short  msg_type = em_msg_type_client_disassoc_stats;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    unsigned int len = 0;
-    unsigned short sz;
+    unsigned int i, len = 0;
+    unsigned short sz, stats_sz, tlv_total_len;
     em_cmdu_t *cmdu;
     em_tlv_t *tlv;
     unsigned char buff[MAX_EM_BUFF_SZ];
     unsigned char *tmp = buff;
     unsigned short type = htons(ETH_P_1905);
     dm_easy_mesh_t *dm;
-    dm_sta_t *dassoc_sta = NULL;
     em_assoc_sta_mld_info_t *mld_info = NULL;
-    unsigned int i, j;
-    mac_address_t logical_sta = {0};
-    unsigned short tlv_total_len;
+    dm_sta_t dassoc_stats_sta;
+    em_sta_info_t *dassoc_stats_sta_info;
+    const em_sta_info_t *sta_info;
+    mac_address_t sta_id = {0}, radio_mac = {0};
+    bssid_t bssid = {0};
 
     dm = get_data_model();
-    memcpy(logical_sta, sta, sizeof(mac_address_t));
+    if (dassoc_sta == NULL) {
+        em_printfout("Client disassoc stats: input disassoc row is NULL");
+        return -1;
+    }
+
+    sta_info = &dassoc_sta->m_sta_info;
+    memcpy(sta_id, dassoc_sta->m_sta_info.id, sizeof(mac_address_t));
+    memcpy(bssid, dassoc_sta->m_sta_info.bssid, sizeof(bssid_t));
+    memcpy(radio_mac, dassoc_sta->m_sta_info.radiomac, sizeof(mac_address_t));
+
+    // Resolve stats from the global DM to get the correct values instead of using the input from command.
+    dassoc_stats_sta_info = dm->get_sta_info(sta_id, bssid, radio_mac, em_target_sta_map_disassoc);
+    if (dassoc_stats_sta_info != NULL) {
+        dassoc_stats_sta = *dassoc_sta;
+        memcpy(&dassoc_stats_sta.m_sta_info, dassoc_stats_sta_info, sizeof(em_sta_info_t));
+        dassoc_sta = &dassoc_stats_sta;
+        sta_info = &dassoc_stats_sta.m_sta_info;
+    }
 
     // Ethernet header: dst (controller AL MAC), src (agent AL MAC), EtherType
     memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
@@ -449,30 +363,16 @@ int em_configuration_t::send_client_disassoc_stats_msg(mac_address_t sta, bssid_
     // Resolve whether this STA belongs to an MLD client.
     for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
         em_assoc_sta_mld_info_t &assoc_sta_mld_info = dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
-        if (memcmp(assoc_sta_mld_info.mac_addr, sta, sizeof(mac_address_t)) == 0) {
+        if (memcmp(assoc_sta_mld_info.mac_addr, sta_info->id, sizeof(mac_address_t)) == 0) {
             mld_info = &assoc_sta_mld_info;
-            memcpy(logical_sta, assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
-            break;
-        }
-        for (j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
-            if (memcmp(assoc_sta_mld_info.affiliated_sta[j].mac_addr, sta, sizeof(mac_address_t)) == 0) {
-                mld_info = &assoc_sta_mld_info;
-                memcpy(logical_sta, assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
-                break;
-            }
-        }
-        if (mld_info != NULL) {
             break;
         }
     }
 
-    // Use BSSID for non-MLD lookup to avoid ambiguous STA matches.
-    dassoc_sta = em_cfg_find_dassoc_sta(dm, logical_sta, bssid, (mld_info == NULL));
-
     // STA MAC Address Type TLV (17.2.23)
     tlv = reinterpret_cast<em_tlv_t *>(tmp);
     tlv->type = em_tlv_type_sta_mac_addr;
-    memcpy(tlv->value, logical_sta, sizeof(mac_address_t));
+    memcpy(tlv->value, sta_info->id, sizeof(mac_address_t));
     tlv->len = htons(sizeof(mac_address_t));
 
     tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
@@ -481,11 +381,8 @@ int em_configuration_t::send_client_disassoc_stats_msg(mac_address_t sta, bssid_
     // Reason Code TLV (17.2.64)
     tlv = reinterpret_cast<em_tlv_t *>(tmp);
     tlv->type = em_tlv_type_reason_code;
-    {
-        em_reason_code_t *rc = reinterpret_cast<em_reason_code_t *>(tlv->value);
-        unsigned short reason = (dassoc_sta != NULL) ? dassoc_sta->m_sta_info.reason_code : 1;
-        rc->reason_code = htons(reason);
-    }
+    em_reason_code_t *rc = reinterpret_cast<em_reason_code_t *>(tlv->value);
+    rc->reason_code = htons(dassoc_sta->m_sta_info.reason_code);
     sz = static_cast<unsigned short>(sizeof(em_reason_code_t));
     tlv->len = htons(sz);
 
@@ -494,12 +391,15 @@ int em_configuration_t::send_client_disassoc_stats_msg(mac_address_t sta, bssid_
 
     // Associated STA Traffic Stats TLV (17.2.35)
     tlv = reinterpret_cast<em_tlv_t *>(tmp);
-    tlv_total_len = em_cfg_create_assoc_sta_traffic_stats_tlv(tlv, logical_sta, dm, mld_info, dassoc_sta);
+    tlv->type = em_tlv_type_assoc_sta_traffic_sts;
+    stats_sz = static_cast<unsigned short>(static_cast<em_t *>(this)->create_assoc_sta_traffic_stats_tlv(tlv->value, dassoc_sta));
+    tlv->len = htons(stats_sz);
+    tlv_total_len = static_cast<unsigned short>(sizeof(em_tlv_t) + stats_sz);
     tmp += tlv_total_len;
     len += static_cast<unsigned int>(tlv_total_len);
 
-    // Affiliated STA Metrics TLVs (17.2.100)
-    tlv_total_len = em_cfg_create_affiliated_sta_metrics_tlvs(tmp, dm, mld_info);
+    // Zero or more Affiliated STA Metrics TLVs (17.2.100)
+    tlv_total_len = create_affiliated_sta_metrics_tlvs(tmp, dm, mld_info, em_target_sta_map_disassoc);
     tmp += tlv_total_len;
     len += static_cast<unsigned int>(tlv_total_len);
 
@@ -510,8 +410,6 @@ int em_configuration_t::send_client_disassoc_stats_msg(mac_address_t sta, bssid_
 
     tmp += sizeof(em_tlv_t);
     len += static_cast<unsigned int>(sizeof(em_tlv_t));
-
-    em_printfout("Client disassoc stats msg built, len=%u", len);
 
     if (em_msg_t(em_msg_type_client_disassoc_stats, em_profile_type_3, buff, len).validate(errors) == 0) {
         em_printfout("Client disassoc stats msg validation failed");
@@ -671,7 +569,6 @@ void em_configuration_t::handle_failed_connection_event(const mac_address_t sta,
     if (max_rate == 0) {
         max_rate = device_info->max_reporting_rate;
     }
-    em_printfout("FailedConn: max_rate=%u", max_rate);
 
     if (!allow_failed_conn_report(max_rate)) {
         em_printfout("FailedConn: rate limit reached (max_rate=%u per min), skipping", max_rate);
@@ -800,8 +697,7 @@ void em_configuration_t::handle_state_topology_notify()
             sta_str = util::mac_to_string(sta->m_sta_info.id);
             notif_ret = send_topology_notification_by_client(sta->m_sta_info.id, sta->m_sta_info.bssid, false);
             if (notif_ret >= 0) {
-                disassoc_stats_ret = send_client_disassoc_stats_msg(sta->m_sta_info.id, sta->m_sta_info.bssid);
-
+                disassoc_stats_ret = send_client_disassoc_stats_msg(sta);
                 if (disassoc_stats_ret >= 0) {
                     dm->remove_assoc_sta_mld_info(sta->m_sta_info.id);
                 } else {
@@ -2423,7 +2319,7 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
     em_printfout("Total Assoc STA MLD TLVs parsed: %u, m_num_assoc_sta_mld=%u",
         assoc_sta_mld_count, dm->m_num_assoc_sta_mld);
 
-    if (em_cfg_handle_assoc_sta_mld_topology_updates(dm) == true) {
+    if (handle_assoc_sta_mld_topology_update(dm) == true) {
         dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
     }
 

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -469,13 +469,13 @@ int em_metrics_t::handle_assoc_sta_traffic_stats(unsigned char *buff, bssid_t bs
         return -1;
     }
 
-    sta->m_sta_info.bytes_tx        = sta_metrics->tx_bytes;
-    sta->m_sta_info.bytes_rx        = sta_metrics->rx_bytes;
-    sta->m_sta_info.pkts_tx         = sta_metrics->tx_pkts;
-    sta->m_sta_info.pkts_rx         = sta_metrics->rx_pkts;
-    sta->m_sta_info.errors_tx       = sta_metrics->tx_pkt_errors;
-    sta->m_sta_info.errors_rx       = sta_metrics->rx_pkt_errors;
-    sta->m_sta_info.retrans_count   = sta_metrics->retx_cnt;
+    sta->m_sta_info.bytes_tx        = ntohl(sta_metrics->tx_bytes);
+    sta->m_sta_info.bytes_rx        = ntohl(sta_metrics->rx_bytes);
+    sta->m_sta_info.pkts_tx         = ntohl(sta_metrics->tx_pkts);
+    sta->m_sta_info.pkts_rx         = ntohl(sta_metrics->rx_pkts);
+    sta->m_sta_info.errors_tx       = ntohl(sta_metrics->tx_pkt_errors);
+    sta->m_sta_info.errors_rx       = ntohl(sta_metrics->rx_pkt_errors);
+    sta->m_sta_info.retrans_count   = ntohl(sta_metrics->retx_cnt);
 
     return 0;
 }

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -290,6 +290,12 @@ bool em_orch_agent_t::pre_process_orch_op(em_cmd_t *pcmd)
                     hash_map_put(dm->m_sta_map, strdup(key), new dm_sta_t(*sta));
                 }
 
+                dm_sta_t *stale_dassoc = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_dassoc_map, key));
+                if (stale_dassoc != NULL) {
+                    em_printfout("Assoc row key=%s found in live disassoc map; removing stale disassoc entry", key);
+                    delete stale_dassoc;
+                }
+
                 sta = static_cast<dm_sta_t *> (hash_map_get_next(pcmd->get_data_model()->m_sta_assoc_map, sta));
             }
 
@@ -300,14 +306,23 @@ bool em_orch_agent_t::pre_process_orch_op(em_cmd_t *pcmd)
                 dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
                 snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
 
-                em_sta_info_t *em_sta = dm->get_sta_info(sta->get_sta_info()->id, sta->get_sta_info()->bssid, sta->get_sta_info()->radiomac, em_target_sta_map_consolidated);
-                sta = static_cast<dm_sta_t *>(hash_map_get_next(pcmd->get_data_model()->m_sta_dassoc_map, sta));
+                em_sta_info_t *em_sta = dm->get_sta_info(sta->m_sta_info.id, sta->m_sta_info.bssid, sta->m_sta_info.radiomac, em_target_sta_map_consolidated);
                 if (em_sta != NULL) {
-                    printf("Consolidated Map removed with key: %s\n", key);
-                    dm_sta_t *tmp = sta;
-                    tmp = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_map, key));
+                    // Copy all stats from the consolidated row into the dassoc row.
+                    memcpy(&sta->m_sta_info, em_sta, sizeof(em_sta_info_t));
+                    sta->m_sta_info.associated = false;
+                    em_sta_info_t *em_sta_dassoc = dm->get_sta_info(sta->m_sta_info.id, sta->m_sta_info.bssid, sta->m_sta_info.radiomac, em_target_sta_map_disassoc);
+                    if (em_sta_dassoc != NULL) {
+                        em_printfout("Consolidated Map removed with key: %s, updating em_target_sta_map_disassoc entry", key);
+                        memcpy(em_sta_dassoc, &sta->m_sta_info, sizeof(em_sta_info_t));
+                    } else {
+                        em_printfout("Consolidated Map removed with key: %s, added em_target_sta_map_disassoc entry", key);
+                        dm->put_sta_info(&sta->m_sta_info, em_target_sta_map_disassoc);
+                    }
+                    dm_sta_t *tmp = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_map, key));
                     delete tmp;
                 }
+                sta = static_cast<dm_sta_t *>(hash_map_get_next(pcmd->get_data_model()->m_sta_dassoc_map, sta));
             }
             break;
         case dm_orch_type_sta_insert:


### PR DESCRIPTION
Reason for change: Added changes to fix issue observed with clients DB data override when a new STA joins the network and empty stats values for client disassoc notification message.
Test Procedure: Ensure Client Assoc/Disassoc notification works properly.
Risks: Medium
Priority: P1