### PR TITLE
RDKBWIFI-459: Add EasyMesh Failed Connection message support

### DIFF
--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -212,11 +212,11 @@ class em_agent_t : public em_mgr_t {
 	void handle_recv_assoc_status(em_bus_event_t *event);
 
 	/**
-	 * @brief Handles the reception of connection status event of a STA
+	 * @brief Handles the reception of a failed connection event from OneWifi
 	 *
-	 * @param event The event containing the `em_connection_status_evt_data_t` payload
+	 * @param event The event containing the JSON failed-connection payload (bssid, sta_mac, status, reason)
 	 */
-	void handle_recv_connection_status(em_bus_event_t *event);
+	void handle_recv_failed_conn(em_bus_event_t *event);
 
 	/**!
 	 * @brief Handles the BTM response action frame.
@@ -1061,14 +1061,14 @@ public:
 	static int association_status_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**
-	 * @brief Callback for connection-status event
+	 * @brief Callback for failed-connection event
 	 *
 	 * @param event_name The name of the event
 	 * @param data The raw event data
 	 * @param userData Optional user-provided callback data
 	 * @return int 1 on success, otherwise -1
 	 */
-	static int connection_status_cb(char *event_name, bus_data_prop_t *data, void *userData);
+	static int failed_conn_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**
 	 * @brief Callback for BSS scan events

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -302,6 +302,10 @@ static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff
 #define WIFI_EM_CHANNEL_SCAN_REQUEST          "Device.WiFi.EM.ChannelScanRequest"
 #endif
 
+#ifndef WIFI_EM_FAILED_CONNECTION
+#define WIFI_EM_FAILED_CONNECTION             "Device.WiFi.EM.FailedConnection"
+#endif
+
 #ifndef WIFI_EM_CLIENT_ASSOC_CTRL_REQ
 #define WIFI_EM_CLIENT_ASSOC_CTRL_REQ        "Device.WiFi.EM.ClientAssocCtrlRequest"
 #endif
@@ -3052,7 +3056,6 @@ typedef enum {
     em_bus_event_type_recv_gas_frame,
     em_bus_event_type_get_sta_client_type,
     em_bus_event_type_assoc_status,
-    em_bus_event_type_connection_status,
     em_bus_event_type_ap_metrics_report,
     em_bus_event_type_bss_info,
     em_bus_event_type_get_reset,
@@ -3063,6 +3066,7 @@ typedef enum {
     em_bus_event_type_unassoc_sta_query,
     em_bus_event_type_unassoc_sta_link_metrics_query,
     em_bus_event_type_unassoc_sta_result,
+    em_bus_event_type_failed_conn,
 
     em_bus_event_type_max
 } em_bus_event_type_t;
@@ -3155,7 +3159,7 @@ typedef enum {
     dm_orch_type_link_quality_report,
     dm_orch_type_unassoc_sta_link_req_query,
     dm_orch_type_unassoc_sta_result,
-    
+
 } dm_orch_type_t;
 
 typedef struct {

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -468,6 +468,7 @@ public:
 	void handle_bsta_cap_req(em_bus_event_t *evt);
 
 	void handle_link_stats_alarm_report(em_bus_event_t *evt);
+	void handle_failed_conn_msg(unsigned char *data, unsigned int len) override;
 
         /**!
          * @brief Handles an Unassociated STA Link Metrics Query event.

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -434,7 +434,7 @@ class em_metrics_t {
 	int send_ap_metrics_response();
 
 	int send_link_quality_report();
-    
+
 	/**!
 	 * @brief Creates a beacon metrics response TLV.
 	 *

--- a/inc/em_mgr.h
+++ b/inc/em_mgr.h
@@ -716,7 +716,8 @@ public:
 	 */
 	virtual em_service_type_t get_service_type() = 0;
 
-	
+	virtual void handle_failed_conn_msg(unsigned char *data, unsigned int len) {}
+
 	/**!
 	 * @brief Processes an event.
 	 *

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -35,6 +35,7 @@
 #define DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_SYNC          "Device.WiFi.DataElements.Network.NodeSynchronize"
 #define DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY    "Device.WiFi.DataElements.Network.NodeConfigurePolicy"
 #define DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_LINKSTATS_ALARM    "Device.WiFi.DataElements.Network.NodeLinkStatsAlarm"
+#define DEVICE_WIFI_DATAELEMENTS_FAILED_CONNECTION               "Device.WiFi.DataElements.FailedConnectionEvent.FailedConnection!"
 
 #define LIST_OF_DEFINITION_NAME "List_Of_Def"
 #define MAX_NUM_OF_OBJECTS_NAME "Num_Of_Objects"

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -55,71 +55,6 @@ AlServiceAccessPoint* g_sap;
 MacAddress g_al_mac_sap;
 #endif
 
-static bool is_known_failure_status_code(unsigned short status_code)
-{
-    switch (status_code) {
-        case 1:  // Unspecified failure
-        case 5:  // Association denied; AP unable to handle BSS
-        case 10: // Cannot support all requested capabilities
-        case 11: // Reassociation denied; previous association unknown
-        case 12: // Association denied; reason outside scope
-        case 13: // Auth algorithm not supported
-        case 15: // Challenge failure (authentication denied)
-        case 16: // Association failure due to timeout
-        case 17: // Auth sequence timeout; STA did not respond
-        case 30: // Association rejected temporarily; try again later
-        case 31: // Robust management frame policy violation
-        case 43: // Invalid AKMP
-        case 44: // IEEE 802.1X authentication failed
-        case 45: // PMK not available/cached
-        case 53: // Invalid PMKID
-            return true;
-        default:
-            return false;
-    }
-}
-
-static bool is_known_failure_reason_code(unsigned short reason_code)
-{
-    switch (reason_code) {
-        case 2:  // Previous authentication not valid
-        case 3:  // Deauthenticated; STA is leaving
-        case 6:  // Class 2 frame from nonauthenticated STA
-        case 7:  // Class 3 frame from nonassociated STA
-        case 9:  // STA requested (re)assoc without authentication
-        case 13: // Invalid IE in frame
-        case 14: // Michael MIC failure
-        case 15: // 4-way handshake timeout
-        case 16: // Group key update timeout
-        case 17: // IE in 4-way handshake differs from (re)assoc request
-        case 18: // Group cipher suite not valid
-        case 19: // Pairwise cipher suite not valid
-        case 20: // AKMP not valid
-        case 21: // Unsupported RSN IE version
-        case 22: // Invalid RSN IE capabilities
-        case 23: // IEEE 802.1X authentication failed
-        case 24: // Cipher suite rejected by security policy
-        case 39: // Requested from peer STA (wrong password / MIC failure)
-        case 49: // Invalid PMKID
-            return true;
-        default:
-            return false;
-    }
-}
-
-static bool is_failed_connection_message(const em_connection_status_evt_data_t *conn_status_evt)
-{
-    if (conn_status_evt == nullptr) {
-        return false;
-    }
-
-    if (conn_status_evt->reason_code_present) {
-        return is_known_failure_reason_code(conn_status_evt->reason_code);
-    }
-
-    return is_known_failure_status_code(conn_status_evt->status_code);
-}
-
 void em_agent_t::handle_sta_list(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -474,11 +409,14 @@ void em_agent_t::handle_recv_assoc_status(em_bus_event_t *event)
     }
 }
 
-void em_agent_t::handle_recv_connection_status(em_bus_event_t *event)
+void em_agent_t::handle_recv_failed_conn(em_bus_event_t *event)
 {
-    const em_connection_status_evt_data_t *conn_status_evt = nullptr;
     em_bss_info_t *target_bss = nullptr;
     mac_address_t bssid = {0};
+    mac_address_t sta_mac = {0};
+    unsigned short status_code = 0;
+    unsigned short reason_code = 0;
+    bool reason_code_present = false;
     em_t *em = nullptr;
     em_event_t *qevt = nullptr;
     em_connection_status_evt_data_t *evt_copy = nullptr;
@@ -489,31 +427,55 @@ void em_agent_t::handle_recv_connection_status(em_bus_event_t *event)
         return;
     }
 
-    if (event->u.raw_buff == nullptr || event->data_len != sizeof(em_connection_status_evt_data_t)) {
-        em_printfout("Invalid connection status payload: expected %zu, got %u",
-                     sizeof(em_connection_status_evt_data_t), event->data_len);
+    if (event->u.raw_buff == nullptr || event->data_len == 0) {
+        em_printfout("NULL failed connection payload!");
         return;
     }
 
-    conn_status_evt = reinterpret_cast<const em_connection_status_evt_data_t *>(event->u.raw_buff);
+    // event->u.raw_buff is a fixed-length copy of the bus payload and is not
+    // guaranteed to be NUL-terminated; copy it into a NUL-terminated buffer
+    // before treating it as a C string.
+    std::vector<char> payload(event->data_len + 1, '\0');
+    memcpy(payload.data(), event->u.raw_buff, event->data_len);
 
-    if (!is_failed_connection_message(conn_status_evt)) {
+    cJSON *obj = cJSON_Parse(payload.data());
+    if (obj == nullptr) {
+        em_printfout("Failed connection JSON parse failed, raw: %s", payload.data());
         return;
     }
 
-    memcpy(bssid, conn_status_evt->bssid, sizeof(mac_address_t));
+    cJSON *bssid_item = cJSON_GetObjectItem(obj, "bssid");
+    cJSON *sta_item = cJSON_GetObjectItem(obj, "sta_mac");
+    cJSON *status_item = cJSON_GetObjectItem(obj, "status");
+    cJSON *reason_item = cJSON_GetObjectItem(obj, "reason");
+
+    if (!cJSON_IsString(bssid_item) || !cJSON_IsString(sta_item) || !cJSON_IsNumber(status_item)) {
+        em_printfout("Failed connection JSON missing/invalid mandatory fields (bssid/sta_mac/status), raw: %s", payload.data());
+        cJSON_Delete(obj);
+        return;
+    }
+
+    dm_easy_mesh_t::string_to_macbytes(bssid_item->valuestring, bssid);
+    dm_easy_mesh_t::string_to_macbytes(sta_item->valuestring, sta_mac);
+    status_code = static_cast<unsigned short>(status_item->valueint);
+
+    if (reason_item && cJSON_IsNumber(reason_item)) {
+        reason_code = static_cast<unsigned short>(reason_item->valueint);
+        reason_code_present = true;
+    }
+
+    cJSON_Delete(obj);
+
     target_bss = m_data_model.get_bss_info_with_mac(bssid);
     if (target_bss == nullptr) {
-        em_printfout("No BSS for bssid=%s, drop",
-                     util::mac_to_string(conn_status_evt->bssid).c_str());
+        em_printfout("No BSS for bssid=%s, drop", util::mac_to_string(bssid).c_str());
         return;
     }
 
     ruid_str = util::mac_to_string(target_bss->ruid.mac);
     em = static_cast<em_t *>(hash_map_get(g_agent.m_em_map, ruid_str.c_str()));
     if (em == nullptr) {
-        em_printfout("No radio EM for bssid=%s, drop",
-                     util::mac_to_string(conn_status_evt->bssid).c_str());
+        em_printfout("No radio EM for bssid=%s, drop", util::mac_to_string(bssid).c_str());
         return;
     }
 
@@ -523,14 +485,18 @@ void em_agent_t::handle_recv_connection_status(em_bus_event_t *event)
         return;
     }
 
-    evt_copy = static_cast<em_connection_status_evt_data_t *>(malloc(sizeof(em_connection_status_evt_data_t)));
+    evt_copy = static_cast<em_connection_status_evt_data_t *>(calloc(1, sizeof(em_connection_status_evt_data_t)));
     if (evt_copy == nullptr) {
-        em_printfout("Failed to alloc connection status payload");
+        em_printfout("Failed to alloc failed connection payload");
         free(qevt);
         return;
     }
 
-    memcpy(evt_copy, conn_status_evt, sizeof(em_connection_status_evt_data_t));
+    memcpy(evt_copy->bssid, bssid, sizeof(mac_address_t));
+    memcpy(evt_copy->sta_mac, sta_mac, sizeof(mac_address_t));
+    evt_copy->status_code = status_code;
+    evt_copy->reason_code = reason_code;
+    evt_copy->reason_code_present = reason_code_present;
 
     qevt->type = em_event_type_cmd;
     qevt->u.cevt.type = em_cmd_event_type_failed_connection;
@@ -1284,8 +1250,8 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
             handle_recv_assoc_status(evt);
             break;
 
-        case em_bus_event_type_connection_status:
-            handle_recv_connection_status(evt);
+        case em_bus_event_type_failed_conn:
+            handle_recv_failed_conn(evt);
             break;
 
         case em_bus_event_type_ap_metrics_report:
@@ -1565,9 +1531,8 @@ void em_agent_t::input_listener()
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.ReportConnectionStatus", reinterpret_cast<void *>(&em_agent_t::connection_status_cb), nullptr, 0) != 0) {
-        em_printfout("Error: Failed to subscribe to 'Device.WiFi.EM.ReportConnectionStatus'");
-        return;
+    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_EM_FAILED_CONNECTION, reinterpret_cast<void *>(&em_agent_t::failed_conn_cb), nullptr, 0) != 0) {
+        em_printfout("Warning: Failed to subscribe to '" WIFI_EM_FAILED_CONNECTION "', Failed Connection reporting unavailable");
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EC.BSSInfo", reinterpret_cast<void *>(&em_agent_t::bss_info_cb), nullptr, 0) != 0) {
@@ -1670,19 +1635,13 @@ int em_agent_t::association_status_cb(char *event_name, bus_data_prop_t *data, v
     return 1;
 }
 
-int em_agent_t::connection_status_cb(char *event_name, bus_data_prop_t *data, void *userData)
+int em_agent_t::failed_conn_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
-    (void)event_name;
-    (void)userData;
-
     if (data == nullptr) {
-        em_printfout("NULL data from OneWiFi callback!");
+        em_printfout("NULL data from OneWiFi failed connection callback!");
         return -1;
     }
-
-    g_agent.io_process(em_bus_event_type_connection_status,
-                       reinterpret_cast<unsigned char *>(data->value.raw_data.bytes),
-                       data->value.raw_data_len);
+    g_agent.io_process(em_bus_event_type_failed_conn, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     return 1;
 }
 

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -523,6 +523,7 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_query)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_link_metrics_query)
 	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_result)
+	BUS_EVENT_TYPE_2S(em_bus_event_type_failed_conn)
        
         default:
            break;

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -35,6 +35,7 @@
 #include <sys/socket.h>
 #include <sys/uio.h>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <cjson/cJSON.h>
@@ -497,6 +498,133 @@ void em_ctrl_t::handle_link_stats_alarm_report(em_bus_event_t *evt)
 
     cJSON_Delete(parent);
 }
+
+void em_ctrl_t::handle_failed_conn_msg(unsigned char *data, unsigned int len)
+{
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    if (em_msg_t(em_msg_type_failed_conn, em_profile_type_3, data, len).validate(errors) == 0) {
+        em_printfout("Failed Connection message validation failed");
+        return;
+    }
+
+    unsigned int hdr_size = static_cast<unsigned int>(sizeof(em_raw_hdr_t)) + static_cast<unsigned int>(sizeof(em_cmdu_t));
+    if (len <= hdr_size) {
+        em_printfout("Failed Connection message too short");
+        return;
+    }
+    unsigned char *tmp = data + hdr_size;
+    unsigned int remaining = len - hdr_size;
+    mac_address_t bssid = {0};
+    mac_address_t sta_mac = {0};
+    unsigned short status_code = 0;
+    unsigned short reason_code = 0;
+    bool has_bssid = false, has_sta = false, has_status = false;
+
+    while (remaining >= sizeof(em_tlv_t)) {
+        em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        unsigned short tlv_len = ntohs(tlv->len);
+
+        if (tlv->type == em_tlv_type_eom) {
+            break;
+        }
+        if (remaining < sizeof(em_tlv_t) + tlv_len) {
+            break;
+        }
+
+        switch (tlv->type) {
+            case em_tlv_type_bssid:
+                memcpy(bssid, tlv->value, sizeof(mac_address_t));
+                has_bssid = true;
+                break;
+            case em_tlv_type_sta_mac_addr:
+                memcpy(sta_mac, tlv->value, sizeof(mac_address_t));
+                has_sta = true;
+                break;
+            case em_tlv_type_status_code: {
+                em_status_code_t *sc = reinterpret_cast<em_status_code_t *>(tlv->value);
+                status_code = ntohs(sc->status_code);
+                has_status = true;
+                break;
+            }
+            case em_tlv_type_reason_code: {
+                if (tlv_len < sizeof(em_reason_code_t)) {
+                    em_printfout("Failed Connection message malformed Reason Code TLV (len=%u)", static_cast<unsigned int>(tlv_len));
+                    break;
+                }
+                em_reason_code_t *rc = reinterpret_cast<em_reason_code_t *>(tlv->value);
+                reason_code = ntohs(rc->reason_code);
+                break;
+            }
+            default:
+                break;
+        }
+
+        tmp += sizeof(em_tlv_t) + tlv_len;
+        remaining -= static_cast<unsigned int>(sizeof(em_tlv_t)) + tlv_len;
+    }
+
+    if (!has_bssid || !has_sta || !has_status) {
+        em_printfout("Failed Connection message missing mandatory TLVs");
+        return;
+    }
+
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    struct tm tm_info;
+    gmtime_r(&ts.tv_sec, &tm_info);
+    char timestamp[MAX_TIMESTAMP_STRLEN];
+    snprintf(timestamp, sizeof(timestamp), "%04d-%02d-%02dT%02d:%02d:%02dZ",
+        tm_info.tm_year + 1900, tm_info.tm_mon + 1, tm_info.tm_mday,
+        tm_info.tm_hour, tm_info.tm_min, tm_info.tm_sec);
+
+    mac_addr_str_t bssid_str, sta_str;
+    dm_easy_mesh_t::macbytes_to_string(bssid, bssid_str);
+    dm_easy_mesh_t::macbytes_to_string(sta_mac, sta_str);
+
+    cJSON *obj = cJSON_CreateObject();
+    if (obj == nullptr) {
+        em_printfout("Failed to allocate JSON object for FailedConnectionEvent");
+        return;
+    }
+
+    cJSON_AddStringToObject(obj, "BSSID", bssid_str);
+    cJSON_AddStringToObject(obj, "MACAddress", sta_str);
+    cJSON_AddNumberToObject(obj, "StatusCode", status_code);
+    cJSON_AddNumberToObject(obj, "ReasonCode", reason_code);
+    cJSON_AddStringToObject(obj, "TimeStamp", timestamp);
+
+    char *str = cJSON_Print(obj);
+    cJSON_Delete(obj);
+
+    if (str == nullptr) {
+        em_printfout("Failed to serialize FailedConnectionEvent JSON");
+        return;
+    }
+
+    wifi_bus_desc_t *desc = get_bus_descriptor();
+    if (desc == nullptr) {
+        em_printfout("Bus descriptor is null");
+        free(str);
+        return;
+    }
+
+    raw_data_t raw;
+    memset(&raw, 0, sizeof(raw));
+    raw.data_type = bus_data_type_string;
+    raw.raw_data.bytes = reinterpret_cast<unsigned char *>(str);
+    raw.raw_data_len = static_cast<unsigned int>(strlen(str));
+
+    if (desc->bus_event_publish_fn(m_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_FAILED_CONNECTION, &raw) == 0) {
+        em_printfout("FailedConnectionEvent published: bssid=%s sta=%s status=%u reason=%u",
+            bssid_str, sta_str, status_code, reason_code);
+    } else {
+        em_printfout("FailedConnectionEvent publish failed");
+    }
+
+    free(str);
+}
+
 
 void em_ctrl_t::handle_dirty_dm()
 {
@@ -1177,6 +1305,9 @@ void em_ctrl_t::start_complete()
             { NULL, tr_181_t::policy_config , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
             { bus_data_type_string, false, 0, 0, 0, NULL } },
          { const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_LINKSTATS_ALARM), bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
+            { bus_data_type_string, false, 0, 0, 0, NULL } },
+        { const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_FAILED_CONNECTION), bus_element_type_event,
             { NULL, NULL , NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
             { bus_data_type_string, false, 0, 0, 0, NULL } },
         { const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD), bus_element_type_method,

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -574,7 +574,7 @@ void em_configuration_t::handle_failed_connection_event(const mac_address_t sta,
         return;
     }
 
-    final_reason_code = 1;
+    final_reason_code = 0;
     if ((status_code == 0) && reason_code_present && (reason_code != 0)) {
         final_reason_code = reason_code;
     }
@@ -5917,12 +5917,6 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
             }
             break;
 
-        case em_msg_type_failed_conn:
-            if (get_service_type() == em_service_type_ctrl) {
-                em_printfout("Received failed connection message from agent src_al_mac:%s", util::mac_to_string(src_al_mac).c_str());
-            }
-            break;
-        
         case em_msg_type_ap_mld_config_req:
             if ((get_service_type() == em_service_type_agent)) {
                 handle_ap_mld_config_req(data, len);

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -299,7 +299,6 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_topo_resp:
         case em_msg_type_topo_query:
         case em_msg_type_topo_notif:
-        case em_msg_type_failed_conn:
         case em_msg_type_ap_mld_config_req:
         case em_msg_type_ap_mld_config_resp:
         case em_msg_type_bss_config_req:
@@ -354,6 +353,11 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
             em_printfout("  proto_process, type rcvd: %d\n", htons(cmdu->type));
             em_steering_t::process_msg(data, len);
             break;
+
+        case em_msg_type_failed_conn:
+            em_metrics_t::process_msg(data, len);
+            break;
+
         case em_msg_type_1905_ack:
             if (m_sm.get_state() == em_state_ctrl_ap_mld_configured) {
                 em_configuration_t::process_msg(data, len);

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -1097,6 +1097,7 @@ int em_metrics_t::send_link_quality_report()
     return static_cast<int> (len);
 }
 
+
 int em_metrics_t::send_ap_metrics_response()
 {
     unsigned char buff[MAX_EM_BUFF_SZ] = {0};
@@ -2425,6 +2426,10 @@ void em_metrics_t::process_msg(unsigned char *data, unsigned int len)
             break;
         case em_msg_type_1905_ack:
             handle_1905_ack(data, len);
+            break;
+
+        case em_msg_type_failed_conn:
+            get_mgr()->handle_failed_conn_msg(data, len);
             break;
 
         default:


### PR DESCRIPTION
 Implement the full end-to-end flow for the Multi-AP Failed Connection
 message (em_msg_type_failed_conn):

  - Agent subscribes to Device.WiFi.EM.FailedConnection bus events, parses JSON payload (bssid, sta_mac, status, reason) and submits an em_cmd_failed_conn_t for orchestration
  - New em_metrics_t::send_failed_conn_msg() builds and sends the 1905 CMDU with BSSID, STA MAC, Status Code and optional Reason Code TLVs to the controller
  - Controller handle_failed_conn_msg() validates, parses TLVs and publishes the result as a JSON event on Device.WiFi.DataElements.FailedConnectionEvent.FailedConnection!
  - Adds em_cmd_type_failed_conn, em_bus_event_type_failed_conn, dm_orch_type_failed_conn and em_state_agent_failed_conn_pending throughout the state machine and orchestration layer

Issue: RDKBWIFI-459