### PR TITLE
RDKBWIFI-518: Populate Device CountryCode from CAC Capabilities TLV

### DIFF
--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -1492,6 +1492,20 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
                 return -1;
             }
 
+            /* Country Code = first 2 ASCII octets of the CAC Capabilities TLV;
+               persist it into the reporting device so it surfaces as Device.{i}.CountryCode. */
+            if (ntohs(tlv->len) >= 2) {
+                const unsigned char *cc = tlv->value;
+                em_device_info_t *dev_info = dm->get_device_info();
+                if ((dev_info != NULL) &&
+                    (cc[0] >= 'A') && (cc[0] <= 'Z') &&
+                    (cc[1] >= 'A') && (cc[1] <= 'Z')) {
+                    dev_info->country_code[0] = static_cast<char>(cc[0]);
+                    dev_info->country_code[1] = static_cast<char>(cc[1]);
+                    dev_info->country_code[2] = '\0';
+                }
+            }
+
             for (int idx = 0; idx < cac->radios_num; idx++)
             {
                 dm_radio_cap_t *radio_cap = dm->get_radio_cap(cac->radios[idx].ruid);


### PR DESCRIPTION
Device.WiFi.DataElements Network.Device.{i}.CountryCode was always empty because the controller received the country in the CAC Capabilities TLV but never stored it into the device.

Extract the country code (first two ASCII octets of the TLV) in handle_ap_cap_report() and persist it into the reporting device's device_info so it surfaces northbound as Device.{i}.CountryCode.