### PR TITLE
RDKBWIFI-483: Add EM+ service type support

### DIFF
--- a/inc/ec_configurator.h
+++ b/inc/ec_configurator.h
@@ -240,7 +240,7 @@ public:
 	 * @return true on success, otherwise false.
 	 * 
 	 */
-	virtual bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id) {
+	virtual bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id, bool peer_is_emplus = false) {
 		// impl'd by Controller Configurator only
 		return false;
 	} 

--- a/inc/ec_ctrl_configurator.h
+++ b/inc/ec_ctrl_configurator.h
@@ -89,7 +89,7 @@ public:
 	 * @return true on success, otherwise false.
 	 * 
 	 */
-	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id) override;
+	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id, bool peer_is_emplus = false) override;
 
     
 	/**

--- a/inc/ec_manager.h
+++ b/inc/ec_manager.h
@@ -291,9 +291,9 @@ public:
 	 * @return true on success, otherwise false.
 	 * 
 	 */
-	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id) {
+	bool handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id, bool peer_is_emplus = false) {
 		if (m_configurator) {
-			return m_configurator->handle_autoconf_chirp(chirp, len, src_mac, msg_id);
+			return m_configurator->handle_autoconf_chirp(chirp, len, src_mac, msg_id, peer_is_emplus);
 		}
 		// Not valid for Enrollee
 		return false;

--- a/inc/ec_ops.h
+++ b/inc/ec_ops.h
@@ -54,7 +54,7 @@ using send_autoconf_search_func = std::function<bool(em_dpp_chirp_value_t *, siz
  * @return True on success otherwise false
  * 
  */
-using send_autoconf_search_resp_func = std::function<bool(em_dpp_chirp_value_t *, size_t, uint8_t[ETH_ALEN], unsigned short msg_id)>;
+using send_autoconf_search_resp_func = std::function<bool(em_dpp_chirp_value_t *, size_t, uint8_t[ETH_ALEN], unsigned short msg_id, bool peer_is_emplus)>;
 
 /**
  * @brief Sends a chirp notification

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -500,8 +500,9 @@ public:
 	 * @return true if successful or if the file already exists, false otherwise.
 	 */
 	bool try_create_default_em_cfg(std::string interface);
+	void load_em_plus_cfg();
 
-    
+
 	/**!
 	* @brief Attempts to start DPP onboarding process.
 	*

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -236,6 +236,7 @@ static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff
 #define EM_KEY_FILE	"/nvram//test_cert.key"
 
 #define EM_CFG_FILE "/nvram/EasymeshCfg.json"
+#define EM_PLUS_FILE "/nvram/EasymeshPlus.json"
 #define EM_VENDOR_OUI_SIZE 3
 
 #define EM_MAX_SSID_LEN                33 
@@ -411,9 +412,11 @@ typedef struct {
 typedef unsigned char em_enum_type_t;
 
 typedef enum {
-    em_service_type_ctrl,
-    em_service_type_agent,
-    em_service_type_cli,
+    em_service_type_ctrl         = 0x00,
+    em_service_type_agent        = 0x01,
+    em_service_type_cli          = 0x02,
+    em_service_type_emplus_ctrl  = 0xA0,
+    em_service_type_emplus_agent = 0xA1,
     em_service_type_none
 } em_service_type_t;
 
@@ -2490,6 +2493,8 @@ typedef struct {
     em_small_string_t    primary_device_type;
     em_small_string_t    secondary_device_type;
     ieee_1905_security_t    sec_1905;
+    
+    uint8_t is_emplus_agent;
 } em_device_info_t;
 
 typedef struct {
@@ -3076,6 +3081,7 @@ typedef struct {
     mac_address_t	mac;
     em_long_string_t	net_id;
     int sz;
+    uint8_t is_emplus_agent;
 } __attribute__((__packed__)) em_commit_info_t;
 
 typedef enum {

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -46,7 +46,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure that the buffer is adequately sized to hold the response message.
 	 */
-	int create_autoconfig_resp_msg(unsigned char *buff, em_freq_band_t band, unsigned char *dst, unsigned short msg_id, em_dpp_chirp_value_t *chirp = nullptr, size_t hash_len = 0);
+	int create_autoconfig_resp_msg(unsigned char *buff, em_freq_band_t band, unsigned char *dst, unsigned short msg_id, em_dpp_chirp_value_t *chirp = nullptr, size_t hash_len = 0, bool peer_is_emplus = false);
     
 	/**!
 	 * @brief Creates an auto-configuration search message.
@@ -1626,7 +1626,7 @@ public:
 
 	bool send_autoconf_search_ext_chirp(em_dpp_chirp_value_t *chirp, size_t hash_len);
 
-	bool send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN], unsigned short msg_id);
+	bool send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN], unsigned short msg_id, bool peer_is_emplus);
 
 	bool send_bss_config_req_msg(uint8_t dest_al_mac[ETH_ALEN]);
 

--- a/inc/em_msg.h
+++ b/inc/em_msg.h
@@ -249,7 +249,8 @@ public:
 	* @note Ensure that the profile pointer is valid before calling this function.
 	*/
 	bool get_profile(em_profile_type_t *profile);
-    
+	bool get_supported_service(em_supported_service_t *svc);
+
 	/**!
 	 * @brief Retrieves the frequency band.
 	 *

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1514,6 +1514,8 @@ void em_agent_t::input_listener()
 
     em_printfout("bus open success");
 
+    load_em_plus_cfg();
+
     memset(&data, 0, sizeof(raw_data_t));
 
     while ((bus_error_val = desc->bus_data_get_fn(&m_bus_hdl, WIFI_WEBCONFIG_INIT_DML_DATA, &data)) != bus_error_success) {
@@ -2346,6 +2348,51 @@ bool em_agent_t::try_create_default_em_cfg(std::string interface)
     free(json_str);
 
     return true;
+}
+
+void em_agent_t::load_em_plus_cfg()
+{
+
+    m_data_model.get_device_info()->is_emplus_agent = 0;
+
+    FILE *fp = fopen(EM_PLUS_FILE, "r");
+    if (fp == NULL) {
+        return;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return;
+    }
+    long sz = ftell(fp);
+    rewind(fp);
+
+    if (sz <= 0) {
+        fclose(fp);
+        return;
+    }
+
+    char *buf = static_cast<char *>(malloc(static_cast<size_t>(sz) + 1));
+    if (buf == NULL) {
+        fclose(fp);
+        return;
+    }
+    size_t nread = fread(buf, 1, static_cast<size_t>(sz), fp);
+    buf[nread] = '\0';
+    fclose(fp);
+
+    cJSON *root = cJSON_Parse(buf);
+    free(buf);
+    if (root == NULL) {
+      return;
+    }
+
+    cJSON *item = cJSON_GetObjectItem(root, "EM_Plus");
+    if (cJSON_IsBool(item) && cJSON_IsTrue(item)) {
+        m_data_model.get_device_info()->is_emplus_agent = 1;
+        em_printfout("EM+ agent mode enabled");
+    }
+    cJSON_Delete(root);
 }
 
 bool em_agent_t::try_start_dpp_onboarding()  {

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -97,8 +97,12 @@ void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
         }
         em_printfout("data model dev mac: %s and int.mac: %s\n", util::mac_to_string(new_dm.m_device.m_device_info.id.dev_mac).c_str(),
             util::mac_to_string(new_dm.m_device.m_device_info.intf.mac).c_str());
+        new_dm.m_device.m_device_info.is_emplus_agent = info->is_emplus_agent;
         new_dm.set_db_cfg_param(db_cfg_type_device_list_update, "");
         m_data_model.set_config(&new_dm);
+    } else {
+        dm->get_device_info()->is_emplus_agent = info->is_emplus_agent;
+        dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
     }
 }
 
@@ -838,8 +842,10 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
     em_profile_type_t profile;
     unsigned int i;
     mac_addr_str_t mac_str1 = {0}, mac_str2 = {0};
-    em_commit_info_t dm_commit;
+    em_commit_info_t dm_commit = {};
     mac_address_t fallback_ruid = {0};
+    em_supported_service_t svc = {};
+    uint8_t is_emplus;
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
     if (len < ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)))) {
@@ -866,6 +872,17 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
 
             dm_easy_mesh_t::macbytes_to_string(intf.mac, mac_str1);
             em_printfout("[%s] Received autoconfig search from agent al mac: %s\n", __func__, mac_str1);
+
+            is_emplus = 0;
+            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)), len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_supported_service(&svc)) {
+                for (i = 0; i < svc.num && i < EM_MAX_SERVICE; i++) {
+                    if (svc.service[i] == em_service_type_emplus_agent) {
+                        is_emplus = 1;
+                        break;
+                    }
+                }
+            }
+
             if ((dm = get_data_model(GLOBAL_NET_ID, const_cast<const unsigned char *> (intf.mac))) == NULL) {
                 if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)), len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_profile(&profile) == false) {
                     profile = em_profile_type_1;
@@ -873,11 +890,14 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
                 //dm = create_data_model(GLOBAL_NET_ID, const_cast<const em_interface_t *> (&intf), profile);
                 memcpy(dm_commit.mac, intf.mac, sizeof(mac_addr_t));
                 strncpy(dm_commit.net_id, GLOBAL_NET_ID, sizeof(dm_commit.net_id));
+                dm_commit.is_emplus_agent = is_emplus;
                 io_process(em_bus_event_type_dm_commit, reinterpret_cast<unsigned char *> (&dm_commit), sizeof(em_commit_info_t));
-                em_printfout("[%s] Creating data model for mac: %s net: %s\n", __func__, mac_str1, GLOBAL_NET_ID);
+                em_printfout("[%s] Creating data model for mac: %s net: %s emplus: %d\n", __func__, mac_str1, GLOBAL_NET_ID, is_emplus);
             } else {
+                dm->get_device_info()->is_emplus_agent = is_emplus;
+                dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
                 dm_easy_mesh_t::macbytes_to_string(dm->get_agent_al_interface_mac(), mac_str1);
-                em_printfout("[%s] Found existing data model for mac: %s net: %s\n", __func__, mac_str1, GLOBAL_NET_ID);
+                em_printfout("[%s] Found existing data model for mac: %s net: %s emplus: %d\n", __func__, mac_str1, GLOBAL_NET_ID, is_emplus);
             }
             em = al_em;
             break;

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -143,7 +143,9 @@ int dm_easy_mesh_t::commit_config(dm_easy_mesh_t& dm, em_commit_target_t target)
     if (target.type == em_commit_target_sta_hash_map ) {
     } else if (target.type == em_commit_target_al) {
         m_network = dm.m_network;
+        uint8_t saved_emplus = m_device.m_device_info.is_emplus_agent;
         m_device = dm.m_device;
+        m_device.m_device_info.is_emplus_agent = saved_emplus;
     } else if (target.type == em_commit_target_radio) {
         string_to_macbytes(reinterpret_cast<char *> (target.params),mac);
         radio = dm.get_radio(mac);
@@ -281,9 +283,12 @@ int dm_easy_mesh_t::commit_config(em_cmd_t  *cmd)
             break;
         case em_cmd_type_dev_init: {
                 switch (cmd->get_orch_op()) {
-                    case dm_orch_type_al_insert:
+                    case dm_orch_type_al_insert: {
+                        uint8_t saved_emplus = m_device.m_device_info.is_emplus_agent;
                         m_device = cmd->m_data_model.m_device;
+                        m_device.m_device_info.is_emplus_agent = saved_emplus;
                         break;
+                    }
                     case dm_orch_type_em_insert:
                         m_radio[m_num_radios] = cmd->m_data_model.m_radio[0];
                         m_num_radios++;

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -1456,14 +1456,34 @@ int em_configuration_t::send_topology_response_msg(unsigned char *dst, unsigned 
     len += static_cast<unsigned int> (sizeof (em_tlv_t) + tlv_len);
 
     // supported service tlv 17.2.1
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_supported_service;
-    tlv->len = htons(sizeof(em_enum_type_t) + 1);
-    tlv->value[0] = 1;
-    memcpy(&tlv->value[1], &service_type, sizeof(em_enum_type_t));
-
-    tmp += (sizeof(em_tlv_t) + sizeof(em_enum_type_t) + 1);
-    len += static_cast<unsigned int> (sizeof(em_tlv_t) + sizeof(em_enum_type_t) + 1);
+    {
+        uint8_t is_emplus = 0;
+        if (service_type == em_service_type_ctrl) {
+            dm_easy_mesh_t *agent_dm = get_mgr()->get_data_model(GLOBAL_NET_ID, hdr->src);
+            is_emplus = agent_dm && agent_dm->get_device_info()->is_emplus_agent;
+        } else {
+            is_emplus = dm->get_device_info()->is_emplus_agent;
+        }
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_supported_service;
+        if (is_emplus) {
+            unsigned char emplus_svc = (service_type == em_service_type_ctrl)
+                ? static_cast<unsigned char>(em_service_type_emplus_ctrl)
+                : static_cast<unsigned char>(em_service_type_emplus_agent);
+            tlv->len = htons(3);
+            tlv->value[0] = 2;
+            tlv->value[1] = static_cast<unsigned char>(service_type);
+            tlv->value[2] = emplus_svc;
+            tmp += (sizeof(em_tlv_t) + 3);
+            len += static_cast<unsigned int>(sizeof(em_tlv_t) + 3);
+        } else {
+            tlv->len = htons(sizeof(em_enum_type_t) + 1);
+            tlv->value[0] = 1;
+            memcpy(&tlv->value[1], &service_type, sizeof(em_enum_type_t));
+            tmp += (sizeof(em_tlv_t) + sizeof(em_enum_type_t) + 1);
+            len += static_cast<unsigned int>(sizeof(em_tlv_t) + sizeof(em_enum_type_t) + 1);
+        }
+    }
 
     // AP operational BSS
     tlv_len = static_cast<short unsigned int> (create_operational_bss_tlv_topology(tmp));
@@ -3300,10 +3320,14 @@ int em_configuration_t::create_bss_config_req_msg(uint8_t *buff, uint8_t dest_al
     //  One Multi-AP Profile TLV.
     tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_profile, reinterpret_cast<uint8_t *> (&profile_type), sizeof(em_profile_type_t));
 
-    //  One SupportedService TLV.
-    // 1 service type followed by the service type value
-    uint8_t service_type_buff[2] = {1, service_type};
-    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_supported_service, service_type_buff, sizeof(service_type_buff));
+    //  One SupportedService TLV.
+    if (get_data_model()->get_device_info()->is_emplus_agent) {
+        uint8_t service_type_buff[3] = {2, static_cast<uint8_t>(service_type), static_cast<uint8_t>(em_service_type_emplus_agent)};
+        tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_supported_service, service_type_buff, sizeof(service_type_buff));
+    } else {
+        uint8_t service_type_buff[2] = {1, static_cast<uint8_t>(service_type)};
+        tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_supported_service, service_type_buff, sizeof(service_type_buff));
+    }
 
     // Zero or One Backhaul STA Radio Capabilities TLV.
     tlv_size = create_bsta_radio_cap_tlv(tlv_buff); // Data
@@ -4002,7 +4026,7 @@ int em_configuration_t::create_autoconfig_wsc_m1_msg(unsigned char *buff, unsign
     return len;
 }
 
-int em_configuration_t::create_autoconfig_resp_msg(unsigned char* buff, em_freq_band_t band, unsigned char* dst, unsigned short msg_id, em_dpp_chirp_value_t* chirp, size_t hash_len)
+int em_configuration_t::create_autoconfig_resp_msg(unsigned char* buff, em_freq_band_t band, unsigned char* dst, unsigned short msg_id, em_dpp_chirp_value_t* chirp, size_t hash_len, bool peer_is_emplus)
 {
     unsigned short  msg_type = em_msg_type_autoconf_resp;
     int len = 0;
@@ -4059,12 +4083,20 @@ int em_configuration_t::create_autoconfig_resp_msg(unsigned char* buff, em_freq_
     // supported service tlv 17.2.1
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_supported_service;
-    tlv->len = htons(sizeof(em_enum_type_t) + 1);
-    tlv->value[0] = 1;
-    memcpy(&tlv->value[1], &service_type, sizeof(em_enum_type_t));
-
-    tmp += (sizeof(em_tlv_t) + sizeof(em_enum_type_t) + 1);
-    len += static_cast<int> (sizeof(em_tlv_t) + sizeof(em_enum_type_t) + 1);
+    if (peer_is_emplus) {
+        tlv->len = htons(3);
+        tlv->value[0] = 2;
+        tlv->value[1] = static_cast<unsigned char>(em_service_type_ctrl);
+        tlv->value[2] = static_cast<unsigned char>(em_service_type_emplus_ctrl);
+        tmp += (sizeof(em_tlv_t) + 3);
+        len += static_cast<int>(sizeof(em_tlv_t) + 3);
+    } else {
+        tlv->len = htons(sizeof(em_enum_type_t) + 1);
+        tlv->value[0] = 1;
+        memcpy(&tlv->value[1], &service_type, sizeof(em_enum_type_t));
+        tmp += (sizeof(em_tlv_t) + sizeof(em_enum_type_t) + 1);
+        len += static_cast<int>(sizeof(em_tlv_t) + sizeof(em_enum_type_t) + 1);
+    }
 
     // 1905 layer security capability tlv 17.2.67
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -4118,10 +4150,10 @@ int em_configuration_t::create_autoconfig_resp_msg(unsigned char* buff, em_freq_
 
 }
 
-bool em_configuration_t::send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN], unsigned short msg_id)
+bool em_configuration_t::send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN], unsigned short msg_id, bool peer_is_emplus)
 {
     uint8_t buff[4096] = {0};
-    int msg_len = create_autoconfig_resp_msg(buff, get_band(), dest_mac, msg_id, chirp, len);
+    int msg_len = create_autoconfig_resp_msg(buff, get_band(), dest_mac, msg_id, chirp, len, peer_is_emplus);
     if (msg_len < 0) {
         em_printfout("Failed to create Autoconf Search Response (extended)");
         return false;
@@ -4179,8 +4211,13 @@ int em_configuration_t::create_autoconfig_search_msg(unsigned char *buff, em_dpp
 
     // Extended fields
     // Zero or one SupportedService TLV (see section 17.2.1).
-    uint8_t service[2] = {1, get_service_type()};
-    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_supported_service, service, sizeof(service));
+    if (get_data_model()->get_device_info()->is_emplus_agent) {
+        uint8_t service[3] = {2, static_cast<uint8_t>(get_service_type()), static_cast<uint8_t>(em_service_type_emplus_agent)};
+        tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_supported_service, service, sizeof(service));
+    } else {
+        uint8_t service[2] = {1, static_cast<uint8_t>(get_service_type())};
+        tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_supported_service, service, sizeof(service));
+    }
 
     // Zero or one SearchedService TLV (see section 17.2.2).
     // 0x00: Controller, 0x01 - 0xFF reserved
@@ -5745,6 +5782,19 @@ int em_configuration_t::handle_autoconfig_search(unsigned char *buff, unsigned i
         return -1;
     }
 
+    bool peer_is_emplus = false;
+    {
+        em_supported_service_t svc = {};
+        if (em_msg_t(buff + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)), len - static_cast<unsigned int>(sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_supported_service(&svc)) {
+            for (unsigned int i = 0; i < svc.num && i < EM_MAX_SERVICE; i++) {
+                if (svc.service[i] == em_service_type_emplus_agent) {
+                    peer_is_emplus = true;
+                    break;
+                }
+            }
+        }
+    }
+
     ec_manager_t &ec_mgr = get_ec_mgr();
 
     // Autoconf Search (extended) optionally contains a DPP chirp
@@ -5753,10 +5803,10 @@ int em_configuration_t::handle_autoconfig_search(unsigned char *buff, unsigned i
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
     if (dpp_chirp_tlv) {
         em_printfout("Found DPP Chirp in Autoconfig Search (extended), forwarding to EC");
-        return ec_mgr.handle_autoconf_chirp(reinterpret_cast<em_dpp_chirp_value_t*>(dpp_chirp_tlv->value), SWAP_LITTLE_ENDIAN(dpp_chirp_tlv->len), al_mac, ntohs(cmdu->id));
+        return ec_mgr.handle_autoconf_chirp(reinterpret_cast<em_dpp_chirp_value_t*>(dpp_chirp_tlv->value), SWAP_LITTLE_ENDIAN(dpp_chirp_tlv->len), al_mac, ntohs(cmdu->id), peer_is_emplus);
     }
     
-    int msg_len = create_autoconfig_resp_msg(msg, band, al_mac, ntohs(cmdu->id));
+    int msg_len = create_autoconfig_resp_msg(msg, band, al_mac, ntohs(cmdu->id), nullptr, 0, peer_is_emplus);
     if (msg_len < 0) {
         em_printfout("Error: Failed to create autoconfig response msg");
         return -1;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -2970,7 +2970,7 @@ bool em_t::initialize_ec_manager(){
                                                 this, std::placeholders::_1);
         ops.send_autoconf_search_resp =
             std::bind(&em_t::send_autoconf_search_resp_ext_chirp, this, std::placeholders::_1,
-                      std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
+                      std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5);
     }
 
     // Read in the persistent security context for the controller or agent

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -86,6 +86,42 @@ bool em_msg_t::get_al_mac_address(unsigned char *mac)
     return false;
 }
 
+bool em_msg_t::get_supported_service(em_supported_service_t *svc)
+{
+    unsigned int tlv_len;
+    if (!svc) {
+        return false;
+    }
+
+    em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(m_buff);
+    unsigned int len = m_len;
+    while ((len >= sizeof(em_tlv_t)) && (tlv->type != em_tlv_type_eom)) {
+        tlv_len = ntohs(tlv->len);
+        if (len < sizeof(em_tlv_t) + tlv_len) {
+            return false;
+        }
+        if (tlv->type == em_tlv_type_supported_service) {
+             if (tlv_len < 2) {
+                 return false;
+            }
+            unsigned int copy_len = tlv_len - 1;
+            if (copy_len > EM_MAX_SERVICE) {
+                copy_len = EM_MAX_SERVICE;
+            }
+            svc->num = tlv->value[0];
+            if (svc->num > copy_len) {
+                svc->num = static_cast<unsigned char>(copy_len);
+            }
+            memset(svc->service, 0, EM_MAX_SERVICE);
+            memcpy(svc->service, &tlv->value[1], svc->num);
+            return true;
+        }
+        len -= static_cast<unsigned int>(sizeof(em_tlv_t) + tlv_len);
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + sizeof(em_tlv_t) + tlv_len);
+    }
+    return false;
+}
+
 bool em_msg_t::get_profile(em_profile_type_t *profile)
 {
     em_tlv_t    *tlv;

--- a/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
+++ b/src/em/prov/easyconnect/ec_ctrl_configurator.cpp
@@ -322,7 +322,7 @@ bool ec_ctrl_configurator_t::process_direct_encap_dpp_msg(uint8_t* dpp_frame, ui
     return did_finish;
 }
 
-bool ec_ctrl_configurator_t::handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id)
+bool ec_ctrl_configurator_t::handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, size_t len, uint8_t src_mac[ETH_ALEN], unsigned short msg_id, bool peer_is_emplus)
 {
     em_printfout("Received Autoconf Search (extended) chirp from Enrollee '%s'", util::mac_to_string(src_mac).c_str());
     if (!chirp) {
@@ -372,7 +372,7 @@ bool ec_ctrl_configurator_t::handle_autoconf_chirp(em_dpp_chirp_value_t* chirp, 
         return false;
     }
 
-    if (!m_send_autoconf_resp_fn(resp_chirp, resp_chirp_len, src_mac, msg_id)) {
+    if (!m_send_autoconf_resp_fn(resp_chirp, resp_chirp_len, src_mac, msg_id, peer_is_emplus)) {
         em_printfout("Failed to send Autoconf Response (extended) with Chirp TLV");
         free(resp_chirp);
         return false;


### PR DESCRIPTION
  Controller detects EM+ agents via supported service TLV in autoconfig
  search and propagates the flag through dm_commit. Autoconfig response,
  topology response, autoconfig search, and BSS config request messages
  include EM+ service type when peer/self is EM+ capable. Agent reads
  EM_Plus field from /nvram/EasymeshPlus.json at startup to enable EM+
  mode; file absence means standard mode.

  DPP chirp path propagates peer_is_emplus through the full
  ec_manager → ec_configurator → send_autoconf_resp chain. Controller
  also persists is_emplus_agent via set_db_cfg_param on re-registration.

  Enable EM+ on agent: echo '{"EM_Plus": true}' > /nvram/EasymeshPlus.json

  0xA0 for EM+ controller
  0xA1 for EM+ agent

Issue: RDKBWIFI-483