### PR TITLE
RDKBWIFI-497 : TR181 ChannelSelectionRequest : Controller should accept the commands with index 1 or more.

### DIFF
--- a/docs/TR181-ChannelSelectionRequest-usage-and-testing.md
+++ b/docs/TR181-ChannelSelectionRequest-usage-and-testing.md
@@ -1,0 +1,192 @@
+# TR-181 ChannelSelectionRequest usage and testing
+
+## Summary
+
+The TR-181 ChannelSelectionRequest handling in the EasyMesh control path was tightened to validate incoming requests more strictly before they are forwarded to the EM control document.
+
+This update covers:
+
+- parsing of Class.N and Channel.M entries using 1-based indexing
+- validation of OpClass values for the target radio
+- validation that requested channels belong to the requested OpClass
+- validation that the OpClass band matches the radio band
+- validation of preference values and incomplete channel entries
+
+## Method format
+
+The request method name is expected to follow this pattern:
+
+```text
+Device.WiFi.DataElements.Network.Device.<device>.Radio.<radio>.ChannelSelectionRequest()
+```
+
+The payload uses nested Class.N and Channel.M objects, for example:
+
+```text
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()"
+  Class.1.OpClass uint32 81
+  Class.1.Channel.1.Channel uint32 1
+  Class.1.Channel.1.Preference uint32 14
+```
+
+### Validation rules
+
+The implementation now rejects requests when:
+
+- Class indices are not valid positive integers starting at 1, or are not contiguous from 1
+- Channel indices are not valid positive integers starting at 1, or are not contiguous from 1 within each Class.N
+- OpClass is missing or invalid for the selected radio
+- OpClass band does not match the radio band
+- Requested channels are not valid for the selected OpClass
+- Preference values are invalid for the implementation range
+- A preference is supplied without a matching channel entry
+- An incomplete or malformed class payload is provided
+
+## Representative positive and negative cases
+
+### 2.4 GHz (Radio.1) - Positive
+
+```text
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 6 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 11 Class.1.Channel.3.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 82 Class.1.Channel.1.Channel uint32 14 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 83 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 5 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 9 Class.1.Channel.3.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 84 Class.1.Channel.1.Channel uint32 5 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 9 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 13 Class.1.Channel.3.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 83 Class.2.Channel.1.Channel uint32 5 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 84 Class.3.Channel.1.Channel uint32 9 Class.3.Channel.1.Preference uint32 14
+```
+
+### 2.4 GHz (Radio.1) - Negative
+
+```text
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 14 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 82 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 83 Class.1.Channel.1.Channel uint32 13 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 100 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 6 Class.1.Channel.1.Preference uint32 255
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 6 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 6 Class.1.Channel.2.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 6
+```
+
+### 5 GHz (Radio.2) - Positive
+
+```text
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 40 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 44 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel uint32 48 Class.1.Channel.4.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 116 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 44 Class.1.Channel.2.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 118 Class.1.Channel.1.Channel uint32 52 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 56 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 60 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel uint32 64 Class.1.Channel.4.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 121 Class.1.Channel.1.Channel uint32 100 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 104 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 108 Class.1.Channel.3.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 124 Class.1.Channel.1.Channel uint32 149 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 153 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 157 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel uint32 161 Class.1.Channel.4.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 128 Class.1.Channel.1.Channel uint32 42 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 58 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 106 Class.1.Channel.3.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 129 Class.1.Channel.1.Channel uint32 50 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 114 Class.1.Channel.2.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 118 Class.2.Channel.1.Channel uint32 52 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 121 Class.3.Channel.1.Channel uint32 100 Class.3.Channel.1.Preference uint32 14 Class.4.OpClass uint32 124 Class.4.Channel.1.Channel uint32 149 Class.4.Channel.1.Preference uint32 14
+```
+
+### 5 GHz (Radio.2) - Negative
+
+```text
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 149 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 116 Class.1.Channel.1.Channel uint32 40 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 128 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 129 Class.1.Channel.1.Channel uint32 100 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 500 Class.1.Channel.1.Preference uint32 14
+```
+
+### 6 GHz (Radio.3) - Positive
+
+```text
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 5 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 9 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel uint32 13 Class.1.Channel.4.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 132 Class.1.Channel.1.Channel uint32 3 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 11 Class.1.Channel.2.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 133 Class.1.Channel.1.Channel uint32 7 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 23 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 39 Class.1.Channel.3.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 134 Class.1.Channel.1.Channel uint32 15 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 47 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 79 Class.1.Channel.3.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 132 Class.2.Channel.1.Channel uint32 3 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 133 Class.3.Channel.1.Channel uint32 7 Class.3.Channel.1.Preference uint32 14 Class.4.OpClass uint32 134 Class.4.Channel.1.Channel uint32 15 Class.4.Channel.1.Preference uint32 14
+```
+
+### 6 GHz (Radio.3) - Negative
+
+```text
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 250 Class.1.Channel.1.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 255
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 1 Class.1.Channel.2.Preference uint32 14
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1
+
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 999 Class.1.Channel.2.Preference uint32 14
+```
+
+## Testing done
+The test suite exercises:
+
+- valid 2.4 GHz requests
+- valid 5 GHz requests
+- valid 6 GHz requests
+- invalid OpClass values
+- invalid channel values
+- invalid preference values
+- malformed class/channel structure
+- missing channel or missing OpClass entries
+
+### Expected behavior
+
+- Valid requests are accepted and converted into the EM control subdocument / JSON payload.
+- Invalid requests return an input error instead of being processed.
+- Logging clearly identifies whether the failure is due to invalid OpClass, channel membership, band mismatch, or malformed structure.
+
+## Notes for usage
+
+When sending new requests:
+
+1. Use radio-specific OpClass values that match the target band.
+2. Keep channel values within the allowed set for the selected OpClass.
+3. Start Class and Channel indexes at 1.
+4. Include a matching channel entry whenever a preference is provided.
+5. Prefer a single Class entry per request for simple channel lists; multiple classes can be used when requesting multiple independent channel sets.
+6. To determine which physical radio an index refers to, query the corresponding radio identifier using:
+
+```text
+get Device.WiFi.DataElements.Network.Device.2.Radio.1.ID
+```
+
+Use the returned ID value together with the radio index in the request path so the channel selection is applied to the intended radio.

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -34,6 +34,9 @@
 #include <fcntl.h>
 #include <string.h>
 #include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+#include <vector>
 #include "dm_easy_mesh_ctrl.h"
 #include "dm_easy_mesh.h"
 #include "em_ctrl.h"
@@ -971,76 +974,121 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
     em_device_info_t *di = dm->get_device()->get_device_info();
     em_radio_info_t *ri = radio->get_radio_info();
 
-    // Data structures used to collect nested Class.N.* channel preference input
+    // Data structures used to collect nested Class.N.* channel preference input.
+    // The instance number is represented by the array slot itself, so the
+    // incoming values must be contiguous and start at 1.
+    // Each channel entry stores the parsed channel number and preference value.
     struct channel_info {
-        bool have_channel;
-        bool have_pref;
         int channel;
         int preference;
     };
 
+    // Track one parsed Class.N instance and all of its Channel.M children.
     struct class_info {
-        int instance_index;
-        bool have_op_class;
         int op_class;
-        int max_channel_index;
+        int num_channels;
+        int highest_channel_instance;
         channel_info channels[MAX_CHANSEL_CHANNELS];
     };
 
+    // Store parsed classes in slot-based arrays keyed by their 1-based instance number.
     class_info classes[MAX_CHANSEL_CLASSES];
-    int num_classes = 0;
+    int highest_class_instance = 0;
 
-    // Initialize or reset a class_info slot
+    // Reset a class slot so it can be reused for a newly parsed instance.
     auto clear_class = [&](class_info &cls) {
-        cls.instance_index = -1;
-        cls.have_op_class = false;
         cls.op_class = -1;
-        cls.max_channel_index = -1;
+        cls.num_channels = 0;
+        cls.highest_channel_instance = 0;
         for (int i = 0; i < MAX_CHANSEL_CHANNELS; i++) {
-            cls.channels[i].have_channel = false;
-            cls.channels[i].have_pref = false;
             cls.channels[i].channel = -1;
             cls.channels[i].preference = -1;
         }
     };
 
-    // Find an existing class_info by instance index, or allocate a new one
+    // Initialize every slot so the emptiness checks are always well-defined.
+    for (int i = 0; i < MAX_CHANSEL_CLASSES; i++) {
+        clear_class(classes[i]);
+    }
+
+    // Locate the storage slot for a given Class.N instance, creating it when needed.
     auto find_or_create_class_by_instance = [&](int instance_index) -> class_info* {
-        for (int i = 0; i < num_classes; i++) {
-            if (classes[i].instance_index == instance_index) {
-                return &classes[i];
-            }
-        }
-        if (num_classes >= MAX_CHANSEL_CLASSES) {
+        if (instance_index < 1 || instance_index > MAX_CHANSEL_CLASSES) {
             return NULL;
         }
-        clear_class(classes[num_classes]);
-        classes[num_classes].instance_index = instance_index;
-        classes[num_classes].have_op_class = false;
-        classes[num_classes].max_channel_index = -1;
-        num_classes++;
-        return &classes[num_classes - 1];
+
+        int slot = instance_index - 1;
+        if (classes[slot].op_class == -1 && classes[slot].num_channels == 0 && classes[slot].highest_channel_instance == 0) {
+            clear_class(classes[slot]);
+            if (instance_index > highest_class_instance) {
+                highest_class_instance = instance_index;
+            }
+        }
+        return &classes[slot];
     };
 
-    // Parse incoming TR-181 parameters and populate class/channel structures
+    // Locate the storage slot for a given Channel.M entry inside a class instance.
+    auto find_or_create_channel_slot = [&](class_info *cls, int channel_instance) -> int {
+        if (channel_instance < 1 || channel_instance > MAX_CHANSEL_CHANNELS) {
+            return -1;
+        }
+
+        int slot = channel_instance - 1;
+        bool slot_is_empty = (cls->channels[slot].channel == -1 && cls->channels[slot].preference == -1);
+        if (cls->num_channels == 0 || slot_is_empty) {
+            cls->num_channels++;
+            if (channel_instance > cls->highest_channel_instance) {
+                cls->highest_channel_instance = channel_instance;
+            }
+            cls->channels[slot].channel = -1;
+            cls->channels[slot].preference = -1;
+        }
+        return slot;
+    };
+
+    // Parse incoming TR-181 parameters and populate the temporary class/channel structures.
+    // Maximum number of tokens in a TR-181 parameter
+    static const int TR181_MAX_TOKENS = 6;
+    // Token indexes for Class.N.Channel.M.* "Class" string and "N" index
+    static const int TR181_CLASS_STR_TOKEN = 0;
+    static const int TR181_CLASS_INDEX_TOKEN = 1;
+
+    // Token indexes for Class.N.Channel.M.* "Channel" string and "M" index
+    static const int TR181_PARAM_TOKEN = 2;
+    static const int TR181_CHANNEL_INSTANCE_TOKEN = 3;
+
+    // Token index for Class.N.Channel.M.* "Channel" or "Preference" string
+    static const int TR181_CHANNEL_ATTR_TOKEN = 4;
+
+    // Number of tokens in Class.N.* parameters and Class.N.Channel.M.* parameters
+    static const int TR181_NUM_OF_TOKENS_IN_CLASS = 3;
+    static const int TR181_NUM_OF_TOKENS_IN_CHANNEL = 5;
+
+    // TR-181 strings used in parsing
+    static const char TR181_CLASS_STR[] = "Class";
+    static const char TR181_OPCLASS_STR[] = "OpClass";
+    static const char TR181_CHANNEL_STR[] = "Channel";
+    static const char TR181_PREFERENCE_STR[] = "Preference";
+
     for (prop = input_params; prop; prop = prop->next_data) {
         char prop_name[BUS_MAX_NAME_LENGTH];
         snprintf(prop_name, sizeof(prop_name), "%s", prop->name);
 
-        char *tokens[6] = { NULL };
+        char *tokens[TR181_MAX_TOKENS] = { NULL };
         char *saveptr = NULL;
         int token_count = 0;
         char *tok = strtok_r(prop_name, ".", &saveptr);
-        while (tok != NULL && token_count < 6) {
+        while (tok != NULL && token_count < TR181_MAX_TOKENS) {
             tokens[token_count++] = tok;
             tok = strtok_r(NULL, ".", &saveptr);
         }
 
         // Only nested Class.N.* properties are valid for ChannelSelectionRequest()
-        if (token_count >= 2 && strcmp(tokens[0], "Class") == 0) {
+        if (token_count >= 2 && strcmp(tokens[TR181_CLASS_STR_TOKEN], TR181_CLASS_STR) == 0) {
             char *end = NULL;
-            long class_index_l = strtol(tokens[1], &end, 10);
-            if (end == tokens[1] || *end != '\0' || class_index_l < 0 || class_index_l >= MAX_CHANSEL_CLASSES) {
+            errno = 0;
+            long class_index_l = strtol(tokens[TR181_CLASS_INDEX_TOKEN], &end, 10);
+            if (end == tokens[TR181_CLASS_INDEX_TOKEN] || *end != '\0' || errno == ERANGE || class_index_l < 1 || class_index_l > INT_MAX) {
                 em_printfout("Invalid class index in '%s'", prop->name);
                 rc = bus_error_invalid_input;
                 goto finish;
@@ -1053,38 +1101,44 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
                 goto finish;
             }
 
-            if (token_count == 3 && strcmp(tokens[2], "OpClass") == 0) {
+            if (token_count == TR181_NUM_OF_TOKENS_IN_CLASS && strcmp(tokens[TR181_PARAM_TOKEN], TR181_OPCLASS_STR) == 0) {
                 // Parse Class.N.OpClass
                 if (!tr_181_t::tr181_get_prop_int(prop, &cls->op_class)) {
                     rc = bus_error_invalid_input;
                     goto finish;
                 }
-                cls->have_op_class = true;
-            } else if (token_count == 5 && strcmp(tokens[2], "Channel") == 0) {
+            } else if (token_count == TR181_NUM_OF_TOKENS_IN_CHANNEL && strcmp(tokens[TR181_PARAM_TOKEN], TR181_CHANNEL_STR) == 0) {
                 // Parse Class.N.Channel.M.Channel or Class.N.Channel.M.Preference
                 char *end = NULL;
-                long channel_idx_l = strtol(tokens[3], &end, 10);
-                if (end == tokens[3] || *end != '\0' || channel_idx_l < 0 || channel_idx_l >= MAX_CHANSEL_CHANNELS) {
+                errno = 0;
+                long channel_instance_l = strtol(tokens[TR181_CHANNEL_INSTANCE_TOKEN], &end, 10);
+                if (end == tokens[TR181_CHANNEL_INSTANCE_TOKEN] || *end != '\0' || errno == ERANGE || channel_instance_l < 1 || channel_instance_l > INT_MAX) {
                     em_printfout("Invalid channel index in '%s'", prop->name);
                     rc = bus_error_invalid_input;
                     goto finish;
                 }
-                int channel_idx = static_cast<int>(channel_idx_l);
-                if (strcmp(tokens[4], "Channel") == 0) {
-                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_idx].channel)) {
+                int channel_instance = static_cast<int>(channel_instance_l);
+                int channel_slot = find_or_create_channel_slot(cls, channel_instance);
+                if (channel_slot < 0) {
+                    em_printfout("Too many Channel entries in '%s'", prop->name);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+                if (strcmp(tokens[TR181_CHANNEL_ATTR_TOKEN], TR181_CHANNEL_STR) == 0) {
+                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_slot].channel)) {
                         rc = bus_error_invalid_input;
                         goto finish;
                     }
-                    cls->channels[channel_idx].have_channel = true;
-                    if (channel_idx > cls->max_channel_index) {
-                        cls->max_channel_index = channel_idx;
-                    }
-                } else if (strcmp(tokens[4], "Preference") == 0) {
-                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_idx].preference)) {
+                } else if (strcmp(tokens[TR181_CHANNEL_ATTR_TOKEN], TR181_PREFERENCE_STR) == 0) {
+                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_slot].preference)) {
                         rc = bus_error_invalid_input;
                         goto finish;
                     }
-                    cls->channels[channel_idx].have_pref = true;
+                    if (cls->channels[channel_slot].preference < 0 || cls->channels[channel_slot].preference >= EM_CH_PREF_MAX) {
+                        em_printfout("Invalid preference value in '%s'", prop->name);
+                        rc = bus_error_invalid_input;
+                        goto finish;
+                    }
                 } else {
                     em_printfout("Invalid parameter: %s", prop->name);
                     rc = bus_error_invalid_input;
@@ -1102,8 +1156,8 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
         }
     }
 
-    // Fail if there were no nested class definitions in the request
-    if (num_classes == 0) {
+    // Fail fast if the request does not contain any class instances at all.
+    if (highest_class_instance == 0) {
         em_printfout("Mandatory parameters missing: expected nested Class.N.* entries");
         if (output_params) {
             *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
@@ -1111,7 +1165,103 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
         return bus_error_invalid_input;
     }
 
-    // Build the EM control subdocument and JSON payload for ChannelSelectionRequest
+    // Validate that all requested class instances have an OpClass and at least one channel entry.
+    for (int class_index = 1; class_index <= highest_class_instance; class_index++) {
+        if (classes[class_index - 1].op_class == -1 && classes[class_index - 1].num_channels == 0 && classes[class_index - 1].highest_channel_instance == 0) {
+            em_printfout("Missing Class.%d instance", class_index);
+            rc = bus_error_invalid_input;
+            goto finish;
+        }
+    }
+
+    // Validate each parsed class entry against the radio band and operating-class rules.
+    for (int class_index = 1; class_index <= highest_class_instance; class_index++) {
+        class_info &cls = classes[class_index - 1];
+        if (cls.op_class == -1) {
+            em_printfout("Missing OpClass for Class.%d", class_index);
+            rc = bus_error_invalid_input;
+            goto finish;
+        }
+        if (cls.op_class < 1) {
+            em_printfout("Invalid OpClass %d for Class.%d", cls.op_class, class_index);
+            rc = bus_error_invalid_input;
+            goto finish;
+        }
+        
+        // Validate that every requested channel entry has both values populated.
+        for (int channel_index = 1; channel_index <= cls.highest_channel_instance; channel_index++) {
+            int channel_slot = channel_index - 1;
+            if (cls.channels[channel_slot].channel == -1 && cls.channels[channel_slot].preference == -1) {
+                em_printfout("Missing Channel.%d instance for Class.%d", channel_index, class_index);
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+        }
+
+        std::vector<int> valid_channels = dm_easy_mesh_t::get_channel_list_by_op_class(cls.op_class);
+        if (valid_channels.empty()) {
+            em_printfout("Unknown OpClass %d for Class.%d", cls.op_class, class_index);
+            rc = bus_error_invalid_input;
+            goto finish;
+        }
+
+        em_freq_band_t opclass_band = dm_easy_mesh_t::get_freq_band_by_op_class(cls.op_class);
+        if (opclass_band == em_freq_band_unknown) {
+            em_printfout("Unknown band for OpClass %d in Class.%d", cls.op_class, class_index);
+            rc = bus_error_invalid_input;
+            goto finish;
+        }
+        if (opclass_band != ri->band) {
+            em_printfout("OpClass %d in Class.%d does not match radio band %d", cls.op_class, class_index, ri->band);
+            rc = bus_error_invalid_input;
+            goto finish;
+        }
+
+        for (int channel_index = 1; channel_index <= cls.highest_channel_instance; channel_index++) {
+            int channel_slot = channel_index - 1;
+            if (cls.channels[channel_slot].channel == -1) {
+                if (cls.channels[channel_slot].preference != -1) {
+                    em_printfout("Missing Channel for Class.%d.Channel.%d", class_index, channel_index);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+                continue;
+            }
+            if (cls.channels[channel_slot].channel < 1) {
+                em_printfout("Invalid channel value %d in Class.%d.Channel.%d",
+                              cls.channels[channel_slot].channel, class_index, channel_index);
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+
+            // Reject duplicate channel values within the same Class
+            for (int prev = 0; prev < channel_slot; prev++) {
+                if (cls.channels[channel_slot].channel != -1 &&
+                    cls.channels[prev].channel == cls.channels[channel_slot].channel) {
+                    em_printfout("Duplicate Channel %d in Class.%d",
+                                   cls.channels[channel_slot].channel, class_index);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+            }
+
+            bool channel_matches_opclass = false;
+            for (int valid_channel : valid_channels) {
+                if (valid_channel == cls.channels[channel_slot].channel) {
+                    channel_matches_opclass = true;
+                    break;
+                }
+            }
+            if (!channel_matches_opclass) {
+                em_printfout("Channel %d not allowed for OpClass %d in Class.%d",
+                              cls.channels[channel_slot].channel, cls.op_class, class_index);
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+        }
+    }
+
+    // Build the EM control subdocument and JSON payload for ChannelSelectionRequest.
     subdoc = reinterpret_cast<em_subdoc_info_t *>(buff);
     memset(subdoc, 0, sizeof(em_subdoc_info_t));
     strncpy(subdoc->name, "ChannelSelectionRequest", sizeof(subdoc->name) - 1);
@@ -1130,7 +1280,7 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
         goto finish;
     }
 
-    // Create the Network/Device/Radio container structure for the payload
+    // Create the Network/Device/Radio container structure used by the EM payload.
     net_obj = cJSON_AddObjectToObject(json, "Network");
     if (!net_obj) {
         em_printfout("Add Network failed");
@@ -1195,7 +1345,7 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
         goto finish;
     }
 
-    // Add the radio-level ChannelSelectionRequest array
+    // Add the radio-level ChannelSelectionRequest array that will carry the parsed classes.
     class_arr = cJSON_AddArrayToObject(radio_obj, "ChannelSelectionRequest");
     if (!class_arr) {
         em_printfout("Add ChannelSelectionRequest failed");
@@ -1203,11 +1353,11 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
         goto finish;
     }
 
-    if (num_classes > 0) {
-        // Convert each parsed class entry into JSON with ChannelList and ChannelPrefList
-        for (int i = 0; i < num_classes; i++) {
-            class_info &cls = classes[i];
-            if (!cls.have_op_class || cls.max_channel_index < 0) {
+    if (highest_class_instance > 0) {
+        // Convert each validated class entry into JSON with ChannelList and ChannelPrefList.
+        for (int class_index = 1; class_index <= highest_class_instance; class_index++) {
+            class_info &cls = classes[class_index - 1];
+            if (cls.op_class == -1 || cls.num_channels == 0) {
                 em_printfout("Incomplete class entry");
                 rc = bus_error_invalid_input;
                 goto finish;
@@ -1239,22 +1389,20 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
                 goto finish;
             }
 
-            for (int idx = 0; idx <= cls.max_channel_index; idx++) {
-                if (!cls.channels[idx].have_channel) {
-                    continue;
-                }
-                if (!cls.channels[idx].have_pref) {
-                    em_printfout("Missing Preference for channel index %d", idx);
+            for (int channel_index = 1; channel_index <= cls.highest_channel_instance; channel_index++) {
+                int channel_slot = channel_index - 1;
+                if (cls.channels[channel_slot].channel == -1 || cls.channels[channel_slot].preference == -1) {
+                    em_printfout("Missing Channel or Preference for channel instance %d", channel_index);
                     rc = bus_error_invalid_input;
                     goto finish;
                 }
-                cJSON_AddItemToArray(channel_list_obj, cJSON_CreateNumber(cls.channels[idx].channel));
-                cJSON_AddItemToArray(channel_pref_obj, cJSON_CreateNumber(cls.channels[idx].preference));
+                cJSON_AddItemToArray(channel_list_obj, cJSON_CreateNumber(cls.channels[channel_slot].channel));
+                cJSON_AddItemToArray(channel_pref_obj, cJSON_CreateNumber(cls.channels[channel_slot].preference));
             }
         }
     }
 
-    // Serialize the final JSON payload and send it to the EM control bus
+    // Serialize the final JSON payload and send it to the EM control bus.
     json_buff = cJSON_PrintUnformatted(root);
     if (!json_buff) {
         em_printfout("Print JSON failed");
@@ -1270,7 +1418,7 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
     }
     memcpy(subdoc->buff, json_buff, json_len);
 
-    em_printfout("Sending ChannelSelectionRequest with JSON payload len %zu:\n", json_len - 1);
+    em_printfout("Sending ChannelSelectionRequest with JSON payload len %zu:", json_len - 1);
     em_ctrl->io_process(em_bus_event_type_channel_select, subdoc->buff, json_len);
     free(json_buff);
     cJSON_Delete(root);


### PR DESCRIPTION
- Fix cmd_channelselect parsing in src/ctrl/dm_easy_mesh_ctrl.cpp so
  Class.N and Channel.M indexes should start from 1, matching TR-181
  semantics.
- Add strict validation of OpClass, channel membership, and preference values
  based on dm_easy_mesh_t::m_e4_table.
- Enforce that requested OpClass values are valid for the target radio and
  that requested channels belong to that OpClass.
- Validate the radio path against the radio number in the request.
- Ensure OpClass band consistency by checking the OpClass frequency band
  against the radio's configured band.
- Added unit test cases for updated code