### PR TITLE
[RDK Controller/Agent] DFS Events Handling

### DIFF
--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -24,6 +24,7 @@
 #include "dm_easy_mesh.h"
 #include "webconfig_external_proto.h"
 #include "bus.h"
+#include "em_mgr.h"
 
 class dm_easy_mesh_agent_t : public dm_easy_mesh_t {
 
@@ -136,7 +137,7 @@ public:
 	 *
 	 * @note Ensure that the event and command structures are properly initialized before calling this function.
 	 */
-	int analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+	int analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t *pcmd[], em_mgr_t *mgr);
 	
 	/**!
 	 * @brief Analyzes the M2 control configuration.
@@ -206,6 +207,8 @@ public:
 	 * @note Ensure that the event and descriptor pointers are valid before calling this function.
 	 */
 	int analyze_csa_beacon_frame(em_bus_event_t *evt, wifi_bus_desc_t *desc, bus_handle_t *bus_hdl);
+
+	int analyze_dfs_state(em_bus_event_type_dfs_event_params_t *dfs_params, em_mgr_t *mgr);
 
 	/**!
 	 * @brief Analyzes the station link metrics.

--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -1529,7 +1529,9 @@ public:
 	 * @note Ensure that the key and op_class are valid and properly initialized before calling this function.
 	 */
 	void put_op_class(const char *key, const dm_op_class_t *op_class) { m_data_model_list.put_op_class(key, op_class); }
-	
+
+	int delete_db_row(dm_op_class_t *opclass);
+
 	/**!
 	 * @brief Retrieves the first pre-set operational class by type.
 	 *

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -2605,6 +2605,67 @@ typedef struct {
 	em_cac_comp_rprt_pair_t	detected_pairs[EM_MAX_CAC_METHODS];
 } em_cac_comp_info_t;
 
+// CAC Event Types
+typedef enum {
+    em_dfs_event_type_started = 0,
+    em_dfs_event_type_finished,
+    em_dfs_event_type_radar_detected,
+    em_dfs_event_type_aborted,
+    em_dfs_event_type_nop_finished
+} em_dfs_event_type_t;
+
+// CAC Event Parameters Structure
+typedef struct {
+    em_dfs_event_type_t event_type;
+    unsigned char radio_index;
+    unsigned char op_class;
+    unsigned char channel;
+    unsigned short sec_remain_non_occ_dur;
+    unsigned char status;
+} __attribute__((__packed__)) em_bus_event_type_dfs_event_params_t;
+
+typedef struct {
+    unsigned int last_channel;
+    unsigned int num_detected;
+    long long int timestamp;
+} __attribute__((__packed__)) em_radar_info_t;
+
+typedef enum
+{
+    WIFI_EVNT_CHANNELS_CHANGED, /**< Channels changed. */
+    WIFI_EVNT_DFS_RADAR_DETECTED /**< DFS radar detected. */
+} wifi_Chan_evntType_t;
+
+typedef enum
+{
+    WIFI_EVNT_RADAR_DETECTED,       /**< Radar detected. */
+    WIFI_EVNT_RADAR_CAC_FINISHED,   /**< Radar Channel Availability Check (CAC) finished. */
+    WIFI_EVNT_RADAR_CAC_ABORTED,    /**< Radar CAC aborted. */
+    WIFI_EVNT_RADAR_NOP_FINISHED,   /**< Radar Non-Occupancy Period (NOP) finished. */
+    WIFI_EVNT_RADAR_PRE_CAC_EXPIRED, /**< Radar pre-CAC expired. */
+    WIFI_EVNT_RADAR_CAC_STARTED     /**< Radar CAC started. */
+} wifi_radar_evntType_t;
+
+typedef enum
+{
+    WIFI_CHANNEL_BANDWIDTH_20MHZ = 0x1, /**< 20MHz. */
+    WIFI_CHANNEL_BANDWIDTH_40MHZ = 0x2, /**< 40MHz. */
+    WIFI_CHANNEL_BANDWIDTH_80MHZ = 0x4, /**< 80MHz. */
+    WIFI_CHANNEL_BANDWIDTH_160MHZ = 0x8, /**< 160MHz. */
+    WIFI_CHANNEL_BANDWIDTH_80_80MHZ = 0x10, /**< 80+80MHz. */
+    WIFI_CHANNEL_BANDWIDTH_320MHZ = 0x20 /**< 320MHz. */
+} wifi_ChannelBandwidth_t;
+
+typedef struct {
+    //wifi_Radio_index_t RadioIndex;
+    UINT RadioIndex;
+    wifi_Chan_evntType_t Event;
+    wifi_radar_evntType_t Sub_event;
+    UINT Channel;
+    wifi_ChannelBandwidth_t ChannelWidth;
+    UINT Op_class;
+} __attribute__((__packed__)) wifi_channel_change_evnt_t;
+
 typedef struct {
     mac_address_t   id;
     mac_address_t   bssid;
@@ -2866,6 +2927,10 @@ typedef struct {
     unsigned char srg_bss_color_bitmap[8];
     unsigned char srg_partial_bssid_bitmap[8];
     unsigned char neigh_bss_color_in_use_bitmap[8];
+    char radarDetected[256];
+    em_radar_info_t radar_info;
+    unsigned int num_dfs_events;
+    em_bus_event_type_dfs_event_params_t dfs_events[EM_MAX_CHANNELS_IN_LIST];
 } em_radio_info_t;
 
 typedef struct {
@@ -3437,6 +3502,7 @@ typedef struct {
 typedef enum {
     em_cmd_event_type_ap_metrics_report,
     em_cmd_event_type_failed_connection,
+    em_cmd_event_type_operating_channel_report,
 
     em_cmd_event_type_max
 } em_cmd_event_type_t;

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -468,7 +468,9 @@ public:
 	 * this function.
 	 */
 	int send_channel_pref_report_msg();
-    
+
+	int send_unsolicited_channel_pref_report(em_channel_pref_reason_t reason);
+
 	/**!
 	 * @brief Sends an inquiry message to check available spectrum.
 	 *
@@ -482,7 +484,6 @@ public:
 	 */
 	int send_available_spectrum_inquiry_msg();
 
-    
 	/**!
 	 * @brief Handles the channel scan request.
 	 *
@@ -546,7 +547,14 @@ public:
 	 * @note Ensure that the buffer is properly allocated and the length is correctly specified to avoid buffer overflow issues.
 	 */
 	int handle_channel_scan_result(unsigned char *buff, unsigned int len);
-    
+	
+	int handle_cac_status_rprt_tlv_ctrl(unsigned char *buff, unsigned int len);
+	int handle_cac_completion_rprt_tlv_ctrl(unsigned char *buff, unsigned int len);
+	void propagate_cac_availability(unsigned char op_class, unsigned char channel, unsigned short mins_since_cac_comp);
+	int update_op_class_cac_status(unsigned char op_class, unsigned char channel, em_op_class_type_t type, unsigned int val);
+	int get_bandwidth_by_op_class(unsigned char op_class, unsigned char channel);
+	int get_freq_by_channel(unsigned char op_class, unsigned char channel);
+
 	/**!
 	 * @brief Handles the channel preference report.
 	 *
@@ -793,11 +801,12 @@ public:
 	 */
 	void process_state();
 
-    unsigned int m_channel_pref_query_tx_cnt;
-    unsigned int m_channel_sel_req_tx_cnt;
-    //stores Channel request msg_id
-    unsigned short m_chan_req_msg_id = 0;
-	
+	unsigned int m_channel_pref_query_tx_cnt;
+	unsigned int m_channel_sel_req_tx_cnt;
+	//stores Channel request msg_id
+	unsigned short m_chan_req_msg_id = 0;
+	em_channel_pref_reason_t m_current_reason;
+
 	/**!
 	 * @brief Retrieves the frequency band.
 	 *

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -862,6 +862,7 @@ public:
 	 */
 	~em_ctrl_t();
 
+	int delete_db_row(dm_op_class_t *opclass) override;
 };
 
 #endif

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -776,6 +776,8 @@ public:
 	 * @note Ensure that all resources are properly released before the object is destroyed.
 	 */
 	virtual ~em_mgr_t();
+
+	virtual int delete_db_row(dm_op_class_t *opclass) { return -1; }
 };
 
 #endif

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -386,7 +386,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
     return num;
 }
 
-int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t *pcmd[])
+int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t *pcmd[], em_mgr_t *mgr)
 {
     webconfig_t config;
     webconfig_external_easymesh_t ext;
@@ -418,19 +418,61 @@ int dm_easy_mesh_agent_t::analyze_onewifi_radio_cb(em_bus_event_t *evt, em_cmd_t
         em_printfout("Radio subdoc decode fail");
     }
 
-	dm_easy_mesh_t::macbytes_to_string(dm.get_radio(index)->get_radio_info()->intf.mac, mac_str);
-	cm_config.type = em_commit_target_radio;
-	snprintf(reinterpret_cast<char *> (cm_config.params), sizeof(cm_config.params), "%s", mac_str);
-	commit_config(dm, cm_config);
-	pcmd[num] = new em_cmd_op_channel_report_t(evt->params, dm);
-	tmp = pcmd[num];
-	num++;
+    em_radio_info_t *radio_info = dm.get_radio(index)->get_radio_info();
+    dm_easy_mesh_t::macbytes_to_string(radio_info->intf.mac, mac_str);
+    cm_config.type = em_commit_target_radio;
+    snprintf(reinterpret_cast<char *> (cm_config.params), sizeof(cm_config.params), "%s", mac_str);
 
-	while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
-		tmp = pcmd[num];
-		num++;
-	}
-	return num;
+    /*
+     * Analyze DFS state for channels in dm that are in CAC Non-Occupancy state
+     * when a matching DFS event is found.
+     */
+    for (unsigned int oc = 0; oc < m_num_opclass; oc++) {
+        if ((m_op_class[oc].m_op_class_info.id.type == em_op_class_type_cac_non_occ) && (memcmp(radio_info->intf.mac,
+                m_op_class[oc].m_op_class_info.id.ruid, sizeof(mac_address_t)) == 0)) {
+            for (unsigned int i = 0; i < radio_info->num_dfs_events; i++) {
+                em_bus_event_type_dfs_event_params_t *dfs = &radio_info->dfs_events[i];
+                if(m_op_class[oc].m_op_class_info.channel == dfs->channel){
+                    analyze_dfs_state(dfs,mgr);
+                    break;
+                }
+            }
+        }
+    }
+
+    commit_config(dm, cm_config);
+
+    /*
+     * Analyze DFS state if:
+     * 1. The current operating channel is a DFS channel and matches a DFS event.
+     * 2. Radar has been detected and the DFS event corresponds to the last radar-detected channel.
+     */
+    for (unsigned int oc = 0; oc < dm.m_num_opclass; oc++) {
+        if ((memcmp(radio_info->intf.mac,dm.m_op_class[oc].m_op_class_info.id.ruid, sizeof(mac_address_t)) == 0) &&
+               (dm.m_op_class[oc].m_op_class_info.id.type == em_op_class_type_current)) {
+            int current_channel = dm.m_op_class[oc].m_op_class_info.channel;
+            bool dfs_channel = ((current_channel >= 52) && (current_channel <= 144));
+
+            for (unsigned int i = 0; i < radio_info->num_dfs_events; i++) {
+                em_bus_event_type_dfs_event_params_t *dfs = &radio_info->dfs_events[i];
+                if ((dfs_channel && dfs->channel == current_channel) || (radio_info->radar_info.num_detected && dfs->channel == radio_info->radar_info.last_channel)) {
+                    analyze_dfs_state(dfs, mgr);
+                }
+            }
+            break;
+        }
+    }
+
+    pcmd[num] = new em_cmd_op_channel_report_t(evt->params, dm);
+    tmp = pcmd[num];
+    num++;
+
+    while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
+        tmp = pcmd[num];
+        num++;
+    }
+
+    return num;
 }
         
 int dm_easy_mesh_agent_t::analyze_channel_pref_query(em_bus_event_t *evt, em_cmd_t *pcmd[])
@@ -659,6 +701,175 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
         return refresh_onewifi_subdoc(desc, bus_hdl, "Radio", get_subdoc_radio_type_for_freq(channel_sel->freq_band));
     }
 
+}
+
+int dm_easy_mesh_agent_t::analyze_dfs_state(em_bus_event_type_dfs_event_params_t *dfs_params,em_mgr_t *mgr)
+{
+    dm_easy_mesh_t *dm;
+    dm = mgr->get_data_model(NULL, NULL);
+    em_channel_pref_reason_t dfs_event_reason;
+    unsigned int i;
+    dm_op_class_t *op_class;
+    dm_radio_t *radio;
+    bool found = false;
+
+    em_printfout("Processing DFS event type=%d, op_class=%d, channel=%d, radio=%d", dfs_params->event_type, dfs_params->op_class, dfs_params->channel, dfs_params->radio_index);
+
+    // Validate radio index
+    if (dfs_params->radio_index >= get_num_radios()) {
+        em_printfout("Invalid radio index %d", dfs_params->radio_index);
+        return -1;
+    }
+
+    radio = get_radio(dfs_params->radio_index);
+    if (radio == NULL) {
+        em_printfout("Radio not found for index %d", dfs_params->radio_index);
+        return -1;
+    }
+
+    mac_address_t ruid;
+    memcpy(ruid, radio->get_radio_interface_mac(), sizeof(mac_address_t));
+
+    mac_addr_str_t mac_str;
+    dm_easy_mesh_t::macbytes_to_string(ruid, mac_str);
+
+    em_t *radio_em = reinterpret_cast<em_t *>(hash_map_get(mgr->m_em_map, mac_str));
+    if (radio_em == NULL) {
+        em_printfout("No EM instance found for radio %s", mac_str);
+        return -1;
+    }
+
+    switch (dfs_params->event_type) {
+        case em_dfs_event_type_radar_detected: {
+            // Mark channel as non-occupancy and trigger unsolicited report
+            for (i = 0; i < dm->get_num_op_class(); i++) {
+                op_class = dm->get_op_class(i);
+                if ((memcmp(op_class->m_op_class_info.id.ruid, ruid, sizeof(mac_address_t)) == 0) &&
+                    (op_class->m_op_class_info.op_class == dfs_params->op_class) &&
+                    (op_class->m_op_class_info.channel == dfs_params->channel) &&
+                    ((op_class->m_op_class_info.id.type == em_op_class_type_cac_available) || (op_class->m_op_class_info.id.type == em_op_class_type_cac_active))) {
+                    op_class->m_op_class_info.id.type = em_op_class_type_cac_non_occ;
+                    op_class->m_op_class_info.sec_remain_non_occ_dur = dfs_params->sec_remain_non_occ_dur;
+                    found = true;
+                    break;
+                }
+            }
+
+            // Update dm_cac_comp_t for radar detection
+            memcpy(dm->m_cac_comp.m_cac_comp_info.ruid, ruid, sizeof(mac_address_t));
+            dm->m_cac_comp.m_cac_comp_info.op_class = dfs_params->op_class;
+            dm->m_cac_comp.m_cac_comp_info.channel = dfs_params->channel;
+            dm->m_cac_comp.m_cac_comp_info.status = 1; // Radar detected
+            dm->m_cac_comp.m_cac_comp_info.detected_pairs_num = 1;
+            dm->m_cac_comp.m_cac_comp_info.detected_pairs[0].op_class = dfs_params->op_class;
+            dm->m_cac_comp.m_cac_comp_info.detected_pairs[0].channel = dfs_params->channel;
+
+            dfs_event_reason = em_channel_pref_reason_operation_disallowed_dfs_radar_detection;
+            break;
+        }
+        case em_dfs_event_type_finished: {
+            // Update data model with available entry
+            // Mark channel as available (success)
+            for (i = 0; i < dm->get_num_op_class(); i++) {
+                op_class = dm->get_op_class(i);
+                if ((memcmp(op_class->m_op_class_info.id.ruid, ruid, sizeof(mac_address_t)) == 0) &&
+                    (op_class->m_op_class_info.op_class == dfs_params->op_class) &&
+                    (op_class->m_op_class_info.channel == dfs_params->channel) &&
+                    (op_class->m_op_class_info.id.type == em_op_class_type_cac_active)) {
+                    op_class->m_op_class_info.id.type = em_op_class_type_cac_available;
+                    op_class->m_op_class_info.num_channels = 1;
+                    op_class->m_op_class_info.channels[0] = dfs_params->channel;
+                    //op_class->m_op_class_info.channel = cac_params->channel;
+                    op_class->m_op_class_info.id.op_class = dfs_params->op_class;
+                    op_class->m_op_class_info.op_class = dfs_params->op_class;
+                    op_class->m_op_class_info.mins_since_cac_comp = 0;
+                    found = true;
+                    break;
+                }
+            }
+
+            dfs_event_reason = em_channel_pref_reason_immediate_operation_possible_dfs;
+            break;
+        }
+        case em_dfs_event_type_started: {
+            // Mark channel as active CAC
+            for (i = 0; i < dm->get_num_op_class(); i++) {
+                op_class = dm->get_op_class(i);
+
+                if ((memcmp(op_class->m_op_class_info.id.ruid, ruid, sizeof(mac_address_t)) == 0) &&
+                    (op_class->m_op_class_info.op_class == dfs_params->op_class) &&
+                    (op_class->m_op_class_info.channel == dfs_params->channel) &&
+                    (op_class->m_op_class_info.id.type == em_op_class_type_cac_active)) {
+                    op_class->m_op_class_info.id.type = em_op_class_type_cac_active;
+                    op_class->m_op_class_info.countdown_cac_comp = 0;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found && dm->get_num_op_class() < EM_MAX_OPCLASS) {
+                op_class = dm->get_op_class(dm->get_num_op_class());
+                memset(op_class, 0, sizeof(dm_op_class_t));
+                memcpy(op_class->m_op_class_info.id.ruid, ruid, sizeof(mac_address_t));
+                op_class->m_op_class_info.id.type = em_op_class_type_cac_active;
+                op_class->m_op_class_info.id.op_class = dfs_params->op_class;
+                op_class->m_op_class_info.op_class = dfs_params->op_class;
+                op_class->m_op_class_info.num_channels = 1;
+                op_class->m_op_class_info.channels[0] = dfs_params->channel;
+                op_class->m_op_class_info.channel = dfs_params->channel;
+                op_class->m_op_class_info.countdown_cac_comp = 0;
+                dm->set_num_op_class(dm->get_num_op_class() + 1);
+            }
+
+            break;
+        }
+        case em_dfs_event_type_aborted: {
+	    // Clear active CAC state
+            for (i = 0; i < dm->get_num_op_class(); i++) {
+                op_class = dm->get_op_class(i);
+                if ((memcmp(op_class->m_op_class_info.id.ruid, ruid, sizeof(mac_address_t)) == 0) &&
+                    (op_class->m_op_class_info.op_class == dfs_params->op_class) &&
+                    (op_class->m_op_class_info.channel == dfs_params->channel) &&
+                    (op_class->m_op_class_info.id.type == em_op_class_type_cac_active)) {
+                     op_class->m_op_class_info.id.type = em_op_class_type_none;
+                     found = true;
+                     break;
+                }
+            }
+
+            dfs_event_reason = em_channel_pref_reason_dfs_state_unknown_cac_not_run_or_expired;
+            break;
+        }
+        case em_dfs_event_type_nop_finished: {
+            // Clear non-occupancy state
+            for (i = 0; i < dm->get_num_op_class(); i++) {
+                 op_class = dm->get_op_class(i);
+                 if ((memcmp(op_class->m_op_class_info.id.ruid, ruid, sizeof(mac_address_t)) == 0) &&
+                     (op_class->m_op_class_info.op_class == dfs_params->op_class) &&
+                     (op_class->m_op_class_info.channel == dfs_params->channel) &&
+                     (op_class->m_op_class_info.id.type == em_op_class_type_cac_non_occ)) {
+                      op_class->m_op_class_info.id.type = em_op_class_type_cac_available;
+                      op_class->m_op_class_info.sec_remain_non_occ_dur = 0;
+                      found = true;
+                      break;
+                 }
+            }
+
+            dfs_event_reason = em_channel_pref_reason_controller_dfs_clear_indication;
+            break;
+        }
+        default: {
+            em_printfout("Unknown DFS event type %d", dfs_params->event_type);
+            return 0;
+        }
+    }
+
+    // Update data model with changes
+    dm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
+
+    radio_em->send_unsolicited_channel_pref_report(dfs_event_reason);
+
+    return 0;
 }
 
 int dm_easy_mesh_agent_t::analyze_csa_beacon_frame(em_bus_event_t *evt, wifi_bus_desc_t *desc, bus_handle_t *bus_hdl)

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -298,17 +298,58 @@ void em_agent_t::handle_onewifi_radio_cb(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num;
     wifi_bus_desc_t *desc;
+    dm_radio_t *radio;
 
     if ((desc = get_bus_descriptor()) == NULL) {
         em_printfout("descriptor is null");
     }
 
-    if (m_orch->is_cmd_type_in_progress(evt) == true) {
-        m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_onewifi_radio_cb(evt, pcmd))) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_onewifi_radio_cb(evt, pcmd, this))) == 0)
+    {
         em_printfout("analyze_onewifi_radio_cb completed");
-    } else if (m_orch->submit_commands(pcmd, num) > 0) {
-        em_printfout("submitted command for orchestration");
+    }
+
+    // push directly to the matching em thread same ruid selection as build_candidates
+    for (unsigned int i = 0; i < num; i++)
+    {
+        if (pcmd[i] == NULL) continue;
+
+        em_t *em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+        while (em != NULL) {
+            if (!(em->is_al_interface_em())) {
+                radio = pcmd[i]->m_data_model.get_radio(static_cast<unsigned int>(0));
+                if (radio == NULL) {
+                    printf("%s:%d channel sel radio cannot be found.\n", __func__, __LINE__);
+                    break;
+                }
+                if (memcmp(radio->get_radio_interface_mac(), em->get_radio_interface_mac(), sizeof(mac_address_t)) == 0) {
+                    em_event_t *qevt = static_cast<em_event_t *>(malloc(sizeof(em_event_t)));
+                    if (qevt != NULL) {
+                        em_printfout("%s:%d: Allocated event for operating channel report, pushing to em %p for radio %s",
+                                     __func__, __LINE__, em, util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                        memset(qevt, 0, sizeof(em_event_t));
+                        qevt->type = em_event_type_cmd;
+                        qevt->u.cevt.type = em_cmd_event_type_operating_channel_report;
+                        qevt->u.cevt.cmd_ptr = pcmd[i]; // store pointer directly
+                        em->push_to_queue(qevt);
+                        pcmd[i] = NULL;
+                    } else {
+                        em_printfout("failed to allocate event for ap_metrics_report, dropping for radio %s",
+                                     util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                        delete pcmd[i];
+                        pcmd[i] = NULL;
+                    }
+                    break; // found the matching em, no need to continue
+                }
+            }
+            em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
+        }
+        // if no matching em was found, pcmd[i] still non-null here, clean it up
+        if (pcmd[i] != NULL) {
+            pcmd[i]->deinit();
+            delete pcmd[i];
+            pcmd[i] = NULL;
+        }
     }
 }
 

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -2347,6 +2347,18 @@ int dm_easy_mesh_ctrl_t::analyze_unassoc_sta_metrics_query(em_bus_event_t *evt, 
     return num;
 }
 
+int dm_easy_mesh_ctrl_t::delete_db_row(dm_op_class_t *opclass)
+{
+    std::string opclass_id =
+    util::mac_to_string(opclass->m_op_class_info.id.ruid) + "@" +
+    std::to_string(static_cast<unsigned int>(opclass->m_op_class_info.id.type)) + "@" +
+    std::to_string(static_cast<unsigned int>(opclass->m_op_class_info.id.op_class));
+
+    em_printfout("Deleting op-class from DB: %s", opclass_id.c_str());
+    dm_op_class_list_t::delete_row(m_db_client, opclass_id.c_str());
+    return 0;
+}
+
 int dm_easy_mesh_ctrl_t::analyze_sta_link_metrics(em_cmd_t *pcmd[])
 {
     int num = 0;

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -60,6 +60,12 @@ AlServiceAccessPoint* g_sap;
 MacAddress g_al_mac_sap;
 #endif
 
+int em_ctrl_t::delete_db_row(dm_op_class_t *opclass)
+{
+    m_data_model.delete_db_row(opclass);
+    return 0;
+}
+
 void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
 {
     em_commit_info_t *info;

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -984,70 +984,72 @@ dm_op_class_t *dm_easy_mesh_list_t::get_next_op_class(dm_op_class_t *op_class)
 
 dm_op_class_t *dm_easy_mesh_list_t::get_op_class(const char *key)
 {
-	em_op_class_id_t id;
+    em_op_class_id_t id;
     dm_easy_mesh_t *dm;
-	dm_radio_t *radio;
-	bool found_dm = false;
-	unsigned int i;
+    dm_radio_t *radio;
+    bool found_dm = false;
+    unsigned int i;
     dm_op_class_t *pop_class;
-	mac_addr_str_t	mac_str;
+    mac_addr_str_t mac_str;
 	
     dm_op_class_t::parse_op_class_id_from_key(key, &id);
 
-	dm_easy_mesh_t::macbytes_to_string(id.ruid, mac_str);
-	//printf("%s:%d: MAC: %s\tType: %d\tClass: %d\n", __func__, __LINE__, mac_str, id.type, id.op_class);
+    dm_easy_mesh_t::macbytes_to_string(id.ruid, mac_str);
+    //printf("%s:%d: MAC: %s\tType: %d\tClass: %d\n", __func__, __LINE__, mac_str, id.type, id.op_class);
 	
     dm = static_cast<dm_easy_mesh_t *> (hash_map_get_first(m_list));
     while (dm != NULL) {
-        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference || id.type == em_op_class_type_anticipated ) {
-		    for (i = 0; i < dm->get_num_radios(); i++) {
-			    radio = dm->get_radio(i);
-			    if (memcmp(radio->m_radio_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) {
-				    found_dm = true;
-			    	break;
-			    }
-		    }
+        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference ||
+            id.type == em_op_class_type_anticipated || id.type == em_op_class_type_cac_available ||
+            id.type == em_op_class_type_cac_active || id.type == em_op_class_type_cac_non_occ) {
+            for (i = 0; i < dm->get_num_radios(); i++) {
+                radio = dm->get_radio(i);
+                if (memcmp(radio->m_radio_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) {
+                    found_dm = true;
+                    break;
+                }
+            }
         } else {
-			if (memcmp(dm->m_device.m_device_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) {
-            	found_dm = true;
-           	}
-		}
+            if (memcmp(dm->m_device.m_device_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) {
+                found_dm = true;
+            }
+        }
 
         if (found_dm == true) {
             break;
         } else {
             if (((memcmp(dm->m_device.m_device_info.intf.mac, id.ruid, sizeof(mac_address_t)) == 0) ||
-                (memcmp(EM_GLOBAL_MAC_ADDRESS, id.ruid, sizeof(mac_address_t)) == 0)) &&
-                (id.type == em_op_class_type_anticipated))
+                 (memcmp(EM_GLOBAL_MAC_ADDRESS, id.ruid, sizeof(mac_address_t)) == 0)) &&
+                 (id.type == em_op_class_type_anticipated))
             {
                 found_dm = true;
                 break;
             }
         }
         dm = static_cast<dm_easy_mesh_t *> (hash_map_get_next(m_list, dm));
-	}
+    }
 
-	if (found_dm == false) {
-		return NULL;
-	}
-	//printf("%s:%d: Number of op classes: %d\n", __func__, __LINE__, dm->get_num_op_class());
+    if (found_dm == false) {
+        return NULL;
+    }
+    //printf("%s:%d: Number of op classes: %d\n", __func__, __LINE__, dm->get_num_op_class());
 
     // now check if the op class is already there
-	for (i = 0; i < dm->get_num_op_class(); i++) {
-		pop_class = &dm->m_op_class[i];
-		dm_easy_mesh_t::macbytes_to_string(pop_class->m_op_class_info.id.ruid, mac_str);
-		//printf("%s:%d: MAC: %s\tType: %d\tClass: %d\n", __func__, __LINE__, 
-				//mac_str, pop_class->m_op_class_info.id.type, pop_class->m_op_class_info.id.op_class);
-		if ((memcmp(pop_class->m_op_class_info.id.ruid, id.ruid, sizeof(mac_address_t)) == 0) && 
-					(pop_class->m_op_class_info.id.type == id.type) &&
-					(pop_class->m_op_class_info.id.op_class == id.op_class)) {
-			//printf("%s:%d: Found match\n\n\n", __func__, __LINE__);
-			return pop_class;
-		}	
-	}
+    for (i = 0; i < dm->get_num_op_class(); i++) {
+        pop_class = &dm->m_op_class[i];
+        dm_easy_mesh_t::macbytes_to_string(pop_class->m_op_class_info.id.ruid, mac_str);
+        //printf("%s:%d: MAC: %s\tType: %d\tClass: %d\n", __func__, __LINE__, 
+        //mac_str, pop_class->m_op_class_info.id.type, pop_class->m_op_class_info.id.op_class);
+        if ((memcmp(pop_class->m_op_class_info.id.ruid, id.ruid, sizeof(mac_address_t)) == 0) && 
+            (pop_class->m_op_class_info.id.type == id.type) &&
+            (pop_class->m_op_class_info.id.op_class == id.op_class)) {
+            //printf("%s:%d: Found match\n\n\n", __func__, __LINE__);
+            return pop_class;
+        }
+    }
 
-	//printf("%s:%d: Match not found\n\n\n", __func__, __LINE__);
-	return NULL;
+    //printf("%s:%d: Match not found\n\n\n", __func__, __LINE__);
+    return NULL;
 }
 
 dm_op_class_t *dm_easy_mesh_list_t::get_first_pre_set_op_class_by_type(em_op_class_type_t type)
@@ -1114,23 +1116,25 @@ void dm_easy_mesh_list_t::remove_op_class(const char *key)
 
 void dm_easy_mesh_list_t::put_op_class(const char *key, const dm_op_class_t *op_class)
 {
-	em_op_class_id_t id;
-	mac_addr_str_t mac_str;
-	dm_easy_mesh_t *dm;
-	bool found_dm = false;
-	unsigned int i;
-	dm_op_class_t	*pop_class;
-	dm_radio_t *radio;
+    em_op_class_id_t id;
+    mac_addr_str_t mac_str;
+    dm_easy_mesh_t *dm;
+    bool found_dm = false;
+    unsigned int i;
+    dm_op_class_t	*pop_class;
+    dm_radio_t *radio;
 
-	dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (op_class->m_op_class_info.id.ruid), mac_str);
-	//printf("%s:%d: key: %s, ruid: %s, type: %d, op_class: %d\n", __func__, __LINE__, 
-		//key, mac_str, op_class->m_op_class_info.id.type, op_class->m_op_class_info.id.op_class);
-	dm_op_class_t::parse_op_class_id_from_key(key, &id);
+    dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (op_class->m_op_class_info.id.ruid), mac_str);
+    //printf("%s:%d: key: %s, ruid: %s, type: %d, op_class: %d\n", __func__, __LINE__, 
+    //key, mac_str, op_class->m_op_class_info.id.type, op_class->m_op_class_info.id.op_class);
+    dm_op_class_t::parse_op_class_id_from_key(key, &id);
 
-	// find the dm that has this radio
+    // find the dm that has this radio
     dm = static_cast<dm_easy_mesh_t *> (hash_map_get_first(m_list));
     while (dm != NULL) {
-        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference || id.type == em_op_class_type_anticipated) {
+        if (id.type <= em_op_class_type_capability || id.type == em_op_class_type_preference ||
+            id.type == em_op_class_type_anticipated || id.type == em_op_class_type_cac_available ||
+            id.type == em_op_class_type_cac_active || id.type == em_op_class_type_cac_non_occ) {
             for (i = 0; i < dm->get_num_radios(); i++) {
                 radio = dm->get_radio(i);
                 dm_easy_mesh_t::macbytes_to_string(radio->m_radio_info.intf.mac, mac_str);

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -60,7 +60,7 @@ short em_channel_t::create_channel_pref_tlv_agent(unsigned char *buff, unsigned 
     dm_easy_mesh_t *dm;
     dm_op_class_t	*op_class;
     unsigned char *tmp;
-    unsigned char pref_bits = EM_CH_PREF_NON_OPERABLE | em_channel_pref_reason_t::em_channel_pref_reason_operation_disallowed_regulatory_restriction;
+    unsigned char pref_bits = EM_CH_PREF_NON_OPERABLE | m_current_reason;
     unsigned int num_of_channel = 0;
     em_channels_list_t *channel_list;
 
@@ -342,12 +342,13 @@ void em_channel_t::fill_map_with_opclass_channel_prefs(std::map<unsigned char, s
 void em_channel_t::update_map_with_agent_capability_preference(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs)
 {
     dm_easy_mesh_t *dm = get_data_model();
+    dm_op_class_t *op_class;
     unsigned int i, j;
 
     // Mark non-operable channels and add supported operating classes from Agent's Capability Report
     std::set<unsigned int> supported_opclasses;
     for (i = 0; i < dm->get_num_op_class(); i++) {
-        dm_op_class_t *op_class = &dm->m_op_class[i];
+        op_class = &dm->m_op_class[i];
         em_op_class_info_t *info = &op_class->m_op_class_info;
 
         if ((info->id.type == em_op_class_type_capability) &&
@@ -368,7 +369,7 @@ void em_channel_t::update_map_with_agent_capability_preference(const unsigned ch
     // Update non-operable/operable preference from Agent's Preference Report
     for (i = 0; i < dm->get_num_op_class(); i++) {
 
-        dm_op_class_t *op_class = &dm->m_op_class[i];
+        op_class = &dm->m_op_class[i];
         em_op_class_info_t *info = &op_class->m_op_class_info;
         if ((info->id.type == em_op_class_type_preference) &&
             (info->pref_valid == EM_CH_PREF_ENTRY_VALID) &&
@@ -393,6 +394,27 @@ void em_channel_t::update_map_with_agent_capability_preference(const unsigned ch
             // Opclass not present in AP Capability Report.
             opclass_channel_prefs.erase(opclass);
             break;
+        }
+    }
+
+    // Mark non_occ channels with appropriate reason code in the map
+    for (unsigned int k = 0; k < dm->m_num_opclass; k++) {
+        op_class = &dm->m_op_class[k];
+
+	if ((op_class->m_op_class_info.id.type == em_op_class_type_cac_non_occ) &&
+            (memcmp(op_class->m_op_class_info.id.ruid, ruid, sizeof(mac_address_t)) == 0)) {
+	    unsigned int op_class_num = op_class->m_op_class_info.op_class;
+	    unsigned int channel = op_class->m_op_class_info.channel;
+
+	    auto opclass_it = opclass_channel_prefs.find(op_class_num);
+	    if (opclass_it != opclass_channel_prefs.end()) {
+                auto& channel_map = opclass_it->second;
+                if (op_class->m_op_class_info.sec_remain_non_occ_dur > 0) {
+                   channel_map[channel] = em_channel_pref_reason_operation_disallowed_dfs_radar_detection;
+	        } else {
+                   channel_map[channel] = em_channel_pref_reason_controller_dfs_clear_indication;
+                }
+            }
         }
     }
 }
@@ -1105,6 +1127,7 @@ int em_channel_t::send_channel_sel_response_msg(em_chan_sel_resp_code_type_t cod
         printf("%s:%d: Channel Selection Response msg failed, error:%d\n", __func__, __LINE__, errno);
         return -1;
     }
+    set_state(em_state_ctrl_configured);
 
     return static_cast<int> (len);
 
@@ -1430,12 +1453,29 @@ short em_channel_t::create_cac_complete_report_tlv(unsigned char *buff)
     unsigned int num_radios = static_cast<unsigned int>(dm->get_num_radios());
 
     for (radio_index = 0; radio_index < num_radios; radio_index++) {
+        dm_radio_t *radio = dm->get_radio(radio_index);
+        if (radio == NULL) {
+            continue;
+        }
+        em_radio_info_t *radio_info = radio->get_radio_info();
+        if (radio_info->band != em_freq_band_5) {
+            continue;
+        }
+
         em_cac_comp_rprt_radio_t *cac_comp_radio = reinterpret_cast<em_cac_comp_rprt_radio_t *>(tmp);
         memcpy(cac_comp_radio->ruid, dm->get_radio_by_ref(radio_index).get_radio_interface_mac() , sizeof(mac_address_t));
         cac_comp_radio->op_class = comp->m_cac_comp_info.op_class;
         cac_comp_radio->channel = comp->m_cac_comp_info.channel;
         cac_comp_radio->status = comp->m_cac_comp_info.status;
         cac_comp_radio->detected_pairs_num = comp->m_cac_comp_info.detected_pairs_num;
+
+        // Skip entries with channel 0, opclass 0, or radar detected count 0
+        if (comp->m_cac_comp_info.channel == 0 ||
+            comp->m_cac_comp_info.op_class == 0 ||
+            comp->m_cac_comp_info.detected_pairs_num == 0) {
+            em_printfout("Skip entries with channel 0, opclass 0, or radar detected count 0");
+            continue;
+        }
 
         tmp += sizeof(em_cac_comp_rprt_radio_t);
         len += static_cast<short>(sizeof(em_cac_comp_rprt_radio_t));
@@ -1460,7 +1500,7 @@ short em_channel_t::create_cac_complete_report_tlv(unsigned char *buff)
 int em_channel_t::send_channel_pref_report_msg()
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
-    unsigned short msg_id = get_current_cmd()->get_data_model()->get_msg_id();
+    unsigned short msg_id = get_mgr()->get_next_msg_id();
     unsigned short  msg_type = em_msg_type_channel_pref_rprt;
     unsigned int len = 0, radio_index = 0;
     short sz;
@@ -1548,6 +1588,16 @@ int em_channel_t::send_channel_pref_report_msg()
         
     printf("%s:%d: Channel Preference Report send success\n", __func__, __LINE__);
     return static_cast<int> (len);
+}
+
+int em_channel_t::send_unsolicited_channel_pref_report(em_channel_pref_reason_t reason)
+{
+    em_printfout("Sending unsolicited channel preference report for DFS event reason: %d", reason);
+
+    m_current_reason = reason;
+
+    // Send the channel preference report
+    return send_channel_pref_report_msg();
 }
 
 int em_channel_t::send_available_spectrum_inquiry_msg()
@@ -1649,8 +1699,14 @@ int em_channel_t::handle_op_channel_report(unsigned char *buff, unsigned int len
         op_class_info = &dm->m_op_class[i].m_op_class_info;
         if (((memcmp(op_class_info->id.ruid, rpt->ruid, sizeof(mac_address_t)) == 0) &&
                     (op_class_info->id.type == em_op_class_type_current)) == true) {
-            op_class_info->op_class = static_cast<unsigned int> (rpt->op_classes[0].op_class);
-            op_class_info->channel = static_cast<unsigned int> (rpt->op_classes[0].channel);
+            if((op_class_info->op_class != static_cast<unsigned int> (rpt->op_classes[0].op_class)) ||
+               (op_class_info->channel != static_cast<unsigned int> (rpt->op_classes[0].channel))) {
+                op_class_info->op_class = static_cast<unsigned int> (rpt->op_classes[0].op_class);
+                op_class_info->id.op_class = op_class_info->op_class;
+                op_class_info->channel = static_cast<unsigned int> (rpt->op_classes[0].channel);
+                dm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
+                dm->set_db_cfg_param(db_cfg_type_radio_list_update, "");
+            }
             found++;
         }
     }
@@ -1804,6 +1860,244 @@ int em_channel_t::handle_channel_pref_tlv_ctrl(unsigned char *buff, unsigned int
     return 0;
 }
 
+int em_channel_t::update_op_class_cac_status(unsigned char op_class, unsigned char channel, em_op_class_type_t type, unsigned int val)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    em_op_class_info_t *info = NULL;
+    bool found = false;
+    unsigned int i;
+    mac_address_t ruid_5ghz;
+
+    em_freq_band_t band = dm_easy_mesh_t::get_freq_band_by_op_class(op_class);
+    if (band != em_freq_band_5) {
+        em_printfout("Skipping CAC status update for non 5GHz band %d", band);
+        return -1;
+    }
+
+    for (i = 0; i < dm->get_num_radios(); i++) {
+        dm_radio_t *radio = dm->get_radio(i);
+        if (radio == NULL)
+            continue;
+
+        em_radio_info_t *radio_info = radio->get_radio_info();
+        if (radio_info->band == em_freq_band_5) {
+            memcpy(ruid_5ghz, radio_info->id.ruid, sizeof(mac_address_t));
+            break;
+        }
+    }
+
+    // Find the old entries for cac types (active, available, non_occ)
+    for (i = 0; i < dm->get_num_op_class(); i++) {
+        info = &dm->m_op_class[i].m_op_class_info;
+        if ((memcmp(info->id.ruid, ruid_5ghz, sizeof(mac_address_t)) == 0) &&
+            (info->id.op_class == op_class) &&
+            (info->channel == channel) &&
+            (info->id.type >= em_op_class_type_cac_available) &&
+            (info->id.type <= em_op_class_type_cac_active)) {
+            found = true;
+            break;
+        }
+    }
+
+    if (found) {
+        // Delete row from op_class table in DB to avoid duplicate entries for the same RUID, op_class, and different type
+        std::string opclass_id = util::mac_to_string(info->id.ruid) + "@" +
+                                 std::to_string(static_cast<unsigned int>(info->id.type)) + "@" +
+                                 std::to_string(info->id.op_class);
+        get_mgr()->delete_db_row(&dm->m_op_class[i]);
+
+        info->id.type = type;
+
+        // Update the specific value based on type
+        if (type == em_op_class_type_cac_available) {
+            info->mins_since_cac_comp = static_cast<unsigned short>(val);
+            info->sec_remain_non_occ_dur = 0;
+        } else if (type == em_op_class_type_cac_non_occ) {
+            info->sec_remain_non_occ_dur = static_cast<unsigned short>(val);
+        } else if (type == em_op_class_type_cac_active) {
+            info->countdown_cac_comp = val;
+        }
+    }
+    else {
+        info =  &dm->m_op_class[dm->get_num_op_class()].m_op_class_info;
+        memset(info, 0, sizeof(em_op_class_info_t));
+
+        memcpy(info->id.ruid, ruid_5ghz, sizeof(mac_address_t));
+        info->id.type = type;
+        info->op_class = op_class;
+        info->id.op_class = op_class;
+        info->channel = channel;
+        info->pref_valid = EM_CH_PREF_ENTRY_VALID;
+
+        // Update the specific value based on type
+        if (type == em_op_class_type_cac_available) {
+            info->mins_since_cac_comp = static_cast<unsigned short>(val);
+        } else if (type == em_op_class_type_cac_non_occ) {
+            info->sec_remain_non_occ_dur = static_cast<unsigned short>(val);
+        } else if (type == em_op_class_type_cac_active) {
+            info->countdown_cac_comp = val;
+        }
+        dm->set_num_op_class(dm->get_num_op_class() + 1);
+    }
+
+    // Trigger DB update
+    dm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
+
+    return 0;
+}
+
+int em_channel_t::get_freq_by_channel(unsigned char op_class, unsigned char channel)
+{
+    return util::em_chan_to_freq(op_class, channel);
+}
+
+int em_channel_t::get_bandwidth_by_op_class(unsigned char op_class, unsigned char channel)
+{
+    size_t table_sz = dm_easy_mesh_t::m_e4_table_size;
+
+    for (size_t i = 0; i < table_sz; ++i) {
+        if (dm_easy_mesh_t::m_e4_table[i].op_class == op_class) {
+            return dm_easy_mesh_t::m_e4_table[i].channel_spacing;
+        }
+    }
+
+    return 20; // Default to 20MHz if not found
+}
+
+void em_channel_t::propagate_cac_availability(unsigned char op_class, unsigned char channel, unsigned short mins_since_cac_comp)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    unsigned int i;
+
+    // Get frequency range for the reported channel
+    unsigned int freq_start = static_cast<unsigned int>(get_freq_by_channel(op_class, channel));
+    unsigned int bandwidth = static_cast<unsigned int>(get_bandwidth_by_op_class(op_class, channel));
+    unsigned int freq_end = freq_start + bandwidth;
+
+    // Iterate through all operating classes in the data model
+    for (i = 0; i < dm->m_num_opclass; i++) {
+        em_op_class_info_t *info = &dm->m_op_class[i].m_op_class_info;
+
+        // Only check CAC available entries
+        if (info->id.type != em_op_class_type_cac_available) {
+            continue;
+        }
+
+        // Get frequency range for the reported channel
+        unsigned int entry_freq_start = static_cast<unsigned int>(get_freq_by_channel(info->op_class, info->channel));
+        unsigned int entry_bandwidth = static_cast<unsigned int>(get_bandwidth_by_op_class(info->op_class, info->channel));
+        unsigned int entry_freq_end = entry_freq_start + entry_bandwidth;
+
+        // Get frequency range for this entry
+        if ((freq_start < entry_freq_end) && (freq_end > entry_freq_start)) {
+            // Update this overlapping entry with the same availability
+            info->mins_since_cac_comp = mins_since_cac_comp;
+        }
+    }
+
+    // Update DB
+    dm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
+}
+
+int em_channel_t::handle_cac_completion_rprt_tlv_ctrl(unsigned char *buff, unsigned int len)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    em_cac_comp_rprt_t *cac_comp = reinterpret_cast<em_cac_comp_rprt_t *>(buff);
+    unsigned char *tmp = buff;
+
+    if (cac_comp == NULL || dm == NULL) {
+        em_printfout("Invalid parameters");
+        return -1;
+    }
+
+    tmp += sizeof(em_cac_comp_rprt_t);
+    
+    em_printfout("CAC Completion Report received, radios_num: %d", cac_comp->radios_num);
+
+    dm_cac_comp_t *comp = &dm->m_cac_comp;
+
+    for (unsigned int radio_index = 0; radio_index < cac_comp->radios_num; radio_index++) {
+
+        em_cac_comp_rprt_radio_t *radio = reinterpret_cast<em_cac_comp_rprt_radio_t *>(tmp);
+
+        // Copy fixed fields
+        memcpy(comp->m_cac_comp_info.ruid, radio->ruid, sizeof(mac_address_t));
+        comp->m_cac_comp_info.op_class = radio->op_class;
+        comp->m_cac_comp_info.channel = radio->channel;
+        comp->m_cac_comp_info.status = radio->status;
+        comp->m_cac_comp_info.detected_pairs_num = radio->detected_pairs_num;
+
+        tmp += sizeof(em_cac_comp_rprt_radio_t);
+
+        // Now parse detected pairs (variable part)
+        for (unsigned int pair_index = 0; pair_index < radio->detected_pairs_num; pair_index++) {
+
+            em_cac_comp_rprt_pair_t *pair = reinterpret_cast<em_cac_comp_rprt_pair_t *>(tmp);
+
+            if (pair_index < EM_MAX_CAC_METHODS) {
+                comp->m_cac_comp_info.detected_pairs[pair_index].op_class = pair->op_class;
+                comp->m_cac_comp_info.detected_pairs[pair_index].channel = pair->channel;
+            }
+
+            // Update CAC status
+            update_op_class_cac_status(pair->op_class, pair->channel, em_op_class_type_cac_non_occ, 1800);
+
+            tmp += sizeof(em_cac_comp_rprt_pair_t);
+        }
+    }
+
+    return 0;
+}
+
+int em_channel_t::handle_cac_status_rprt_tlv_ctrl(unsigned char *buff, unsigned int len)
+{
+    unsigned char *tmp = buff;
+    unsigned int i;
+
+    // Process Available Channels
+    em_cac_status_rprt_avail_t *avail_rprt = reinterpret_cast<em_cac_status_rprt_avail_t *>(tmp);
+    tmp += sizeof(em_cac_status_rprt_avail_t);
+    em_printfout("DFS_DEBUG: avail_rprt->avail_num = %d", avail_rprt->avail_num);
+    for (i = 0; i < avail_rprt->avail_num; i++) {
+        em_cac_avail_t *avail = reinterpret_cast<em_cac_avail_t *>(tmp);
+        update_op_class_cac_status(avail->op_class, avail->channel, em_op_class_type_cac_available, ntohs(avail->mins_since_cac_comp));
+
+        // Propagate availability to overlapping channels
+        propagate_cac_availability(avail->op_class, avail->channel, ntohs(avail->mins_since_cac_comp));
+
+        tmp += sizeof(em_cac_avail_t);
+    }
+
+    // Process Non-Occupancy Channels
+    em_cac_status_rprt_non_occ_t *non_occ_rprt = reinterpret_cast<em_cac_status_rprt_non_occ_t *>(tmp);
+    tmp += sizeof(em_cac_status_rprt_non_occ_t);
+    em_printfout("DFS_DEBUG: non_occ_rprt->non_occ_num = %d", non_occ_rprt->non_occ_num);
+    for (i = 0; i < non_occ_rprt->non_occ_num; i++) {
+        em_cac_non_occ_t *non_occ = reinterpret_cast<em_cac_non_occ_t *>(tmp);
+        update_op_class_cac_status(non_occ->op_class, non_occ->channel, em_op_class_type_cac_non_occ, ntohs(non_occ->sec_remain_non_occ_dur));
+        tmp += sizeof(em_cac_non_occ_t);
+    }
+
+    // Process Active CAC Channels
+    em_cac_status_rprt_active_t *active_rprt = reinterpret_cast<em_cac_status_rprt_active_t *>(tmp);
+    tmp += sizeof(em_cac_status_rprt_active_t);
+
+    em_printfout("DFS_DEBUG: active_rprt->active_num = %d", active_rprt->active_num);
+    for (i = 0; i < active_rprt->active_num; i++) {
+        em_cac_active_t *active = reinterpret_cast<em_cac_active_t *>(tmp);
+
+        // Decode the 3-byte countdown from TLV
+        unsigned int countdown;
+        countdown |= (static_cast<unsigned int>(active->countdown_cac_comp[2]));
+        countdown |= (static_cast<unsigned int>(active->countdown_cac_comp[1]) << 8);
+        countdown |= (static_cast<unsigned int>(active->countdown_cac_comp[2]) << 16);
+
+        update_op_class_cac_status(active->op_class, active->channel, em_op_class_type_cac_active, countdown);
+        tmp += sizeof(em_cac_active_t);
+    }
+
+    return 0;
+}
 
 int em_channel_t::handle_channel_pref_rprt(unsigned char *buff, unsigned int len)
 {
@@ -1831,6 +2125,8 @@ int em_channel_t::handle_channel_pref_rprt(unsigned char *buff, unsigned int len
         }
     }
 
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
 
@@ -1842,12 +2138,23 @@ int em_channel_t::handle_channel_pref_rprt(unsigned char *buff, unsigned int len
             handle_eht_operations_tlv(tlv->value, htons(tlv->len));
             break;
         }
+        if (tlv->type == em_tlv_type_cac_sts_rprt) {
+            handle_cac_status_rprt_tlv_ctrl(tlv->value, htons(tlv->len));
+        }
+        if (tlv->type == em_tlv_type_cac_cmpltn_rprt) {
+            handle_cac_completion_rprt_tlv_ctrl(tlv->value, htons(tlv->len));
+        }
 
         tlv_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
         tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
     }
-	set_state(em_state_ctrl_channel_queried);
-	return 0;
+
+    // Send 1905 ACK for unsolicited channel preference report
+    send_1905_ack_message(ntohs(cmdu->id), ACK_FROM_CTRL);
+
+    set_state(em_state_ctrl_channel_queried);
+
+    return 0;
 }
 
 int em_channel_t::handle_channel_pref_tlv(unsigned char *buff, op_class_channel_sel *op_class)

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -192,10 +192,6 @@ void em_t::orch_execute(em_cmd_t *pcmd)
 	    }
             break;
 
-        case em_cmd_type_op_channel_report:
-            m_sm.set_state(em_state_agent_channel_report_pending);
-            break;
-
         case em_cmd_type_sta_link_metrics:
             m_sm.set_state((m_service_type == em_service_type_agent) ?
                 em_state_agent_sta_link_metrics_pending:em_state_ctrl_sta_link_metrics_pending);
@@ -419,6 +415,23 @@ void em_t::proto_process(em_cmd_event_t *cevt)
             }
             break;
         }
+        case em_cmd_event_type_operating_channel_report:
+        {
+            em_printfout("%s:%d: Received operating channel report event", __func__, __LINE__);
+            em_cmd_t *saved_cmd = m_cmd;
+            em_cmd_t *op_chan_cmd = static_cast<em_cmd_t*>(cevt->cmd_ptr);
+            m_cmd = op_chan_cmd;
+            if (get_service_type() == em_service_type_agent) {
+                send_operating_channel_report_msg();
+                em_printfout("%s:%d operating_channel_report_msg send\n", __func__, __LINE__);
+            }
+            if (op_chan_cmd != NULL) {
+                op_chan_cmd->deinit();
+            }
+            delete op_chan_cmd;
+            m_cmd = saved_cmd;
+            break;
+        }
         default:
             em_printfout("unhandled cmd type %d", cevt->type);
             break;
@@ -468,7 +481,6 @@ void em_t::handle_agent_state()
             }
             break;
         case em_cmd_type_channel_pref_query:
-        case em_cmd_type_op_channel_report:
             em_channel_t::process_state();
             break;
 

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -108,12 +108,6 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
                 return true;
             }
             break;
-		
-        case em_cmd_type_op_channel_report:
-            if (em->get_state() == em_state_agent_configured) {
-                return true;
-            }
-            break;
 
         case em_cmd_type_btm_report:
             if (em->get_state() == em_state_agent_configured) {
@@ -169,8 +163,6 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         return true;
     } else if ((pcmd->m_type == em_cmd_type_channel_pref_query) && (em->get_state() >= em_state_agent_ap_cap_report)) {
 		return true;
-    } else if (pcmd->m_type == em_cmd_type_op_channel_report) {
-        return true;
     } else if (pcmd->m_type == em_cmd_type_btm_report) {
 		if (em->get_state() == em_state_agent_configured) {
 			return true;
@@ -458,21 +450,6 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
 					}
 				}
 				break;
-            case em_cmd_type_op_channel_report:
-                if (!(em->is_al_interface_em())) {
-                    radio = pcmd->m_data_model.get_radio(static_cast<unsigned int> (0));
-                    if (radio == NULL) {
-                        printf("%s:%d channel sel radio cannot be found.\n", __func__, __LINE__);
-                        break;
-                    }
-                    if ((memcmp(radio->get_radio_interface_mac(),em->get_radio_interface_mac(),sizeof(mac_address_t)) == 0) && (em->get_state() == em_state_agent_channel_select_configuration_pending)) {
-                        queue_push(pcmd->m_em_candidates, em);
-                        count++;
-                        dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), dst_mac_str);
-                        printf("%s:%d Operating Channel Report build candidate MAC=%s\n", __func__, __LINE__,dst_mac_str);
-                    }
-                }
-                break;
 
             case em_cmd_type_btm_report:
                 if (!(em->is_al_interface_em())) {


### PR DESCRIPTION
Agent
- Processing the DFSEvent JSON received from oneWifi
- Updating DataBase and DataModel with DFS Status for available/non occ/active on RDK Agent
- Sending Unsolicted Channel Preference Report for any DFS State change Controller
- Processing Unsolicited Channel Preference Report received by Agent
- Storing the DFS status from CAC Status Report TLV and CAC Completion Report TLVs into DataModel/DataBase
- Excluding non occupancy channels from Channel Preference TLV in Channel Selection Request