### PR TITLE
Read EasyMesh peer profile from AL node during message handling from agent

### DIFF
--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -1203,6 +1203,31 @@ class em_configuration_t {
 	 * @note This function does not take any parameters and returns a pointer to the manager.
 	 */
 	virtual em_mgr_t *get_mgr() = 0;
+
+	/**!
+	 * @brief Retrieves the peer profile from the AL-node EM instance.
+	 *
+	 * The AL-node EM instance is treated as the source of truth for
+	 * the peer profile during message handling when available.
+	 *
+	 * @returns The AL-node cached peer profile if set; otherwise the local cached profile
+	 * (treating em_profile_type_reserved as em_profile_type_1).
+	 */
+	em_profile_type_t get_peer_profile_from_al_em();
+
+	/**!
+	 * @brief Retrieves the cached peer profile for this EM instance.
+	 *
+	 * @returns The cached peer profile.
+	 */
+	em_profile_type_t get_peer_profile() const { return m_peer_profile; }
+
+	/**!
+	 * @brief Updates the cached peer profile for this EM instance.
+	 *
+	 * @param[in] profile The peer profile to cache.
+	 */
+	void set_peer_profile(em_profile_type_t profile) { m_peer_profile = profile; }
     
 	/**!
 	 * @brief Retrieves the EC Manager instance.

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2017,10 +2017,10 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
 
 	dm = get_data_model();
-	em_printfout("Topology Notification received, length: %d", len);
+	em_printfout("Topology Notification received, length: %u", len);
 
-	if (em_msg_t(em_msg_type_topo_notif, m_peer_profile, buff, len).validate(errors) == 0) {
-        printf("%s:%d: topology response msg validation failed\n", __func__, __LINE__);
+	if (em_msg_t(em_msg_type_topo_notif, get_peer_profile_from_al_em(), buff, len).validate(errors) == 0) {
+        em_printfout("Topology notification msg validation failed");
             
         //return -1;
     }       
@@ -2040,7 +2040,7 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
     }
 
 	if (found_dev_mac == false) {
-		printf("%s:%d: Could not find device al mac address\n", __func__, __LINE__);
+		em_printfout("Could not find device al mac address");
 		return -1;
 	}
 
@@ -2155,6 +2155,25 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
 	return 0;
 }
 
+em_profile_type_t em_configuration_t::get_peer_profile_from_al_em()
+{
+    // Use the locally cached profile as a safe fallback for validation.
+    em_profile_type_t fallback = (m_peer_profile == em_profile_type_reserved) ? em_profile_type_1 : m_peer_profile;
+
+    em_mgr_t *mgr = get_mgr();
+    if (mgr == nullptr) {
+        return fallback;
+    }
+
+    em_t *al_em = mgr->get_al_node();
+    if (al_em == nullptr) {
+        return fallback;
+    }
+
+    em_profile_type_t al_profile = al_em->get_peer_profile();
+    return (al_profile == em_profile_type_reserved) ? fallback : al_profile;
+}
+
 int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned int len)
 {
     em_tlv_t *tlv;
@@ -2168,10 +2187,14 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
     unsigned int assoc_sta_mld_count = 0;
     em_profile_type_t profile = em_profile_type_reserved;
 	dm_easy_mesh_t *dm;
+    em_t *al_em = nullptr;
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
     uint8_t *src_al_mac = hdr->src;
     
 	dm = get_data_model();
+    if (em_mgr_t *mgr = get_mgr()) {
+        al_em = mgr->get_al_node();
+    }
 
     tlv =  reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tmp_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
@@ -2184,21 +2207,34 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
             continue;
 
         } else {
-            found_profile = true;
-			memcpy(&profile, tlv->value, ntohs(tlv->len));
-            break; 
+            // Validation of length before assigning profile to avoid potential buffer overflows or invalid data.
+            uint16_t tlv_len = ntohs(tlv->len);
+            if (tlv_len == sizeof(uint8_t)) {
+                found_profile = true;
+                profile = static_cast<em_profile_type_t>(tlv->value[0]);
+            } else {
+                em_printfout("Invalid Profile TLV length %u in topology response", static_cast<unsigned int>(tlv_len));
+            }
+            break;
         }
     }
 
     // For backward compatibility with earlier EasyMesh specifications.
-    if (found_profile == true) {
+    if (found_profile == true && profile != em_profile_type_reserved) {
         m_peer_profile = profile;
+        em_printfout("Topology response received from %s with profile: %d", util::mac_to_string(src_al_mac).c_str(), m_peer_profile);
     } else {
-        // MultiAP profile TLV is mandatory for profile >= em_profile_type_2
+        // MultiAP profile TLV is mandatory for profile >= em_profile_type_2.
+        // FALL back to profile 1 for backward compatibility with earlier EasyMesh specifications.
         m_peer_profile = em_profile_type_1;
+        em_printfout("Topology response received from %s with no profile TLV, assuming profile: %d", util::mac_to_string(src_al_mac).c_str(), m_peer_profile);
+    }
+    // Update the peer profile in the AL node
+    if (al_em != nullptr) {
+        al_em->set_peer_profile(m_peer_profile);
     }
     if (em_msg_t(em_msg_type_topo_resp, m_peer_profile, buff, len).validate(errors) == 0) {
-        printf("%s:%d: topology response msg validation failed\n", __func__, __LINE__);
+        em_printfout("topology response msg validation failed");
             
         //return -1;
     }       
@@ -2232,7 +2268,7 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
     }
 
     if (found_op_bss == false) {
-        printf("%s:%d: Could not find operational bss, failing mesaage\n", __func__, __LINE__);
+        em_printfout("Could not find operational bss, failing message");
         return -1;
     }
 
@@ -2240,10 +2276,10 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
         int rc = handle_ap_operational_bss(tlv->value, tlv->len);
         if (rc != 0) {
             if (rc == -2) {
-                em_printfout("%s:%d: Failed to handle operational BSS due to SSID misconfiguration.", __func__, __LINE__);
+                em_printfout("Failed to handle operational BSS due to SSID misconfiguration.");
                 static_cast<em_t*>(this)->set_ssid_mismatch(true);
             } else {
-                em_printfout("%s:%d: Operational BSS handling failed rc=%d\n", __func__, __LINE__, rc);
+                em_printfout("Operational BSS handling failed rc=%d", rc);
             }
             return rc;
         }
@@ -2264,7 +2300,7 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
 
     if (found_bss_config_rprt) {
         if (handle_bss_configuration_report(tlv->value, tlv->len) != 0) {
-            printf("%s:%d: BSS Configuration Report handling failed\n", __func__, __LINE__);
+            em_printfout("BSS Configuration Report handling failed");
             return -1;
         }
     } else {
@@ -4345,9 +4381,8 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
     dm_network_t network;
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *> (buff);
 
-    if (em_msg_t(em_msg_type_autoconf_wsc, m_peer_profile, buff, len).validate(errors) == 0) {
-        printf("%s:%d: received wsc m2 msg failed validation\n", __func__, __LINE__);
-
+    if (em_msg_t(em_msg_type_autoconf_wsc, get_peer_profile_from_al_em(), buff, len).validate(errors) == 0) {
+        em_printfout("Received wsc m2 msg failed validation");
         return -1;
     }
    
@@ -4366,19 +4401,19 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
 
             // first compute keys
             if (compute_keys(get_r_public(), static_cast<short unsigned int> (get_r_public_len()), get_e_private(), static_cast<short unsigned int> (get_e_private_len())) != 1) {
-                printf("%s:%d: Keys computation failed\n", __func__, __LINE__);
+                em_printfout("Keys computation failed");
                 return -1;
             }
 
             if (create_authenticator(hash) == -1) {
-                printf("%s:%d: Authenticator create failed\n", __func__, __LINE__);
+                em_printfout("Authenticator create failed");
                 return -1;
             } else {
-                printf("%s:%d: Authenticator verification succeeded\n", __func__, __LINE__);
+                em_printfout("Authenticator verification succeeded");
             }
 
             if (memcmp(m_m2_authenticator[wsc_tlv_count], hash, AUTHENTICATOR_LEN) != 0) {
-                printf("%s:%d: Authenticator validation failed\n", __func__, __LINE__);
+                em_printfout("Authenticator validation failed");
                 //return -1;
             }
             wsc_tlv_count++;
@@ -5554,17 +5589,15 @@ int em_configuration_t::handle_autoconfig_wsc_m1(unsigned char *buff, unsigned i
     unsigned char msg[MAX_EM_BUFF_SZ*em_haul_type_max] = {0};
     unsigned int sz = 0;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    mac_addr_str_t  mac_str;
     em_tlv_t    *tlv;
     unsigned int tlv_len;
     em_bus_event_type_m2_tx_params_t   raw;
 
-    dm_easy_mesh_t::macbytes_to_string(get_peer_mac(), mac_str);
-    printf("%s:%d: Device AL MAC: %s\n", __func__, __LINE__, mac_str);
-
-    if (em_msg_t(em_msg_type_autoconf_wsc, m_peer_profile, buff, len).validate(errors) == 0) {
-        printf("%s:%d: received autoconfig wsc m1 msg failed validation\n", __func__, __LINE__);
-
+    const em_profile_type_t peer_profile = get_peer_profile_from_al_em();
+    em_printfout("Received autoconfig wsc m1 msg len:%u AL MAC: %s radio id %s peer profile %d", len,
+        util::mac_to_string(get_peer_mac()).c_str(), util::mac_to_string(get_radio_interface_mac()).c_str(), peer_profile);
+    if (em_msg_t(em_msg_type_autoconf_wsc, peer_profile, buff, len).validate(errors) == 0) {
+        em_printfout("Received autoconfig wsc m1 msg failed validation");
         return -1;
     }
 
@@ -5593,23 +5626,23 @@ int em_configuration_t::handle_autoconfig_wsc_m1(unsigned char *buff, unsigned i
     sz = static_cast<unsigned int> (ret);
 
     if (em_msg_t(em_msg_type_autoconf_wsc, em_profile_type_3, msg, sz).validate(errors) == 0) {
-        printf("Autoconfig wsc m2 msg failed validation in tnx end\n");
+        em_printfout("Autoconfig wsc m2 msg failed validation in tx end");
 
         return -1;
     }
 
     if (send_frame(msg, sz)  < 0) {
-        printf("%s:%d: autoconfig wsc m2 send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("autoconfig wsc m2 send failed, error:%d", errno);
         return -1;
     }
 
-    em_printfout("%s:%d: Removing previous em_config command for radio " MACSTRFMT "\n", __func__, __LINE__, MAC2STR(get_radio_interface_mac()));
+    em_printfout("Removing previous em_config command for radio " MACSTRFMT, MAC2STR(get_radio_interface_mac()));
     if (em_orch_t *orch = get_mgr()->get_orch()) {
 	 orch->remove_em_config_cmd_for_em(get_radio_interface_mac());
     }
 
 	set_state(em_state_ctrl_wsc_m2_sent);
-	printf("%s:%d: autoconfig wsc m2 send, len:%d\n", __func__, __LINE__, sz);
+	em_printfout("autoconfig wsc m2 send, len:%u", sz);
     memcpy(raw.al, const_cast<unsigned char *> (get_peer_mac()), sizeof(mac_address_t));
     memcpy(raw.radio, get_radio_interface_mac(), sizeof(mac_address_t));
 
@@ -5693,21 +5726,22 @@ int em_configuration_t::handle_autoconfig_search(unsigned char *buff, unsigned i
 
     if (em_msg_t(buff + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
                len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_profile_type(&m_peer_profile) == false) { 
-        printf("%s:%d: Could not get peer profile type\n", __func__, __LINE__);
+        em_printfout("Could not get peer profile type, fallback to profile type 1");
         m_peer_profile = em_profile_type_1;
     }
+    em_printfout("Received autoconfig search with profile type %d", m_peer_profile);
     if (em_msg_t(em_msg_type_autoconf_search, m_peer_profile, buff, len).validate(errors) == 0) {
-        em_printfout("received autoconfig search msg failed validation\n");
+        em_printfout("received autoconfig search msg failed validation");
         return -1;
     }
 
     if (em_msg_t(buff + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)), len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_freq_band(&band) == false) {
-        printf("%s:%d: Could not get freq band\n", __func__, __LINE__);
+        em_printfout("Could not get freq band");
         return -1;
     }
 
     if (em_msg_t(buff + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)), len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_al_mac_address(al_mac) == false) {
-        printf("%s:%d: Could not get al mac address\n", __func__, __LINE__);
+        em_printfout("Could not get al mac address");
         return -1;
     }
 


### PR DESCRIPTION


This change updates the message handling flow to fetch the peer profile directly from the AL node, as the profile type is only updated on the AL node during autoconfig search handling. This ensures the correct profile is used even when the profile TLV is absent, and keeps the local EM state aligned with the AL nodes profile information.