### PR TITLE
RDKBWIFI-496: Generate Channel Scan Report based on scan request

### DIFF
--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -19,6 +19,7 @@
 #ifndef EM_CHANNEL_H
 #define EM_CHANNEL_H
 
+#include <memory>
 #include "em_base.h"
 
 #define ACK_FROM_AGENT 0
@@ -26,8 +27,12 @@
 
 class em_cmd_t;
 class em_channel_t {
+    /* Cached Channel Scan Request received from controller.
+     * Freed after corresponding report is sent.
+     */
+    std::unique_ptr<em_scan_params_t> m_last_scan_req;
+    bool                              m_last_scan_req_valid;
 
-    
 	/**!
 	 * @brief Sends a frame of data.
 	 *
@@ -728,6 +733,21 @@ public:
 	*/
 	void set_channel_sel_req_tx_count(unsigned int cnt) { m_channel_sel_req_tx_cnt = cnt; }
 
+	/**
+     * @brief Checks whether a scan result matches the most recent Channel Scan Request.
+     *
+     * Compares the scan result's operating class and channel against the cached
+     * Channel Scan Request parameters received from the controller. Only scan
+     * results that were explicitly requested are included in the Channel Scan
+     * Report sent back to the controller.
+     *
+     * @param scan_res Pointer to the scan result to validate.
+     *
+     * @return true if the scan result matches one of the requested operating
+     *         class/channel combinations.
+     * @return false otherwise.
+     */
+    bool is_requested_scan_result(const dm_scan_result_t *scan_res) const;
 	
 	/**!
 	 * @brief Fills the scan result structure with data from the channel scan result.

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1616,7 +1616,7 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_anticipated, 135}, 135, 0, 0, 0, 1, {7}, {0xe0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 81}, 81, 0, 0, 0, 3, {3, 6, 9},{0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 115}, 115, 0, 0, 0, 9, {36, 40, 44, 48, 149, 153, 157, 161, 165}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0}),
-		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 135}, 135, 0, 0, 0, 1, {1}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0})
+		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 131}, 131, 0, 0, 0, 1, {1}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0})
 									};
 	dm_policy_t	policy[] = {
 								dm_policy_t(em_policy[0]), dm_policy_t(em_policy[1]),

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -802,6 +802,32 @@ short em_channel_t::create_channel_scan_res_tlv(unsigned char *buff, unsigned in
         return len;
 }
 
+bool em_channel_t::is_requested_scan_result(const dm_scan_result_t *scan_res) const
+{
+    if (scan_res == NULL)
+        return false;
+
+    if (!m_last_scan_req_valid || !m_last_scan_req)
+        return true;    // No cached request
+
+    unsigned char scan_op_class = scan_res->m_scan_result.id.op_class;
+    unsigned char scan_channel = scan_res->m_scan_result.id.channel;
+
+    for (unsigned int i = 0; i < m_last_scan_req->num_op_classes; i++) {
+        if (m_last_scan_req->op_class[i].op_class != scan_op_class)
+            continue;
+
+        /* Empty channel list => all channels in this op class */
+        if (m_last_scan_req->op_class[i].num_channels == 0)
+            return true;
+
+        for (unsigned int j = 0; j < m_last_scan_req->op_class[i].num_channels; j++) {
+            if (m_last_scan_req->op_class[i].channels[j] == scan_channel)
+                return true;
+        }
+    }
+    return false;
+}
 
 int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
 {
@@ -860,15 +886,19 @@ int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
     // One or more Channel Scan Result TLVs (see section 17.2.40).
     for (i = start_idx; i < dm->get_num_scan_results(); i++) {
         scan_res = dm->get_scan_result(i);
-        if(memcmp(get_radio_interface_mac(), scan_res->m_scan_result.id.scanner_mac, sizeof(mac_address_t)) == 0) { 
-            tlv = reinterpret_cast<em_tlv_t *> (tmp);
-            tlv->type = em_tlv_type_channel_scan_rslt;
-            sz = create_channel_scan_res_tlv(tlv->value, i);
-            tlv->len = htons(static_cast<short unsigned int> (sz));
+        if(memcmp(get_radio_interface_mac(), scan_res->m_scan_result.id.scanner_mac, sizeof(mac_address_t)) != 0) {
+	        continue;
+        }	
+        if (!is_requested_scan_result(scan_res)) {
+            continue;
+        }
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_channel_scan_rslt;
+        sz = create_channel_scan_res_tlv(tlv->value, i);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
 
-            tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-            len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
-	}
+        tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
+        len += static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<short unsigned int> (sz));
     }
 
     *last_index = i + 1;
@@ -893,6 +923,10 @@ int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
     }
 
     set_state(em_state_ctrl_configured);
+    if (*last_index >= dm->get_num_scan_results()) {
+        m_last_scan_req.reset();
+        m_last_scan_req_valid = false;
+    }
 
     return static_cast<int> (len);
 
@@ -2046,47 +2080,104 @@ int em_channel_t::handle_1905_ack(unsigned char *buff, unsigned int len)
 
 int em_channel_t::handle_channel_scan_req(unsigned char *buff, unsigned int len)
 {
-    em_tlv_t    *tlv;
+    em_tlv_t *tlv;
     int tlv_len;
-	em_channel_scan_req_t *req;
-	em_channel_scan_req_op_class_t	*op_class;
-	em_scan_params_t	params;
-	unsigned int i;
+    em_channel_scan_req_t *req;
+    em_channel_scan_req_op_class_t *op_class;
+    em_scan_params_t params;
+    unsigned int i;
 
-	memset(&params, 0, sizeof(em_scan_params_t));
-    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+    memset(&params, 0, sizeof(params));
+    unsigned int header_len = sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t);
 
-    tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
-
-    while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
-        if (tlv->type == em_tlv_type_channel_scan_req) {
-			req = reinterpret_cast<em_channel_scan_req_t *> (tlv->value);
-
-			memcpy(params.ruid, get_radio_interface_mac(), sizeof(mac_address_t));
-			params.num_op_classes = req->num_op_classes;
-					
-			op_class = req->op_class;
-			for (i = 0; i < params.num_op_classes; i++) {
-				params.op_class[i].op_class = op_class->op_class;
-				params.op_class[i].num_channels = op_class->num_channels;
-				memcpy(params.op_class[i].channels, op_class->channel_list, op_class->num_channels);
-
-				op_class = reinterpret_cast<em_channel_scan_req_op_class_t *> (reinterpret_cast<unsigned char *> (op_class) +
-							sizeof(em_channel_scan_req_op_class_t) + op_class->num_channels);
-			}	
-        }
-
-        tlv_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+    if (len < header_len + sizeof(em_tlv_t)) {
+        em_printfout("%s:%d Invalid Channel Scan Request (len=%u)",__func__, __LINE__, len);
+        return -1;
     }
 
-	if (params.num_op_classes > 0) {
-		get_mgr()->io_process(em_bus_event_type_channel_scan_params,  reinterpret_cast<unsigned char *> (&params), sizeof(em_scan_params_t));
-	}
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+    tlv = reinterpret_cast<em_tlv_t *>(buff + header_len);
+    tlv_len = static_cast<int>(len - header_len);
 
-	send_1905_ack_message(ntohs(cmdu->id), ACK_FROM_AGENT);
-	return 0;
+    while (tlv_len >= static_cast<int>(sizeof(em_tlv_t)) && tlv->type != em_tlv_type_eom) {
+        unsigned int cur_tlv_len = ntohs(tlv->len);
+
+        if (tlv_len < static_cast<int>(sizeof(em_tlv_t) + cur_tlv_len)) {
+            em_printfout("%s:%d Truncated TLV in Channel Scan Request",__func__, __LINE__);
+            return -1;
+        }	    
+        
+        if (tlv->type == em_tlv_type_channel_scan_req) {
+
+            unsigned char *payload = tlv->value;
+            unsigned char *payload_end = payload + cur_tlv_len;
+
+            /* Validate fixed request header */
+            if (payload + sizeof(em_channel_scan_req_t) > payload_end) {
+                em_printfout("%s:%d Invalid Channel Scan Request TLV",__func__, __LINE__);
+                return -1;
+            }
+
+            req = reinterpret_cast<em_channel_scan_req_t *>(payload);
+
+            memcpy(params.ruid, get_radio_interface_mac(), sizeof(mac_address_t));
+            params.num_op_classes = req->num_op_classes;
+
+            if (params.num_op_classes > EM_MAX_OP_CLASS) {
+                em_printfout("%s:%d Invalid num_op_classes=%u", __func__, __LINE__, params.num_op_classes);
+                return -1;
+            }
+
+            op_class = req->op_class;
+
+            for (i = 0; i < params.num_op_classes; i++) {
+
+                /* Validate fixed op-class entry */
+                if (reinterpret_cast<unsigned char *>(op_class) + sizeof(em_channel_scan_req_op_class_t) > payload_end) {
+                    em_printfout("%s:%d Truncated operating class entry", __func__, __LINE__);
+                    return -1;
+                }
+
+                if (op_class->num_channels > EM_MAX_CHANNELS_IN_LIST) {
+                    em_printfout("%s:%d Invalid num_channels=%u", __func__, __LINE__, op_class->num_channels);
+                    return -1;
+                }
+
+                /* Validate variable-length channel list */
+                if (reinterpret_cast<unsigned char *>(op_class) + sizeof(em_channel_scan_req_op_class_t) +
+                                                                             op_class->num_channels > payload_end) {
+                    em_printfout("%s:%d Truncated channel list", __func__, __LINE__);
+                    return -1;
+                }
+
+                params.op_class[i].op_class = op_class->op_class;
+                params.op_class[i].num_channels = op_class->num_channels;
+
+                memcpy(params.op_class[i].channels, op_class->channel_list, op_class->num_channels);
+
+                op_class = reinterpret_cast<em_channel_scan_req_op_class_t *>(reinterpret_cast<unsigned char *>(op_class) +
+                                                 sizeof(em_channel_scan_req_op_class_t) + op_class->num_channels);
+            }
+        }
+	
+	tlv_len -= static_cast<int>(sizeof(em_tlv_t) + cur_tlv_len);
+
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + sizeof(em_tlv_t) + cur_tlv_len);
+    }
+
+    if (params.num_op_classes > 0) {
+        if (!m_last_scan_req) {
+	        m_last_scan_req = std::make_unique<em_scan_params_t>();
+	    }
+	    memcpy(m_last_scan_req.get(), &params, sizeof(em_scan_params_t));
+        m_last_scan_req_valid = true;
+	    get_mgr()->io_process(em_bus_event_type_channel_scan_params,  reinterpret_cast<unsigned char *> (&params), sizeof(em_scan_params_t));
+    } else {
+        m_last_scan_req.reset();
+        m_last_scan_req_valid = false;
+    }
+    send_1905_ack_message(ntohs(cmdu->id), ACK_FROM_AGENT);
+    return 0;
 }
 
 void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_result_t *res)
@@ -2112,10 +2203,10 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
 
 	strncpy(scan_res->m_scan_result.timestamp, res->timestamp, static_cast<size_t>(res->timestamp_len + 1));
 	tmp = reinterpret_cast<unsigned char *> (res) + sizeof(em_channel_scan_result_t) + res->timestamp_len;
-	
+
 	memcpy(&scan_res->m_scan_result.util, tmp, sizeof(unsigned char));
 	tmp += sizeof(unsigned char);
-	
+
 	memcpy(&scan_res->m_scan_result.noise, tmp, sizeof(unsigned char));
 	tmp += sizeof(unsigned char);
 
@@ -2435,10 +2526,10 @@ em_channel_t::em_channel_t()
 {
     m_channel_pref_query_tx_cnt = 0;
     m_channel_sel_req_tx_cnt = 0;
+    m_last_scan_req_valid = false;
 }
 
 em_channel_t::~em_channel_t()
 {
-
 }
 


### PR DESCRIPTION
Integration test of NBAPI and Channel Scan Request shows that CS report contains all the Op class/Channels belonging to the radio. 
This fix will:
- Cache the latest Channel Scan Request parameters.
- Report only the requested operating class/channel scan results.
- Clear cached request after sending the Channel Scan Report.
- Add validation while parsing Channel Scan Request TLVs.
This change ensures the Agent generates Channel Scan Reports that comply with the EasyMesh specification by reporting only the requested operating class/channel combinations, even when the driver returns additional scan results.