### PR TITLE
Fixing dm_easy_mesh_list, dm_assoc_sta_mld and em_cmd_sta_assoc unit tests

### DIFF
--- a/src/dm/dm_assoc_sta_mld.cpp
+++ b/src/dm/dm_assoc_sta_mld.cpp
@@ -56,7 +56,8 @@ void dm_assoc_sta_mld_t::operator = (const dm_assoc_sta_mld_t& obj)
     this->m_assoc_sta_mld_info.nstr = obj.m_assoc_sta_mld_info.nstr;
     this->m_assoc_sta_mld_info.emlsr = obj.m_assoc_sta_mld_info.emlsr;
     this->m_assoc_sta_mld_info.emlmr = obj.m_assoc_sta_mld_info.emlmr;
-    this->m_assoc_sta_mld_info.num_affiliated_sta = obj.m_assoc_sta_mld_info.num_affiliated_sta;
+    this->m_assoc_sta_mld_info.num_affiliated_sta = (obj.m_assoc_sta_mld_info.num_affiliated_sta > EM_MAX_AP_MLD)
+                                                    ? EM_MAX_AP_MLD : obj.m_assoc_sta_mld_info.num_affiliated_sta;
     for (unsigned int i = 0; i < this->m_assoc_sta_mld_info.num_affiliated_sta; i++) {
         memcpy(&this->m_assoc_sta_mld_info.affiliated_sta[i].bssid,
             &obj.m_assoc_sta_mld_info.affiliated_sta[i].bssid, sizeof(mac_address_t));
@@ -76,7 +77,9 @@ bool dm_assoc_sta_mld_t::operator == (const dm_assoc_sta_mld_t& obj)
     ret += !(this->m_assoc_sta_mld_info.emlsr == obj.m_assoc_sta_mld_info.emlsr);
     ret += !(this->m_assoc_sta_mld_info.emlmr == obj.m_assoc_sta_mld_info.emlmr);
     ret += !(this->m_assoc_sta_mld_info.num_affiliated_sta == obj.m_assoc_sta_mld_info.num_affiliated_sta);
-    for (unsigned int i = 0; i < this->m_assoc_sta_mld_info.num_affiliated_sta; i++) {
+    unsigned int num_sta = (this->m_assoc_sta_mld_info.num_affiliated_sta > EM_MAX_AP_MLD)
+                           ? EM_MAX_AP_MLD : this->m_assoc_sta_mld_info.num_affiliated_sta;
+    for (unsigned int i = 0; i < num_sta; i++) {
         ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].bssid,
             &obj.m_assoc_sta_mld_info.affiliated_sta[i].bssid, sizeof(mac_address_t)) != 0);
         ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].mac_addr,

--- a/tests/test_l1_dm_assoc_sta_mld.cpp
+++ b/tests/test_l1_dm_assoc_sta_mld.cpp
@@ -918,8 +918,8 @@ TEST(dm_assoc_sta_mld_t_Test, AssigningDefaultObject) {
  * | Variation / Step | Description | Test Data |Expected Result |Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01| Create an object of dm_assoc_sta_mld_t and assign maximum values to its members | obj1.m_assoc_sta_mld_info.str = true, obj1.m_assoc_sta_mld_info.num_affiliated_sta = 255 | Values should be assigned correctly | Should be successful |
- * | 02| Assign obj1 to another object obj2 using the assignment operator | obj2 = obj1 | obj2 should have the same values as obj1 | Should Pass |
- * | 03| Verify the values of obj2 | obj2.m_assoc_sta_mld_info.str, obj2.m_assoc_sta_mld_info.num_affiliated_sta | obj2.m_assoc_sta_mld_info.str == obj1.m_assoc_sta_mld_info.str, obj2.m_assoc_sta_mld_info.num_affiliated_sta == obj1.m_assoc_sta_mld_info.num_affiliated_sta | Should Pass |
+ * | 02| Assign obj1 to another object obj2 using the assignment operator | obj2 = obj1 | obj2.str should equal obj1.str; obj2.num_affiliated_sta should be clamped to EM_MAX_AP_MLD (not copied verbatim from obj1) | Should Pass |
+ * | 03| Verify the values of obj2 | obj2.m_assoc_sta_mld_info.str, obj2.m_assoc_sta_mld_info.num_affiliated_sta | obj2.m_assoc_sta_mld_info.str == obj1.m_assoc_sta_mld_info.str, obj2.m_assoc_sta_mld_info.num_affiliated_sta == EM_MAX_AP_MLD | Should Pass |
  */
 TEST(dm_assoc_sta_mld_t_Test, AssigningMaxValues) {
     std::cout << "Entering AssigningMaxValues" << std::endl;
@@ -931,7 +931,7 @@ TEST(dm_assoc_sta_mld_t_Test, AssigningMaxValues) {
     obj1.m_assoc_sta_mld_info.num_affiliated_sta = 255;
     obj2 = obj1;
     ASSERT_EQ(obj2.m_assoc_sta_mld_info.str, obj1.m_assoc_sta_mld_info.str);
-    ASSERT_EQ(obj2.m_assoc_sta_mld_info.num_affiliated_sta, obj1.m_assoc_sta_mld_info.num_affiliated_sta);
+    ASSERT_EQ(obj2.m_assoc_sta_mld_info.num_affiliated_sta, static_cast<unsigned char>(EM_MAX_AP_MLD));
     std::cout << "Exiting AssigningMaxValues" << std::endl;
 }
 

--- a/tests/test_l1_dm_easy_mesh_list.cpp
+++ b/tests/test_l1_dm_easy_mesh_list.cpp
@@ -1082,7 +1082,7 @@ TEST_F(dm_easy_mesh_list_tTEST, get_first_device_returns_valid_pointer)
  * | 03               | Assert that the returned firstElement is not null                          | firstElement, expected value: non-null                                                             | Assertion passes when firstElement != nullptr                           | Should Pass     |
  * | 04               | Validate that the network id of firstElement is "Network2"                  | firstElement->m_device.m_device_info.id.net_id = "Network2"                                          | The network id string is equal to "Network2"                           | Should Pass     |
  * | 05               | Validate that the profile type of firstElement is em_profile_type_3         | firstElement->m_device.m_device_info.profile, expected: em_profile_type_3                             | Profile type matches em_profile_type_3                                 | Should Pass     |
- * | 06               | Validate that the number of policies for firstElement is 7                  | firstElement->m_num_policy, expected: 7                                                              | Policy count equals 7                                                   | Should Pass     |
+ * | 06               | Validate that the number of policies for firstElement is 8                  | firstElement->m_num_policy, expected: 8                                                              | Policy count equals 8                                                   | Should Pass     |
  * | 07               | Log the exit message "Exiting get_first_dm_valid test"                    | No input arguments                                                                                 | "Exiting get_first_dm_valid test" printed to stdout                     | Should be successful |
  */
 TEST_F(dm_easy_mesh_list_tTEST, get_first_dm_valid)
@@ -1092,7 +1092,7 @@ TEST_F(dm_easy_mesh_list_tTEST, get_first_dm_valid)
     ASSERT_NE(firstElement, nullptr);
 	EXPECT_STREQ(firstElement->m_device.m_device_info.id.net_id, "Network2");
 	EXPECT_EQ(firstElement->m_device.m_device_info.profile, em_profile_type_3);
-	EXPECT_EQ(firstElement->m_num_policy, 7);
+	EXPECT_EQ(firstElement->m_num_policy, 8);
     std::cout << "Exiting get_first_dm_valid test" << std::endl;
 }
 

--- a/tests/test_l1_em_cmd_sta_assoc.cpp
+++ b/tests/test_l1_em_cmd_sta_assoc.cpp
@@ -39,7 +39,7 @@
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set up valid parameters for the API call | validParam.u.args.num_args = 1, validParam.u.args.args[0] = "ValidArg", validParam.u.args.fixed_args = "FixedValid", dm instance of dm_easy_mesh_t | Parameters are set correctly and ready for use | Should be successful |
- * | 02 | Construct the em_cmd_sta_assoc_t object using valid parameters | Input: validParam and dm | Object's members m_param reflect the provided valid parameters; m_type equals em_cmd_type_sta_assoc; m_name equals "sta_assoc"; m_svc equals em_service_type_ctrl; m_orch_op_idx equals 0; m_num_orch_desc equals 1; m_orch_desc[0].op equals dm_orch_type_sta_cap; m_orch_desc[0].submit equals true; m_data_model.m_cmd_ctx.type equals dm_orch_type_sta_cap | Should Pass |
+ * | 02 | Construct the em_cmd_sta_assoc_t object using valid parameters | Input: validParam and dm | Object's members m_param reflect the provided valid parameters; m_type equals em_cmd_type_sta_assoc; m_name equals "sta_assoc"; m_svc equals em_service_type_ctrl; m_orch_op_idx equals 0; m_num_orch_desc equals 3; m_orch_desc[0].op equals dm_orch_type_topo_sync; m_orch_desc[1].op equals dm_orch_type_sta_cap; m_orch_desc[2].op equals dm_orch_type_topo_publish; all submit equals true; m_data_model.m_cmd_ctx.type equals dm_orch_type_topo_sync | Should Pass |
  * | 03 | Validate object properties using assertions | Comparisons: em_cmd_sta_assoc_t object's members against expected values | EXPECT_EQ and EXPECT_STREQ assertions confirm correct initialization | Should Pass |
  * | 04 | Invoke deinit to cleanup the object | API call: assoc.deinit() | Successful deinitialization without errors | Should Pass |
  */
@@ -59,12 +59,14 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_parameters) {
     EXPECT_STREQ(assoc.m_name, "sta_assoc");
     EXPECT_EQ(assoc.m_svc, em_service_type_ctrl);
     EXPECT_EQ(assoc.m_orch_op_idx, 0);
-    EXPECT_EQ(assoc.m_num_orch_desc, 2);
-    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_num_orch_desc, 3);
+    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_topo_sync);
     EXPECT_TRUE(assoc.m_orch_desc[0].submit);
-    EXPECT_EQ(assoc.m_orch_desc[1].op, dm_orch_type_topo_publish);
+    EXPECT_EQ(assoc.m_orch_desc[1].op, dm_orch_type_sta_cap);
     EXPECT_TRUE(assoc.m_orch_desc[1].submit);
-    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_orch_desc[2].op, dm_orch_type_topo_publish);
+    EXPECT_TRUE(assoc.m_orch_desc[2].submit);
+    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_topo_sync);
     assoc.deinit();
     std::cout << "Exiting em_cmd_sta_assoc_t_valid_parameters test" << std::endl;
 }
@@ -87,7 +89,7 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_parameters) {
  * | 01 | Initialize em_cmd_params_t with minimal parameters | num_args = 0, fixed_args = "" | Structure initialized with zero arguments and empty fixed_args | Should be successful |
  * | 02 | Instantiate dm_easy_mesh_t object | None | dm object created successfully | Should be successful |
  * | 03 | Invoke em_cmd_sta_assoc_t constructor with minimal parameters | param (num_args = 0, fixed_args = ""), dm instance | em_cmd_sta_assoc_t object constructed with default values | Should Pass |
- * | 04 | Validate initialized fields of em_cmd_sta_assoc_t object | assoc.m_param.u.args.num_args = 0, assoc.m_param.u.args.fixed_args = "", assoc.m_type = em_cmd_type_sta_assoc, assoc.m_name = "sta_assoc", assoc.m_svc = em_service_type_ctrl, assoc.m_orch_op_idx = 0, assoc.m_num_orch_desc = 1, assoc.m_orch_desc[0].op = dm_orch_type_sta_cap, assoc.m_orch_desc[0].submit = true, assoc.m_data_model.m_cmd_ctx.type = dm_orch_type_sta_cap | Each field matches expected value as per the API design | Should Pass |
+ * | 04 | Validate initialized fields of em_cmd_sta_assoc_t object | assoc.m_param.u.args.num_args = 0, assoc.m_param.u.args.fixed_args = "", assoc.m_type = em_cmd_type_sta_assoc, assoc.m_name = "sta_assoc", assoc.m_svc = em_service_type_ctrl, assoc.m_orch_op_idx = 0, assoc.m_num_orch_desc = 3, assoc.m_orch_desc[0].op = dm_orch_type_topo_sync, assoc.m_orch_desc[1].op = dm_orch_type_sta_cap, assoc.m_orch_desc[2].op = dm_orch_type_topo_publish, all submit = true, assoc.m_data_model.m_cmd_ctx.type = dm_orch_type_topo_sync | Each field matches expected value as per the API design | Should Pass |
  * | 05 | Cleanup by invoking deinit() method on the em_cmd_sta_assoc_t object | None | Object deinitialized successfully | Should be successful |
  */
 TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_minimal_parameters) {
@@ -105,10 +107,14 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_minimal_parameters) {
     EXPECT_STREQ(assoc.m_name, "sta_assoc");
     EXPECT_EQ(assoc.m_svc, em_service_type_ctrl);
     EXPECT_EQ(assoc.m_orch_op_idx, 0);
-    EXPECT_EQ(assoc.m_num_orch_desc, 2);
-    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_num_orch_desc, 3);
+    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_topo_sync);
     EXPECT_TRUE(assoc.m_orch_desc[0].submit);
-    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_orch_desc[1].op, dm_orch_type_sta_cap);
+    EXPECT_TRUE(assoc.m_orch_desc[1].submit);
+    EXPECT_EQ(assoc.m_orch_desc[2].op, dm_orch_type_topo_publish);
+    EXPECT_TRUE(assoc.m_orch_desc[2].submit);
+    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_topo_sync);
     assoc.deinit();
     std::cout << "Exiting em_cmd_sta_assoc_t_valid_minimal_parameters test" << std::endl;
 }
@@ -132,7 +138,7 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_minimal_parameters) {
  * | 02 | Initialize the first argument in args array with maximum characters. | args[0] = 127 'Y' characters, null-terminated | The args[0] string in param is correctly set and null-terminated. | Should be successful |
  * | 03 | Set num_args value and prepare the parameter structure before constructor invocation. | num_args = 5 | The num_args field in param is set to 5. | Should be successful |
  * | 04 | Call the em_cmd_sta_assoc_t constructor with the parameter structure and dm instance. | Input: param structure and dm instance | A new assoc instance is created with its members initialized according to the input parameters, including m_param.u.args, m_type, m_name, m_svc, m_orch_op_idx, m_num_orch_desc, m_orch_desc, and m_data_model fields. | Should Pass |
- * | 05 | Verify the initialization by asserting each member's value and then deinitialize the instance. | Expected values: num_args = 5, fixed_args, args[0] match, m_type = em_cmd_type_sta_assoc, m_name = "sta_assoc", m_svc = em_service_type_ctrl, m_orch_op_idx = 0, m_num_orch_desc = 1, m_orch_desc[0].op = dm_orch_type_sta_cap, m_orch_desc[0].submit true, m_data_model.m_cmd_ctx.type = dm_orch_type_sta_cap. | All assertions pass confirming the proper initialization. | Should Pass |
+ * | 05 | Verify the initialization by asserting each member's value and then deinitialize the instance. | Expected values: num_args = 5, fixed_args, args[0] match, m_type = em_cmd_type_sta_assoc, m_name = "sta_assoc", m_svc = em_service_type_ctrl, m_orch_op_idx = 0, m_num_orch_desc = 3, m_orch_desc[0].op = dm_orch_type_topo_sync, m_orch_desc[1].op = dm_orch_type_sta_cap, m_orch_desc[2].op = dm_orch_type_topo_publish, all submit true, m_data_model.m_cmd_ctx.type = dm_orch_type_topo_sync. | All assertions pass confirming the proper initialization. | Should Pass |
  */
 TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_ctor_max_fixed_args) {
     std::cout << "Entering em_cmd_sta_assoc_t_ctor_max_fixed_args test" << std::endl;
@@ -157,10 +163,14 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_ctor_max_fixed_args) {
     EXPECT_STREQ(assoc.m_name, "sta_assoc");
     EXPECT_EQ(assoc.m_svc, em_service_type_ctrl);
     EXPECT_EQ(assoc.m_orch_op_idx, 0);
-    EXPECT_EQ(assoc.m_num_orch_desc, 2);
-    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_num_orch_desc, 3);
+    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_topo_sync);
     EXPECT_TRUE(assoc.m_orch_desc[0].submit);
-    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_orch_desc[1].op, dm_orch_type_sta_cap);
+    EXPECT_TRUE(assoc.m_orch_desc[1].submit);
+    EXPECT_EQ(assoc.m_orch_desc[2].op, dm_orch_type_topo_publish);
+    EXPECT_TRUE(assoc.m_orch_desc[2].submit);
+    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_topo_sync);
     assoc.deinit();
     std::cout << "Exiting em_cmd_sta_assoc_t_ctor_max_fixed_args test" << std::endl;
 }


### PR DESCRIPTION
Reason for change: after several recent commits some unit tests start to fail, so align them to have correct results
1) 77a1763 - "RDKBWIFI-464: EasyMesh - Client Assoc/Disassoc notification"
Modified em_cmd_sta_assoc.cpp, prepended a new `dm_orch_type_topo_sync` from 2 to 3 and shifting all descriptor indices;
2) 7aad068 - "Multi-ap policy config"
Modified dm_easy_mesh_list.cpp, added `em_policy_id_type_qos_mgt`, bumping m_num_policy from 7 to 8;
3) 5c6eddf - "RDKBWIFI-464: Fix issue with clients DB data override and empty stats value"
refactored `operator=` and `operator==` in `dm_assoc_sta_mld_t` to iterate over `affiliated_sta[]` per-entry instead of using a single `memcpy`. This exposed a pre-existing bug: the test `AssigningMaxValues` sets `num_affiliated_sta = 255` but `affiliated_sta[]` is a fixed-size array of only 64, causing ASAN failure for testing binary. Clamp `num_affiliated_sta` with `EM_MAX_AP_MLD`;

Risk: Low
Priority: P2