### PR TITLE
RDKBWIFI-480: Fix onewifi_em_ctrl crash on Apply Radio Settings

### DIFF
--- a/install/bin/Channel.json
+++ b/install/bin/Channel.json
@@ -3,6 +3,19 @@
 
 		"Network":	{
 			"ID":	"OneWifiMesh",
+			"AnticipatedChannelPreference":	[{
+					"Class":	134,
+					"ChannelList":	[1, 2],
+					"ChannelPrefList":	[0, 0]
+				}, {
+					"Class":	136,
+					"ChannelList":	[1, 2],
+					"ChannelPrefList":	[0, 0]
+				}, {
+					"Class":	137,
+					"ChannelList":	[1, 2],
+					"ChannelPrefList":	[0, 0]
+				}],
 			"DeviceList":	[{
 					"ID":	"00:0c:29:dc:63:48",
 					"RadioList":	[{
@@ -22,20 +35,10 @@
 						}, {
 							"ID":	"00:ab:cd:ef:00:10",
 							"CurrentOperatingClasses":	[{
-                                            "Class":	135,
+									"Class":	135,
 									"Channel":	1,
 									"TxPower":	20
 								}]
-						}],
-					"AnticipatedChannelPreference":	[{
-							"Class":	134,
-							"ChannelList":	[1, 2]
-						}, {
-							"Class":	136,
-							"ChannelList":	[1, 2]
-						}, {
-							"Class":	137,
-							"ChannelList":	[1, 2]
 						}]
 				}]
 		},

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -2525,8 +2525,7 @@ int dm_easy_mesh_ctrl_t::analyze_set_channel(em_bus_event_t *evt, em_cmd_t *pcmd
        	return ret;
    	}
 
-	assert(dm.get_num_op_class() == EM_MAX_BANDS);
-
+	// Fewer bands than EM_MAX_BANDS is valid; empty/invalid input is handled by decode_config above.
 	evt->params.u.args.num_args = 0;
 
 	// Reset pref_valid for all anticipated operating classes before update

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -102,6 +102,13 @@ void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
     }
 }
 
+// Non-positive analyze_*() result: 0/NO_CHANGE is a no-op, any other negative is an error.
+static em_cmd_out_status_t status_for_noncmd(int num)
+{
+    return (num == 0 || num == EM_PARSE_ERR_NO_CHANGE) ?
+        em_cmd_out_status_no_change : em_cmd_out_status_invalid_input;
+}
+
 void em_ctrl_t::handle_client_steer(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -109,8 +116,8 @@ void em_ctrl_t::handle_client_steer(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_steer(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_command_steer(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -125,8 +132,8 @@ void em_ctrl_t::handle_client_disassoc(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_disassoc(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_command_disassoc(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -141,8 +148,8 @@ void em_ctrl_t::handle_client_btm(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_btm(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_command_btm(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -157,8 +164,8 @@ void em_ctrl_t::handle_start_dpp(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_dpp_start(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_dpp_start(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -174,8 +181,8 @@ void em_ctrl_t::handle_set_channel_list(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_channel(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_set_channel(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -191,8 +198,8 @@ void em_ctrl_t::handle_scan_channel_list(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_scan_channel(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_scan_channel(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -208,8 +215,8 @@ void em_ctrl_t::handle_set_policy(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_policy(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_set_policy(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -254,8 +261,8 @@ void em_ctrl_t::handle_set_radio(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_radio(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_set_radio(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -291,8 +298,8 @@ void em_ctrl_t::handle_remove_device(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_remove_device(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_remove_device(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -362,8 +369,8 @@ void em_ctrl_t::handle_reset(em_bus_event_t *evt)
 	
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_reset(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_reset(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -379,8 +386,8 @@ void em_ctrl_t::handle_mld_reconfig(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_mld_reconfig(pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_mld_reconfig(pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -405,8 +412,8 @@ void em_ctrl_t::handle_unassoc_sta_metrics_query(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_unassoc_sta_metrics_query(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_unassoc_sta_metrics_query(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -1342,8 +1342,11 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
             return EM_PARSE_ERR_GEN;
         }
     } else {
-        if ((target_arr_obj = cJSON_GetObjectItem(dev_obj, target_key)) == NULL) {
-            em_printfout("'%s' not found in Device", target_key);
+        // Anticipated preference is carried at Network scope; Set/Scan at device scope
+        cJSON *src_obj = (type == em_op_class_type_anticipated) ? net_obj : dev_obj;
+        if ((target_arr_obj = cJSON_GetObjectItem(src_obj, target_key)) == NULL) {
+            em_printfout("'%s' not found in %s", target_key,
+                         (type == em_op_class_type_anticipated) ? "Network" : "Device");
             cJSON_Delete(parent_obj);
             return EM_PARSE_ERR_GEN;
         }
@@ -1351,7 +1354,7 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
 
     m_num_opclass = 0;
     arr_size = cJSON_GetArraySize(target_arr_obj); // may be 0 for scan
-    for (i = 0; i < arr_size; i++) {
+    for (i = 0; i < arr_size && m_num_opclass < EM_MAX_OPCLASS; i++) {
         if ((target_obj = cJSON_GetArrayItem(target_arr_obj, i)) == NULL) {
             em_printfout("Invalid input index: %d", i);
             cJSON_Delete(parent_obj);
@@ -1382,13 +1385,15 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
                 cJSON_Delete(parent_obj);
                 return EM_PARSE_ERR_GEN;
             }
-            for (j = 0; j < cJSON_GetArraySize(channel_arr_obj); j++) {
+            for (j = 0; j < cJSON_GetArraySize(channel_arr_obj) &&
+                        m_op_class[m_num_opclass].m_op_class_info.num_channels < EM_MAX_CHANNELS_IN_LIST; j++) {
                 m_op_class[m_num_opclass].m_op_class_info.channels[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_arr_obj, j)));
                 m_op_class[m_num_opclass].m_op_class_info.channel_pref[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_pref_arry_obj, j)));
                 m_op_class[m_num_opclass].m_op_class_info.num_channels++;
             }
         } else {
-            for (j = 0; j < cJSON_GetArraySize(channel_arr_obj); j++) {
+            for (j = 0; j < cJSON_GetArraySize(channel_arr_obj) &&
+                        m_op_class[m_num_opclass].m_op_class_info.num_channels < EM_MAX_CHANNELS_IN_LIST; j++) {
                 m_op_class[m_num_opclass].m_op_class_info.channels[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_arr_obj, j)));
                 m_op_class[m_num_opclass].m_op_class_info.num_channels++;
             }
@@ -1400,7 +1405,7 @@ int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const ch
     if (type == em_op_class_type_anticipated && m_num_opclass == 0) {
         em_printfout("OpClass list is empty");
         cJSON_Delete(parent_obj);
-        return EM_PARSE_ERR_GEN;
+        return EM_PARSE_ERR_NO_CHANGE;
     }
 
     cJSON_Delete(parent_obj);

--- a/src/orch/em_orch.cpp
+++ b/src/orch/em_orch.cpp
@@ -45,10 +45,18 @@ unsigned int em_orch_t::submit_commands(em_cmd_t *pcmd[], unsigned int num)
     unsigned int submitted = 0;
     bool submit = true;
 
-    for (i = 0; i < num; i++) {
+    if (pcmd == NULL) {
+        return 0;
+    }
+
+    for (i = 0; i < num && i < EM_MAX_CMD; i++) {
+        // Skip unset slots (analyze_* may return fewer commands than num)
+        if (pcmd[i] == NULL) {
+            continue;
+        }
         if ((submit = pre_process_orch_op(pcmd[i])) == false) {
             // complete the command
-            destroy_command(pcmd[i]);	
+            destroy_command(pcmd[i]);
             submit = true;
             continue;
         } else {

--- a/tests/test_l1_dm_easy_mesh.cpp
+++ b/tests/test_l1_dm_easy_mesh.cpp
@@ -2716,7 +2716,7 @@ TEST(dm_easy_mesh_t, decode_client_cap_config_null_radio_mac) {
  * **Test Procedure:**
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Invoke decode_config with JSON template for "SetAnticipatedChannelPreference" | input: subdoc->buff = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"AnticipatedChannelPreference\": [{ \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }] }]}} } }", key = "SetAnticipatedChannelPreference", num pointer = valid address | API return value is 0 and ASSERT_NE(subdoc, nullptr) passes | Should Pass |
+ * | 01 | Invoke decode_config with JSON template for "SetAnticipatedChannelPreference" | input: subdoc->buff = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": {\"Network\": {\"ID\": \"TestNetwork\", \"AnticipatedChannelPreference\": [{ \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }], \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\" }]}} } }", key = "SetAnticipatedChannelPreference", num pointer = valid address | API return value is 0 and ASSERT_NE(subdoc, nullptr) passes | Should Pass |
  * | 02 | Invoke decode_config with JSON template for "ChannelScanRequest" | input: subdoc->buff = "{ \"wfa-dataelements:ChannelScanRequest\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"RadioList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"ChannelScanParameters\": [{ \"Class\": 1, \"ChannelList\": [1,6,11] }] }] }]}} } }", key = "ChannelScanRequest", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
  * | 03 | Invoke decode_config with JSON template for "SetPolicy" | input: subdoc->buff = "{ \"wfa-dataelements:SetPolicy\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"Policy\": { \"AP Metrics Reporting Policy\": {} }}]}} } }", key = "SetPolicy", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
  * | 04 | Invoke decode_config with JSON template for "RadioEnable" | input: subdoc->buff = "{ \"wfa-dataelements:RadioEnable\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"RadioList\": [{ \"ID\": \"Radio1\", \"Enable\": true }]}]}} } }", key = "RadioEnable", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
@@ -2739,12 +2739,11 @@ TEST(dm_easy_mesh_t, decode_config_supported_routing)
     "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": {"
     "  \"Network\": {"
     "    \"ID\": \"TestNetwork\","
+    "    \"AnticipatedChannelPreference\": ["
+    "      { \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }"
+    "    ],"
     "    \"DeviceList\": ["
-    "      { \"ID\": \"AA:BB:CC:DD:EE:FF\","
-    "        \"AnticipatedChannelPreference\": ["
-    "          { \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }"
-    "        ]"
-    "      }"
+    "      { \"ID\": \"AA:BB:CC:DD:EE:FF\" }"
     "    ]"
     "  }"
     "} }",
@@ -3398,7 +3397,7 @@ TEST(dm_easy_mesh_t, decode_config_reset_null_key_pointer)
  * | Variation / Step | Description                                                                                             | Test Data                                                                                                                                                                              | Expected Result                                      | Notes          |
  * | :--------------: | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------------- |
  * | 01               | Initialize dm_easy_mesh_t object and subdoc structure; print entering message                           | None                                                                                                                                                                                   | Objects initialized and entering message printed   | Should be successful  |
- * | 02               | Setup JSON string in subdoc->buff for anticipated channel configuration                                  | json = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": { \"Network\": { \"ID\": \"TestNet\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"AnticipatedChannelPreference\": [{ \"Class\": 81, \"ChannelList\": [1, 6, 11], \"ChannelPrefList\": [0, 0, 0] }] }] } } }" | subdoc->buff correctly assigned the JSON configuration | Should be successful  |
+ * | 02               | Setup JSON string in subdoc->buff for anticipated channel configuration                                  | json = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": { \"Network\": { \"ID\": \"TestNet\", \"AnticipatedChannelPreference\": [{ \"Class\": 81, \"ChannelList\": [1, 6, 11], \"ChannelPrefList\": [0, 0, 0] }], \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\" }] } } }" | subdoc->buff correctly assigned the JSON configuration | Should be successful  |
  * | 03               | Invoke decode_config_set_channel API with valid input parameters                                        | subdoc (with valid JSON), key = "wfa-dataelements:SetAnticipatedChannelPreference", offset = 0, num pointer                                                     | API returns 0 and updates num to 1                   | Should Pass    |
  * | 04               | Assert that the return value and output parameter (num) are as expected                                   | ret = 0, num = 1                                                                                                                                                                       | EXPECT_EQ(ret, 0) and EXPECT_EQ(num, 1)               | Should Pass    |
  */
@@ -3413,16 +3412,16 @@ TEST(dm_easy_mesh_t, decode_config_set_channel_valid_anticipated)
         " \"wfa-dataelements:SetAnticipatedChannelPreference\": {"
         "   \"Network\": {"
         "     \"ID\": \"TestNet\","
+        "     \"AnticipatedChannelPreference\": ["
+        "       {"
+        "         \"Class\": 81,"
+        "         \"ChannelList\": [1, 6, 11],"
+        "         \"ChannelPrefList\": [0, 0, 0]"
+        "       }"
+        "     ],"
         "     \"DeviceList\": ["
         "       {"
-        "         \"ID\": \"AA:BB:CC:DD:EE:FF\","
-        "         \"AnticipatedChannelPreference\": ["
-        "           {"
-        "             \"Class\": 81,"
-        "             \"ChannelList\": [1, 6, 11],"
-        "             \"ChannelPrefList\": [0, 0, 0]"
-        "           }"
-        "         ]"
+        "         \"ID\": \"AA:BB:CC:DD:EE:FF\""
         "       }"
         "     ]"
         "   }"

--- a/tests/test_l1_em_orch.cpp
+++ b/tests/test_l1_em_orch.cpp
@@ -842,7 +842,7 @@ TEST_F(EmOrchTest, ZeroCommands) {
  * **Test Procedure:**
  * | Variation / Step | Description                                            | Test Data                           | Expected Result                              | Notes      |
  * | :--------------: | ------------------------------------------------------ | ----------------------------------- | -------------------------------------------- | ---------- |
- * |       01         | Invoke submit_commands with a nullptr command pointer  | commands = nullptr, num = 3           | Returns 0 and EXPECT_NE(result, 0) assertion   | Should Pass|
+ * |       01         | Invoke submit_commands with a nullptr command pointer  | commands = nullptr, num = 3           | Returns 0 and EXPECT_EQ(result, 0) assertion   | Should Pass|
  */
 TEST_F(EmOrchTest, NullCommandsPointer) {
     std::cout << "Entering NullCommandsPointer test" << std::endl;
@@ -850,7 +850,7 @@ TEST_F(EmOrchTest, NullCommandsPointer) {
     std::cout << "Invoking submit_commands with a nullptr for the command array and num = 3" << std::endl;
     unsigned int result = orch->submit_commands(nullptr, 3);
     std::cout << "submit_commands returned: " << result << std::endl;
-    EXPECT_NE(result, 0);
+    EXPECT_EQ(result, 0);
 
     std::cout << "Exiting NullCommandsPointer test" << std::endl;
 }

--- a/tests/test_l1_em_orch_agent.cpp
+++ b/tests/test_l1_em_orch_agent.cpp
@@ -787,7 +787,7 @@ TEST_F(em_orch_agent_t_TEST, ZeroCommands) {
 /**
  * @brief Verify that submit_commands handles a nullptr command array correctly.
  *
- * This test verifies that when a nullptr is passed as the command array along with a valid count (num = 3), the submit_commands API returns a non-zero value. This behavior indicates that the function correctly handles invalid input.
+ * This test verifies that when a nullptr is passed as the command array along with a valid count (num = 3), the submit_commands API returns 0 (no commands submitted). This behavior indicates that the function handles the null command array gracefully without crashing.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 023@n
@@ -800,14 +800,14 @@ TEST_F(em_orch_agent_t_TEST, ZeroCommands) {
  * **Test Procedure:**
  * | Variation / Step | Description                                                        | Test Data                                 | Expected Result                                   | Notes       |
  * | :--------------: | ------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------------------- | ----------- |
- * | 01               | Invoke submit_commands with a nullptr for the command array and num=3 | command = nullptr, num = 3                | Return value is non-zero and EXPECT_NE(result, 0) passes | Should Pass |
+ * | 01               | Invoke submit_commands with a nullptr for the command array and num=3 | command = nullptr, num = 3                | No commands submitted; returns 0 and EXPECT_EQ(result, 0) passes | Should Pass |
  */
 TEST_F(em_orch_agent_t_TEST, NullCommandsPointer) {
     std::cout << "Entering NullCommandsPointer test" << std::endl;
     std::cout << "Invoking submit_commands with a nullptr for the command array and num = 3" << std::endl;
     unsigned int result = orch->submit_commands(nullptr, 3);
     std::cout << "submit_commands returned: " << result << std::endl;
-    EXPECT_NE(result, 0);
+    EXPECT_EQ(result, 0);
     std::cout << "Exiting NullCommandsPointer test" << std::endl;
 }
 /**

--- a/tests/test_l1_em_orch_ctrl.cpp
+++ b/tests/test_l1_em_orch_ctrl.cpp
@@ -786,7 +786,7 @@ TEST_F(em_orch_ctrl_t_TEST, ZeroCommands) {
 /**
  * @brief Verify that submit_commands handles a nullptr command array correctly.
  *
- * This test verifies that when a nullptr is passed as the command array along with a valid count (num = 3), the submit_commands API returns a non-zero value. This behavior indicates that the function correctly handles invalid input.
+ * This test verifies that when a nullptr is passed as the command array along with a valid count (num = 3), the submit_commands API returns 0 (no commands submitted). This behavior indicates that the function handles the null command array gracefully without crashing.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 023@n
@@ -799,14 +799,14 @@ TEST_F(em_orch_ctrl_t_TEST, ZeroCommands) {
  * **Test Procedure:**
  * | Variation / Step | Description                                                        | Test Data                                 | Expected Result                                   | Notes       |
  * | :--------------: | ------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------------------- | ----------- |
- * | 01               | Invoke submit_commands with a nullptr for the command array and num=3 | command = nullptr, num = 3                | Return value is non-zero and EXPECT_NE(result, 0) passes | Should Pass |
+ * | 01               | Invoke submit_commands with a nullptr for the command array and num=3 | command = nullptr, num = 3                | No commands submitted; returns 0 and EXPECT_EQ(result, 0) passes | Should Pass |
  */
 TEST_F(em_orch_ctrl_t_TEST, NullCommandsPointer) {
     std::cout << "Entering NullCommandsPointer test" << std::endl;
     std::cout << "Invoking submit_commands with a nullptr for the command array and num = 3" << std::endl;
     unsigned int result = orch->submit_commands(nullptr, 3);
     std::cout << "submit_commands returned: " << result << std::endl;
-    EXPECT_NE(result, 0);
+    EXPECT_EQ(result, 0);
     std::cout << "Exiting NullCommandsPointer test" << std::endl;
 }
 /**


### PR DESCRIPTION
Pressing "Apply Radio Settings" crashed and restarted the controller on every Apply (NULL em_cmd dereference in submit_commands).

Root cause: the anticipated channel preference is carried at Network scope in the subdoc, but it was parsed from Device scope. Parsing always failed and returned a negative error code, which the handler cast to a huge unsigned command count and passed to submit_commands over an all NULL array. This also meant the preference set from the UI was never applied.

Fix:
- Parse anticipated preference from Network scope so Apply applies it.
- Treat a negative analyze_* result as no-submit (== 0 -> <= 0).
- Harden submit_commands to clamp to EM_MAX_CMD and skip NULL slots.
- Replace a strict op class count assert with a graceful no op.

Issue: RDKBWIFI-480
Signed-off-by: Durmus Koyuncu <durmus.kyncu.kd@gmail.com>