### PR TITLE
RDKBWIFI-516: Handle AKM Suite Capabilities TLV to populate BSS AKMs

### DIFF
--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -1599,6 +1599,11 @@ private:
 
 public:
 
+	/* Parse a received AKM Suite Capabilities TLV and store the
+	 * advertised fronthaul/backhaul AKMs into every BSS of the data model. Wire format:
+	 * [bh_count][bh_suite*4][fh_count][fh_suite*4], each suite OUI[3] + type[1]. */
+	static void store_akm_suite_cap(dm_easy_mesh_t *dm, unsigned char *buff, unsigned int len);
+
 	bool send_autoconf_search_ext_chirp(em_dpp_chirp_value_t *chirp, size_t hash_len);
 
 	bool send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN], unsigned short msg_id);

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -6904,7 +6904,7 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_tget_params(dm_easy_mesh_t *dm, const char 
         dm_ctrl->property_append_tail(property, root, idx, "FronthaulAKMsAllowed", val_str);
         dm_ctrl->property_append_tail(property, root, idx, "FronthaulSuiteSelector", 0U);
         memset(val_str, 0, sizeof(val_str));
-        dm_ctrl->fill_comma_sep(bi->fronthaul_akm, ARRAY_SIZE(bi->backhaul_akm), val_str);
+        dm_ctrl->fill_comma_sep(bi->backhaul_akm, ARRAY_SIZE(bi->backhaul_akm), val_str);
         dm_ctrl->property_append_tail(property, root, idx, "BackhaulAKMsAllowed", val_str);
         dm_ctrl->property_append_tail(property, root, idx, "BackhaulSuiteSelector", 0U);
         dm_ctrl->property_append_tail(property, root, idx, "STANumberOfEntries", bi->numberofsta);

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -1410,6 +1410,9 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
         } else if (tlv->type == em_tlv_type_ap_radio_basic_cap){
             em_printfout("Received AP Radio Basic Capability TLV");
             handle_ap_radio_basic_cap(tlv->value, htons(tlv->len));
+        } else if (tlv->type == em_tlv_type_akm_suite){
+            em_printfout("Received AKM Suite Capabilities TLV");
+            em_configuration_t::store_akm_suite_cap(dm, tlv->value, htons(tlv->len));
         } else if (tlv->type == em_tlv_type_ht_cap){
             em_printfout("Received HT Capability TLV");
             em_ap_ht_cap_t *ht_cap = reinterpret_cast<em_ap_ht_cap_t *>(tlv->value);

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -4502,6 +4502,86 @@ int em_configuration_t::handle_encrypted_settings(unsigned int wsc_tlv_count)
     return ret;
 }
 
+void em_configuration_t::store_akm_suite_cap(dm_easy_mesh_t *dm, unsigned char *buff, unsigned int len)
+{
+    if ((dm == NULL) || (buff == NULL) || (len < 1)) {
+        return;
+    }
+
+    unsigned char *pos = buff;
+    const unsigned char *end = buff + len;
+
+    /* Each suite is OUI[3] + type[1]; convert to the "OUIOUIOUITYPE" hex form used by util::oui_to_akm().
+       Returns false when the TLV is truncated or the suite count does not fit the remaining length. */
+    auto parse_suites = [&](std::vector<std::string> &out) -> bool {
+        if (pos >= end) {
+            return false;
+        }
+        uint8_t count = *pos++;
+        if ((static_cast<size_t>(count) * 4) > static_cast<size_t>(end - pos)) {
+            return false;
+        }
+        for (uint8_t i = 0; i < count; i++) {
+            char hex[9];
+            snprintf(hex, sizeof(hex), "%02X%02X%02X%02X", pos[0], pos[1], pos[2], pos[3]);
+            std::string akm = util::oui_to_akm(hex);
+            if (!akm.empty()) {
+                out.push_back(akm);
+            } else {
+                em_printfout("Unknown AKM suite selector %s in AKM Suite Cap TLV", hex);
+            }
+            pos += 4;
+        }
+        return true;
+    };
+
+    /* Backhaul first, then fronthaul (matches em_t::create_akm_suite_cap_tlv()). */
+    std::vector<std::string> bh_akms;
+    std::vector<std::string> fh_akms;
+    if (!parse_suites(bh_akms) || !parse_suites(fh_akms)) {
+        em_printfout("Malformed AKM Suite Cap TLV (len %u), ignoring", len);
+        return;
+    }
+
+    /* The TLV carries the agent wide AKM sets, so apply to every BSS (mirrors the M1 auth type flags path).
+       Empty sets are applied too: an agent advertising 0 suites must clear the previously stored AKMs. */
+    for (unsigned int i = 0; i < dm->get_num_bss(); i++) {
+        em_bss_info_t *bss_info = dm->get_bss_info(i);
+        if (bss_info == NULL) {
+            continue;
+        }
+
+        /* Clear the entries past the new counts: readers such as fill_comma_sep()
+           collect every non-empty entry, so stale AKMs must not linger. */
+        bss_info->num_fronthaul_akms =
+            static_cast<unsigned char>(std::min<size_t>(fh_akms.size(), EM_MAX_AKMS));
+        for (unsigned char j = 0; j < EM_MAX_AKMS; j++) {
+            if (j < bss_info->num_fronthaul_akms) {
+                snprintf(bss_info->fronthaul_akm[j], sizeof(em_short_string_t), "%s", fh_akms[j].c_str());
+            } else {
+                bss_info->fronthaul_akm[j][0] = '\0';
+            }
+        }
+
+        bss_info->num_backhaul_akms =
+            static_cast<unsigned char>(std::min<size_t>(bh_akms.size(), EM_MAX_AKMS));
+        for (unsigned char j = 0; j < EM_MAX_AKMS; j++) {
+            if (j < bss_info->num_backhaul_akms) {
+                snprintf(bss_info->backhaul_akm[j], sizeof(em_short_string_t), "%s", bh_akms[j].c_str());
+            } else {
+                bss_info->backhaul_akm[j][0] = '\0';
+            }
+        }
+    }
+
+    em_printfout("Stored AKM Suite Cap: %zu FH AKMs, %zu BH AKMs into %u BSS(es)",
+        fh_akms.size(), bh_akms.size(), dm->get_num_bss());
+
+    if (dm->get_num_bss() > 0) {
+        dm->set_db_cfg_param(db_cfg_type_bss_list_update, "");
+    }
+}
+
 int em_configuration_t::handle_bss_config_req_msg(uint8_t *buff, unsigned int len, uint8_t src_al_mac[ETH_ALEN]) {
     // Controller
 
@@ -4574,10 +4654,8 @@ int em_configuration_t::handle_bss_config_req_msg(uint8_t *buff, unsigned int le
                 handle_ap_radio_basic_cap(tlv->value, htons(tlv->len));
                 break;
             case em_tlv_type_akm_suite:
-                 // Not handled by UWM right now?
                 em_printfout("Processing AKM Suite Capabilities TLV");
-                // TODO: HANDLE AKM Suite Capabilities TLV
-                util::print_hex_dump(ntohs(tlv->len), tlv->value);
+                store_akm_suite_cap(get_data_model(), tlv->value, htons(tlv->len));
                 break;
             case em_tlv_type_profile_2_ap_cap:
                 // Not handled by UWM right now?


### PR DESCRIPTION
Under Device.WiFi.DataElements, every BSS reported empty FronthaulAKMsAllowed / BackhaulAKMsAllowed. The agent reports the per VAP AKMs in the AKM Suite Capabilities TLV, but the controller ignored it on receive: handle_ap_cap_report had no case for it and handle_bss_config_req_msg only hex dumped it (no-op).

Fix:
- Add em_configuration_t::store_akm_suite_cap() to parse the TLV ([bh_count][bh_suite*4][fh_count][fh_suite*4], each suite OUI[3]+type[1]), convert each selector via util::oui_to_akm(), and store the fronthaul/backhaul AKMs into every BSS of the data model.
- Call it from both receive sites (AP Capability Report and BSS Config Request).
- Fix a copy/paste bug in bss_tget_params() that filled BackhaulAKMsAllowed from fronthaul_akm.

Verified on target. The AKM fields now report the actual AKMs (e.g. sae).