### PR TITLE
RDKCOM-5607: RDKBDEV-3461 Add check and skip bridge creation if exists already

### DIFF
--- a/config/rdkb/banana-pi/setup_veth_for_em.sh
+++ b/config/rdkb/banana-pi/setup_veth_for_em.sh
@@ -19,10 +19,14 @@ ip link del $VETH_END 2>/dev/null
 echo "Cleanup complete."
 
 # --- Create the Bridge ---
-echo "Creating bridge $BRIDGE_NAME..."
-ip link add name $BRIDGE_NAME type bridge
-ip link set dev $BRIDGE_NAME up
-echo "Bridge $BRIDGE_NAME created and brought up."
+if ip link show "$BRIDGE_NAME" >/dev/null 2>&1; then
+    echo "Bridge $BRIDGE_NAME already exists."
+else
+    echo "Creating bridge $BRIDGE_NAME..."
+    ip link add name $BRIDGE_NAME type bridge
+    ip link set dev $BRIDGE_NAME up
+    echo "Bridge $BRIDGE_NAME created and brought up."
+fi
 
 # --- Create veth pair and add one end to the bridge ---
 echo "Creating veth pair ($VETH_END <-> $VETH_PEER)..."


### PR DESCRIPTION
Reason for change: add check to avoid RTNETLINK error
Test procedure:
check `journalctl -u ieee1905_em_ctrl.service` output would show "Bridge brlan0 already exists" indicating creation skipped if it is already created before.
Risks: None