### PR TITLE
RDKBWIFI-495 EasyMesh Channel Scan Report Processing Crash for Non-Su…

### DIFF
--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -2097,8 +2097,18 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
 	mac_addr_str_t bssid_str;
 
 	scan_res->m_scan_result.scan_status = res->scan_status;
-	strncpy(scan_res->m_scan_result.timestamp, res->timestamp, static_cast<size_t>(res->timestamp_len + 1));
+	if (res->scan_status != 0) {
+            em_printfout("%s:%d scan failed with status=%u", __func__, __LINE__, res->scan_status);
+            scan_res->m_scan_result.timestamp[0] = '\0';
+            scan_res->m_scan_result.util = 0;
+            scan_res->m_scan_result.noise = 0;
+            scan_res->m_scan_result.num_neighbors = 0;
+            scan_res->m_scan_result.aggr_scan_duration = 0;
+            scan_res->m_scan_result.scan_type = 0;
+	    return;
+	}
 
+	strncpy(scan_res->m_scan_result.timestamp, res->timestamp, static_cast<size_t>(res->timestamp_len + 1));
 	tmp = reinterpret_cast<unsigned char *> (res) + sizeof(em_channel_scan_result_t) + res->timestamp_len;
 	
 	memcpy(&scan_res->m_scan_result.util, tmp, sizeof(unsigned char));
@@ -2142,7 +2152,7 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
         } else if (strncmp(bandwidth, "40", strlen("40")) == 0) {
             nbr->bandwidth = WIFI_CHANNELBANDWIDTH_40MHZ;
         } else if (strncmp(bandwidth, "80", strlen("80")) == 0) {
-            nbr->bandwidth = WIFI_CHANNELBANDWIDTH_40MHZ;
+            nbr->bandwidth = WIFI_CHANNELBANDWIDTH_80MHZ;
         } else if (strncmp(bandwidth, "160", strlen("160")) == 0) {
             nbr->bandwidth = WIFI_CHANNELBANDWIDTH_160MHZ;
         } else if (strncmp(bandwidth, "320", strlen("320")) == 0) {


### PR DESCRIPTION
RDKBWIFI-495 EasyMesh Channel Scan Report Processing Crash for Non-Success Scan Status

Prevent crash during Channel Scan Report processing when scan results are returned with non-success scan status codes.
- Added validation to process Channel Scan Result TLVs based on the received scan_status
- Handled non-success scan responses according to EasyMesh Scan Status definitions
- Corrected incorrect bandwidth mapping for 80 MHz channels to use the appropriate bandwidth enum
- Ensured Timestamp and scan result data are parsed only when scan_status = 0x00 (Success)

Signed-off-by:
Alekhya Ambati <ambati.alekhya@capgemini.com>
Shaik Shaheeda <shaheeda.shaik@capgemini.com>