### PR TITLE
beacon metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
             container: 'ubuntu:20.04'
             setup-cmd: 'apt-get update && apt-get install -y libssl1.1 libssl-dev'
           - openssl-version: '3.0'
-            container: 'ubuntu:latest'
+            container: 'ubuntu:20.04'
             setup-cmd: 'apt-get update && apt-get install -y libssl-dev'
       # Add this to continue jobs even if one matrix job fails
       fail-fast: false

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,11 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_CONDITIONAL([EM_EXTENDER], [test x$EM_EXTENDER = xtrue])
 # Check for em unittest
 AM_CONDITIONAL([EM_UNITTEST], [test "x$EM_UNITTEST" = "xtrue"])
+# Check for ASAN in em_ctrl
+AM_CONDITIONAL([EM_ASAN_CTRL], [test "x$EM_ASAN_CTRL" = "xtrue"])
+# Check for ASAN in em_agent
+AM_CONDITIONAL([EM_ASAN_AGENT], [test "x$EM_ASAN_AGENT" = "xtrue"])
+
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX

--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -91,6 +91,11 @@ public:
     unsigned int    m_num_assoc_sta_mld;
     dm_assoc_sta_mld_t m_assoc_sta_mld[EM_MAX_ASSOC_STA_MLD];
     dm_tid_to_link_t m_tid_to_link;
+    em_unassoc_sta_metrics_rsp_t    m_unassoc_sta_metrics_rsp;
+    em_unassoc_query_list_t m_unassoc_query_list;
+
+    unsigned int m_num_unassoc_sta_metrics;
+    em_unassoc_sta_metric_entry_t  m_unassoc_sta_metrics[EM_MAX_UNASSOC_STA];
 
 public:
 
@@ -102,8 +107,8 @@ public:
 	unsigned int get_ssid_mismatch_check_time() const { return ssid_mismatch_check_time; }
 	void set_last_topo_query_sent_time(unsigned int time) { last_topo_query_sent_time = time; }
 	unsigned int get_last_topo_query_sent_time() const { return last_topo_query_sent_time; }
-
-	static em_e4_table_t m_e4_table[];
+        static em_e4_table_t m_e4_table[];
+        static const size_t m_e4_table_size;
 
        /**!
         * @brief Retrieves the beacon channel based on center channel and bandwidth.
@@ -204,6 +209,18 @@ public:
 	 * EasyMesh framework to avoid unexpected results.
 	 */
 	static std::vector<int> get_channel_list_by_op_class(int op_class);
+
+	/**!
+	 * @brief Maps an operating class to its 20 MHz primary-channel equivalent.
+	 *
+	 * If op_class already has primary (beacon) channels with 20 MHz spacing it is
+	 * returned unchanged. Otherwise the table is searched for the first entry with
+	 * the same frequency band that does have primary channels at 20 MHz spacing.
+	 *
+	 * @param[in] op_class The operating class to map.
+	 * @returns The 20 MHz primary-channel op_class, or op_class itself if not found.
+	 */
+	static int get_primary_channel_op_class(int op_class);
 
 	/**!
 	 * @brief Retrieves the operating class information for a given BSS with an optional check for integer operating class.
@@ -1520,7 +1537,19 @@ public:
 	 */
 	dm_policy_t& get_policy_by_ref(unsigned int index) { return m_policy[index]; }
 
-	
+	/**!
+	 * @brief Checks whether this data model contains a policy of the given type.
+	 *
+	 * @param[in] type The policy ID type to search for.
+	 * @returns true if at least one policy with the given type exists, false otherwise.
+	 */
+	bool has_policy_type(em_policy_id_type_t type) const {
+		for (unsigned int i = 0; i < m_num_policy; i++) {
+			if (m_policy[i].m_policy.id.type == type) return true;
+		}
+		return false;
+	}
+
 	/**!
 	 * @brief Finds a matching scan result based on the provided scan result ID.
 	 *
@@ -1738,8 +1767,12 @@ public:
 	void update_assoc_sta_mld_info(em_assoc_sta_mld_info_t *assoc_sta_mld_info);
 	static void update_assoc_sta_mld_info(void *dm, em_assoc_sta_mld_info_t *assoc_sta_mld_info) { (static_cast<dm_easy_mesh_t *>(dm))->update_assoc_sta_mld_info(assoc_sta_mld_info); }
 
-	em_radio_cap_info_t *get_radio_cap_info(int index);
-	static em_radio_cap_info_t *get_radio_cap_info(void *dm, int index) { return (static_cast<dm_easy_mesh_t *>(dm))->get_radio_cap_info(index); }
+	void remove_assoc_sta_mld_info(mac_address_t sta_mld_mac);
+	bool is_ap_mld_mac(const mac_address_t mac);
+	bool resolve_ap_mld_to_fallback_ruid(const mac_address_t ap_mld_mac, mac_address_t fallback_ruid);
+
+	em_radio_cap_info_t *get_radio_cap_info(unsigned int index);
+	static em_radio_cap_info_t *get_radio_cap_info(void *dm, unsigned int index) { return (static_cast<dm_easy_mesh_t *>(dm))->get_radio_cap_info(index); }
 
 	/**!
 	 * @brief Retrieves the Data Model DPP object.
@@ -1916,7 +1949,7 @@ public:
 	 * @note Ensure that the MAC address provided is valid and registered in the system.
 	 */
 	dm_radio_cap_t *get_radio_cap(mac_address_t mac);
-	dm_radio_cap_t *get_radio_cap(int index);
+	dm_radio_cap_t *get_radio_cap(unsigned int index);
 
     
 	/**!
@@ -2237,6 +2270,8 @@ public:
 	 *       the network's configuration.
 	 */
 	dm_sta_t *find_sta(mac_address_t sta_mac, bssid_t bssid);
+
+	dm_sta_t *find_sta(mac_address_t sta_mac);
     
 	/**!
 	 * @brief Retrieves the first station associated with the given MAC address.
@@ -2290,7 +2325,8 @@ public:
 	 */
 	int get_num_bss_for_associated_sta(mac_address_t sta_mac);
     
-    
+    bool is_sta_mld(mac_address_t sta_mac);
+
 	/**!
 	 * @brief Converts a byte array to a hexadecimal string representation.
 	 *

--- a/inc/dm_easy_mesh_agent.h
+++ b/inc/dm_easy_mesh_agent.h
@@ -327,6 +327,28 @@ public:
 	int analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 	int analyze_link_report(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 
+        /**!
+         * @brief Analyzes the Unassociated STA Link Metrics Result.
+         *
+         * This function processes the Unassociated STA Link Metrics
+         * Response received from the agent, extracts RCPI measurements,
+         * and populates the corresponding internal command structures.
+         *
+         * @param[in] evt Pointer to the event structure containing the
+         *                Unassociated STA Metrics Response.
+         * @param[in] pcmd Array of pointers to command structures used
+         *                 for further processing.
+         *
+         * @returns int Status code indicating success or failure.
+         * @retval 0 on success.
+         * @retval Non-zero error code on failure.
+         *
+         * @note The response may contain zero STA entries as per the
+         *       EasyMesh specification when no RCPI measurements could
+         *       be collected within the implementation-specific timeout.
+         */
+        int analyze_unassoc_sta_result(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
 	/**!
 	 * @brief Refreshes the OneWiFi subdocument.
 	 *

--- a/inc/dm_easy_mesh_ctrl.h
+++ b/inc/dm_easy_mesh_ctrl.h
@@ -35,6 +35,7 @@
 #include "db_client.h"
 #include "dm_easy_mesh_list.h"
 #include "em_network_topo.h"
+#include "dm_easy_mesh.h"
 
 class em_cmd_t;
 class dm_easy_mesh_t;
@@ -85,6 +86,7 @@ public:
     static bus_error_t curops_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property);
 
     void fill_comma_sep(em_short_string_t str[], size_t max, char *buf);
+    dm_bss_t *get_dm_bss(dm_easy_mesh_t *dm, em_radio_info_t *ri, char *instance, bool is_num);
     bus_error_t bss_get(char* event_name, raw_data_t* p_data);
     static bus_error_t bss_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     bus_error_t bss_tget(char* event_name, raw_data_t* p_data);
@@ -99,6 +101,8 @@ public:
 
     char* get_ht_caps_str(em_ap_ht_cap_t *ht, char *buf, size_t buf_len);
     char* get_vht_caps_str(em_ap_vht_cap_t *vht, char *buf, size_t buf_len);
+    char* get_capop_nonoper_str(em_op_class_info_t *oci, char *buf, size_t buf_len);
+    char* get_supported_standards_str(wifi_ieee80211Variant_t variant, char *buf, size_t buf_size);
     bus_error_t rcaps_get(char* event_name, raw_data_t* p_data);
     static bus_error_t rcaps_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t rcaps_tget_inner(dm_easy_mesh_t *dm, const char *root, bus_data_prop_t **property);
@@ -118,7 +122,15 @@ public:
     bus_error_t curops_get(char* event_name, raw_data_t* p_data);
     static bus_error_t curops_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
 
+    dm_op_class_t* get_dm_capop(dm_easy_mesh_t *dm, dm_radio_t *radio, int instance);
+    bus_error_t capops_get(char* event_name, raw_data_t* p_data);
+    static bus_error_t capops_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    bus_error_t capops_tget(char *event_name, raw_data_t *p_data);
+    static bus_error_t capops_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t capops_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property);
+
     dm_sta_t* get_dm_sta(dm_easy_mesh_t *dm, em_bss_info_t *bi, int instance);
+    dm_sta_t *get_dm_sta(dm_easy_mesh_t *dm, em_bss_info_t *bi, char *instance, bool is_num);
     void fill_haul_type(em_haul_type_t hauls[], size_t max, char *buf);
     bus_error_t sta_get(char* event_name, raw_data_t* p_data);
     bus_error_t sta_tget(char *event_name, raw_data_t *p_data);
@@ -354,6 +366,23 @@ public:
 	 */
 	int analyze_set_radio(em_bus_event_t *evt, em_cmd_t *cmd[]);
     
+	/**!
+	 * @brief Analyzes the channel selection based on the provided event and command.
+	 *
+	 * This function processes the event and command to determine the appropriate channel selection.
+	 *
+	 * @param[in] evt Pointer to the event structure containing channel selection data.
+	 * @param[in] cmd Array of pointers to command structures for processing.
+	 *
+	 * @returns int Number of generated commands (>0) on success.
+	 * @retval 0 No-op (nothing to do).
+	 * @retval EM_PARSE_ERR_NO_CHANGE No config changes detected.
+	 * @retval <0 Negative parse/validation error code.
+	 * @note Ensure that the event and command structures are properly initialized
+	 * before calling this function.
+	 */
+	int analyze_channel_select(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
 	/**!
 	 * @brief Analyzes and sets the channel based on the provided event and command.
 	 *
@@ -725,6 +754,29 @@ public:
 	 * this function.
 	 */
 	int analyze_bsta_cap_req(em_bus_event_t *evt, em_cmd_t *pcmd[]);
+
+	/**!
+         * @brief Analyzes the Unassociated STA Link Metrics Query event.
+         *
+         * This function processes the Unassociated STA Link Metrics Query
+         * received from the controller, validates the query parameters,
+         * and prepares the corresponding internal command structures for
+         * agent-side handling and RCPI measurement collection.
+         *
+         * @param[in] evt Pointer to the event structure containing the
+         *                Unassociated STA Link Metrics Query payload.
+         * @param[in] pcmd Array of pointers to command structures used
+         *                 for internal processing.
+         *
+         * @returns int Status code indicating success or failure.
+         * @retval 0 on success.
+         * @retval Non-zero error code on failure.
+         *
+         * @note The query may contain one or more operating classes,
+         *       channels, and STA MAC entries as defined by the
+         *       EasyMesh specification.
+         */
+         int analyze_unassoc_sta_metrics_query(em_bus_event_t *evt, em_cmd_t *pcmd[]);
 
 	/**!
 	 * @brief Resets the configuration to its default state.

--- a/inc/dm_radio_cap.h
+++ b/inc/dm_radio_cap.h
@@ -74,7 +74,7 @@ public:
 	 */
 	void encode(cJSON *obj);
 
-    bool operator == (const dm_radio_cap_t& obj);
+    bool operator == (const dm_radio_cap_t& obj) const;
     void operator = (const dm_radio_cap_t& obj);
 
     

--- a/inc/dm_sta.h
+++ b/inc/dm_sta.h
@@ -118,6 +118,15 @@ public:
 	 * calling this function.
 	 */
 	static void decode_sta_capability(dm_sta_t *sta);
+
+    /**!
+     * @brief Returns true if the STA advertises support for at least one 802.11k
+     *        beacon measurement mode (Passive, Active, or Table).
+     *
+     * Reads m_sta_info.rm_cap (a compact hex string) and tests bits 4-6 of the
+     * first RM Enabled Capabilities octet (IEEE 802.11-2020 Table 9-157).
+     */
+    bool supports_beacon_measurement() const;
     
 	/**!
 	 * @brief Decodes the beacon report for the given station.

--- a/inc/ec_base.h
+++ b/inc/ec_base.h
@@ -481,14 +481,14 @@ typedef struct {
 } __attribute__((packed)) gtk_1905_kde_t;
 
 // Used to avoid many many if-not-null checks
-#define ASSERT_MSG_FALSE(x, ret, errMsg, ...) \
+#define ASSERT_MSG_FALSE(x, ret, ...) \
     if(x) { \
-        fprintf(stderr, errMsg, ## __VA_ARGS__); \
+        fprintf(stderr, __VA_ARGS__); \
         return ret; \
     }
 
-#define ASSERT_MSG_TRUE(x, ret, errMsg, ...) ASSERT_MSG_FALSE(!(x), ret, errMsg, ## __VA_ARGS__)
-#define ASSERT_NOT_NULL(x, ret, errMsg, ...) ASSERT_MSG_FALSE(x == NULL, ret, errMsg, ## __VA_ARGS__)
+#define ASSERT_MSG_TRUE(x, ret, ...) ASSERT_MSG_FALSE(!(x), ret, __VA_ARGS__)
+#define ASSERT_NOT_NULL(x, ret, ...) ASSERT_MSG_FALSE(x == NULL, ret, __VA_ARGS__)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 3 pointers and returns a value
@@ -497,13 +497,12 @@ typedef struct {
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
  * @param ptr3 Third pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+#define ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, ...) \
     do { \
         if(x == NULL) { \
-            fprintf(stderr, errMsg, ## __VA_ARGS__); \
+            fprintf(stderr, __VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
             void *_tmp3 = (ptr3); \
@@ -523,19 +522,19 @@ typedef struct {
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 2 pointers and returns a value
  */
-#define ASSERT_NOT_NULL_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
-    ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+#define ASSERT_NOT_NULL_FREE2(x, ret, ptr1, ptr2, ...) \
+    ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees one pointer and returns a value
  */
-#define ASSERT_NOT_NULL_FREE(x, ret, ptr1, errMsg, ...) \
-    ASSERT_NOT_NULL_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+#define ASSERT_NOT_NULL_FREE(x, ret, ptr1, ...) \
+    ASSERT_NOT_NULL_FREE2(x, ret, ptr1, NULL, __VA_ARGS__)
 
 
-#define ASSERT_NULL(x, ret, errMsg, ...) ASSERT_MSG_TRUE(x == 0, ret, errMsg, ## __VA_ARGS__)
-#define ASSERT_EQUALS(x, y, ret, errMsg, ...) ASSERT_MSG_TRUE(x == y, ret, errMsg, ## __VA_ARGS__)
-#define ASSERT_NOT_EQUALS(x, y, ret, errMsg, ...) ASSERT_MSG_FALSE(x == y, ret, errMsg, ## __VA_ARGS__)
+#define ASSERT_NULL(x, ret, ...) ASSERT_MSG_TRUE(x == 0, ret, __VA_ARGS__)
+#define ASSERT_EQUALS(x, y, ret, ...) ASSERT_MSG_TRUE(x == y, ret, __VA_ARGS__)
+#define ASSERT_NOT_EQUALS(x, y, ret, ...) ASSERT_MSG_FALSE(x == y, ret, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and if it doesn't, frees up to 3 pointers and returns a value
@@ -544,13 +543,12 @@ typedef struct {
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
  * @param ptr3 Third pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+#define ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, ...) \
     do { \
         if(!x.has_value()) { \
-            fprintf(stderr, errMsg, ## __VA_ARGS__); \
+            fprintf(stderr, __VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
             void *_tmp3 = (ptr3); \
@@ -573,31 +571,28 @@ typedef struct {
  * @param ret The value to return if x is nullopt
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
-    ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+#define ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, ...) \
+    ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and if it doesn't, frees a pointer and returns a value
  * @param x The std::optional to check for a value
  * @param ret The value to return if x is nullopt
  * @param ptr1 First pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, errMsg, ...) \
-    ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+#define ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, ...) \
+    ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and returns a value if it doesn't
  * @param x The std::optional to check for a value
  * @param ret The value to return if x is nullopt
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and optional arguments for the error message
  */
-#define ASSERT_OPT_HAS_VALUE(x, ret, errMsg, ...) ASSERT_MSG_TRUE(x.has_value(), ret, errMsg, ## __VA_ARGS__)
+#define ASSERT_OPT_HAS_VALUE(x, ret, ...) ASSERT_MSG_TRUE(x.has_value(), ret, __VA_ARGS__)
 
 #ifndef SSL_KEY
 #if OPENSSL_VERSION_NUMBER < 0x30000000L

--- a/inc/em.h
+++ b/inc/em.h
@@ -843,7 +843,7 @@ public:
 	 * @note Ensure that the buffer is properly allocated before calling this function.
 	 */
 	short create_ht_tlv(unsigned char *buff);
-    
+
 	/**!
 	 * @brief Creates a VHT TLV (Very High Throughput Tag Length Value) structure.
 	 *
@@ -912,6 +912,17 @@ public:
 	 * @note Ensure that the buffer provided is large enough to hold the TLV structure.
 	 */
 	unsigned short create_eht_operations_tlv(unsigned char *buff);
+
+	/**!
+	 * @brief Handles the EHT operations TLV.
+	 *
+	 * @param[in] buff Pointer to the buffer containing the TLV data.
+	 *
+	 * @returns int
+	 * @retval 0 on success
+	 * @retval -1 on failure
+	 */
+	int handle_eht_operations_tlv(unsigned char *buff, unsigned short len);
     
 	/**!
 	 * @brief Creates a channel scan TLV.
@@ -960,22 +971,6 @@ public:
 	short create_device_inventory_tlv(unsigned char *buff);
     
 	/**!
-	 * @brief Creates a radio advertisement TLV.
-	 *
-	 * This function is responsible for creating a radio advertisement TLV (Type-Length-Value) structure
-	 * and storing it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
-	 *
-	 * @returns A short integer indicating the success or failure of the operation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure that the buffer is properly allocated before calling this function.
-	 */
-	short create_radioad_tlv(unsigned char *buff);
-    
-	/**!
 	 * @brief Creates a metric collection integer TLV.
 	 *
 	 * This function initializes a metric collection integer TLV using the provided buffer.
@@ -1016,6 +1011,30 @@ public:
 	 * @note Ensure that the buffer is properly allocated before calling this function.
 	 */
 	short create_ap_radio_basic_cap(unsigned char *buff);
+
+	/**!
+	 * @brief Creates a traffic separation policy.
+	 *
+	 * This function is responsible for creating a traffic separation policy using the provided buffer.
+	 *
+	 * @param[in] buff A pointer to an unsigned char buffer that contains the data required for creating the policy.
+	 *
+	 * @returns An unsigned short value indicating the result of the policy creation.
+	 * @retval 0 on success.
+	 * @retval non-zero error code on failure.
+	 *
+	 * @note Ensure that the buffer is properly initialized before calling this function.
+	 */
+	unsigned short create_traffic_separation_policy_tlv(unsigned char *buff);
+
+	/**!
+	 * @brief Creates a Default 802.1Q Settings TLV from the data model policy.
+	 *
+	 * Reads the em_policy_id_type_default_8021q_settings entry from the DM and
+	 * serialises it into buff.  Returns the number of bytes written (0 if no
+	 * matching policy entry is found).
+	 */
+	short create_def_8021q_settings_policy_tlv(unsigned char *buff);
     //Msg-End
 
 	//START: DPP Callbacks for BSS information
@@ -1074,6 +1093,21 @@ public:
 	cJSON *create_bss_dpp_response_obj(const em_bss_info_t *bss_info, bool is_sta_response, bool tear_down_bss, dm_easy_mesh_t *data_model = NULL);
 
 	// END: DPP Callbacks for BSS information
+
+	/**
+	 * @brief Creates Airties radio capability vendor TLV.
+	 *
+	 * Builds a vendor-specific TLV containing radio capability information
+	 * (supported 802.11 standards) using Airties OUI and TLV ID.
+	 *
+	 * @param buff Output buffer for TLV data.
+	 *
+	 * @return TLV length in bytes, or 0 if radio capability is unavailable.
+	 *
+	 * @note Uses network byte order for multi-byte fields.
+	 */
+
+	short create_airties_radio_capability_tlv(unsigned char *buff);
 
 	int handle_wifi6_cap_tlv(unsigned char *buff);
 	int handle_wifi7_agent_cap_tlv(unsigned char *buff);

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -210,7 +210,14 @@ class em_agent_t : public em_mgr_t {
 	 * @param event The event containing the `rdk_sta_data_t` info which includes the association status along with other information
 	 */
 	void handle_recv_assoc_status(em_bus_event_t *event);
-    
+
+	/**
+	 * @brief Handles the reception of connection status event of a STA
+	 *
+	 * @param event The event containing the `em_connection_status_evt_data_t` payload
+	 */
+	void handle_recv_connection_status(em_bus_event_t *event);
+
 	/**!
 	 * @brief Handles the BTM response action frame.
 	 *
@@ -292,6 +299,67 @@ class em_agent_t : public em_mgr_t {
 
 	void handle_link_stats_report(em_bus_event_t *evt);
 
+       /**!
+        * @brief Handles an Unassociated STA Link Metrics Query event.
+        *
+        * This function processes the Unassociated STA Link Metrics Query
+        * received from the controller, parses the requested operating
+        * classes, channels and STA MAC addresses, and triggers the
+        * agent-side measurement workflow.
+        *
+        * @param[in] evt Pointer to the event structure containing the
+        *                Unassociated STA Query payload.
+        */
+       void handle_unassoc_sta_link_metrics_qry(em_bus_event_t *evt);
+
+       /**!
+        * @brief Handles the Unassociated STA Link Metrics Result event.
+        *
+        * This function processes the collected Unassociated STA RCPI
+        * measurements and prepares them for transmission back to the
+        * controller in one or more Unassociated STA Link Metrics
+        * Response messages.
+        *
+        * @param[in] evt Pointer to the event structure containing the
+        *                Unassociated STA Metrics result payload.
+        */
+       void handle_unassoc_sta_result(em_bus_event_t *evt);
+
+       /**!
+        * @brief Sends the Unassociated STA Query subdocument.
+        *
+        * This function constructs and publishes the Unassociated STA
+        * Query subdocument to the OneWiFi subsystem for RCPI measurement
+        * collection on the requested operating classes and channels.
+        *
+        * @param[in] desc Pointer to the WiFi bus descriptor.
+        * @param[in] bus_hdl Pointer to the bus handle used for communication.
+        * @param[in] work Pointer to the internal work list containing
+        *                 opclass, channel and STA information.
+        *
+        * @returns int Status code indicating success or failure.
+        * @retval 0 on success.
+        * @retval Non-zero error code on failure.
+        */
+       int send_unassoc_sta_query_subdoc(wifi_bus_desc_t *desc, bus_handle_t *bus_hdl, em_unassoc_work_list_t *work);
+
+       /**!
+        * @brief Callback invoked on receiving Unassociated STA Link Metrics results.
+        *
+        * This callback processes asynchronous Unassociated STA RCPI
+        * measurement results received from the OneWiFi subsystem and
+        * forwards them into the EasyMesh agent processing pipeline.
+        *
+        * @param[in] event_name Name of the event triggering the callback.
+        * @param[in] data Pointer to the raw event payload.
+        * @param[in] userData Pointer to user-specific callback context.
+        *
+        * @returns int Status code indicating success or failure.
+        * @retval 0 on success.
+        * @retval Non-zero error code on failure.
+        */
+       static int unassoc_sta_link_metrics_cb(char *event_name, bus_data_prop_t  *data, void *userData);
+
 	/**
 	 * @brief Send an action frame
 	 *
@@ -308,6 +376,7 @@ class em_agent_t : public em_mgr_t {
 	 */
 	bool send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, uint8_t vap_idx, unsigned int frequency=0, unsigned int wait_time_ms=0);
 
+	void send_beacon_query(em_bus_event_t *evt);
 public:
 
     bus_handle_t m_bus_hdl;
@@ -880,7 +949,7 @@ public:
 	 *
 	 * @note Ensure that the `event_name` and `data` are valid before processing.
 	 */
-	static void sta_cb(char *event_name, raw_data_t *data, void *userData);
+	static void sta_cb(char *event_name, bus_data_prop_t *data, void *userData);
     
 	/**!
 	 * @brief Callback function for handling WiFi events.
@@ -895,7 +964,7 @@ public:
 	 * @note Ensure that the data pointer is valid and properly initialized before
 	 * passing it to this function.
 	 */
-	static void onewifi_cb(char *event_name, raw_data_t *data, void *userData);
+	static void onewifi_cb(char *event_name, bus_data_prop_t *data, void *userData);
     
 	/**!
 	 * @brief Callback function for association statistics.
@@ -912,7 +981,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid before calling this function.
 	 */
-	static int assoc_stats_cb(char *event_name, raw_data_t *data, void *userData);
+	static int assoc_stats_cb(char *event_name, bus_data_prop_t *data, void *userData);
     
 	/**!
 	 * @brief Callback function for management action frames.
@@ -929,7 +998,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid and points to the correct data structure.
 	 */
-	static int mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *userData);
+	static int mgmt_action_frame_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**!
 	 * @brief Callback function for management csa beacon frames.
@@ -946,7 +1015,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid and points to the correct data structure.
 	 */
-	static int mgmt_csa_beacon_frame_cb(char *event_name, raw_data_t *data, void *userData);
+	static int mgmt_csa_beacon_frame_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**!
 	 * @brief Callback function for channel scanning.
@@ -963,7 +1032,7 @@ public:
 	 *
 	 * @note Ensure that the event_name and data are valid before processing.
 	 */
-	static int channel_scan_cb(char *event_name, raw_data_t *data, void *userData);
+	static int channel_scan_cb(char *event_name, bus_data_prop_t *data, void *userData);
     
 	/**!
 	 * @brief Callback function for handling beacon reports.
@@ -980,7 +1049,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid before accessing its contents.
 	 */
-	static int beacon_report_cb(char *event_name, raw_data_t *data, void *userData);
+	static int beacon_report_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**
 	 * @brief Callback for association status event
@@ -990,7 +1059,17 @@ public:
 	 * @param userData Optional user-provided callback data
 	 * @return int 1 on success, otherwise -1
 	 */
-	static int association_status_cb(char *event_name, raw_data_t *data, void *userData);
+	static int association_status_cb(char *event_name, bus_data_prop_t *data, void *userData);
+
+	/**
+	 * @brief Callback for connection-status event
+	 *
+	 * @param event_name The name of the event
+	 * @param data The raw event data
+	 * @param userData Optional user-provided callback data
+	 * @return int 1 on success, otherwise -1
+	 */
+	static int connection_status_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**
 	 * @brief Callback for BSS scan events
@@ -1000,7 +1079,7 @@ public:
 	 * @param userData Optional user-provided callback data
 	 * @return int 1 on success, otherwise -1
 	 */
-	static int bss_info_cb(char *event_name, raw_data_t *data, void *userData);
+	static int bss_info_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**!
 	 * @brief Callback function for handling AP Metrics reports.
@@ -1017,7 +1096,7 @@ public:
 	 *
 	 * @note Ensure that the data pointer is valid before accessing its contents.
 	 */
-	static int report_cb(char *event_name, raw_data_t *data, void *userData);
+	static int report_cb(char *event_name, bus_data_prop_t *data, void *userData);
 
 	/**!
 	 * @brief Retrieves the associated data for the given input.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -30,6 +30,7 @@ extern "C"
 #endif
 
 #include "wifi_webconfig.h"
+#include <time.h>
 #include <openssl/evp.h>
 #include <uuid/uuid.h>
 #include <sys/socket.h>
@@ -69,10 +70,11 @@ extern "C"
 #define EM_LONG_IO_BUFF_SZ   4096*4
 
 #define EM_MAX_OP_CLASS    48
-#define EM_MAX_POLICIES	16	
+#define EM_MAX_POLICIES	32
 #define EM_MAX_CHANNEL_PER_OP_CLASS  59
 #define EM_MAX_SERVICE          8
 #define EM_MAX_BSS_PER_RADIO           16
+#define EM_MAX_QOS_MGMT_POLICY         4
 #define EM_MAX_RADIO_PER_AGENT         4
 #define EM_MAX_TRAFFIC_SEP_SSID        8
 #define EM_MAX_FREQ_RECORDS_PER_RADIO  8
@@ -80,9 +82,13 @@ extern "C"
 #define MAX_MCS  3
 #define MAP_AP_ROLE_MAX 2
 // #define MAX_MCS_NSS 6
-#define EM_MAX_CAC_METHODS 4
+#define EM_MAX_CAC_METHODS             4
+#define EM_MAX_CAC_OP_CLASS_PER_METHOD 8
+#define EM_MAX_CAC_CHANS_PER_CLASS     16
 #define EM_MAX_STA_PER_BSS         64
 #define EM_MAX_STA_PER_STEER_POLICY        16 
+#define EM_MAX_MSC_PER_TRAFFIC_SEPAR       16
+#define EM_MAX_SCS_PER_TRAFFIC_SEPAR       16
 #define EM_MAX_STA_PER_AGENT       (EM_MAX_RADIO_PER_AGENT * EM_MAX_STA_PER_BSS)
 #define EM_MAX_NEIGHBORS	16
 #define EM_MAX_CHANNEL_SCAN_RPRT_MSG_LEN		166
@@ -182,10 +188,25 @@ extern "C"
 #define EM_CH_PREF_NON_OPERABLE 0x00
 #define EM_CH_PREF_MAX          0x0F
 
+#define CTRL_DEFAULT_CH_PREF    0x01 // Least preferred
+#define AGENT_DEFAULT_CH_PREF   0x0F // Most preferred
+
+/**
+ * Bit shift for preference value (high nibble of preference byte).
+ * Preference bytes store the preference value in bits 7-4.
+ * Use this macro when shifting preference values to/from the high nibble.
+ */
+#define EM_CH_PREF_SHIFT 4
+
 /* Flags indicating whether a channel preference entry
    is considered valid or invalid */
 #define EM_CH_PREF_ENTRY_VALID      0x01
 #define EM_CH_PREF_ENTRY_INVALID    0x00
+
+#define EM_SCAN_TYPE_PASSIVE 0U
+#define EM_SCAN_TYPE_ACTIVE  1U
+
+#define EM_SCAN_TYPE_BIT     (1U << 7)  // bit 7 in TLV
 
 /* Global MAC Address */
 static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -198,6 +219,9 @@ static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff
 #define EM_MAX_AP_MLD   64
 #define EM_MAX_ASSOC_STA_MLD   64
 #define EM_MAX_PRE_SET_CHANNELS   6
+
+#define EM_MAX_CHANNELS_PER_OPCLASS   16
+#define EM_MAX_STA_PER_CHANNEL        64
 
 #define EM_MAX_CMD  16
 
@@ -414,11 +438,31 @@ typedef struct {
 } __attribute__((__packed__)) em_channels_list_t;
 
 typedef struct {
+    unsigned char   channel[EM_MAX_CHANNELS_IN_LIST];
+} __attribute__((__packed__)) em_per_op_class_channels_list_t;
+
+typedef struct {
     unsigned char   op_class;
     unsigned char   max_tx_eirp;
 	unsigned char   num;
     em_channels_list_t  channels;
 } __attribute__((__packed__)) em_op_class_t;
+
+typedef struct {
+    unsigned char op_class;
+       unsigned char   num;
+    em_per_op_class_channels_list_t channels;
+} __attribute__((__packed__)) em_scan_cap_op_class_info_t;
+
+/* Per-op-class entry inside em_cac_cap_method_t.
+ * EM_MAX_CAC_CHANS_PER_CLASS channels (class 121 has 12 - largest DFS class).
+ * EM_MAX_CAC_OP_CLASS_PER_METHOD x sizeof == 144 bytes, preserving
+ * sizeof(em_cac_cap_method_t) == 150 and sizeof(em_cac_cap_radio_t) == 607. */
+typedef struct {
+    unsigned char   op_class;
+    unsigned char   num;      /* channels listed; 0 = all channels in op class */
+    unsigned char   channels[EM_MAX_CAC_CHANS_PER_CLASS];
+} __attribute__((__packed__)) em_cac_op_class_t;
 
 typedef struct {
     mac_address_t   ruid;
@@ -427,6 +471,138 @@ typedef struct {
     em_op_class_t   op_classes[0];
 } __attribute__((__packed__)) em_ap_radio_basic_cap_t;
 
+
+/**
+ * ============================================================================
+ * Unassociated STA Work List Structures
+ * ============================================================================
+ *
+ * These structures are used internally by the Controller/Agent to organize
+ * and process Unassociated STA Link Metrics operations grouped by:
+ *
+ *      Operating Class -> Channel -> STA List
+ *
+ * The work list acts as an intermediate runtime structure while preparing,
+ * scheduling, parsing, or processing Unassociated STA metrics queries.
+ * ============================================================================
+ */
+
+/**
+ * @brief Stores the list of STAs belonging to a specific channel.
+ *
+ * Each channel entry contains:
+ *  - Channel number
+ *  - Number of STAs associated with the channel
+ *  - List of STA MAC addresses to be queried
+ */
+typedef struct {
+    uint8_t channel;
+    uint8_t num_sta;
+    mac_address_t sta_list[EM_MAX_STA_PER_CHANNEL];
+} em_unassoc_work_channel_t;
+
+/**
+ * @brief Stores all channels belonging to a single operating class.
+ *
+ * Each operating class may contain multiple channels,
+ * and each channel may contain multiple STAs.
+ */
+typedef struct {
+    uint8_t op_class;
+    uint8_t num_channels;
+    em_unassoc_work_channel_t channel_list[EM_MAX_CHANNELS_PER_OPCLASS];
+} em_unassoc_work_opclass_t;
+
+/**
+ * @brief Top-level runtime work list for Unassociated STA processing.
+ *
+ * This structure groups all operating classes that are currently
+ * involved in Unassociated STA metrics processing.
+ */
+typedef struct {
+    uint8_t num_opclass;
+    em_unassoc_work_opclass_t opclass_list[EM_MAX_OPCLASS];
+} em_unassoc_work_list_t;
+
+/**
+ * @brief Represents a single channel entry in the query.
+ *
+ * Contains:
+ *  - Channel number
+ *  - Number of STAs on the channel
+ *  - List of STA MAC addresses requested for metrics reporting
+ */
+typedef struct {
+    uint8_t channel;
+    uint8_t num_sta;
+    mac_address_t sta_list[EM_MAX_STA_PER_CHANNEL];
+} em_unassoc_query_channel_t;
+
+/**
+ * @brief Represents an operating class entry in the query.
+ *
+ * Each operating class contains:
+ *  - Number of channels
+ *  - Channel-wise STA query information
+ */
+typedef struct {
+    uint8_t op_class;
+    uint8_t num_channels;
+    em_unassoc_query_channel_t channel_list[EM_MAX_CHANNELS_PER_OPCLASS];
+} em_unassoc_query_opclass_t;
+
+/**
+ * @brief Top-level query structure for Unassociated STA metrics.
+ *
+ * This structure is used by the Controller to organize all requested
+ * operating classes, channels, and STA lists before sending the query.
+ */
+typedef struct {
+    uint8_t num_opclass;
+    em_unassoc_query_opclass_t opclass_list[EM_MAX_OPCLASS];
+} em_unassoc_query_list_t;
+
+#define EM_MAX_UNASSOC_STA 64
+
+/**
+ * @brief Stores metrics information for a single Unassociated STA.
+ *
+ * This structure is populated after parsing an Unassociated STA
+ * Link Metrics Response TLV.
+ *
+ * Contains:
+ *  - STA MAC address
+ *  - Operating class
+ *  - Channel number
+ *  - RCPI value
+ *  - Time delta associated with the measurement
+ */
+typedef struct {
+    mac_address_t sta_mac;
+    unsigned char channel;
+    unsigned char op_class;
+    unsigned char rcpi;
+    unsigned int  time_delta;
+} em_unassoc_sta_metric_entry_t;
+
+typedef struct {
+    unsigned int num_entries;
+    em_unassoc_sta_metric_entry_t entry[EM_MAX_UNASSOC_STA];
+} em_unassoc_sta_metrics_rsp_t;
+
+//For TLV structure
+typedef struct {
+    mac_address_t sta_mac;
+    unsigned char channel;
+    unsigned int  time_delta;
+    unsigned char rcpi;
+}__attribute__((__packed__)) em_unassoc_sta_metric_t;
+
+typedef struct {
+    unsigned char op_class;
+    unsigned char num_sta;
+    em_unassoc_sta_metric_t sta_metric[0];
+}__attribute__((__packed__))em_unassoc_sta_link_metrics_rsp_t;
 
 typedef enum {
     mandatory,
@@ -662,6 +838,7 @@ typedef enum {
     em_tlv_type_ap_mld_config = 0xe0,
     em_tlv_type_bsta_mld_config = 0xe1,
     em_tlv_type_assoc_sta_mld_conf_rep = 0xe2,
+    em_tlv_type_affiliated_sta_metrics = 0xe4,
     em_tlv_type_tid_to_link_map_policy = 0xe6,
     em_tlv_eht_operations = 0xe7,
     em_tlv_type_avail_spectrum_inquiry_reg = 0xe8,
@@ -670,6 +847,10 @@ typedef enum {
 
     em_tlv_type_max
 } em_tlv_type_t;
+
+typedef enum {
+    em_tlv_type_radio_capability = 0x0013,
+} em_vendor_airties_tlv_type_t;
 
 typedef enum {
     em_channel_pref_reason_unspecified = 0x00,
@@ -809,6 +990,7 @@ typedef struct {
     unsigned char bss_color;
     unsigned char channel_util;
     unsigned short sta_count;
+    unsigned char bss_load_element_present;
 } em_neighbor_t;
 
 typedef struct {
@@ -954,7 +1136,7 @@ typedef struct {
 typedef struct {
     unsigned char ap_channel_rprt_len;
     unsigned char ap_channel_op_class;
-    unsigned char ap_channel_list[6];
+    unsigned char ap_channel_list[EM_MAX_CHANNELS_IN_LIST]; /* up to EM_MAX_CHANNELS_IN_LIST primary channels per report entry */
 }__attribute__((__packed__)) em_beacon_ap_channel_rprt_t;
 
 typedef struct {
@@ -971,10 +1153,13 @@ typedef struct {
     unsigned char ssid_len;
     ssid_t ssid;
     unsigned char num_ap_channel_rprt;
-    em_beacon_ap_channel_rprt_t ap_channel_rprt[6];
-    unsigned char num_element_id;
+    // up to EM_MAX_NEIGHBORS (16) AP Channel Report entries in a Beacon Metrics Query
+    em_beacon_ap_channel_rprt_t ap_channel_rprt[EM_MAX_NEIGHBORS];
+    // unsigned char num_element_id;
     em_beacon_element_list_t element_list;
 }__attribute__((__packed__)) em_beacon_metrics_query_t;
+
+// typedef em_beacon_metrics_query_t em_beacon_query_params_t;
 
 typedef struct {
     unsigned char op_class;
@@ -983,15 +1168,6 @@ typedef struct {
     unsigned char num_sta_mac_addr;
     mac_address_t sta_mac_addr;
 }__attribute__((__packed__)) em_unassoc_sta_link_metrics_query_t;
-
-typedef struct {
-    unsigned char op_class;
-    unsigned char num_sta_entries;
-    mac_address_t sta_mac_addr;
-    unsigned char channel_num;
-    unsigned int  time_delta_ms;
-    unsigned char uplink_rcpi;
-}__attribute__((__packed__)) em_unassoc_sta_link_metrics_rsp_t;
 
 typedef struct {
      mac_address_t sta_mac_addr;
@@ -1100,8 +1276,8 @@ typedef struct {
 } __attribute__((__packed__)) em_assoc_wifi6_sta_sts_t;
 
 typedef struct {
-    mac_address_t client_mac_addr;
     unsigned char bssid[6];
+    mac_address_t client_mac_addr;
 } __attribute__((__packed__)) em_client_info_t;
 
 typedef struct {
@@ -1416,6 +1592,16 @@ typedef struct {
     unsigned short reason_code;
 } __attribute__((__packed__)) em_reason_code_t;
 
+typedef struct
+{
+    mac_address_t sta_mac_addr;
+    unsigned int bytes_sent;
+    unsigned int bytes_recv;
+    unsigned int packets_sent;
+    unsigned int packets_recv;
+    unsigned int tx_packets_errors;
+} __attribute__((__packed__)) em_affiliated_sta_metrics_t;
+
 typedef struct {
     unsigned char *dpp_config_obj;
 } __attribute__((__packed__)) em_bss_conf_rsp_t;
@@ -1438,7 +1624,7 @@ typedef struct {
 
 typedef struct {
     unsigned char  ssids_num;
-    em_traffic_sep_policy_ssid_t  ssids[0];
+    em_traffic_sep_policy_ssid_t  ssids[EM_MAX_TRAFFIC_SEP_SSID];
 } __attribute__((__packed__)) em_traffic_sep_policy_t;
 
 typedef struct {
@@ -1543,6 +1729,17 @@ typedef struct {
 } __attribute__((__packed__)) em_vendor_specific_t;
 
 typedef struct {
+    unsigned char  vendor_oui[3];
+    unsigned char  data[0];
+} __attribute__((__packed__)) em_vendor_specific_v_t;
+
+typedef struct {
+    mac_address_t interface_mac;
+    unsigned char supported_standards[2];
+    unsigned char reserved[2];
+}__attribute__((__packed__)) em_radio_capability_vendor_t;
+
+typedef struct {
     unsigned char  destination;    
     mac_address_t  specific_neigh;
     unsigned char  link_metrics_type; 
@@ -1590,13 +1787,6 @@ typedef struct {
 } __attribute__((__packed__)) em_radio_vendor_t;
 
 typedef struct {
-    unsigned char   serial_len;
-    unsigned char   serial[MAP_INVENTORY_ITEM_LEN];
-    unsigned char   ver_len;
-    unsigned char   version[MAP_INVENTORY_ITEM_LEN];
-    unsigned char   envi_len;
-    unsigned char   environment[MAP_INVENTORY_ITEM_LEN];
-    unsigned char   radios_num;
     em_radio_vendor_t radios[EM_MAX_RADIO_PER_AGENT];
 } __attribute__((__packed__)) em_device_inventory_t;
 
@@ -1770,7 +1960,6 @@ typedef struct {
 } __attribute__((__packed__)) em_eht_operations_radio_t;
 
 typedef struct {
-    unsigned char reserved[32];
     unsigned char radios_num;
     em_eht_operations_radio_t radios[EM_MAX_RADIO_PER_AGENT];
 } __attribute__((__packed__)) em_eht_operations_t;
@@ -1790,7 +1979,7 @@ typedef struct {
     unsigned char  boot_only : 1;
     unsigned int   min_scan_interval;
     unsigned char  op_classes_num;
-    em_op_class_t  op_classes[EM_MAX_OP_CLASS];
+    em_scan_cap_op_class_info_t  op_classes[EM_MAX_OPCLASS];
 } __attribute__((__packed__))em_channel_scan_cap_radio_t;
 
 typedef struct {
@@ -1798,11 +1987,19 @@ typedef struct {
     em_channel_scan_cap_radio_t  radios[EM_MAX_RADIO_PER_AGENT];
 } __attribute__((__packed__))em_channel_scan_cap_t;
 
+/* CAC Method types — Wi-Fi Easy Mesh spec - 17.2.46 Table 16 */
+typedef enum {
+    em_cac_method_continuous              = 0, /* Continuous CAC */
+    em_cac_method_continuous_dedicated    = 1, /* Continuous with dedicated radio */
+    em_cac_method_mimo_reduced            = 2, /* MIMO dimension reduced */
+    em_cac_method_time_sliced             = 3, /* Time-sliced CAC */
+} em_cac_method_type_t;
+
 typedef struct {
     unsigned char   cac_method;
-    unsigned int    cac_duration;
+    unsigned int    cac_duration : 24;
     unsigned char   op_classes_num;
-    em_op_class_t   op_classes[EM_MAX_OP_CLASS];
+    em_cac_op_class_t   op_classes[EM_MAX_OP_CLASS];
 } __attribute__((__packed__)) em_cac_cap_method_t;
 
 typedef struct {
@@ -1904,8 +2101,10 @@ typedef struct {
     em_traffic_sep_policy_t traffic_separation_policy;
     em_channel_scan_rprt_policy_t channel_scan_policy;
     em_unsuccessful_assoc_policy_t unsuccessful_assoc_policy;
-    em_bh_bss_config_t bh_bss_cfg_policy;
-    em_qos_mgmt_policy_t qos_mgmt_policy;
+    unsigned int num_bh_bss_cfg;
+    em_bh_bss_config_t bh_bss_cfg_policy[EM_MAX_BSS_PER_RADIO];
+    unsigned int num_qos_mgmt;
+    em_qos_mgmt_policy_t qos_mgmt_policy[EM_MAX_QOS_MGMT_POLICY];
     em_vendor_policy_t vendor_policy;
 } em_policy_cfg_params_t;
 
@@ -2070,6 +2269,7 @@ typedef enum {
 	em_state_agent_channel_select_configuration_pending,
     em_state_agent_channel_report_pending,
 	em_state_agent_channel_scan_result_pending,
+    em_state_agent_unassoc_sta_metrics_report_pending,	
     em_state_agent_configured,
 	
 	// Transient agent stats
@@ -2111,6 +2311,7 @@ typedef enum {
     em_state_ctrl_avail_spectrum_inquiry_pending,
     em_state_ctrl_bsta_cap_pending,
     em_state_ctrl_topo_publish_pending,
+    em_state_ctrl_unassoc_sta_link_metrics_pending, 
 
     em_state_max,
 } em_state_t;
@@ -2163,6 +2364,8 @@ typedef enum {
     em_cmd_type_get_reset,
     em_cmd_type_bsta_cap,
     em_cmd_type_get_link_quality_report,
+    em_cmd_type_unassoc_sta_query,
+    em_cmd_type_unassoc_sta_result,
 
     em_cmd_type_max,
 } em_cmd_type_t;
@@ -2286,6 +2489,7 @@ typedef struct {
     unsigned char assoc_sta_reporting_int;
     unsigned char max_nummlds;
     unsigned char bstamld_maxlinks;
+    em_string_t   environment;
 
     em_small_string_t    primary_device_type;
     em_small_string_t    secondary_device_type;
@@ -2338,6 +2542,7 @@ typedef enum {
     em_op_class_type_preference,
     em_op_class_type_anticipated,
     em_op_class_type_scan_param,
+    em_op_class_type_selection,
 } em_op_class_type_t;
 
 typedef struct {
@@ -2397,6 +2602,7 @@ typedef struct {
     unsigned char	frame_body[EM_MAX_FRAME_BODY_LEN];
     unsigned int    num_vendor_infos;
     bool            multi_band_cap;
+    time_t          beacon_query_sent_time; /* 0 = none in flight; epoch of last query sent (self-heals after timeout) */
     unsigned int    num_beacon_meas_report;
     unsigned int    beacon_report_len;
     unsigned char   beacon_report_elem[EM_MAX_BEACON_MEASUREMENT_LEN];
@@ -2424,6 +2630,7 @@ typedef struct {
 
     wifi_BeaconReport_t beacon_reports[EM_MAX_BEACON_REPORTS_PER_SCAN];
     em_link_report_t link_stats_report;
+    unsigned short  reason_code;
 } em_sta_info_t;
 
 typedef enum {
@@ -2547,11 +2754,11 @@ typedef struct {
 
 typedef struct {
     mac_address_t  bssid;
-    mac_address_t  mac_addr;
+    mac_address_t  link_addr;//link_address of the sta
 } em_affiliated_sta_info_t;
 
 typedef struct {
-    mac_address_t  mac_addr;
+    mac_address_t  mac_addr;//sta mac address
     mac_address_t  ap_mld_mac_addr;
     bool  str;
     bool  nstr;
@@ -2616,7 +2823,6 @@ typedef struct {
     bool    support_rcpi_steering;
     em_long_string_t    chip_vendor;
     bool    ap_metrics_wifi6;
-    em_device_inventory_t inventory_info;
     int     transmit_power_limit;
     unsigned char partial_bss_color;
     unsigned char bss_color;
@@ -2635,6 +2841,7 @@ typedef struct {
 
 typedef struct {
     em_interface_t  ruid;
+    wifi_ieee80211Variant_t mode;
     em_ap_ht_cap_t  ht_cap;
     em_ap_vht_cap_t vht_cap;
     em_ap_he_cap_t  he_cap;
@@ -2811,6 +3018,7 @@ typedef enum {
     em_bus_event_type_set_channel,
     em_bus_event_type_scan_channel,
     em_bus_event_type_scan_result,
+    em_bus_event_type_channel_select,
     em_bus_event_type_get_bss,
     em_bus_event_type_get_sta,
     em_bus_event_type_steer_sta,
@@ -2844,11 +3052,13 @@ typedef enum {
 	em_bus_event_type_channel_scan_params,
     em_bus_event_type_get_mld_config,
     em_bus_event_type_mld_reconfig,
+    em_bus_event_type_beacon_query,
     em_bus_event_type_beacon_report,
     em_bus_event_type_recv_wfa_action_frame,
     em_bus_event_type_recv_gas_frame,
     em_bus_event_type_get_sta_client_type,
     em_bus_event_type_assoc_status,
+    em_bus_event_type_connection_status,
     em_bus_event_type_ap_metrics_report,
     em_bus_event_type_bss_info,
     em_bus_event_type_get_reset,
@@ -2856,6 +3066,9 @@ typedef enum {
     em_bus_event_type_bsta_cap_req,
     em_bus_event_type_link_quality_report,
     em_bus_event_type_client_assoc_ctrl_req,
+    em_bus_event_type_unassoc_sta_query,
+    em_bus_event_type_unassoc_sta_link_metrics_query,
+    em_bus_event_type_unassoc_sta_result,
 
     em_bus_event_type_max
 } em_bus_event_type_t;
@@ -2945,7 +3158,10 @@ typedef enum {
     dm_orch_type_mld_reconfig,
     dm_orch_type_beacon_report,
     dm_orch_type_bsta_cap_query,
-    dm_orch_type_link_quality_report
+    dm_orch_type_link_quality_report,
+    dm_orch_type_unassoc_sta_link_req_query,
+    dm_orch_type_unassoc_sta_result,
+    
 } dm_orch_type_t;
 
 typedef struct {
@@ -3044,17 +3260,9 @@ typedef struct {
 } em_cmd_args_t;
 
 typedef enum {
-    em_steering_opportunity_none,
-} em_steering_opportunity_t;
-
-typedef enum {
-    em_steering_mandate_none,
-} em_steering_mandate_t;
-
-typedef struct {
-    em_steering_opportunity_t	opportunity;
-    em_steering_mandate_t	mandate;
-} em_steer_req_mode_t;
+    em_steering_req_mode_opportunity,
+    em_steering_req_mode_mandate
+} em_steering_req_mode_t;
 
 typedef struct {
     mac_address_t	sta_mac;
@@ -3129,6 +3337,10 @@ typedef struct em_network_node {
     struct em_network_node     *child[EM_MAX_DM_CHILDREN];
 } em_network_node_t;
 
+typedef struct {
+    mac_address_t al_mac;
+} em_cmd_unassoc_sta_query_params_t;
+
 typedef em_scan_params_t em_cmd_scan_params_t;
 typedef struct {
     union {
@@ -3138,6 +3350,7 @@ typedef struct {
         em_cmd_disassoc_params_t	disassoc_params;
 		em_cmd_scan_params_t	scan_params;
         em_cmd_ap_metrics_rprt_params_t ap_metrics_params;
+        em_cmd_unassoc_sta_query_params_t unassoc_sta_query_params;
     } u;
 	em_network_node_t *net_node;
 } em_cmd_params_t;
@@ -3194,9 +3407,19 @@ typedef struct {
  */
 typedef enum {
     em_cmd_event_type_ap_metrics_report,
+    em_cmd_event_type_failed_connection,
 
     em_cmd_event_type_max
 } em_cmd_event_type_t;
+
+typedef struct {
+    int             ap_index;
+    mac_address_t   sta_mac;
+    mac_address_t   bssid;
+    unsigned short  status_code;
+    unsigned short  reason_code;
+    bool            reason_code_present;
+} em_connection_status_evt_data_t;
 
 typedef struct {
     em_cmd_event_type_t type;
@@ -3306,6 +3529,10 @@ typedef enum {
     tag_vht_capability = 191,
     tag_vendor_specific = 221,
     tag_extended_tags = 255,
+    //he
+    //he_6ghz
+    //eht
+    //other tags can be added here
 } tag_type_t;
 
 typedef struct {
@@ -3386,6 +3613,19 @@ typedef struct {
 } em_traffic_separation_policy_t;
 
 typedef struct {
+    unsigned char num_mscs;
+    mac_address_t msc_mac[EM_MAX_MSC_PER_TRAFFIC_SEPAR];
+    unsigned char num_scs;
+    mac_address_t sc_mac[EM_MAX_SCS_PER_TRAFFIC_SEPAR];
+} em_qos_mgt_policy_t;
+
+typedef struct {
+    bssid_t bssid;
+    bool b_profile_1_sta_disallowed;
+    bool b_profile_2_sta_disallowed;
+} em_backhaul_bss_config_policy_t;
+
+typedef struct {
 	em_policy_id_t	id;
 	unsigned int num_sta;
 	mac_address_t	sta_mac[EM_MAX_STA_PER_STEER_POLICY];
@@ -3399,10 +3639,17 @@ typedef struct {
 	bool	sta_status;
 	em_long_string_t	managed_sta_marker;
 	bool	independent_scan_report;
+    bssid_t bssid;
 	bool	profile_1_sta_disallowed;
 	bool	profile_2_sta_disallowed;
+    bool report_unassoc_sta;
+    unsigned int max_reporting_rate;
 	em_8021q_settings_policy_t  def_8021q_settings;
 	em_traffic_separation_policy_t traffic_separ;
+    unsigned int num_qos_mgt;
+    em_qos_mgt_policy_t qos_mgt[EM_MAX_STA_PER_AGENT];
+    unsigned int num_backhaul_bss_config;
+    em_backhaul_bss_config_policy_t backhaul_bss_config[EM_MAX_BSS_PER_RADIO];
     em_link_stats_alarm_cfg_t link_stats_alarm_cfg;
     em_client_filters_cfg_t client_filters;
 } em_policy_t;
@@ -3463,6 +3710,8 @@ static const SecurityTypeMap securityTypeMap[] = {
     { "WPA3 Personal",   EM_AUTH_WPA3_PERSONAL },
     { "WPA3 Transition", EM_AUTH_WPA3_TRANSITION }
 };
+
+static const unsigned char airties_vendor_oui[EM_VENDOR_OUI_SIZE] = {0x88, 0x41, 0xfc};
 
 #ifndef SSL_KEY
 #if OPENSSL_VERSION_NUMBER < 0x30000000L

--- a/inc/em_capability.h
+++ b/inc/em_capability.h
@@ -275,8 +275,8 @@ class em_capability_t {
 	 *
 	 * @note This is a pure virtual function and must be implemented by derived classes.
 	 */
+
 	virtual short create_ht_tlv(unsigned char *buff) = 0;
-    
 	/**!
 	 * @brief Creates a VHT TLV.
 	 *
@@ -321,6 +321,21 @@ class em_capability_t {
 	 * @note This is a pure virtual function and must be implemented by derived classes.
 	 */
 	virtual short create_wifi6_tlv(unsigned char *buff) = 0;
+
+	/**!
+	 * @brief Creates Airties radio capability vendor TLV.
+	 *
+	 * Builds a vendor-specific TLV containing radio capability information
+	 * (supported 802.11 standards) using Airties OUI and TLV ID.
+	 *
+	 * @param buff Output buffer for TLV data.
+	 *
+	 * @return TLV length in bytes, or 0 if radio capability is unavailable.
+	 *
+	 * @note This is a pure virtual function and must be implemented by derived classes.
+	 */
+
+	virtual short create_airties_radio_capability_tlv(unsigned char *buff) = 0;
 
 	virtual int handle_wifi6_cap_tlv(unsigned char *buff) = 0;
 	virtual int handle_wifi7_agent_cap_tlv(unsigned char *buff) = 0;
@@ -411,7 +426,7 @@ class em_capability_t {
 	 *
 	 * @note Ensure that the buffer is properly allocated before calling this function.
 	 */
-	virtual short create_radioad_tlv(unsigned char *buff) = 0;
+	virtual short create_ap_radio_advanced_cap_tlv(unsigned char *buff) = 0;
     
 	/**!
 	 * @brief Creates a metric collection integer TLV.
@@ -543,7 +558,9 @@ class em_capability_t {
 	 *
 	 * @note Ensure the buffer is properly allocated and contains valid TLV data before calling this function.
 	 */
-	int handle_eht_operations_tlv(unsigned char *buff);
+	virtual int handle_eht_operations_tlv(unsigned char *buff, unsigned short len) = 0;
+
+	int handle_channel_scan_cap_tlv(unsigned char *buff, unsigned int len);
 
 	/**!
 	 * @brief Creates an AP capability report message.
@@ -699,7 +716,7 @@ class em_capability_t {
 	 * @note Ensure that the data buffer is valid and the length is correctly specified.
 	 */
 	int handle_ap_cap_report(unsigned char *data, unsigned int len);
-    
+
 	/**!
 	 * @brief Handles the client capability report.
 	 *
@@ -737,26 +754,52 @@ class em_capability_t {
 	 *
 	 * This function processes the capability report received from the Extender.
 	 *
-	 * @param[in] buff Pointer to the buffer containing the notification data.
-	 * @param[in] len Length of the data received.
+	 * @param[in] pkt_buff Pointer to the buffer containing the notification data.
+	 * @param[in] pkt_len Length of the data received.
 	 *
 	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
 	 */
-	int handle_bsta_cap_report(unsigned char *buff, unsigned int len);
+	int handle_bsta_cap_report(unsigned char *pkt_buff, unsigned int pkt_len);
 
 	/**!
 	 * @brief Handles the backhaul sta radio capability TLV
 	 *
 	 * This function processes the backhaul sta radio capability TLV.
 	 *
-	 * @param[in] buff Pointer to the buffer containing the TLV data.
-	 * @param[in] len Length of the data received.
+	 * @param[in] tlv_buff Pointer to the buffer containing the TLV data.
+	 * @param[in] tlv_len Length of the data received.
 	 *
 	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
 	 */
-	int handle_bsta_radio_cap(unsigned char *buff, unsigned int len);
+	int handle_bsta_radio_cap(unsigned char *tlv_buff, unsigned int tlv_len);
+
+	/**!
+	 * @brief Handles the client info TLV
+	 *
+	 * This function processes the client info TLV.
+	 *
+	 * @param[in] tlv_buff Pointer to the buffer containing the TLV data.
+	 * @param[in] tlv_len Length of the data received.
+	 *
+	 * @note Ensure that the data pointer is valid and the length is correct before calling this function.
+	 */
+	int handle_client_info(unsigned char *tlv_buff, unsigned int tlv_len);
+
+	/**!
+	 * @brief Processes a 1905 message with the given data and length.
+	 *
+	 * This function takes a pointer to a data buffer containing 1905 message with Ethernet header and its length, then processes the message contained within.
+	 *
+	 * @param[in] pkt_buff Pointer to the data buffer containing the message to be processed.
+	 * @param[in] pkt_len The length of the data buffer.
+	 * @param[in] tlv_type Type of TLV
+	 * @param[in] handler Handler function to process specific TLV
+	 *
+	 * @note Ensure that the data buffer is valid and the length is correctly specified to avoid undefined behavior.
+	 */
+	int process_single_tlv_in_1905_message(unsigned char *pkt_buff, unsigned int pkt_len, em_tlv_type_t tlv_type, int (em_capability_t::*handler)(unsigned char*, unsigned int));
 public:
-    
+
 	/**!
 	 * @brief Processes a message with the given data and length.
 	 *
@@ -768,7 +811,7 @@ public:
 	 * @note Ensure that the data buffer is valid and the length is correctly specified to avoid undefined behavior.
 	 */
 	void    process_msg(unsigned char *data, unsigned int len);
-    
+
 	/**!
 	 * @brief Processes the state of the agent.
 	 *

--- a/inc/em_channel.h
+++ b/inc/em_channel.h
@@ -205,6 +205,52 @@ public:
 	short create_channel_pref_tlv(unsigned char *buff);
 
 	/**!
+	 * @brief Updates map with non-operable and unsupported channels as per
+	 * Agent's Capability and Channel Preference Report
+	 *
+	 * Marks non-op channels for the operating classes from AP Capability Report with preference 0
+	 * Updates non-operable/operable preference from Preference Report. Preference report
+	 * overrides operable/non-operable preference from AP Capability Report
+	 * Removes unsupported opclasses as per AP Capability Report from the map
+	 *
+	 * @param[in] ruid Radio unique identifier (MAC address)
+	 * @param[in,out] opclass_channel_prefs Map keyed by op-class (outer key = opclass ID).
+	 * Each entry in outer map has an inner map keyed by channel number with preference byte as value
+	 */
+	void update_map_with_agent_capability_preference(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs);
+
+	/**!
+	 * @brief This function updates the map with ctrl anticipated preferences
+	 *
+	 * Create a merged list of anticipated entries for Global, Device and RUID from datamodel
+	 * Assumes, only one entry for an OPCLASS for Global, Device or RUID in the datamodel
+	 * For an OPCLASS, RUID entry overrides the Global/Device ID entry
+	 * Updates the preferences for operable channels in the map with anticipated preferences
+	 *
+	 * @param[in] ruid Radio unique identifier (MAC address)
+	 * @param[in,out] opclass_channel_prefs Map keyed by op-class (outer key = opclass ID).
+	 * Each entry in outer map has an inner map keyed by channel number with preference byte as value
+	 *
+	 * @returns bool
+	 * @retval true if at least one entry was updated with anticipated preference for the RUID
+	 * @retval false otherwise
+	 *
+	 */
+	bool update_map_with_ctrl_anticipated(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs);
+
+	/**!
+	 * @brief This function fills the map with opclass->channel entries from m_e4_table
+	 * with default preference for controller/agent
+	 *
+	 * This function is responsible for filling the map which is keyed by op-class (outer key = opclass ID).
+	 * Each entry in outer map has an inner map keyed by channel number with preference byte as value
+	 * Default preference is CTRL_DEFAULT_CH_PREF / AGENT_DEFAULT_CH_PREF
+	 *
+	 * @param[in,out] opclass_channel_prefs Map to fill with opclass and channel entries
+	 */
+	void fill_map_with_opclass_channel_prefs(std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs);
+
+	/**!
 	 * @brief Creates an operating channel report TLV.
 	 *
 	 * This function generates a TLV (Type-Length-Value) report for the operating channel
@@ -314,6 +360,8 @@ public:
 	 * @note Ensure that the buffer is allocated with sufficient size before calling this function.
 	 */
 	virtual unsigned short create_eht_operations_tlv(unsigned char *buff) = 0;
+
+	virtual int handle_eht_operations_tlv(unsigned char *buff, unsigned short len) = 0;
     
 	/**!
 	 * @brief Sends a channel scan request message.
@@ -638,40 +686,6 @@ public:
 	 * @note Ensure that the buffer is properly allocated and the length is correctly specified.
 	 */
 	int handle_spatial_reuse_report(unsigned char *buff, unsigned int len);
-    
-	/**!
-	 * @brief Handles EHT operations TLV.
-	 *
-	 * This function processes the EHT operations TLV from the provided buffer and populates the
-	 * eht_ops structure with the relevant data.
-	 *
-	 * @param[in] buff Pointer to the buffer containing the EHT operations TLV data.
-	 * @param[out] eht_ops Pointer to the em_eht_operations_t structure to be populated.
-	 *
-	 * @returns int
-	 * @retval 0 on success
-	 * @retval -1 on failure
-	 *
-	 * @note Ensure that the buffer is properly initialized and contains valid TLV data before calling this function.
-	 */
-	int handle_eht_operations_tlv(unsigned char *buff, em_eht_operations_t *eht_ops);
-    
-	/**!
-	 * @brief Handles EHT operations for TLV control.
-	 *
-	 * This function processes the EHT operations based on the provided TLV control buffer.
-	 *
-	 * @param[in] buff Pointer to the buffer containing TLV data.
-	 * @param[in] len Length of the buffer.
-	 *
-	 * @returns int
-	 * @retval 0 on success
-	 * @retval -1 on failure
-	 *
-	 * @note Ensure that the buffer is properly initialized before calling this function.
-	 */
-	int handle_eht_operations_tlv_ctrl(unsigned char *buff, unsigned int len);
-
     
 	/**!
 	 * @brief Retrieves the channel preference query transmission count.

--- a/inc/em_cmd.h
+++ b/inc/em_cmd.h
@@ -29,7 +29,7 @@
 class em_cmd_t {
 public:
     em_cmd_type_t   m_type;
-    em_service_type_t   m_svc;
+    em_service_type_t   m_svc = em_service_type_none;
     em_cmd_params_t m_param;
     em_event_t  *m_evt;
     em_string_t m_name;

--- a/inc/em_cmd_unassoc_sta_query.h
+++ b/inc/em_cmd_unassoc_sta_query.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_UNASSOC_STA_QUERY_H
+#define EM_CMD_UNASSOC_STA_QUERY_H
+
+#include "em_cmd.h"
+
+class em_cmd_unassoc_sta_query_t : public em_cmd_t {
+
+private:
+
+    em_unassoc_query_list_t m_query;
+
+public:
+
+    em_cmd_unassoc_sta_query_t(em_cmd_params_t param, dm_easy_mesh_t& dm, em_unassoc_query_list_t *query);
+
+    em_unassoc_query_list_t *get_query()
+    {
+        return &m_query;
+    }
+};
+
+#endif
+

--- a/inc/em_cmd_unassoc_sta_result.h
+++ b/inc/em_cmd_unassoc_sta_result.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef EM_CMD_UNASSOC_STA_RESULT_H
+#define EM_CMD_UNASSOC_STA_RESULT_H
+
+#include "em_cmd.h"
+
+class em_cmd_unassoc_sta_result_t : public em_cmd_t {
+
+public:
+    /**!
+     * @brief Creates an unassociated STA link metrics result command.
+     *
+     * Initializes the unassociated STA result command using the provided
+     * command parameters and EasyMesh data model context.
+     *
+     * @param[in] param Command parameters associated with the unassociated
+     *                  STA metrics result.
+     * @param[in] dm Reference to the EasyMesh data model instance.
+     *
+     * @note Ensure that the provided data model instance is properly
+     * initialized before invoking this constructor.
+     */
+    em_cmd_unassoc_sta_result_t(em_cmd_params_t param, dm_easy_mesh_t& dm);	
+};
+#endif

--- a/inc/em_configuration.h
+++ b/inc/em_configuration.h
@@ -424,6 +424,8 @@ class em_configuration_t {
 	 */
 	virtual short create_ap_radio_advanced_cap_tlv(unsigned char *buff) = 0;
 
+	virtual short create_def_8021q_settings_policy_tlv(unsigned char *buff) = 0;
+
 	/**!
 	 * @brief Creates a list of enrollee BSTA.
 	 *
@@ -474,7 +476,43 @@ class em_configuration_t {
 	 * @note Ensure that the MAC address and BSSID are valid before calling this function.
 	 */
 	int send_topology_notification_by_client(mac_address_t sta, bssid_t bssid, bool assoc);
-    
+
+	/**!
+	 * @brief Sends a Client Disassociation Stats message as required by EasyMesh spec (17.1.41).
+	 *
+	 * When a client disassociates, this message shall be sent to the Multi-AP Controller
+	 * including STA MAC Address Type TLV, Reason Code TLV, Associated STA Traffic Stats TLV,
+	 * and zero or more Affiliated STA Metrics TLVs (for MLD clients).
+	 *
+	 * @param[in] dassoc_sta Pointer to the disassociated sta
+	 *
+	 * @returns int
+	 * @retval message length on success
+	 * @retval -1 on failure
+	 */
+	int send_client_disassoc_stats_msg(const dm_sta_t *dassoc_sta);
+
+	/**!
+	 * @brief Sends a Failed Connection message
+	 *
+	 * Message content:
+	 * - One BSSID TLV
+	 * - One STA MAC Address Type TLV
+	 * - One Status Code TLV
+	 * - Zero or one Reason Code TLV
+	 *
+	 * @param[in] sta MAC address of the STA that attempted to connect.
+	 * @param[in] bssid BSSID to which the connection attempt was made.
+	 * @param[in] status_code IEEE 802.11 status code. If non-zero, reason TLV is omitted.
+	 * @param[in] reason_code IEEE 802.11 reason code used when status_code is zero.
+	 *
+	 * @returns int
+	 * @retval message length on success
+	 * @retval -1 on failure
+	 */
+	int send_failed_connection_msg(mac_address_t sta, bssid_t bssid,
+								   unsigned short status_code, unsigned short reason_code);
+
 	/**!
 	 * @brief Sends a BSTA MLD configuration request message.
 	 *
@@ -804,6 +842,7 @@ class em_configuration_t {
 	 */
 	int handle_topology_notification(unsigned char *buff, unsigned int len);
 	int handle_bsta_radio_cap(unsigned char *buff, unsigned int len);
+	int handle_assoc_sta_mld_conf_rep_tlv(unsigned char *buff, unsigned int len);
 
 	/**!
 	 * @brief Handles the operational BSS for the access point.
@@ -928,7 +967,7 @@ class em_configuration_t {
 	 *
 	 * @note Ensure the buffer is properly allocated and contains valid TLV data before calling this function.
 	 */
-	int handle_eht_operations_tlv(unsigned char *buff);
+	virtual int handle_eht_operations_tlv(unsigned char *buff, unsigned short len) = 0;
     
 	/**!
 	 * @brief Handles the Access Point MLD (Multi-Link Device) configuration request.
@@ -1000,20 +1039,7 @@ class em_configuration_t {
 	 */
 	unsigned short create_m2_msg(unsigned char *buff, em_haul_type_t haul_type);
     
-	/**!
-	 * @brief Creates a traffic separation policy.
-	 *
-	 * This function is responsible for creating a traffic separation policy using the provided buffer.
-	 *
-	 * @param[in] buff A pointer to an unsigned char buffer that contains the data required for creating the policy.
-	 *
-	 * @returns An unsigned short value indicating the result of the policy creation.
-	 * @retval 0 on success.
-	 * @retval non-zero error code on failure.
-	 *
-	 * @note Ensure that the buffer is properly initialized before calling this function.
-	 */
-	unsigned short create_traffic_separation_policy(unsigned char *buff);
+	virtual unsigned short create_traffic_separation_policy_tlv(unsigned char *buff) = 0;
     
 	/**!
 	 * @brief Creates an error code TLV.
@@ -1578,7 +1604,21 @@ public:
 	bool send_autoconf_search_resp_ext_chirp(em_dpp_chirp_value_t *chirp, size_t len, uint8_t dest_mac[ETH_ALEN], unsigned short msg_id);
 
 	bool send_bss_config_req_msg(uint8_t dest_al_mac[ETH_ALEN]);
-    
+
+	/**!
+	 * @brief Evaluates Unsuccessful Association Policy and sends a Failed Connection message if permitted.
+	 *
+	 * Checks report_unsuccess_assocs and rate-limiting before calling send_failed_connection_msg.
+	 *
+	 * @param[in] sta MAC address of the STA that attempted to connect.
+	 * @param[in] bssid BSSID to which the connection attempt was made.
+	 * @param[in] status_code IEEE 802.11 status code.
+	 * @param[in] reason_code IEEE 802.11 reason code.
+	 * @param[in] reason_code_present Indicates whether reason_code is valid in the event payload.
+	 */
+	void handle_failed_connection_event(const mac_address_t sta, const bssid_t bssid,
+									 unsigned short status_code, unsigned short reason_code,
+									 bool reason_code_present);
 	/**!
 	 * @brief Processes a message with the given data and length.
 	 *

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -266,6 +266,17 @@ public:
 	void handle_set_ssid_list(em_bus_event_t *evt);
     
 	/**!
+	 * @brief Handles channel selection events.
+	 *
+	 * This function processes channel selection events and schedules channel selection commands.
+	 *
+	 * @param[in] evt Pointer to the event structure containing channel select information.
+	 *
+	 * @note Ensure that the event structure is properly initialized before calling this function.
+	 */
+	void handle_channel_select(em_bus_event_t *evt);
+
+	/**!
 	 * @brief Handles the removal of a device from the bus.
 	 *
 	 * This function processes the event associated with the removal of a device.
@@ -457,6 +468,22 @@ public:
 	void handle_bsta_cap_req(em_bus_event_t *evt);
 
 	void handle_link_stats_alarm_report(em_bus_event_t *evt);
+
+	/**!
+	 * @brief Handles an Unassociated STA Link Metrics Query event.
+	 *
+	 * This function processes the Unassociated STA Link Metrics Query
+	 * received from the controller, validates the requested operating
+	 * classes, channels and STA MAC entries, and initiates the
+	 * corresponding agent-side RCPI measurement workflow.
+	 *
+	 * @param[in] evt Pointer to the event structure containing the
+	 *                Unassociated STA Link Metrics Query payload.
+	 *
+	 * @note Ensure that the event structure is properly initialized
+	 *       before calling this function.
+	 */
+	void handle_unassoc_sta_metrics_query(em_bus_event_t *evt);
 
 	/**!
 	 * @brief 
@@ -657,7 +684,7 @@ public:
 	 * Validates SetSSID input properties, dispatches the request to the EasyMesh
 	 * controller, and optionally populates response properties for the caller.
 	 *
-	 * @param[in] event_name Bus method name (Device.WiFi.DataElements.Network.SetSSID).
+	 * @param[in] method_name Bus method name (Device.WiFi.DataElements.Network.SetSSID).
 	 * @param[in] input_params Linked list of input properties carrying the request payload.
 	 * @param[out] output_params Populated with response properties when provided.
 	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
@@ -668,7 +695,106 @@ public:
 	 *
 	 * @note Input property ownership remains with the caller; this function does not free them.
 	 */
-	static bus_error_t cmd_setssid (const char *event_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+	static bus_error_t cmd_setssid (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+
+	/**!
+	 * @brief Handles the bus SteerWiFiBackhaul method request.
+	 *
+	 * Validates SteerWiFiBackhaul input properties, dispatches the request to the EasyMesh
+	 * controller, and optionally populates response properties for the caller.
+	 *
+	 * @param[in] method_name Bus method name (...Device.{i}.MultiAPDevice.Backhaul.SteerWiFiBackhaul).
+	 * @param[in] input_params Linked list of input properties carrying the request payload.
+	 * @param[out] output_params Populated with response properties when provided.
+	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
+	 *
+	 * @returns bus_error_t
+	 * @retval bus_error_none on successful SteerWiFiBackhaul handling.
+	 * @retval bus_error_failed on validation or controller execution failure.
+	 *
+	 * @note Input property ownership remains with the caller; this function does not free them.
+	 */
+	static bus_error_t cmd_steerwifibh (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+
+	/**!
+	 * @brief Handles the bus ChannelScanRequest method request.
+	 *
+	 * Validates ChannelScanRequest input properties, dispatches the request to the EasyMesh
+	 * controller, and optionally populates response properties for the caller.
+	 *
+	 * @param[in] method_name Bus method name (...Network.Device.{i}.Radio.{i}.ChannelScanRequest).
+	 * @param[in] input_params Linked list of input properties carrying the request payload.
+	 * @param[out] output_params Populated with response properties when provided.
+	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
+	 *
+	 * @returns bus_error_t
+	 * @retval bus_error_none on successful ChannelScanRequest handling.
+	 * @retval bus_error_failed on validation or controller execution failure.
+	 *
+	 * @note Input property ownership remains with the caller; this function does not free them.
+	 */
+	static bus_error_t cmd_channelscan (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+
+	// Constants for channel selection request parsing
+	static const int MAX_CHANSEL_CLASSES = 32;
+	static const int MAX_CHANSEL_CHANNELS = 64;
+
+	/**!
+	 * @brief Handles the bus ChannelSelectionRequest method request.
+	 *
+	 * Validates ChannelSelectionRequest input properties, dispatches the request to the EasyMesh
+	 * controller, and optionally populates response properties for the caller.
+	 *
+	 * @param[in] method_name Bus method name (...Network.Device.{i}.Radio.{i}.ChannelSelectionRequest()).
+	 * @param[in] input_params Linked list of input properties carrying the request payload.
+	 * @param[out] output_params Populated with response properties when provided.
+	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
+	 *
+	 * @returns bus_error_t
+	 * @retval bus_error_success on successful ChannelSelectionRequest handling.
+	 * @retval bus_error_invalid_input on validation failure.
+	 * @retval other non-zero bus_error_t values on error.
+	 * @note Input property ownership remains with the caller; this function does not free them.
+	 */
+	static bus_error_t cmd_channelselect(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+
+	/**!
+	 * @brief Handles the bus ClientSteer method request.
+	 *
+	 * Validates ClientSteer input properties, dispatches the request to the EasyMesh
+	 * controller, and optionally populates response properties for the caller.
+	 *
+	 * @param[in] method_name Bus method name (...Device.{i}.Radio.{i}.BSS.{i}.STA.{i}.ClientSteer).
+	 * @param[in] input_params Linked list of input properties carrying the request payload.
+	 * @param[out] output_params Populated with response properties when provided.
+	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
+	 *
+	 * @returns bus_error_t
+	 * @retval bus_error_none on successful ClientSteer handling.
+	 * @retval bus_error_failed on validation or controller execution failure.
+	 *
+	 * @note Input property ownership remains with the caller; this function does not free them.
+	 */
+	static bus_error_t cmd_clientsteer (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
+
+	/**!
+	 * @brief Handles the bus Disassociate method request.
+	 *
+	 * Validates Disassociate input properties, dispatches the request to the EasyMesh
+	 * controller, and optionally populates response properties for the caller.
+	 *
+	 * @param[in] method_name Bus method name (....Radio.{i}.BSS.{i}.STA.{i}.MultiAPSTA.Disassociate).
+	 * @param[in] input_params Linked list of input properties carrying the request payload.
+	 * @param[out] output_params Populated with response properties when provided.
+	 * @param[in] async_handle Async context handle when the bus call is asynchronous.
+	 *
+	 * @returns bus_error_t
+	 * @retval bus_error_none on successful Disassociate handling.
+	 * @retval bus_error_failed on validation or controller execution failure.
+	 *
+	 * @note Input property ownership remains with the caller; this function does not free them.
+	 */
+	static bus_error_t cmd_disassociate (const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle);
 
 	/**!
 	 *

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -190,6 +190,7 @@ class em_metrics_t {
 	 * of an associated station.
 	 *
 	 * @param[in] buff Pointer to the buffer containing the TLV data.
+	 * @param[in] tlv_len Length of the TLV value field.
 	 *
 	 * @returns int Status code indicating success or failure of the operation.
 	 * @retval 0 on success.
@@ -197,8 +198,12 @@ class em_metrics_t {
 	 *
 	 * @note Ensure that the buffer is properly allocated and contains valid TLV data
 	 * before calling this function.
+	 * @note The TLV length must strictly follow: (7 + k × 19), where
+	 * 7 bytes = STA MAC (6) + number of BSSIDs (1),
+	 * and 19 bytes per BSSID metrics entry.
+	 * Invalid or partial TLVs are rejected to prevent out-of-bounds access.
 	 */
-	int handle_assoc_sta_link_metrics_tlv(unsigned char *buff);
+	int handle_assoc_sta_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len);
     
 	/**!
 	 * @brief Handles the association of station external link metrics TLV.
@@ -207,14 +212,21 @@ class em_metrics_t {
 	 * station external link metrics TLV.
 	 *
 	 * @param[in] buff Pointer to the buffer containing the TLV data.
-	 *
+	 * @param[in] tlv_len Length of the TLV value field in bytes.
+	 * 
 	 * @returns int
 	 * @retval 0 on success
 	 * @retval -1 on failure
 	 *
 	 * @note Ensure that the buffer is properly allocated and contains valid TLV data.
+         * - Minimum required length is 7 bytes (STA MAC + k).
+         * - Each BSSID entry contains one `em_assoc_ext_link_metrics_t` block
+         * - Total TLV length must strictly follow:
+	 *   tlv_len = 7 + (k * sizeof(em_assoc_ext_link_metrics_t))
+         * - Any deviation from expected length results in rejection to prevent
+         *   out-of-bounds memory access
 	 */
-	int handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff);
+	int handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len);
     
 	/**!
 	 * @brief Handles the association of station vendor link metrics TLV.
@@ -349,23 +361,6 @@ class em_metrics_t {
 	short create_assoc_ext_sta_link_metrics_tlv(unsigned char *buff, mac_address_t sta_mac, const dm_sta_t *const sta);
     
 	/**!
-	 * @brief Creates an error code TLV.
-	 *
-	 * This function generates a TLV (Type-Length-Value) structure for error codes.
-	 *
-	 * @param[out] buff Buffer where the TLV will be stored.
-	 * @param[in] sta MAC address of the station.
-	 * @param[in] sta_found Boolean indicating if the station was found.
-	 *
-	 * @returns Short integer representing the status of the TLV creation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure the buffer is large enough to hold the TLV.
-	 */
-	short create_error_code_tlv(unsigned char *buff, mac_address_t sta, bool sta_found);
-    
-	/**!
 	 * @brief Creates an association vendor STA link metrics TLV.
 	 *
 	 * This function generates a TLV (Type-Length-Value) structure for the association
@@ -397,21 +392,20 @@ class em_metrics_t {
 	short create_beacon_metrics_query_tlv(unsigned char *buff, mac_address_t sta_mac, bssid_t bssid);
     
 	/**!
-	 * @brief Sends a beacon metrics query to a specified station.
-	 *
-	 * This function initiates a query to gather beacon metrics from a station identified by its MAC address.
-	 *
-	 * @param[in] sta_mac The MAC address of the station to which the beacon metrics query is sent.
-	 * @param[in] bssid The BSSID of the network to which the station is connected.
-	 *
-	 * @returns A short integer indicating the success or failure of the operation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure that the station is within range and the MAC address is correct before sending the query.
+	 * @brief Sends a 1905 ACK for a received Beacon Metrics Response.
+	 * @param[in] msg_id The message ID from the CMDU being acknowledged.
 	 */
-	short send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid);
-    
+	int send_beacon_metrics_ack(unsigned short msg_id);
+
+	/**!
+	 * @brief Sends a 1905 ACK to the controller after receiving a Beacon Metrics Query.
+	 *        Includes an Error Code TLV (Reason 0x02) if the STA is not associated.
+	 * @param[in] sta_mac STA MAC address from the query.
+	 * @param[in] msg_id  Message ID from the CMDU being acknowledged.
+	 * @param[in] reason  0 = success; 0x02 = STA not associated with any BSS.
+	 */
+	int send_beacon_metrics_query_ack(mac_address_t sta_mac, unsigned short msg_id, unsigned char reason);
+
 	/**!
 	 * @brief Sends a beacon metrics response.
 	 *
@@ -497,22 +491,7 @@ class em_metrics_t {
 	 * @note Ensure that the buffer is large enough to hold the TLV.
 	 */
 	short create_radio_metrics_tlv(unsigned char *buff, int index);
-    
-	/**!
-	 * @brief Creates an associated station traffic statistics TLV.
-	 *
-	 * This function generates a TLV (Type-Length-Value) structure for the traffic statistics
-	 * of an associated station and stores it in the provided buffer.
-	 *
-	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
-	 * @param[in] sta Constant pointer to the station data structure containing the statistics.
-	 *
-	 * @returns short The length of the TLV created.
-	 *
-	 * @note Ensure that the buffer is large enough to hold the TLV data.
-	 */
-	short create_assoc_sta_traffic_stats_tlv(unsigned char *buff, const dm_sta_t *const sta);
-    
+
 	/**!
 	 * @brief Creates an association report TLV for a WiFi 6 station.
 	 *
@@ -533,7 +512,166 @@ class em_metrics_t {
 
 	short create_link_stats_alarm_tlv(unsigned char *buff);
 
+        /*
+         * @brief Tracks whether an Unassociated STA Link Metrics Query
+         *        has already been transmitted and is awaiting response.
+         */
+        bool m_unassoc_query_sent = false;
+
+        /*
+         * @brief Tracks whether an Unassociated STA Link Metrics Response
+         *        has already been handled.
+         */
+	bool m_unassoc_in_progress = false;
+
+        /*
+         * @brief Sends an Unassociated STA Link Metrics Response message.
+         *
+         * @note Used by Agent to send measured RCPI metrics
+         *       for requested unassociated STAs.
+         */
+        void send_unassoc_sta_link_metrics_resp_msg();
+
+       /*!
+        * @brief Creates Unassociated STA Link Metrics Query TLV
+        *        for a given operating class.
+        *
+        * @param buff Output buffer where TLV is written.
+        * @param op   Operating class query structure.
+        *
+        * @return Length of generated TLV.
+        */
+        unsigned short create_unassoc_sta_link_metrics_query_tlv(unsigned char *buff, em_unassoc_query_opclass_t *op);
+
+       /*
+        * @brief Handles received Unassociated STA Link Metrics
+        *        Response CMDU.
+        *
+        * @param buff Incoming CMDU buffer.
+        * @param len  CMDU length.
+        *
+        * @return 0 on success.
+        */
+        int handle_unassoc_sta_link_metrics_rsp(unsigned char *buff, unsigned int len);
+
+       /*
+        * @brief Parses and processes an Unassociated STA
+        *        Link Metrics TLV.
+        *
+        * @param buff TLV payload buffer.
+	* @param tlv_len TLV length
+        *
+        * @return 0 on success.
+        */
+        int handle_unassoc_sta_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len);
+
+       /* 
+        * @brief Sends an Unassociated STA Link Metrics Query
+        *        message from Controller to Agent.
+        *
+        * @return 0 on success.
+        */
+        int send_unassoc_sta_link_metrics_query_msg();
+
+       /*
+        * @brief Handles received Unassociated STA Link Metrics Query.
+        *
+        * @param buff Incoming CMDU buffer.
+        * @param len  CMDU length.
+        *
+        * @return 0 on success.
+        */
+        int handle_unassoc_sta_link_metrics_query(unsigned char *buff, unsigned int len);
+
+       /*
+        * @brief Handles incoming 1905 ACK message.
+        *
+        * @param buff Incoming ACK CMDU buffer.
+        * @param len  CMDU length.
+        *
+        * @return 0 on success.
+        */
+        int handle_1905_ack(unsigned char *buff, unsigned int len);
+
+       /*
+        * @brief Sends a 1905 ACK for an Unassociated STA
+        *        Metrics Query request.
+        *
+        * @param sta_list List of queried STA MAC addresses.
+        * @param sta_count Number of STA MAC addresses.
+        * @param msg_id Original CMDU message ID being acknowledged.
+        *
+        * @return 0 on success.
+        */
+        int send_1905_ack_unassoc_sta_query(mac_address_t *sta_list, int sta_count, unsigned short msg_id);
+
+       /*
+        * @brief Creates Unassociated STA Link Metrics Response TLV.
+        *
+        * @param buff      Output buffer where TLV is written.
+        * @param op_class  Operating class of response metrics.
+        * @param rsp       Response metrics structure.
+        *
+        * @return Length of generated TLV.
+        */
+        unsigned short create_unassoc_sta_link_metrics_resp_tlv(unsigned char *buff, unsigned char op_class, em_unassoc_sta_metrics_rsp_t *rsp);
+
+       /*
+        * @brief Creates an Error Code TLV for STA metrics responses.
+        *
+        * @param buff          Output buffer where TLV is written.
+        * @param sta           STA MAC address associated with error.
+        * @param sta_found     Indicates whether STA was found.
+        * @param is_associated Indicates whether STA is associated.
+        *
+        * @return Length of generated TLV.
+        */
+        short create_error_code_tlv(unsigned char *buff, mac_address_t sta, bool sta_found, bool is_associated);
+
+       /*
+        * @brief Stores the CMDU Message ID of the last transmitted
+        *        Unassociated STA Link Metrics Query.
+        *
+        * @note Used for ACK tracking and response correlation.
+        */
+        unsigned short m_unassoc_sta_query_msg_id = 0;
+ 
+       /**
+        * @brief Get the current Unassociated STA Query message ID.
+        *
+        * Returns the message ID associated with the outstanding
+        * Unassociated STA Link Metrics Query.
+        *
+        * @return Message ID of the pending query.
+        */
+        unsigned short get_unassoc_sta_query_msg_id() const { return m_unassoc_sta_query_msg_id; }
+
+       /**
+        * @brief Clear the Unassociated STA Query message ID.
+        *
+        * Resets the stored query message ID after the corresponding
+        * ACK has been received and processed.
+        */
+        void clear_unassoc_sta_query_msg_id() { m_unassoc_sta_query_msg_id = 0; }	
+
 public:
+
+	short send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid);
+
+	/**!
+	 * @brief Creates an associated station traffic statistics TLV.
+	 *
+	 * This function generates a TLV (Type-Length-Value) structure for the traffic statistics
+	 * of an associated station and stores it in the provided buffer.
+	 *
+	 * @param[out] buff Pointer to the buffer where the TLV will be stored.
+	 * @param[in] sta Constant pointer to the station data structure containing the statistics.
+	 *
+	 * @returns short The length of the TLV created.
+	 *
+	 * @note Ensure that the buffer is large enough to hold the TLV data.
+	 */
+	virtual short create_assoc_sta_traffic_stats_tlv(unsigned char *buff, const dm_sta_t *const sta);
 
 	/**!
 	 * @brief Retrieves the manager instance.

--- a/inc/em_policy_cfg.h
+++ b/inc/em_policy_cfg.h
@@ -162,7 +162,7 @@ public:
 	short create_metrics_rep_policy_tlv(unsigned char *buff);
 
 	/**!
-	 * @brief Creates a default 802.1q settings policy TLV.
+	 * @brief Creates a default 802.1Q settings policy TLV.
 	 *
 	 * This function generates a default 802.1q settings TLV (Type-Length-Value) and stores it in the provided buffer.
 	 *
@@ -172,9 +172,10 @@ public:
 	 *
 	 * @note Ensure that the buffer is large enough to hold the TLV.
 	 */
-	short create_def_8021q_settings_policy_tlv(unsigned char *buff);
+	virtual short create_def_8021q_settings_policy_tlv(unsigned char *buff) = 0;
 
 	/**!
+
 	 * @brief Creates a traffic separation policy TLV.
 	 *
 	 * This function generates a traffic separation policy TLV (Type-Length-Value) and stores it in the provided buffer.
@@ -185,7 +186,7 @@ public:
 	 *
 	 * @note Ensure that the buffer is large enough to hold the TLV.
 	 */
-	short create_traffic_sep_policy_tlv(unsigned char *buff);
+	virtual unsigned short create_traffic_separation_policy_tlv(unsigned char *buff) = 0;
 
 	/**!
 	 * @brief Creates a channel scan report policy TLV.
@@ -224,7 +225,7 @@ public:
 	 *
 	 * @note Ensure that the buffer is large enough to hold the TLV.
 	 */
-	short create_backhaul_bss_conf_policy_tlv(unsigned char *buff);
+short create_backhaul_bss_conf_policy_tlv(unsigned char *buff, const em_backhaul_bss_config_policy_t *entry);
 
 	/**!
 	 * @brief Creates a qos management policy TLV.
@@ -237,7 +238,7 @@ public:
 	 *
 	 * @note Ensure that the buffer is large enough to hold the TLV.
 	 */
-	short create_qos_mgt_policy_tlv(unsigned char *buff);
+short create_qos_mgt_policy_tlv(unsigned char *buff, dm_policy_t *policy, unsigned int qi);
 
 	/**!
 	 * @brief Creates a vendor policy configuration TLV.

--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -89,6 +89,9 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define TR181_BAND_MAX_LEN         16
 #define TR181_ADDREMOVE_MAX_LEN    16
 #define TR181_HAULTYPE_MAX_LEN     32
+#define TR181_CHLIST_MAX_LEN       128
+#define TR181_BSSID_MAX_LEN        32
+#define TR181_REQMODE_MAX_LEN      24
 
 #define MAX_INSTANCE_LEN        32
 #define MAX_CAPS_STR_LEN        32
@@ -97,6 +100,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define MAX_TIME_STRLEN         24
 #define MAX_ZONE_STRLEN         8
 #define MAX_TIMESTAMP_STRLEN    64
+#define MAX_STDLEN              64
 #define ARRAY_SIZE(a)           (sizeof(a) / sizeof(a[0]))
 
 /* Device.WiFi.DataElements.Network */
@@ -185,6 +189,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_DEVICE_MAPDEV        DE_NETWORK_DEVICE       "MultiAPDevice."
 /* Device.WiFi.DataElements.Network.Device.MultiAPDevice.Backhaul */
 #define DE_MAPDEV_BACKHAUL      DE_DEVICE_MAPDEV        "Backhaul."
+#define DE_MAPDEVBH_STEERWIFIBH DE_MAPDEV_BACKHAUL      "SteerWiFiBackhaul()"
 /* Device.WiFi.DataElements.Network.Device.MultiAPDevice.Backhaul.Stats */
 #define DE_MAPDEVBH_STATS       DE_MAPDEV_BACKHAUL      "Stats."
 #define DE_MDBHSTATS_BYTESSNT   DE_MAPDEVBH_STATS       "BytesSent"
@@ -211,6 +216,9 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_RADIO_CURROPNOE      DE_DEVICE_RADIO         "CurrentOperatingClassProfileNumberOfEntries"
 #define DE_RADIO_BSSNOE         DE_DEVICE_RADIO         "BSSNumberOfEntries"
 #define DE_RADIO_NOUNASSCSTA    DE_DEVICE_RADIO         "UnassociatedSTANumberOfEntries"
+#define DE_RADIO_CHSCANREQ      DE_DEVICE_RADIO         "ChannelScanRequest()"
+#define DE_RADIO_CHSELREQ       DE_DEVICE_RADIO         "ChannelSelectionRequest()"
+#define DE_RADIO_XAIRTIES_OPERSTANDARDS DE_DEVICE_RADIO "X_AIRTIES_OperatingStandards"
 /* Device.WiFi.DataElements.Network.Device.Radio.BackhaulSta */
 #define DE_RADIO_BHSTA          DE_DEVICE_RADIO         "BackhaulSta."
 #define DE_BHSTA_MACADDR        DE_RADIO_BHSTA          "MACAddress"
@@ -275,20 +283,6 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_WF6BSTA_TWT_RSP      DE_CAPS_WF6BSTA         "TWTResponder"
 #define DE_WF6BSTA_SPAT_REUSE   DE_CAPS_WF6BSTA         "SpatialReuse"
 #define DE_WF6BSTA_ANT_CH_USE   DE_CAPS_WF6BSTA         "AnticipatedChannelUsage"
-/* Device.WiFi.DataElements.Network.Device.Radio.Capabilities.CapableOperatingClassProfile */
-#define DE_CAPS_CAPOP           DE_RADIO_CAPS           "CapableOperatingClassProfile.{i}."
-#define DE_CAPOP_TABLE          DE_RADIO_CAPS           "CapableOperatingClassProfile.{i}"
-#define DE_CAPOP_CLASS          DE_CAPS_CAPOP           "Class"
-#define DE_CAPOP_MAXTXPOWER     DE_CAPS_CAPOP           "MaxTxPower"
-#define DE_CAPOP_NONOPERABLE    DE_CAPS_CAPOP           "NonOperable"
-#define DE_CAPOP_NONOPCNT       DE_CAPS_CAPOP           "NumberOfNonOperChan"
-/* Device.WiFi.DataElements.Network.Device.Radio.CurrentOperatingClassProfile */
-#define DE_RADIO_CUROP          DE_DEVICE_RADIO         "CurrentOperatingClassProfile.{i}."
-#define DE_CUROP_TABLE          DE_DEVICE_RADIO         "CurrentOperatingClassProfile.{i}"
-#define DE_CUROP_TIMESTAMP      DE_RADIO_CUROP          "TimeStamp"
-#define DE_CUROP_CLASS          DE_RADIO_CUROP          "Class"
-#define DE_CUROP_CHANNEL        DE_RADIO_CUROP          "Channel"
-#define DE_CUROP_TXPOWER        DE_RADIO_CUROP          "TxPower"
 /* Device.WiFi.DataElements.Network.Device.Radio.Capabilities.WiFi7APRole */
 #define DE_CAPS_WF7AP           DE_RADIO_CAPS           "WiFi7APRole."
 #define DE_WF7AP_EMLMR          DE_CAPS_WF7AP           "EMLMRSupport"
@@ -307,6 +301,24 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_CAPS_SCANCAP         DE_RADIO_CAPS           "ScanCapability."
 #define DE_SCANCAP_TIMESTAMP    DE_CAPS_SCANCAP         "TimeStamp"
 #define DE_SCANCAP_OPCLSCANSNOE DE_CAPS_SCANCAP         "OpClassChannelsNumberOfEntries"
+/* Device.WiFi.DataElements.Network.Device.Radio.Capabilities.CapableOperatingClassProfile */
+#define DE_CAPS_CAPOP           DE_RADIO_CAPS           "CapableOperatingClassProfile.{i}."
+#define DE_CAPOP_TABLE          DE_RADIO_CAPS           "CapableOperatingClassProfile.{i}"
+#define DE_CAPOP_CLASS          DE_CAPS_CAPOP           "Class"
+#define DE_CAPOP_MAXTXPOWER     DE_CAPS_CAPOP           "MaxTxPower"
+#define DE_CAPOP_NONOPERABLE    DE_CAPS_CAPOP           "NonOperable"
+#define DE_CAPOP_NONOPCNT       DE_CAPS_CAPOP           "NumberOfNonOperChan"
+/* Device.WiFi.DataElements.Network.Device.Radio.CurrentOperatingClassProfile */
+#define DE_RADIO_CUROP          DE_DEVICE_RADIO         "CurrentOperatingClassProfile.{i}."
+#define DE_CUROP_TABLE          DE_DEVICE_RADIO         "CurrentOperatingClassProfile.{i}"
+#define DE_CUROP_TIMESTAMP      DE_RADIO_CUROP          "TimeStamp"
+#define DE_CUROP_CLASS          DE_RADIO_CUROP          "Class"
+#define DE_CUROP_CHANNEL        DE_RADIO_CUROP          "Channel"
+#define DE_CUROP_TXPOWER        DE_RADIO_CUROP          "TxPower"
+/* Device.WiFi.DataElements.Network.Device.Radio.ScanResult */
+#define DE_RADIO_SCANRES        DE_DEVICE_RADIO         "ScanResult.{i}."
+#define DE_SCANRES_TABLE        DE_DEVICE_RADIO         "ScanResult.{i}"
+#define DE_SCANRES_TIMESTAMP    DE_RADIO_SCANRES        "TimeStamp"
 /* Device.WiFi.DataElements.Network.Device.Radio.BSS */
 #define DE_RADIO_BSS            DE_DEVICE_RADIO         "BSS.{i}."
 #define DE_BSS_TABLE            DE_DEVICE_RADIO         "BSS.{i}"
@@ -371,10 +383,14 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define DE_STA_PAIRWSAKM        DE_BSS_STA              "PairwiseAKM"
 #define DE_STA_PAIRWSCIPHER     DE_BSS_STA              "PairwiseCipher"
 #define DE_STA_RSNCAPS          DE_BSS_STA              "RSNCapabilities"
+#define DE_STA_CLIENTSTEER      DE_BSS_STA              "ClientSteer()"
 /* Device.WiFi.DataElements.Network.Device.Radio.BSS.STA.WiFi6Capabilities */
 #define DE_STA_WIFI6CAPS        DE_BSS_STA              "WiFi6Capabilities."
 #define DE_STAWF6CAPS_HE160     DE_STA_WIFI6CAPS        "HE160"
 #define DE_STAWF6CAPS_MCSNSS    DE_STA_WIFI6CAPS        "MCSNSS"
+/* Device.WiFi.DataElements.Network.Device.Radio.BSS.STA.MultiAPSTA */
+#define DE_STA_MULTIAP          DE_BSS_STA              "MultiAPSTA."
+#define DE_STAMAP_DISASSOC      DE_STA_MULTIAP          "Disassociate()"
 /* Device.WiFi.DataElements.Network.Device.Radio.UnassociatedSTA */
 #define DE_RADIO_UNASSOCSTA     DE_DEVICE_RADIO         "UnassociatedSTA.{i}."
 #define DE_UNASSOCSTA_TABLE     DE_DEVICE_RADIO         "UnassociatedSTA.{i}"
@@ -545,8 +561,8 @@ public:
      * raw buffer for RBUS callers.
      *
      * @param method_name RBUS method name, expected to match SetSSID.
-     * @param input_data Raw input containing a chained list of bus_data_prop_t entries.
-     * @param output_data Raw output buffer populated with response properties when provided.
+     * @param input_data Input containing a chained list of bus_data_prop_t entries.
+     * @param output_data Output populated with response properties when provided.
      * @param async_handle RBUS async handle when the call is asynchronous (may be null).
      *
      * @returns bus_error_t
@@ -555,7 +571,113 @@ public:
      *
      * @note Ownership of input and output buffers remains with the caller.
      */
-    static bus_error_t setssid_handler(const char *method_name, raw_data_t *input_data, raw_data_t *output_data, void *async_handle);
+    static bus_error_t setssid_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
+
+    /**!
+     * @brief Handles the RBUS SteerWiFiBackhaul method invocation.
+     *
+     * This function extracts SteerWiFiBackhaul properties from the raw input payload, forwards
+     * them to the EasyMesh controller, and optionally writes response properties to the output
+     * raw buffer for RBUS callers.
+     *
+     * @param method_name RBUS method name, expected to match SteerWiFiBackhaul.
+     * @param input_data Input containing a chained list of bus_data_prop_t entries.
+     * @param output_data Output populated with response properties when provided.
+     * @param async_handle RBUS async handle when the call is asynchronous (may be null).
+     *
+     * @returns bus_error_t
+     * @retval bus_error_none on successful SteerWiFiBackhaul handling.
+     * @retval bus_error_failed on validation or controller execution failure.
+     *
+     * @note Ownership of input and output buffers remains with the caller.
+     */
+    static bus_error_t steerwifibh_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
+
+    /**!
+     * @brief Handles the RBUS ChannelScanRequest method invocation.
+     *
+     * This function extracts ChannelScanRequest properties from the raw input payload, forwards
+     * them to the EasyMesh controller, and optionally writes response properties to the output
+     * raw buffer for RBUS callers.
+     *
+     * @param method_name RBUS method name, expected to match ChannelScanRequest.
+     * @param input_data Input containing a chained list of bus_data_prop_t entries.
+     * @param output_data Output populated with response properties when provided.
+     * @param async_handle RBUS async handle when the call is asynchronous (may be null).
+     *
+     * @returns bus_error_t
+     * @retval bus_error_none on successful ChannelScanRequest handling.
+     * @retval bus_error_failed on validation or controller execution failure.
+     *
+     * @note Ownership of input and output buffers remains with the caller.
+     */
+    static bus_error_t channelscan_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
+
+    /**!
+     * @brief Handles the RBUS ChannelSelectionRequest method invocation.
+     *
+     * This function extracts ChannelSelectionRequest properties from the raw input payload, forwards
+     * them to the EasyMesh controller, and optionally writes response properties to the output
+     * raw buffer for RBUS callers.
+     *
+     * @param method_name RBUS method name, expected to match ChannelSelectionRequest().
+     * @param input_data Input containing a chained list of bus_data_prop_t entries.
+     * @param output_data Output populated with response properties when provided.
+     * @param async_handle RBUS async handle when the call is asynchronous (may be null).
+     *
+     * @returns bus_error_t
+     * @retval bus_error_success on successful ChannelSelectionRequest handling.
+     * @retval bus_error_invalid_input on validation failure.
+     * @retval other non-zero bus_error_t values on error.
+     * @note Ownership of input and output buffers remains with the caller.
+     */
+    static bus_error_t channelselect_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
+
+    /**!
+     * @brief Handles the RBUS ClientSteer method invocation.
+     *
+     * This function extracts ClientSteer properties from the raw input payload, forwards them
+     * to the EasyMesh controller, and optionally writes response properties to the output
+     * raw buffer for RBUS callers.
+     *
+     * @param method_name RBUS method name, expected to match ClientSteer.
+     * @param input_data Input containing a chained list of bus_data_prop_t entries.
+     * @param output_data Output populated with response properties when provided.
+     * @param async_handle RBUS async handle when the call is asynchronous (may be null).
+     *
+     * @returns bus_error_t
+     * @retval bus_error_none on successful ClientSteer handling.
+     * @retval bus_error_failed on validation or controller execution failure.
+     *
+     * @note Ownership of input and output buffers remains with the caller.
+     */
+    static bus_error_t clientsteer_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
+
+    /**!
+     * @brief Handles the RBUS Disassociate method invocation.
+     *
+     * This function extracts Disassociate properties from the raw input payload, forwards them
+     * to the EasyMesh controller, and optionally writes response properties to the output
+     * raw buffer for RBUS callers.
+     *
+     * @param method_name RBUS method name, expected to match Disassociate.
+     * @param input_data Input containing a chained list of bus_data_prop_t entries.
+     * @param output_data Output populated with response properties when provided.
+     * @param async_handle RBUS async handle when the call is asynchronous (may be null).
+     *
+     * @returns bus_error_t
+     * @retval bus_error_none on successful Disassociate handling.
+     * @retval bus_error_failed on validation or controller execution failure.
+     *
+     * @note Ownership of input and output buffers remains with the caller.
+     */
+    static bus_error_t disassociate_handler(const char *method_name, bus_data_prop_t *input_data,
+        bus_data_prop_t *output_data, void *async_handle);
 
     //Methods helper utilities
 
@@ -641,7 +763,7 @@ public:
      *
      * @note On success, output_data takes ownership of the allocated property.
      */
-    static void tr181_set_status_output(raw_data_t *output_data, const char *status);
+    static void tr181_set_status_output(bus_data_prop_t *output_data, const char *status);
 
     /**!
      * @brief Copy a string property value into a destination buffer.
@@ -655,6 +777,30 @@ public:
      * @retval false on invalid input or type mismatch.
      */
     static bool tr181_copy_prop_string(const bus_data_prop_t *prop, char *dst, size_t dst_len);
+
+    /**!
+     * @brief Get integer value of property into provided variable.
+     *
+     * @param prop Property expected to contain an integer value.
+     * @param value Destination variable.
+     *
+     * @returns bool
+     * @retval true if the copy succeeded.
+     * @retval false on invalid input or type mismatch.
+     */
+    static bool tr181_get_prop_int(const bus_data_prop_t *prop, int *value);
+
+    /**!
+     * @brief Get boolean value of property into provided variable.
+     *
+     * @param prop Property expected to contain a boolean value.
+     * @param value Destination variable.
+     *
+     * @returns bool
+     * @retval true if the copy succeeded.
+     * @retval false on invalid input or type mismatch.
+     */
+    static bool tr181_get_prop_bool(const bus_data_prop_t *prop, bool *value);
 
     //Device Callbacks
     static bus_error_t device_get(char* event_name, raw_data_t* p_data, struct bus_user_data* user_data);
@@ -677,6 +823,8 @@ public:
     static bus_error_t wf7ap_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t curops_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
     static bus_error_t curops_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t capops_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
+    static bus_error_t capops_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data);
 
     //BSS
     static bus_error_t bss_get(char* event_name, raw_data_t* p_data, struct bus_user_data* user_data);

--- a/inc/util.h
+++ b/inc/util.h
@@ -299,7 +299,6 @@ namespace util {
 	 */
 	std::pair<uint8_t, uint8_t> em_freq_to_chan(unsigned int frequency, const std::string& region="");
 
-
 	/**
 	 * @brief Translate an AKM literal to its OUI representation case-insensitively.
 	 *
@@ -360,22 +359,22 @@ namespace util {
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
-#define em_printf(format, ...)  util::em_util_print(EM_LOG_LVL_INFO, EM_AGENT, __func__, __LINE__, format, ##__VA_ARGS__)// general log
-#define em_printfout(format, ...)  util::em_util_print(EM_LOG_LVL_INFO, EM_STDOUT, __FILENAME__, __LINE__, format, ##__VA_ARGS__)// general log
-#define em_util_dbg_print(module, format, ...)  util::em_util_print(EM_LOG_LVL_DEBUG, module, __func__, __LINE__, format, ##__VA_ARGS__)
-#define em_util_info_print(module, format, ...)  util::em_util_print(EM_LOG_LVL_INFO, module, __func__, __LINE__, format, ##__VA_ARGS__)
-#define em_util_error_print(module, format, ...)  util::em_util_print(EM_LOG_LVL_ERROR, module, __func__, __LINE__, format, ##__VA_ARGS__)
+#define em_printf(...)  util::em_util_print(EM_LOG_LVL_INFO, EM_AGENT, __func__, __LINE__, __VA_ARGS__)// general log
+#define em_printfout(...)  util::em_util_print(EM_LOG_LVL_INFO, EM_STDOUT, __FILENAME__, __LINE__, __VA_ARGS__)// general log
+#define em_util_dbg_print(module, ...)  util::em_util_print(EM_LOG_LVL_DEBUG, module, __func__, __LINE__, __VA_ARGS__)
+#define em_util_info_print(module, ...)  util::em_util_print(EM_LOG_LVL_INFO, module, __func__, __LINE__, __VA_ARGS__)
+#define em_util_error_print(module, ...)  util::em_util_print(EM_LOG_LVL_ERROR, module, __func__, __LINE__, __VA_ARGS__)
 
 
 // Used to avoid many many if-not-null checks
-#define EM_ASSERT_MSG_FALSE(x, ret, errMsg, ...) \
+#define EM_ASSERT_MSG_FALSE(x, ret, ...) \
     if(x) { \
-        em_printfout(errMsg, ## __VA_ARGS__); \
+        em_printfout(__VA_ARGS__); \
         return ret; \
     }
 
-#define EM_ASSERT_MSG_TRUE(x, ret, errMsg, ...) EM_ASSERT_MSG_FALSE(!(x), ret, errMsg, ## __VA_ARGS__)
-#define EM_ASSERT_NOT_NULL(x, ret, errMsg, ...) EM_ASSERT_MSG_FALSE(x == NULL, ret, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_MSG_TRUE(x, ret, ...) EM_ASSERT_MSG_FALSE(!(x), ret, __VA_ARGS__)
+#define EM_ASSERT_NOT_NULL(x, ret, ...) EM_ASSERT_MSG_FALSE(x == NULL, ret, __VA_ARGS__)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 3 pointers and returns a value
@@ -384,13 +383,12 @@ namespace util {
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
  * @param ptr3 Third pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+#define EM_ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, ptr3, ...) \
     do { \
         if(x == NULL) { \
-            em_printfout(errMsg, ## __VA_ARGS__); \
+            em_printfout(__VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
             void *_tmp3 = (ptr3); \
@@ -410,19 +408,19 @@ namespace util {
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees up to 2 pointers and returns a value
  */
-#define EM_ASSERT_NOT_NULL_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
-    EM_ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_NOT_NULL_FREE2(x, ret, ptr1, ptr2, ...) \
+    EM_ASSERT_NOT_NULL_FREE3(x, ret, ptr1, ptr2, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a pointer is not NULL, and if it is, frees one pointer and returns a value
  */
-#define EM_ASSERT_NOT_NULL_FREE(x, ret, ptr1, errMsg, ...) \
-    EM_ASSERT_NOT_NULL_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_NOT_NULL_FREE(x, ret, ptr1, ...) \
+    EM_ASSERT_NOT_NULL_FREE2(x, ret, ptr1, NULL, __VA_ARGS__)
 
 
-#define EM_ASSERT_NULL(x, ret, errMsg, ...) EM_ASSERT_MSG_TRUE(x == 0, ret, errMsg, ## __VA_ARGS__)
-#define EM_ASSERT_EQUALS(x, y, ret, errMsg, ...) EM_ASSERT_MSG_TRUE(x == y, ret, errMsg, ## __VA_ARGS__)
-#define EM_ASSERT_NOT_EQUALS(x, y, ret, errMsg, ...) EM_ASSERT_MSG_FALSE(x == y, ret, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_NULL(x, ret, ...) EM_ASSERT_MSG_TRUE(x == 0, ret, __VA_ARGS__)
+#define EM_ASSERT_EQUALS(x, y, ret, ...) EM_ASSERT_MSG_TRUE(x == y, ret, __VA_ARGS__)
+#define EM_ASSERT_NOT_EQUALS(x, y, ret, ...) EM_ASSERT_MSG_FALSE(x == y, ret, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and if it doesn't, frees up to 3 pointers and returns a value
@@ -431,13 +429,12 @@ namespace util {
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
  * @param ptr3 Third pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, errMsg, ...) \
+#define EM_ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, ptr3, ...) \
     do { \
         if(!x.has_value()) { \
-            em_printfout(errMsg, ## __VA_ARGS__); \
+            em_printfout(__VA_ARGS__); \
             void *_tmp1 = (ptr1); \
             void *_tmp2 = (ptr2); \
             void *_tmp3 = (ptr3); \
@@ -460,30 +457,27 @@ namespace util {
  * @param ret The value to return if x is nullopt
  * @param ptr1 First pointer to free (can be NULL)
  * @param ptr2 Second pointer to free (can be NULL) 
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, errMsg, ...) \
-    EM_ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, ptr2, ...) \
+    EM_ASSERT_OPT_HAS_VALUE_FREE3(x, ret, ptr1, ptr2, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and if it doesn't, frees a pointer and returns a value
  * @param x The std::optional to check for a value
  * @param ret The value to return if x is nullopt
  * @param ptr1 First pointer to free (can be NULL)
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, errMsg, ...) \
-    EM_ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_OPT_HAS_VALUE_FREE(x, ret, ptr1, ...) \
+    EM_ASSERT_OPT_HAS_VALUE_FREE2(x, ret, ptr1, NULL, __VA_ARGS__)
 
 /**
  * @brief Asserts that a std::optional has a value, and returns a value if it doesn't
  * @param x The std::optional to check for a value
  * @param ret The value to return if x is nullopt
- * @param errMsg Format string for error message
- * @param ... Additional arguments for the format string
+ * @param ... Format string and additional arguments for the error message
  */
-#define EM_ASSERT_OPT_HAS_VALUE(x, ret, errMsg, ...) EM_ASSERT_MSG_TRUE(x.has_value(), ret, errMsg, ## __VA_ARGS__)
+#define EM_ASSERT_OPT_HAS_VALUE(x, ret, ...) EM_ASSERT_MSG_TRUE(x.has_value(), ret, __VA_ARGS__)
 
 #endif

--- a/install/bin/Channel.json
+++ b/install/bin/Channel.json
@@ -3,6 +3,19 @@
 
 		"Network":	{
 			"ID":	"OneWifiMesh",
+			"AnticipatedChannelPreference":	[{
+					"Class":	134,
+					"ChannelList":	[1, 2],
+					"ChannelPrefList":	[0, 0]
+				}, {
+					"Class":	136,
+					"ChannelList":	[1, 2],
+					"ChannelPrefList":	[0, 0]
+				}, {
+					"Class":	137,
+					"ChannelList":	[1, 2],
+					"ChannelPrefList":	[0, 0]
+				}],
 			"DeviceList":	[{
 					"ID":	"00:0c:29:dc:63:48",
 					"RadioList":	[{
@@ -22,20 +35,10 @@
 						}, {
 							"ID":	"00:ab:cd:ef:00:10",
 							"CurrentOperatingClasses":	[{
-                                            "Class":	135,
+									"Class":	135,
 									"Channel":	1,
 									"TxPower":	20
 								}]
-						}],
-					"AnticipatedChannelPreference":	[{
-							"Class":	134,
-							"ChannelList":	[1, 2]
-						}, {
-							"Class":	136,
-							"ChannelList":	[1, 2]
-						}, {
-							"Class":	137,
-							"ChannelList":	[1, 2]
 						}]
 				}]
 		},

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -33,6 +33,11 @@ onewifi_em_agent_CPPFLAGS = \
     -I$(top_srcdir)/src/util \
     -I$(top_srcdir)/src/util_crypto
 
+onewifi_em_agent_CXXFLAGS = $(INCLUDEDIRS) -g -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fno-omit-frame-pointer #-Wconversion -Werror -O2
+if EM_ASAN_AGENT
+onewifi_em_agent_CXXFLAGS += -fsanitize=address -fsanitize=undefined
+endif
+
 onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/em/em.cpp \
      $(top_srcdir)/src/em/em_mgr.cpp \
@@ -94,6 +99,7 @@ onewifi_em_agent_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_beacon_report.cpp \
      $(top_srcdir)/src/cmd/em_cmd_ap_metrics_report.cpp \
      $(top_srcdir)/src/cmd/em_cmd_link_stats_report.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_unassoc_sta_result.cpp \
      $(top_srcdir)/src/agent/dm_easy_mesh_agent.cpp \
      $(top_srcdir)/src/agent/em_agent.cpp \
      $(top_srcdir)/src/agent/em_cmd_agent.cpp \
@@ -124,6 +130,10 @@ onewifi_em_agent_SOURCES =  \
 
 
 onewifi_em_agent_LDFLAGS = -lm -lpthread -ldl -lcjson -luuid -lssl -lcrypto -lwifi_webconfig -lrbus
+if EM_ASAN_AGENT
+onewifi_em_agent_LDFLAGS += -fsanitize=address -fsanitize=undefined
+endif
+
 onewifi_em_agent_LDADD = $(top_builddir)/src/al-sap/libalsap.la
 if EM_UNITTEST
 onewifi_em_agent_test_SOURCES = \
@@ -171,14 +181,17 @@ onewifi_em_agent_test_SOURCES = \
 	$(top_srcdir)/tests/test_l1_util.cpp \
 	$(top_srcdir)/tests/test_l1_ec_1905_encrypt_layer.cpp \
 	$(top_srcdir)/tests/test_l1_ec_enrollee.cpp \
-        $(top_srcdir)/tests/test_l1_ec_util.cpp \
+	$(top_srcdir)/tests/test_l1_ec_util.cpp \
 	$(top_srcdir)/tests/test_l1_dm_easy_mesh.cpp \
 	$(top_srcdir)/tests/test_l1_ec_pa_configurator.cpp \
 	$(top_srcdir)/tests/test_l1_ec_manager.cpp
+
 onewifi_em_agent_test_CPPFLAGS = $(onewifi_em_agent_CPPFLAGS) \
-	-I$(PKG_CONFIG_SYSROOT_DIR)$(includedir)/gtest \
-	-DTESTING
-onewifi_em_agent_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST
+                                 -I$(PKG_CONFIG_SYSROOT_DIR)$(includedir)/gtest \
+                                 -DTESTING
+onewifi_em_agent_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -fno-omit-frame-pointer
+onewifi_em_agent_test_CXXFLAGS += -fsanitize=address -fsanitize=undefined
 onewifi_em_agent_test_LDFLAGS = -lcjson -lgtest -lgtest_main -lgmock -lpthread -lssl -lcrypto -lm -luuid -ldl -lwifi_webconfig -lrbus
+onewifi_em_agent_test_LDFLAGS += -fsanitize=address -fsanitize=undefined
 onewifi_em_agent_test_LDADD = $(onewifi_em_agent_LDADD)
-endif
+endif  #EM_UNITTEST

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -52,6 +52,7 @@
 #include "em_cmd_sta_link_metrics.h"
 #include "em_cmd_ap_metrics_report.h"
 #include "em_cmd_link_stats_report.h"
+#include "em_cmd_unassoc_sta_result.h"
 
 #ifdef AL_SAP
 #include "al_service_access_point.h"
@@ -88,10 +89,10 @@ int dm_easy_mesh_agent_t::analyze_dev_init(em_bus_event_t *evt, em_cmd_t *pcmd[]
     pcmd[num] = new em_cmd_dev_init_t(evt->params, dm);
     tmp = pcmd[num];
 
-    for (int i = 0; i < pcmd[num]->m_data_model.m_num_radios; i++) {
-        em_printfout("dm num_role:%d for radio[%d]:%s\n", dm.get_radio_cap_info(i)->wifi6_cap.num_role,
+    for (unsigned int i = 0; i < pcmd[num]->m_data_model.m_num_radios; i++) {
+        em_printfout("dm num_role:%u for radio[%u]:%s\n", dm.get_radio_cap_info(i)->wifi6_cap.num_role,
                 i, util::mac_to_string(dm.get_radio_cap_info(i)->ruid.mac).c_str());
-        em_printfout("num_role:%d\n", pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi6_cap.num_role);
+        em_printfout("num_role:%u\n", pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi6_cap.num_role);
         // em_printfout("su_beam:%d\n", pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi6_cap.su_beam_former);
         em_printfout("wifi 7 rad mac:%s\n", util::mac_to_string(pcmd[num]->m_data_model.get_radio_cap_info(i)->wifi7_cap.mlo_cap_support.ruid).c_str());
         em_printfout("he cap rad mac:%s\n", util::mac_to_string(pcmd[num]->m_data_model.get_radio_cap_info(i)->he_cap.ruid).c_str());
@@ -109,18 +110,21 @@ int dm_easy_mesh_agent_t::analyze_dev_init(em_bus_event_t *evt, em_cmd_t *pcmd[]
 int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     unsigned int num = 0, i = 0, num_radios = 0;
+    unsigned int idx = 0, k = 0;
     dm_easy_mesh_agent_t  dm;
     dm_sta_t *sta = NULL;
     em_cmd_t *tmp = NULL;
+    mac_address_t sta_mld_mac;
     em_long_string_t key;
+    mac_address_t assoc_sta_mld_tracked_macs[EM_MAX_ASSOC_STA_MLD] = {{0}};
+    mac_address_t disassoc_sta_mld_tracked_macs[EM_MAX_ASSOC_STA_MLD] = {{0}};
+    unsigned int assoc_sta_mld_tracked_count = 0;
+    unsigned int disassoc_sta_mld_tracked_count = 0;
+    bool is_tracked_sta_mld = false;
     mac_addr_str_t radio_str;
-    em_cmd_params_t *evt_param = NULL;
     mac_addr_str_t  sta_mac_str, bss_mac_str, radio_mac_str;
 
-    num_radios = get_num_radios();
     dm.init();
-
-    evt_param = &evt->params;
 
     num_radios = m_num_radios;
     for (unsigned int i = 0; i < m_num_radios; i++) {
@@ -134,11 +138,17 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
 
     dm.translate_and_decode_onewifi_subdoc(reinterpret_cast<char *>(evt->u.raw_buff),
         webconfig_subdoc_type_associated_clients, "Assoc clients");
+    // Refresh global STA-MLD entries from the latest decoded snapshot.
+    for (idx = 0; idx < dm.m_num_assoc_sta_mld; idx++) {
+        memcpy(sta_mld_mac, dm.m_assoc_sta_mld[idx].m_assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
+        remove_assoc_sta_mld_info(sta_mld_mac);
+        update_assoc_sta_mld_info(&dm.m_assoc_sta_mld[idx].m_assoc_sta_mld_info);
+    }
 
     for ( i = 0; i < num_radios; i++) {
-        evt_param->u.args.num_args = 1;
+        evt->params.u.args.num_args = 1;
         dm_easy_mesh_t::macbytes_to_string(get_radio_by_ref(i).get_radio_interface_mac(), radio_str);
-        strncpy(evt_param->u.args.args[0], radio_str, strlen(radio_str) + 1);
+        snprintf(evt->params.u.args.args[0], sizeof(evt->params.u.args.args[0]), "%s", radio_str);
 
         pcmd[num] = new em_cmd_sta_list_t(evt->params, dm);
 
@@ -150,8 +160,24 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
             }
 
             dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
-            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
             dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
+            is_tracked_sta_mld = false;
+            for (k = 0; k < assoc_sta_mld_tracked_count; k++) {
+                if (memcmp(assoc_sta_mld_tracked_macs[k], sta->m_sta_info.id, sizeof(mac_address_t)) == 0) {
+                    is_tracked_sta_mld = true;
+                    break;
+                }
+            }
+            if (is_tracked_sta_mld) {
+                sta = static_cast<dm_sta_t *>(hash_map_get_next(dm.m_sta_assoc_map, sta));
+                continue;
+            }
+            if (assoc_sta_mld_tracked_count < EM_MAX_ASSOC_STA_MLD) {
+                memcpy(assoc_sta_mld_tracked_macs[assoc_sta_mld_tracked_count], sta->m_sta_info.id, sizeof(mac_address_t));
+                assoc_sta_mld_tracked_count++;
+            }
+
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
             snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
             hash_map_put(pcmd[num]->m_data_model.m_sta_assoc_map, strdup(key), new dm_sta_t(*sta));
             sta = static_cast<dm_sta_t *> (hash_map_get_next(dm.m_sta_assoc_map, sta));
@@ -165,8 +191,24 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
              }
 
             dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
-            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
             dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
+            is_tracked_sta_mld = false;
+            for (k = 0; k < disassoc_sta_mld_tracked_count; k++) {
+                if (memcmp(disassoc_sta_mld_tracked_macs[k], sta->m_sta_info.id, sizeof(mac_address_t)) == 0) {
+                    is_tracked_sta_mld = true;
+                    break;
+                }
+            }
+            if (is_tracked_sta_mld) {
+                sta = static_cast<dm_sta_t *>(hash_map_get_next(dm.m_sta_dassoc_map, sta));
+                continue;
+            }
+            if (disassoc_sta_mld_tracked_count < EM_MAX_ASSOC_STA_MLD) {
+                memcpy(disassoc_sta_mld_tracked_macs[disassoc_sta_mld_tracked_count], sta->m_sta_info.id, sizeof(mac_address_t));
+                disassoc_sta_mld_tracked_count++;
+            }
+
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
             snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
             hash_map_put(pcmd[num]->m_data_model.m_sta_dassoc_map, strdup(key), new dm_sta_t(*sta));
             sta = static_cast<dm_sta_t *> (hash_map_get_next(dm.m_sta_dassoc_map, sta));
@@ -272,11 +314,11 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
     unsigned int j = 0, index = 0;
     dm_easy_mesh_agent_t  dm;
     em_cmd_t *tmp;
-	mac_addr_str_t mac_str;
-	em_commit_target_t cm_config;
-	dm_radio_t *radio;
-	em_freq_band_t freq_band;
-	const char *json_data = reinterpret_cast<char *> (evt->u.raw_buff);
+    mac_addr_str_t mac_str;
+    em_commit_target_t cm_config;
+    dm_radio_t *radio;
+    em_freq_band_t freq_band = em_freq_band_unknown;
+    const char *json_data = reinterpret_cast<char *> (evt->u.raw_buff);
 
     webconfig_proto_easymesh_init(&ext, &dm, NULL, NULL, get_num_radios, set_num_radios,
             get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
@@ -328,6 +370,7 @@ int dm_easy_mesh_agent_t::analyze_onewifi_vap_cb(em_bus_event_t *evt, em_cmd_t *
 				memcpy(dm.get_bss(index)->get_bss_info()->ruid.mac, radio->get_radio_interface_mac(), sizeof(mac_address_t));
 			}
 		}
+		cJSON_Delete(json);
 	}
 	dm_easy_mesh_t::macbytes_to_string(dm.get_bss(index)->get_bss_info()->ruid.mac, mac_str);
 	em_printfout("%s in owconfig", mac_str);
@@ -392,7 +435,6 @@ int dm_easy_mesh_agent_t::analyze_channel_pref_query(em_bus_event_t *evt, em_cmd
 {
     int num = 0;
     dm_easy_mesh_agent_t  dm;
-    em_radio_info_t *radio;
     em_bus_event_type_channel_pref_query_params_t *params;
     
     params = reinterpret_cast<em_bus_event_type_channel_pref_query_params_t *> (evt->u.raw_buff);
@@ -407,10 +449,9 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
 {
     unsigned int i = 0, j = 0, noofopclass = 0;
     op_class_channel_sel *channel_sel;
-    em_op_class_info_t *dm_op_class;
+    em_op_class_info_t *dm_op_class = nullptr;
     em_tx_power_limit_t *tx_power_limit;
     em_spatial_reuse_req_t *spatial_reuse_req;
-    em_eht_operations_t *eht_ops;
     bool found_mesh_sta = false;
     em_bss_info_t *bss_info;
     dm_radio_t* radio = NULL;
@@ -420,7 +461,9 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     em_printfout("No of opclass=%d tx=%d", channel_sel->num, channel_sel->tx_power.tx_power_eirp);
     tx_power_limit =  const_cast<em_tx_power_limit_t*> (&channel_sel->tx_power);
     spatial_reuse_req =  const_cast<em_spatial_reuse_req_t*> (&channel_sel->spatial_reuse_req);
-    eht_ops =  const_cast<em_eht_operations_t*> (&channel_sel->eht_ops);
+#ifdef REL_6_FEATURE
+    em_eht_operations_t *eht_ops = const_cast<em_eht_operations_t*> (&channel_sel->eht_ops);
+#endif
 
     if (channel_sel->num == 0) {
         // UNEXPECTED: Channel Selection Request will have atleast one OPCLASS in Channel Preference TLV
@@ -494,7 +537,7 @@ int dm_easy_mesh_agent_t::analyze_channel_sel_req(em_bus_event_t *evt, wifi_bus_
     // Ensure highest preference is non-zero to update current channel
     if (highest_anticipated_preference > 0) {
 	//Get beacon channel for the preferred opclass/channel
-        most_preferred_channel = dm_easy_mesh_t::get_beaconchannel_by_opclass(most_preferred_opclass, most_preferred_channel);
+        most_preferred_channel = static_cast<unsigned int>(dm_easy_mesh_t::get_beaconchannel_by_opclass(static_cast<int>(most_preferred_opclass), static_cast<int>(most_preferred_channel)));
         // Update the most preferred channel/opclass in the datamodel
         for (i = 0; i < noofopclass; i++) {
             dm_op_class = this->get_op_class_info(i);
@@ -622,12 +665,13 @@ int dm_easy_mesh_agent_t::analyze_csa_beacon_frame(em_bus_event_t *evt, wifi_bus
 
     bool found_mesh_sta = false;
     bool csa_found = false;
-    int i, j, ie_len;
+    int ie_len;
+    unsigned int i = 0, j = 0;
     uint8_t tag_number, tag_length;
     uint8_t switch_mode = 0, new_channel = 0, switch_count = 0;
 
     em_bss_info_t *mesh_sta_bss, *bss_info;
-    em_op_class_info_t *op_class_info, *info;
+    em_op_class_info_t *op_class_info = nullptr, *info = nullptr;
     dm_radio_t *radio;
     em_freq_band_t freq_band;
 
@@ -760,7 +804,11 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
 
     len = sizeof(ieeeframe->u.action.category) + sizeof(ieeeframe->u.action.u.bss_tm_req) \
         + sizeof(em_80211_neighbor_report_t);
-    aframe = static_cast<action_frame_params_t *> (malloc(sizeof(action_frame_params_t) + len));
+    aframe = static_cast<action_frame_params_t *> (malloc(sizeof(action_frame_params_t) + static_cast<size_t>(len)));
+    if (aframe == NULL) {
+        em_printfout("Error: Failed to allocate action frame");
+        return -1;
+    }
     // Point ieeeframe to aframe->frame_data
     ieeeframe = reinterpret_cast<struct ieee80211_mgmt *> (aframe->frame_data);
 
@@ -784,7 +832,7 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
     ieeeframe->u.action.u.bss_tm_req.validity_interval = 0;
 
     // Copy the variable part
-    em_80211_btm_req_var_t *bss_list = (em_80211_btm_req_var_t *)&ieeeframe->u.action.u.bss_tm_req.variable;
+    em_80211_btm_req_var_t *bss_list = reinterpret_cast<em_80211_btm_req_var_t *>(&ieeeframe->u.action.u.bss_tm_req.variable);
     bss_list->bss_transition_cand_list[0].elem_id = 52;
     bss_list->bss_transition_cand_list[0].length = 13;
     memcpy(bss_list->bss_transition_cand_list[0].bssid, steer_req->target_bssids, sizeof(bssid_t));
@@ -796,26 +844,28 @@ int dm_easy_mesh_agent_t::analyze_btm_request_action_frame(em_bus_event_t *evt, 
     bss_list->bss_transition_cand_list[0].phy_type = 0;
 
     dm_easy_mesh_t::macbytes_to_string(steer_req->sta_mac_addr, mac_str);
-    printf("%s:%d STA MAC for BTM request %s\n", __func__, __LINE__, mac_str);
+    em_printfout("STA MAC for BTM request %s", mac_str);
     memcpy(aframe->dest_addr, steer_req->sta_mac_addr, sizeof(mac_addr_t));
     aframe->frequency = 2412;
     aframe->ap_index = 0;
     //here sendng only the btm_req union to onewifi as header is dealt internally
-    aframe->frame_len = len;
-    memcpy(aframe->frame_data, &ieeeframe->u.action, len);
+    aframe->frame_len = static_cast<unsigned int>(len);
+    memcpy(aframe->frame_data, &ieeeframe->u.action, static_cast<size_t>(len));
 
     l_bus_data.data_type = bus_data_type_bytes;
-    l_bus_data.raw_data.bytes = (void *)aframe;
-    l_bus_data.raw_data_len = len + sizeof(action_frame_params_t);
+    l_bus_data.raw_data.bytes = static_cast<void *>(aframe);
+    l_bus_data.raw_data_len = static_cast<size_t>(len) + sizeof(action_frame_params_t);
 
     if (desc->bus_set_fn(bus_hdl, "Device.WiFi.AccessPoint.1.RawFrame.Mgmt.Action.Tx", &l_bus_data)== 0) {
-        printf("%s:%d Frame subdoc send successfull\n",__func__, __LINE__);
+        em_printfout("Frame subdoc send successfull\n");
     }
     else {
-        printf("%s:%d Frame subdoc send fail\n",__func__, __LINE__);
+        em_printfout("Error: Frame subdoc send fail\n");
+        free(aframe);
         return -1;
     }
 
+    free(aframe);
     return 1;
 }
 
@@ -824,11 +874,8 @@ int dm_easy_mesh_agent_t::analyze_btm_response_action_frame(em_bus_event_t *evt,
     //TODO: if callback would give for multiple entries or one by one
     dm_easy_mesh_agent_t  dm;
     em_cmd_t *tmp;
-    em_cmd_params_t *evt_param;
     int num = 0;
-    em_steering_btm_rprt_t btm;
-    mac_addr_str_t mac_str;
-    struct ieee80211_mgmt *btm_frame = (struct ieee80211_mgmt *)&evt->u.raw_buff;
+    struct ieee80211_mgmt *btm_frame = reinterpret_cast<struct ieee80211_mgmt *>(&evt->u.raw_buff);
 
     em_cmd_btm_report_params_t  btm_report_param;
     memcpy(btm_report_param.source, btm_frame->bssid, sizeof(mac_addr_t));
@@ -837,6 +884,117 @@ int dm_easy_mesh_agent_t::analyze_btm_response_action_frame(em_bus_event_t *evt,
     memcpy(btm_report_param.target, &btm_frame->u.action.u.bss_tm_resp.variable, sizeof(mac_addr_t));
 
     pcmd[num] = new em_cmd_btm_report_t(btm_report_param);
+    tmp = pcmd[num];
+    num++;
+
+    while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
+        tmp = pcmd[num];
+        num++;
+    }
+
+    return num;
+}
+
+int dm_easy_mesh_agent_t::analyze_unassoc_sta_result(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    em_cmd_t *tmp = NULL;
+    unsigned int num = 0;
+
+    cJSON *json;
+    cJSON *resp_array;
+
+    em_unassoc_sta_metrics_rsp_t *rsp;
+
+    translate_and_decode_onewifi_subdoc((char *)evt->u.raw_buff, webconfig_subdoc_type_nasta_query, "Unassoc STA Metrics Response");
+
+    json = cJSON_Parse((const char *)evt->u.raw_buff);
+
+    if (json == NULL) {
+        em_printfout("%s:%d JSON parse failed", __func__, __LINE__);
+        return 0;
+    }
+
+    resp_array = cJSON_GetObjectItemCaseSensitive(json, "UnassocStaLinkMetricsResponse");
+
+    if ((resp_array == NULL) || (!cJSON_IsArray(resp_array))) {
+        em_printfout("%s:%d UnassocStaLinkMetricsResponse missing", __func__, __LINE__);
+        cJSON_Delete(json);
+        return 0;
+    }
+
+    rsp = &m_unassoc_sta_metrics_rsp;
+    memset(rsp, 0, sizeof(*rsp));
+    unsigned int entry_idx = 0;
+    cJSON *opclass_obj = NULL;
+
+    cJSON_ArrayForEach(opclass_obj, resp_array)
+    {
+        cJSON *opclass_json = cJSON_GetObjectItemCaseSensitive(opclass_obj, "opclass");
+
+        if ((opclass_json == NULL) || (!cJSON_IsNumber(opclass_json))) {
+            continue;
+        }
+
+        unsigned char op_class = (unsigned char)opclass_json->valueint;
+
+        cJSON *channels = cJSON_GetObjectItemCaseSensitive(opclass_obj, "channels");
+        if ((channels == NULL) || (!cJSON_IsArray(channels))) {
+            continue;
+        }
+
+        cJSON *channel_obj = NULL;
+
+        cJSON_ArrayForEach(channel_obj, channels)
+        {
+            cJSON *channel_json = cJSON_GetObjectItemCaseSensitive(channel_obj, "channel");
+
+            if ((channel_json == NULL) || (!cJSON_IsNumber(channel_json))) {
+                continue;
+            }
+
+            unsigned char channel = (unsigned char)channel_json->valueint;
+
+            cJSON *sta_list = cJSON_GetObjectItemCaseSensitive(channel_obj, "sta_list");
+            if ((sta_list == NULL) || (!cJSON_IsArray(sta_list))) {
+                continue;
+            }
+
+            cJSON *sta_obj = NULL;
+
+            cJSON_ArrayForEach(sta_obj, sta_list)
+            {
+                if (entry_idx >= EM_MAX_UNASSOC_STA) {
+                    break;
+                }
+
+                cJSON *mac_json = cJSON_GetObjectItemCaseSensitive(sta_obj, "sta_mac");
+
+                cJSON *rcpi_json = cJSON_GetObjectItemCaseSensitive(sta_obj, "rcpi");
+
+                if ((mac_json == NULL) || (!cJSON_IsString(mac_json)) || (rcpi_json == NULL) || (!cJSON_IsNumber(rcpi_json))) {
+                    continue;
+                }
+
+                dm_easy_mesh_t::string_to_macbytes(mac_json->valuestring, rsp->entry[entry_idx].sta_mac);
+                rsp->entry[entry_idx].channel = channel;
+                rsp->entry[entry_idx].op_class = op_class;
+                rsp->entry[entry_idx].rcpi = (unsigned char)rcpi_json->valueint;
+                rsp->entry[entry_idx].time_delta = 0;
+                em_printfout("Parsed STA[%u] opclass=%u channel=%u rcpi=%u", entry_idx, op_class, channel, (unsigned char)rcpi_json->valueint);
+                entry_idx++;
+            }
+        }
+    }
+
+    rsp->num_entries = entry_idx;
+    cJSON_Delete(json);
+
+    if (rsp->num_entries == 0) {
+        em_printfout("%s:%d No valid STA metrics entries found", __func__, __LINE__);
+        return 0;
+    }
+
+    pcmd[num] = new em_cmd_unassoc_sta_result_t(evt->params, *this);
     tmp = pcmd[num];
     num++;
 
@@ -869,26 +1027,29 @@ int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcm
     config.apply_data =  webconfig_dummy_apply;
 
     if (webconfig_init(&config) != webconfig_error_none) {
-        printf( "[%s]:%d Init WiFi Web Config  fail\n",__func__,__LINE__);
+        em_printfout( "Error: Init WiFi Web Config  fail");
         return 0;
     }
 
-    json = cJSON_Parse((const char *)evt->u.raw_buff);
+    json = cJSON_Parse(reinterpret_cast<const char *>(evt->u.raw_buff));
+    if (json == NULL) {
+        em_printfout("Error: Unable to parse scan result JSON");
+        return 0;
+    }
     scanner_mac_obj = cJSON_GetObjectItemCaseSensitive(json, "ScannerMac");
     if ((scanner_mac_obj == NULL) || (cJSON_IsString(scanner_mac_obj) == false) || (scanner_mac_obj->valuestring == NULL) ) {
-        printf("%s:%d Unable to find scanner mac\n", __func__, __LINE__);
+        em_printfout("Error: Unable to find scanner mac");
+        cJSON_Delete(json);
         return 0;
     }
 
-    if ((webconfig_easymesh_decode(&config, (char *)evt->u.raw_buff, &ext, &type)) == webconfig_error_none) {
-        printf("%s:%d scanner mac: %s - analyze_scan_result subdoc decode success\n",__func__, __LINE__, scanner_mac_obj->valuestring);
+    if ((webconfig_easymesh_decode(&config, reinterpret_cast<char *>(evt->u.raw_buff), &ext, &type)) == webconfig_error_none) {
+        em_printfout("scanner mac: %s - analyze_scan_result subdoc decode success", scanner_mac_obj->valuestring);
     } else {
-        printf("%s:%d scanner mac: %s - analyze_scan_result subdoc decode fail\n",__func__, __LINE__, scanner_mac_obj->valuestring);
+        em_printfout("Error: scanner mac: %s - analyze_scan_result subdoc decode fail", scanner_mac_obj->valuestring);
     }
 
-    em_cmd_params_t *evt_param = NULL;
-    evt_param = &evt->params;
-    dm_easy_mesh_t::string_to_macbytes(scanner_mac_obj->valuestring, evt_param->u.scan_params.ruid);
+    dm_easy_mesh_t::string_to_macbytes(scanner_mac_obj->valuestring, evt->params.u.scan_params.ruid);
 
     pcmd[num] = new em_cmd_scan_result_t(evt->params, dm);
     tmp = pcmd[num];
@@ -899,12 +1060,13 @@ int dm_easy_mesh_agent_t::analyze_scan_result(em_bus_event_t *evt, em_cmd_t *pcm
         num++;
     }
 
-    return num;  
+    cJSON_Delete(json);
+    return static_cast<int>(num);
 }
 
 int dm_easy_mesh_agent_t::analyze_set_policy(em_bus_event_t *evt, wifi_bus_desc_t *desc, bus_handle_t *bus_hdl)
 {
-    em_policy_cfg_params_t *policy_cfg = (em_policy_cfg_params_t *)evt->u.raw_buff;
+    em_policy_cfg_params_t *policy_cfg = reinterpret_cast<em_policy_cfg_params_t *>(evt->u.raw_buff);
 
     return refresh_onewifi_subdoc(desc, bus_hdl, "Policy", webconfig_subdoc_type_em_config, NULL, policy_cfg);
 }
@@ -913,36 +1075,32 @@ int dm_easy_mesh_agent_t::analyze_beacon_report(em_bus_event_t *evt, em_cmd_t *p
 {
     dm_sta_t *sta = NULL;
     em_cmd_t *tmp = NULL;
-    em_cmd_params_t *evt_param = NULL;
     dm_easy_mesh_agent_t  dm;
-    unsigned int num = 0, num_radios = 0;
+    unsigned int num = 0;
     mac_addr_str_t macstr;
 
     dm.init();
 
-    evt_param = &evt->params;
-
-    num_radios = m_num_radios;
     for (unsigned int i = 0; i < m_num_radios; i++) {
-        memcpy(&dm.m_radio[i], &m_radio[i], sizeof(dm_radio_t));
+        dm.m_radio[i] = m_radio[i];
     }
 
     dm.m_num_bss = m_num_bss;
     for (unsigned int i = 0; i < EM_MAX_BSSS; i++) {
-        memcpy(&dm.m_bss[i], &m_bss[i], sizeof(dm_bss_t));
+        dm.m_bss[i] = m_bss[i];
     }
 
-    dm.translate_and_decode_onewifi_subdoc((char *)evt->u.raw_buff, webconfig_subdoc_type_beacon_report, "Beacon Report");
+    dm.translate_and_decode_onewifi_subdoc(reinterpret_cast<char *>(evt->u.raw_buff), webconfig_subdoc_type_beacon_report, "Beacon Report");
 
-    sta = (dm_sta_t *)hash_map_get_first((hash_map_t *)dm.m_sta_map);
+    sta = static_cast<dm_sta_t *>(hash_map_get_first(dm.m_sta_map));
     if (sta != NULL) {
-        evt_param->u.args.num_args = 2;
+        evt->params.u.args.num_args = 2;
 
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, macstr);
-        strncpy(evt_param->u.args.args[0], macstr, strlen(macstr) + 1);
+        snprintf(evt->params.u.args.args[0], sizeof(evt->params.u.args.args[0]), "%s", macstr);
 
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, macstr);
-        strncpy(evt_param->u.args.args[1], macstr, strlen(macstr) + 1);
+        snprintf(evt->params.u.args.args[1], sizeof(evt->params.u.args.args[1]), "%s", macstr);
     }
 
     pcmd[num] = new em_cmd_beacon_report_t(evt->params, dm);
@@ -955,24 +1113,27 @@ int dm_easy_mesh_agent_t::analyze_beacon_report(em_bus_event_t *evt, em_cmd_t *p
         num++;
     }
 
-    return num;
+    return static_cast<int>(num);
 }
 
 int dm_easy_mesh_agent_t::analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     em_cmd_t *tmp = NULL;
-    em_cmd_params_t *evt_param = NULL;
     unsigned int num = 0;
-    mac_addr_str_t macstr;
-    cJSON *json, *emap_metrics_report, *param_obj, *arr_obj;
-    int radio_index = 0;
+    cJSON *json, *emap_metrics_report, *param_obj;
+    unsigned int radio_index = 0;
     
-    translate_and_decode_onewifi_subdoc((char *)evt->u.raw_buff, webconfig_subdoc_type_em_ap_metrics_report, "AP Metrics Report");
+    translate_and_decode_onewifi_subdoc(reinterpret_cast<char *>(evt->u.raw_buff), webconfig_subdoc_type_em_ap_metrics_report, "AP Metrics Report");
 
-    json = cJSON_Parse((const char *)evt->u.raw_buff);
+    json = cJSON_Parse(reinterpret_cast<const char *>(evt->u.raw_buff));
+    if (json == NULL) {
+        em_printfout("Failed to parse AP metrics report JSON");
+        return 0;
+    }
     emap_metrics_report = cJSON_GetObjectItem(json, "EMAPMetricsReport");
     if (emap_metrics_report == NULL || !cJSON_IsArray(emap_metrics_report)) {
         em_printfout("Invalid or missing EMAPMetricsReport");
+        cJSON_Delete(json);
         return 0;
     }
 
@@ -980,37 +1141,38 @@ int dm_easy_mesh_agent_t::analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_
         cJSON *arr_obj = cJSON_GetArrayItem(emap_metrics_report, i);
         if (arr_obj == NULL) {
             em_printfout("Invalid EMAPMetricsReport object at index %d\n", i);
+            cJSON_Delete(json);
             return 0;
         }
 
         param_obj = cJSON_GetObjectItemCaseSensitive(arr_obj, "Radio Index");
         if ((param_obj == NULL) || (cJSON_IsNumber(param_obj) == false) ) {
             em_printfout("Unable to find scanner mac");
+            cJSON_Delete(json);
             return 0;
         }
 
-        radio_index = param_obj->valueint;
-        evt_param = &evt->params;
-        memcpy(evt_param->u.ap_metrics_params.ruid[i], get_radio_by_ref(radio_index).get_radio_interface_mac(), sizeof(mac_addr_t));
+        radio_index = static_cast<unsigned int>(param_obj->valueint);
+        memcpy(evt->params.u.ap_metrics_params.ruid[i], get_radio_by_ref(radio_index).get_radio_interface_mac(), sizeof(mac_addr_t));
     }
-    evt_param->u.ap_metrics_params.num_radios = cJSON_GetArraySize(emap_metrics_report);
+    evt->params.u.ap_metrics_params.num_radios = cJSON_GetArraySize(emap_metrics_report);
 
-    if (strstr((const char *)evt->u.raw_buff, "Associated STA Traffic Stats") != NULL) {
-        evt_param->u.ap_metrics_params.sta_traffic_stats_include = true;
+    if (strstr(reinterpret_cast<const char *>(evt->u.raw_buff), "Associated STA Traffic Stats") != NULL) {
+        evt->params.u.ap_metrics_params.sta_traffic_stats_include = true;
     } else {
-        evt_param->u.ap_metrics_params.sta_traffic_stats_include = false;
-    }
-
-    if (strstr((const char *)evt->u.raw_buff, "Associated STA Link Metrics Report") != NULL) {
-        evt_param->u.ap_metrics_params.sta_link_metrics_include = true;
-    } else {
-        evt_param->u.ap_metrics_params.sta_link_metrics_include = false;
+        evt->params.u.ap_metrics_params.sta_traffic_stats_include = false;
     }
 
-    if (strstr((const char *)evt->u.raw_buff, "Associated Wi-Fi 6 STA Status Report") != NULL) {
-        evt_param->u.ap_metrics_params.wifi6_status_report_include = true;
+    if (strstr(reinterpret_cast<const char *>(evt->u.raw_buff), "Associated STA Link Metrics Report") != NULL) {
+        evt->params.u.ap_metrics_params.sta_link_metrics_include = true;
     } else {
-        evt_param->u.ap_metrics_params.wifi6_status_report_include = false;
+        evt->params.u.ap_metrics_params.sta_link_metrics_include = false;
+    }
+
+    if (strstr(reinterpret_cast<const char *>(evt->u.raw_buff), "Associated Wi-Fi 6 STA Status Report") != NULL) {
+        evt->params.u.ap_metrics_params.wifi6_status_report_include = true;
+    } else {
+        evt->params.u.ap_metrics_params.wifi6_status_report_include = false;
     }
 
     pcmd[num] = new em_cmd_ap_metrics_report_t(evt->params, *(this));
@@ -1022,31 +1184,28 @@ int dm_easy_mesh_agent_t::analyze_ap_metrics_report(em_bus_event_t *evt, em_cmd_
         num++;
     }
 
-    return num;
+    cJSON_Delete(json);
+    return static_cast<int>(num);
 }
 
 int dm_easy_mesh_agent_t::analyze_link_report(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
     dm_sta_t *sta = NULL;
     em_cmd_t *tmp = NULL;
-    em_cmd_params_t *evt_param = NULL;
     dm_easy_mesh_agent_t  dm;
-    unsigned int num = 0, num_radios = 0;
+    unsigned int num = 0;
     mac_addr_str_t macstr;
-    webconfig_subdoc_type_t type;
+    webconfig_subdoc_type_t type = webconfig_subdoc_type_em_sta_link_metrics;
 
     dm.init();
 
-    evt_param = &evt->params;
-
-    num_radios = m_num_radios;
     for (unsigned int i = 0; i < m_num_radios; i++) {
-        memcpy(&dm.m_radio[i], &m_radio[i], sizeof(dm_radio_t));
+        dm.m_radio[i] = m_radio[i];
     }
 
     dm.m_num_bss = m_num_bss;
     for (unsigned int i = 0; i < EM_MAX_BSSS; i++) {
-        memcpy(&dm.m_bss[i], &m_bss[i], sizeof(dm_bss_t));
+        dm.m_bss[i] = m_bss[i];
     }
 
     dm.translate_and_decode_onewifi_subdoc(reinterpret_cast<char *> (evt->u.raw_buff), type,
@@ -1059,15 +1218,15 @@ int dm_easy_mesh_agent_t::analyze_link_report(em_bus_event_t *evt, em_cmd_t *pcm
         sta = static_cast<dm_sta_t *> (hash_map_get_next(dm.m_sta_map, sta));
     }
 
-    sta = (dm_sta_t *)hash_map_get_first((hash_map_t *)dm.m_sta_map);
+    sta = static_cast<dm_sta_t *>(hash_map_get_first(dm.m_sta_map));
     if (sta != NULL) {
-        evt_param->u.args.num_args = 2;
+        evt->params.u.args.num_args = 2;
 
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, macstr);
-        strncpy(evt_param->u.args.args[0], macstr, strlen(macstr) + 1);
+        snprintf(evt->params.u.args.args[0], sizeof(evt->params.u.args.args[0]), "%s", macstr);
 
         dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, macstr);
-        strncpy(evt_param->u.args.args[1], macstr, strlen(macstr) + 1);
+        snprintf(evt->params.u.args.args[1], sizeof(evt->params.u.args.args[1]), "%s", macstr);
     }
 
     pcmd[num] = new em_cmd_link_quality_report_t(evt->params, dm);
@@ -1080,13 +1239,13 @@ int dm_easy_mesh_agent_t::analyze_link_report(em_bus_event_t *evt, em_cmd_t *pcm
         num++;
     }
 
-    return num;
+    return static_cast<int>(num);
 }
 
 void dm_easy_mesh_agent_t::translate_and_decode_onewifi_subdoc(char *str, webconfig_subdoc_type_t type, const char* logname)
 {
-    webconfig_t config;
-    webconfig_external_easymesh_t extdata = {0};
+    webconfig_t config = {};
+    webconfig_external_easymesh_t extdata = {};
 
     webconfig_proto_easymesh_init(&extdata, this, NULL, NULL, get_num_radios, set_num_radios,
         get_num_op_class, set_num_op_class, get_num_bss, set_num_bss,
@@ -1098,7 +1257,7 @@ void dm_easy_mesh_agent_t::translate_and_decode_onewifi_subdoc(char *str, webcon
     config.apply_data =  webconfig_dummy_apply;
 
     if (webconfig_init(&config) != webconfig_error_none) {
-        em_printfout( "Init WiFi Web Config  fail");
+        em_printfout( "Init WiFi Web Config fail");
         return;
     }
 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -55,12 +55,77 @@ AlServiceAccessPoint* g_sap;
 MacAddress g_al_mac_sap;
 #endif
 
+static bool is_known_failure_status_code(unsigned short status_code)
+{
+    switch (status_code) {
+        case 1:  // Unspecified failure
+        case 5:  // Association denied; AP unable to handle BSS
+        case 10: // Cannot support all requested capabilities
+        case 11: // Reassociation denied; previous association unknown
+        case 12: // Association denied; reason outside scope
+        case 13: // Auth algorithm not supported
+        case 15: // Challenge failure (authentication denied)
+        case 16: // Association failure due to timeout
+        case 17: // Auth sequence timeout; STA did not respond
+        case 30: // Association rejected temporarily; try again later
+        case 31: // Robust management frame policy violation
+        case 43: // Invalid AKMP
+        case 44: // IEEE 802.1X authentication failed
+        case 45: // PMK not available/cached
+        case 53: // Invalid PMKID
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool is_known_failure_reason_code(unsigned short reason_code)
+{
+    switch (reason_code) {
+        case 2:  // Previous authentication not valid
+        case 3:  // Deauthenticated; STA is leaving
+        case 6:  // Class 2 frame from nonauthenticated STA
+        case 7:  // Class 3 frame from nonassociated STA
+        case 9:  // STA requested (re)assoc without authentication
+        case 13: // Invalid IE in frame
+        case 14: // Michael MIC failure
+        case 15: // 4-way handshake timeout
+        case 16: // Group key update timeout
+        case 17: // IE in 4-way handshake differs from (re)assoc request
+        case 18: // Group cipher suite not valid
+        case 19: // Pairwise cipher suite not valid
+        case 20: // AKMP not valid
+        case 21: // Unsupported RSN IE version
+        case 22: // Invalid RSN IE capabilities
+        case 23: // IEEE 802.1X authentication failed
+        case 24: // Cipher suite rejected by security policy
+        case 39: // Requested from peer STA (wrong password / MIC failure)
+        case 49: // Invalid PMKID
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool is_failed_connection_message(const em_connection_status_evt_data_t *conn_status_evt)
+{
+    if (conn_status_evt == nullptr) {
+        return false;
+    }
+
+    if (conn_status_evt->reason_code_present) {
+        return is_known_failure_reason_code(conn_status_evt->reason_code);
+    }
+
+    return is_known_failure_status_code(conn_status_evt->status_code);
+}
+
 void em_agent_t::handle_sta_list(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num;
 
-    if ((num = m_data_model.analyze_sta_list(evt, pcmd)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_sta_list(evt, pcmd))) == 0) {
         printf("analyze_sta_list failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("analyze_sta_list submit complete\n");
@@ -74,7 +139,7 @@ void em_agent_t::handle_sta_link_metrics(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         printf("analyze_sta_link_metrics in progress\n");
-    } else if ((num = m_data_model.analyze_sta_link_metrics(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_sta_link_metrics(evt, pcmd))) == 0) {
         printf("analyze_sta_link_metrics failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("analyze_sta_link_metrics submit complete\n");
@@ -88,7 +153,7 @@ void em_agent_t::handle_ap_cap_query(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_ap_cap_query(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_ap_cap_query(evt, pcmd))) == 0) {
         m_agent_cmd->send_result(em_cmd_out_status_no_change);
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         m_agent_cmd->send_result(em_cmd_out_status_success);
@@ -105,7 +170,7 @@ void em_agent_t::handle_radio_config(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_radio_config(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_radio_config(evt, pcmd))) == 0) {
         m_agent_cmd->send_result(em_cmd_out_status_no_change);
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         m_agent_cmd->send_result(em_cmd_out_status_success);
@@ -122,7 +187,7 @@ void em_agent_t::handle_vap_config(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_vap_config(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_vap_config(evt, pcmd))) == 0) {
         m_agent_cmd->send_result(em_cmd_out_status_no_change);
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         m_agent_cmd->send_result(em_cmd_out_status_success);
@@ -141,7 +206,7 @@ void em_agent_t::handle_dev_init(em_bus_event_t *evt)
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
         return;
     }
-    if ((num = m_data_model.analyze_dev_init(evt, pcmd)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_dev_init(evt, pcmd))) == 0) {
         m_agent_cmd->send_result(em_cmd_out_status_no_change);
         return;
     }
@@ -158,7 +223,7 @@ void em_agent_t::handle_dev_init(em_bus_event_t *evt)
     }
 
     // Iterate through all of the BSSs and subscribe to receive management action frames
-    for (int bss_idx = 0; bss_idx < m_data_model.m_num_bss; bss_idx++) {
+    for (unsigned int bss_idx = 0; bss_idx < m_data_model.m_num_bss; bss_idx++) {
         auto bss_info = m_data_model.get_bss_info(bss_idx);
         unsigned int vap_index = bss_info->vap_index; // The actual OneWifi VAP index
 
@@ -176,7 +241,7 @@ void em_agent_t::handle_dev_init(em_bus_event_t *evt)
 
 
         std::string path = "Device.WiFi.AccessPoint." + std::to_string(vap_index + 1) + ".RawFrame.Mgmt.Action.Rx";
-        if (desc->bus_event_subs_fn(&m_bus_hdl, path.c_str(), (void *)&em_agent_t::mgmt_action_frame_cb, NULL, 0) != 0) {
+        if (desc->bus_event_subs_fn(&m_bus_hdl, path.c_str(), reinterpret_cast<void *>(&em_agent_t::mgmt_action_frame_cb), NULL, 0) != 0) {
             em_printfout("Subscription failed for path %s", path.c_str());
             continue;
         }
@@ -202,7 +267,7 @@ void em_agent_t::handle_channel_pref_query(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_channel_pref_query(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_channel_pref_query(evt, pcmd))) == 0) {
         printf("%s:%d query send fail \n", __func__, __LINE__);
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("%s:%d send success \n", __func__, __LINE__);
@@ -213,7 +278,6 @@ void em_agent_t::handle_channel_sel_req(em_bus_event_t *evt)
 {
     unsigned int num;
     wifi_bus_desc_t *desc;
-    raw_data_t l_bus_data;
 
     if((desc = get_bus_descriptor()) == NULL) {
        printf("descriptor is null");
@@ -221,7 +285,7 @@ void em_agent_t::handle_channel_sel_req(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_channel_sel_req(evt, desc, &m_bus_hdl)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_channel_sel_req(evt, desc, &m_bus_hdl))) == 0) {
             printf("handle_channel_sel_req complete");
     }
 }
@@ -235,7 +299,7 @@ void em_agent_t::handle_csa_beacon_frame(em_bus_event_t *evt)
        printf("descriptor is null");
     }
 
-    if ((num = m_data_model.analyze_csa_beacon_frame(evt, desc, &m_bus_hdl)) == 1) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_csa_beacon_frame(evt, desc, &m_bus_hdl))) == 1) {
         printf("analyze_csa_beacon_frame completed\n");
     }
 }
@@ -244,7 +308,6 @@ void em_agent_t::handle_m2ctrl_configuration(em_bus_event_t *evt)
 {
     unsigned int num;
     wifi_bus_desc_t *desc;
-    raw_data_t l_bus_data;
 
     if((desc = get_bus_descriptor()) == NULL) {
        printf("descriptor is null");
@@ -252,7 +315,7 @@ void em_agent_t::handle_m2ctrl_configuration(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_m2ctrl_configuration(evt, desc, &m_bus_hdl)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_m2ctrl_configuration(evt, desc, &m_bus_hdl))) == 0) {
 	    printf("analyze_onewifi_private_subdoc complete");
     }
 }
@@ -269,7 +332,7 @@ void em_agent_t::handle_onewifi_private_cb(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_onewifi_vap_cb(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_onewifi_vap_cb(evt, pcmd))) == 0) {
         em_printfout("analyze_onewifi_vap_cb completed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         em_printfout("submitted command for orchestration");
@@ -288,7 +351,7 @@ void em_agent_t::handle_onewifi_mesh_sta_cb(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_onewifi_vap_cb(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_onewifi_vap_cb(evt, pcmd))) == 0) {
         em_printfout("analyze_onewifi_vap_cb completed");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         em_printfout("submitted command for orchestration");
@@ -307,7 +370,7 @@ void em_agent_t::handle_onewifi_radio_cb(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_agent_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_onewifi_radio_cb(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_onewifi_radio_cb(evt, pcmd))) == 0) {
         em_printfout("analyze_onewifi_radio_cb completed");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         em_printfout("submitted command for orchestration");
@@ -351,14 +414,14 @@ void em_agent_t::handle_frame_event(em_frame_event_t *evt)
 {
     struct ieee80211_frame *frame;
 
-    frame = (struct ieee80211_frame *)evt->frame;
+    frame = reinterpret_cast<struct ieee80211_frame *>(evt->frame);
     assert(IEEE80211_IS_MGMT(frame));
 
     printf("%s:%d: Received management 'frame event' type %d\n", __func__, __LINE__, frame->i_fc[0] & 0x0f);
     
     // handle action frames only 
     if ((frame->i_fc[0] & 0x0f) == IEEE80211_FC0_SUBTYPE_ACTION) {
-        handle_action_frame((struct ieee80211_mgmt *)frame);        
+        handle_action_frame(reinterpret_cast<struct ieee80211_mgmt *>(frame));
     }
 }
 
@@ -369,7 +432,7 @@ void em_agent_t::handle_autoconfig_renew(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
 	printf("handle_autoconfig_renew in progress\n");
-    }  else if ((num = m_data_model.analyze_autoconfig_renew(evt, pcmd)) == 0) {
+    }  else if ((num = static_cast<unsigned int>(m_data_model.analyze_autoconfig_renew(evt, pcmd))) == 0) {
         printf("handle_autoconfig_renew cmd creation failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
     }
@@ -385,7 +448,7 @@ void em_agent_t::handle_btm_request_action_frame(em_bus_event_t *evt)
        printf("descriptor is null");
     }
 
-    if ((num = m_data_model.analyze_btm_request_action_frame(evt, desc, &m_bus_hdl)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_btm_request_action_frame(evt, desc, &m_bus_hdl))) == 0) {
 	    printf("analyze_btm_request_action_frame failed\n");
     }
 }
@@ -411,6 +474,80 @@ void em_agent_t::handle_recv_assoc_status(em_bus_event_t *event)
     }
 }
 
+void em_agent_t::handle_recv_connection_status(em_bus_event_t *event)
+{
+    const em_connection_status_evt_data_t *conn_status_evt = nullptr;
+    em_bss_info_t *target_bss = nullptr;
+    mac_address_t bssid = {0};
+    em_t *em = nullptr;
+    em_event_t *qevt = nullptr;
+    em_connection_status_evt_data_t *evt_copy = nullptr;
+    std::string ruid_str;
+
+    if (event == nullptr) {
+        em_printfout("NULL event!");
+        return;
+    }
+
+    if (event->u.raw_buff == nullptr || event->data_len != sizeof(em_connection_status_evt_data_t)) {
+        em_printfout("Invalid connection status payload: expected %zu, got %u",
+                     sizeof(em_connection_status_evt_data_t), event->data_len);
+        return;
+    }
+
+    conn_status_evt = reinterpret_cast<const em_connection_status_evt_data_t *>(event->u.raw_buff);
+
+    if (!is_failed_connection_message(conn_status_evt)) {
+        /*em_printfout("Skip: sta=%s bssid=%s status=%u not in failed-connection filter",
+                     util::mac_to_string(conn_status_evt->sta_mac).c_str(),
+                     util::mac_to_string(conn_status_evt->bssid).c_str(),
+                     conn_status_evt->status_code);*/
+        return;
+    }
+
+    memcpy(bssid, conn_status_evt->bssid, sizeof(mac_address_t));
+    target_bss = m_data_model.get_bss_info_with_mac(bssid);
+    if (target_bss == nullptr) {
+        em_printfout("No BSS for bssid=%s, drop",
+                     util::mac_to_string(conn_status_evt->bssid).c_str());
+        return;
+    }
+
+    ruid_str = util::mac_to_string(target_bss->ruid.mac);
+    em = static_cast<em_t *>(hash_map_get(g_agent.m_em_map, ruid_str.c_str()));
+    if (em == nullptr) {
+        em_printfout("No radio EM for bssid=%s, drop",
+                     util::mac_to_string(conn_status_evt->bssid).c_str());
+        return;
+    }
+
+    qevt = static_cast<em_event_t *>(calloc(1, sizeof(em_event_t)));
+    if (qevt == nullptr) {
+        em_printfout("Failed to alloc failed connection event");
+        return;
+    }
+
+    evt_copy = static_cast<em_connection_status_evt_data_t *>(malloc(sizeof(em_connection_status_evt_data_t)));
+    if (evt_copy == nullptr) {
+        em_printfout("Failed to alloc connection status payload");
+        free(qevt);
+        return;
+    }
+
+    memcpy(evt_copy, conn_status_evt, sizeof(em_connection_status_evt_data_t));
+
+    qevt->type = em_event_type_cmd;
+    qevt->u.cevt.type = em_cmd_event_type_failed_connection;
+    qevt->u.cevt.cmd_ptr = evt_copy;
+
+    em_printfout("Queue failed connection: sta=%s bssid=%s status=%u",
+                 util::mac_to_string(evt_copy->sta_mac).c_str(),
+                 util::mac_to_string(evt_copy->bssid).c_str(),
+                 evt_copy->status_code);
+
+    em->push_to_queue(qevt);
+}
+
 void em_agent_t::handle_bss_info(em_bus_event_t *event)
 {
     if (event == nullptr) {
@@ -422,7 +559,7 @@ void em_agent_t::handle_bss_info(em_bus_event_t *event)
     unsigned int len = event->data_len;
 
     if (len % expected_size != 0) {
-        em_printfout("Expected event size divisible by %d, got %d, not handling", expected_size, event->data_len);
+        em_printfout("Expected event size divisible by %zu, got %u, not handling", expected_size, event->data_len);
         return;
     }
 
@@ -458,7 +595,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
     }
     const size_t full_frame_length = evt->data_len;
     const size_t mgmt_hdr_len = offsetof(struct ieee80211_mgmt, u);
-    ieee80211_mgmt *mgmt_frame = (ieee80211_mgmt *)evt->u.raw_buff;
+    ieee80211_mgmt *mgmt_frame = reinterpret_cast<ieee80211_mgmt *>(evt->u.raw_buff);
 
     std::string dest_mac_str = util::mac_to_string(mgmt_frame->da);
     // Validate that it is a broadcast frame or we have a node that should have received it
@@ -485,7 +622,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
 
     em_t* al_node = get_al_node();
 
-    auto gas_frame_base = (ec_gas_frame_base_t *)(evt->u.raw_buff + mgmt_hdr_len);
+    auto gas_frame_base = reinterpret_cast<ec_gas_frame_base_t *>(evt->u.raw_buff + mgmt_hdr_len);
 
     bool is_wfa_ec_gas = false;
 
@@ -493,7 +630,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
     case dpp_gas_action_type_t::dpp_gas_initial_req: {
         printf("%s:%d: Received GAS Initial Request\n", __func__, __LINE__);
         ec_gas_initial_request_frame_t *gas_initial_req_frame =
-            (ec_gas_initial_request_frame_t *)gas_frame_base;
+            reinterpret_cast<ec_gas_initial_request_frame_t *>(gas_frame_base);
         uint8_t *ap_proto_id = gas_initial_req_frame->ape_id;
         if (ap_proto_id[0] == 0xDD) {
             // Vendor specific GAS frame
@@ -508,7 +645,7 @@ void em_agent_t::handle_recv_gas_frame(em_bus_event_t *evt)
     case dpp_gas_action_type_t::dpp_gas_initial_resp: {
         printf("%s:%d: Received GAS Initial Response\n", __func__, __LINE__);
         ec_gas_initial_response_frame_t *gas_initial_resp_frame =
-            (ec_gas_initial_response_frame_t *)gas_frame_base;
+            reinterpret_cast<ec_gas_initial_response_frame_t *>(gas_frame_base);
         uint8_t *ap_proto_id = gas_initial_resp_frame->ape_id;
         if (ap_proto_id[0] == 0xDD) {
             // Vendor specific GAS frame
@@ -576,14 +713,14 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
         sizeof(uint8_t[3]);  // oui field
 
     if (frame_len <= fixed_full_header_len){
-        printf("%s:%d Recieved WFA Action frame is too short! Must have at least the OUI type in the data field\n", __func__, __LINE__);
+        em_printfout("Error: Received WFA Action frame is too short! Must have at least the OUI type in the data field");
         return;
     }
     auto mgmt_frame = reinterpret_cast<struct ieee80211_mgmt *>(mgmt_frame_buff);
     auto vs_action_data = mgmt_frame->u.action.u.vs_public_action.variable;
     auto vs_data_len = frame_len - fixed_full_header_len;
 
-    printf("%s:%d: Received WFA action frame: Full Length: %d, VS Action Data Length: %d\n", __func__, __LINE__, frame_len, vs_data_len);
+    em_printfout("Received WFA action frame: Full Length: %zu, VS Action Data Length: %zu", frame_len, vs_data_len);
 
     std::string dest_mac_str = util::mac_to_string(mgmt_frame->da);
     em_printfout("Dest Mac Str: %s", dest_mac_str.c_str());
@@ -594,19 +731,19 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
 
     bool is_bcast = (memcmp(mgmt_frame->da, BROADCAST_MAC_ADDR, ETH_ALEN) == 0);
     if (is_bcast) {
-        printf("Received WFA action frame with broadcast destination MAC address\n");
+        em_printfout("Received WFA action frame with broadcast destination MAC address");
     } else {
         // Dest MAC is not necsessarily the same as the radio node's MAC address, so we need to look it up
         em_bss_info_t* dest_bss = m_data_model.get_bss_info_with_mac(mgmt_frame->da);
         if (dest_bss == NULL) {
-            em_printfout("No BSS found for dest mac %s\n", dest_mac_str.c_str());
+            em_printfout("No BSS found for dest mac %s", dest_mac_str.c_str());
             return;
         }
 
         std::string ruid_str = util::mac_to_string(dest_bss->ruid.mac);
         dest_radio_node = static_cast<em_t*>(hash_map_get(g_agent.m_em_map, ruid_str.c_str()));
         if (dest_radio_node == NULL) {
-            em_printfout("No radio node found for dest mac %s\n", dest_mac_str.c_str());
+            em_printfout("No radio node found for dest mac %s", dest_mac_str.c_str());
             return;
         }
     }
@@ -619,7 +756,7 @@ void em_agent_t::handle_recv_wfa_action_frame(em_bus_event_t *evt)
 
     switch (oui_type) {
     case DPP_OUI_TYPE: {
-        printf("%s:%d: Received DPP action frame\n", __func__, __LINE__);
+        em_printfout("Received DPP action frame");
         em_t* al_node = get_al_node();
 
         if (al_node != NULL) {
@@ -642,7 +779,7 @@ void em_agent_t::handle_btm_response_action_frame(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         printf("analyze_btm_response_action_frame in progress\n");
-    } else if ((num = m_data_model.analyze_btm_response_action_frame(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_btm_response_action_frame(evt, pcmd))) == 0) {
         printf("analyze_btm_response_action_frame failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         printf("submitted handle_btm_response_action_frame command for orchestration\n");
@@ -676,7 +813,7 @@ void em_agent_t::handle_client_assoc_ctrl_req(em_bus_event_t *evt)
 
     memset(&raw, 0, sizeof(raw_data_t));
     raw.data_type = bus_data_type_bytes;
-    raw.raw_data.bytes = (void *)&req_data;
+    raw.raw_data.bytes = static_cast<void *>(&req_data);
     raw.raw_data_len = sizeof(client_assoc_ctrl_req_t);
 
     if (desc->bus_set_fn(&m_bus_hdl,WIFI_EM_CLIENT_ASSOC_CTRL_REQ, &raw) != 0) {
@@ -690,7 +827,7 @@ void em_agent_t::handle_channel_scan_result(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num;
 
-    if ((num = m_data_model.analyze_scan_result(evt, pcmd)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_scan_result(evt, pcmd))) == 0) {
         printf("scan results failed\n");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
 		;
@@ -701,24 +838,147 @@ void em_agent_t::handle_channel_scan_params(em_bus_event_t *evt)
 {
     printf("%s:%d: Scan Parameters received\n", __func__, __LINE__);
 #ifdef SCAN_RESULT_TEST
-	m_simulator.configure(m_data_model, (em_scan_params_t *)evt->u.raw_buff);
+	m_simulator.configure(m_data_model, reinterpret_cast<em_scan_params_t *>(evt->u.raw_buff));
 #endif
-    unsigned int num;
     wifi_bus_desc_t *desc;
 
     if((desc = get_bus_descriptor()) == NULL) {
        printf("descriptor is null");
     }
 
-    if (!send_scan_request((em_scan_params_t *)&evt->u.raw_buff, true)) {
+    if (!send_scan_request(reinterpret_cast<em_scan_params_t *>(&evt->u.raw_buff), true)) {
         printf("send_scan_request failed\n");
         return;
     }
 }
 
+void em_agent_t::handle_unassoc_sta_result(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    unsigned int num;
+
+    if ((num = m_data_model.analyze_unassoc_sta_result(evt, pcmd)) == 0) {
+        em_printfout("Unassoc STA Links results failed\n");
+    } else if (m_orch->submit_commands(pcmd, num) > 0) {
+        em_printfout("Unassoc submitting commands");
+    }
+}
+
+int em_agent_t::send_unassoc_sta_query_subdoc(wifi_bus_desc_t *desc, bus_handle_t *bus_hdl, em_unassoc_work_list_t *work)
+{
+    if ((desc == NULL) || (bus_hdl == NULL) || (work == NULL)) {
+        em_printfout("%s:%d Invalid input params desc=%p bus_hdl=%p work=%p",
+                     __func__, __LINE__, desc, bus_hdl, work);
+        return -1;
+    }
+
+    cJSON *root = cJSON_CreateObject();
+    if (root == NULL) {
+        em_printfout("%s:%d root creation failed", __func__, __LINE__);
+        return -1;
+    }
+
+    cJSON_AddStringToObject(root, "Version", "1.0");
+    cJSON_AddStringToObject(root, "SubDocName", "UnassocStaQuery");
+
+    cJSON *query_list = cJSON_AddArrayToObject(root, "UnassocStaQueryList");
+
+    if (query_list == NULL) {
+        em_printfout("%s:%d query_list creation failed", __func__, __LINE__);
+        cJSON_Delete(root);
+        return -1;
+    }
+
+    for (uint8_t i = 0; i < work->num_opclass; i++) {
+        em_unassoc_work_opclass_t *op = &work->opclass_list[i];
+
+        if (op->num_channels == 0) {
+            continue;
+        }
+
+        cJSON *op_obj = cJSON_CreateObject();
+        if (op_obj == NULL) {
+            continue;
+        }
+
+        cJSON_AddNumberToObject(op_obj, "opclass", op->op_class);
+ 
+        cJSON_AddNumberToObject(op_obj, "channels_length", op->num_channels);
+        cJSON *channels = cJSON_AddArrayToObject(op_obj, "channels");
+        if (channels == NULL) {
+            cJSON_Delete(op_obj);
+            continue;
+        }
+
+        for (uint8_t ch_idx = 0; ch_idx < op->num_channels; ch_idx++) {
+            em_unassoc_work_channel_t *ch = &op->channel_list[ch_idx];
+
+            cJSON *ch_obj = cJSON_CreateObject();
+            if (ch_obj == NULL) {
+                continue;
+            }
+
+            cJSON_AddNumberToObject(ch_obj, "channel", ch->channel);
+            cJSON_AddNumberToObject(ch_obj, "sta_list_length", ch->num_sta);
+            cJSON *sta_arr = cJSON_AddArrayToObject(ch_obj, "sta_macs");
+           if (sta_arr == NULL) {
+                cJSON_Delete(ch_obj);
+                continue;
+            }
+
+            for (uint8_t sta_idx = 0; sta_idx < ch->num_sta; sta_idx++)
+            {
+                char mac_str[32] = {0};
+
+                snprintf(mac_str,
+                         sizeof(mac_str),
+                         "%02X:%02X:%02X:%02X:%02X:%02X",
+                         ch->sta_list[sta_idx][0],
+                         ch->sta_list[sta_idx][1],
+                         ch->sta_list[sta_idx][2],
+                         ch->sta_list[sta_idx][3],
+                         ch->sta_list[sta_idx][4],
+                         ch->sta_list[sta_idx][5]);
+
+                cJSON_AddItemToArray(sta_arr, cJSON_CreateString(mac_str));
+            }
+            cJSON_AddItemToArray(channels, ch_obj);
+        }
+        cJSON_AddItemToArray(query_list, op_obj);
+    }
+    char *json_str = cJSON_Print(root);
+
+    if (json_str == NULL) {
+        em_printfout("%s:%d JSON serialization failed",  __func__, __LINE__);
+        cJSON_Delete(root);
+        return -1;
+    }
+
+    em_printfout("========== Unassoc STA Query Subdoc ==========\n%s\n==============================================",
+        json_str);
+
+    raw_data_t bus_data;
+    memset(&bus_data, 0, sizeof(raw_data_t));
+    bus_data.data_type = bus_data_type_string;
+    bus_data.raw_data.bytes = json_str;
+    bus_data.raw_data_len = strlen(json_str);
+
+    if (desc->bus_set_fn(bus_hdl, "Device.WiFi.UnAssoc.STA", &bus_data) != 0) {
+        em_printfout("%s:%d Unassoc subdoc send failed",  __func__, __LINE__);
+        free(json_str);
+        cJSON_Delete(root);	
+        return -1;
+    }
+    em_printfout("%s:%d Unassoc STA Link Metrics Query subdoc send success", __func__, __LINE__);
+    
+    free(json_str);
+    cJSON_Delete(root);
+
+    return 0;
+}
+
 bool em_agent_t::send_scan_request(em_scan_params_t* scan_params, bool perform_fresh_scan, bool is_sta_vap){
     unsigned i, j;
-    mac_addr_str_t radio_mac_str;
     raw_data_t l_bus_data;
     
 
@@ -747,7 +1007,7 @@ bool em_agent_t::send_scan_request(em_scan_params_t* scan_params, bool perform_f
     }
 
     l_bus_data.data_type = bus_data_type_bytes;
-    l_bus_data.raw_data.bytes = (void *)&scan_data;
+    l_bus_data.raw_data.bytes = static_cast<void *>(&scan_data);
     l_bus_data.raw_data_len = sizeof(channel_scan_request_t);
 
     wifi_bus_desc_t *desc;
@@ -768,12 +1028,81 @@ bool em_agent_t::send_scan_request(em_scan_params_t* scan_params, bool perform_f
     return true;
 }
 
+void em_agent_t::handle_unassoc_sta_link_metrics_qry(em_bus_event_t *evt)
+{
+    wifi_bus_desc_t *desc = get_bus_descriptor();
+
+    if ((evt == NULL) || (desc == NULL) || (evt->u.raw_buff == NULL) || (evt->data_len == 0)) {
+        em_printfout("%s:%d Invalid input evt=%p desc=%p buff=%p len=%u", __func__, __LINE__, evt, desc, (evt ? evt->u.raw_buff : NULL),
+                                                                                                 (evt ? evt->data_len : 0));
+        return;
+    }
+
+    unsigned char *buff = reinterpret_cast<unsigned char *>(evt->u.raw_buff);
+    unsigned int len = evt->data_len;
+    int pos = 0;
+
+    em_unassoc_work_list_t work;
+    memset(&work, 0, sizeof(work));
+    int op_idx = 0;
+
+    while ((pos + 2) <= (int)len && op_idx < EM_MAX_OP_CLASS) {
+        auto &op = work.opclass_list[op_idx];
+
+        op.op_class = buff[pos++];
+        op.num_channels = buff[pos++];
+
+        if (op.num_channels > EM_MAX_CHANNELS_PER_OPCLASS) {
+            em_printfout("%s:%d invalid num_channels=%u", __func__, __LINE__, op.num_channels);
+            return;
+        }
+
+        int chan_idx = 0;
+        for (int j = 0; j < op.num_channels; j++) {
+            if ((pos + 2) > (int)len) {
+                em_printfout("%s:%d buffer underrun channel", __func__, __LINE__);
+                return;
+            }
+
+            auto &ch = op.channel_list[chan_idx];
+            ch.channel = buff[pos++];
+            ch.num_sta = buff[pos++];
+
+            if (ch.num_sta > EM_MAX_STA_PER_CHANNEL) {
+                em_printfout("%s:%d invalid num_sta=%u", __func__, __LINE__, ch.num_sta);
+                return;
+            }
+
+            for (int k = 0; k < ch.num_sta; k++) {
+                if ((pos + sizeof(mac_address_t)) > (int)len) {
+                    em_printfout("%s:%d buffer underrun STA", __func__, __LINE__);
+                    return;
+                }
+
+                memcpy(ch.sta_list[k], &buff[pos], sizeof(mac_address_t));
+                pos += sizeof(mac_address_t);
+            }
+            chan_idx++;
+        }
+        op.num_channels = chan_idx;
+        op_idx++;
+    }
+
+    work.num_opclass = op_idx;
+
+    int rc = this->send_unassoc_sta_query_subdoc(desc, &m_bus_hdl, &work);
+
+    if (rc < 0) {
+        em_printfout("%s:%d Failed send subdoc rc=%d", __func__, __LINE__, rc);
+    } else {
+        em_printfout("%s:%d Successfully sent subdoc", __func__, __LINE__);
+    }
+}
+
 void em_agent_t::handle_set_policy(em_bus_event_t *evt)
 {
-    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num;
     wifi_bus_desc_t *desc;
-    raw_data_t l_bus_data;
 
     if((desc = get_bus_descriptor()) == NULL) {
        printf("descriptor is null");
@@ -781,8 +1110,226 @@ void em_agent_t::handle_set_policy(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         printf("set policy in progress\n");
-    } else if ((num = m_data_model.analyze_set_policy(evt, desc, &m_bus_hdl)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_set_policy(evt, desc, &m_bus_hdl))) == 0) {
         printf("set policy failed\n");
+    }
+}
+void em_agent_t::send_beacon_query(em_bus_event_t *evt)
+{
+    raw_data_t l_bus_data;
+    beacon_query_params_t beacon_query = {0};
+    wifi_BeaconRequest_t *beacon_req = &beacon_query.data;
+    em_beacon_metrics_query_t *query_params = reinterpret_cast<em_beacon_metrics_query_t *>(evt->u.raw_buff);
+    bus_error_t rc;
+    wifi_bus_desc_t *desc;
+
+    if ((evt->data_len >= sizeof(em_beacon_metrics_query_t)) &&
+        (memcmp(query_params->sta_mac_addr, ZERO_MAC_ADDR, sizeof(mac_address_t)) == 0)) {
+        em_beacon_metrics_query_t *subdoc_query = reinterpret_cast<em_beacon_metrics_query_t *>(evt->u.subdoc.buff);
+
+        if (memcmp(subdoc_query->sta_mac_addr, ZERO_MAC_ADDR, sizeof(mac_address_t)) != 0) {
+            em_printfout("Beacon Query payload found in subdoc buffer, using fallback decode path");
+            query_params = subdoc_query;
+        }
+    }
+
+    em_printfout("Beacon Query forwarding to OW for sta: %s", util::mac_to_string(query_params->sta_mac_addr).c_str());
+    beacon_req->opClass = query_params->op_class;
+    beacon_req->channel = query_params->channel_num;
+    beacon_req->mode = 0; // Passive (default; may be upgraded to Active for 6 GHz below)
+
+    dm_sta_t *sta = m_data_model.get_first_sta(query_params->sta_mac_addr);
+    bool is_mld = m_data_model.is_sta_mld(query_params->sta_mac_addr);
+
+    // For MLO STAs the controller may request a band that is not one of the
+    // STA's active links (e.g. opClass 81 / 2.4 GHz when the STA is only on
+    // 5/6 GHz).  The STA will scan an idle band and return empty results.
+    // Look up the actual opClass for the STA's connected BSS and override.
+    if (is_mld && sta != NULL) {
+        unsigned int active_op_class = 0;
+        em_op_class_info_t *oci = m_data_model.get_opclass_info_for_bss(
+            sta->m_sta_info.bssid, &active_op_class);
+        if (oci != NULL && active_op_class != 0 &&
+            active_op_class != query_params->op_class) {
+            em_printfout("MLO STA: controller opClass %u does not match active link opClass %u"
+                " (BSSID %s) — overriding",
+                query_params->op_class, active_op_class,
+                util::mac_to_string(sta->m_sta_info.bssid).c_str());
+            beacon_req->opClass = static_cast<uint8_t>(active_op_class);
+        }
+    }
+
+    // After any opClass adaptation, apply band-specific scan settings.
+    // Measurement mode:
+    //   0 = Passive - listen for beacons; works on all bands incl. 6 GHz.
+    //   1 = Active  - send probe requests; faster on 6 GHz PSC channels.
+    bool is_6ghz = (beacon_req->opClass >= 131 && beacon_req->opClass <= 136);
+    if (is_6ghz) {
+        beacon_req->mode = 1; // Active - faster on 6 GHz PSC channels
+        // Active scan: a Probe Request/Response cycle completes in ~10 ms;
+        // 50 TUs (~51 ms) per channel gives sufficient headroom for responses
+        // while still being ~4x faster than the 200 TU passive default.
+        beacon_req->duration = 50;
+        em_printfout("6 GHz opClass %u: using Active scan mode, duration 50 TUs", beacon_req->opClass);
+    }
+    if (is_mld == true) {
+        // MLD STA: resolve to a link-level BSSID that wifidb knows about.
+        // Primary: assoc_sta_mld table (populated by topology handler).
+        bool resolved = false;
+        for (unsigned int i = 0; i < m_data_model.get_num_assoc_sta_mld() && !resolved; i++) {
+            em_assoc_sta_mld_info_t &mld =
+                m_data_model.m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+            if (memcmp(mld.mac_addr, query_params->sta_mac_addr, sizeof(mac_address_t)) != 0) {
+                continue;
+            }
+            if (mld.num_affiliated_sta > 0) {
+                // Pick the affiliated entry whose AP BSSID matches the STA's
+                // connected BSS in the data model. Fall back to [0] if none matches.
+                int pick = 0;
+                for (int c = 0; c < mld.num_affiliated_sta; c++) {
+                    if (memcmp(mld.affiliated_sta[c].bssid, sta->m_sta_info.bssid,
+                               sizeof(mac_address_t)) == 0) {
+                        pick = c;
+                        break;
+                    }
+                }
+                em_printfout("MLD STA %s: using affiliated AP BSSID %s for ap_index resolution",
+                    util::mac_to_string(query_params->sta_mac_addr).c_str(),
+                    util::mac_to_string(mld.affiliated_sta[pick].bssid).c_str());
+                memcpy(beacon_req->bssid, mld.affiliated_sta[pick].bssid, sizeof(mac_address_t));
+                resolved = true;
+            }
+
+            for (int c = 0; c < mld.num_affiliated_sta; c++) {
+                em_printfout("MLD STA %s: using affiliated AP BSSID %s and link address is %s",
+                    util::mac_to_string(query_params->sta_mac_addr).c_str(),
+                    util::mac_to_string(mld.affiliated_sta[c].bssid).c_str(),
+                    util::mac_to_string(mld.affiliated_sta[c].link_addr).c_str());
+
+            }
+        }
+        // Secondary: sta map bssid (set from wifidb VAP bssid in the translator).
+        if (!resolved) {
+            em_printfout("MLD STA %s: using STA map BSSID %s for ap_index resolution",
+                util::mac_to_string(query_params->sta_mac_addr).c_str(),
+                util::mac_to_string(sta->m_sta_info.bssid).c_str());
+            memcpy(beacon_req->bssid, sta->m_sta_info.bssid, sizeof(mac_address_t));
+        }
+    } else {
+        // Non-MLD STA: query_params->bssid is already a link-level address.
+        memcpy(beacon_req->bssid, query_params->bssid, sizeof(mac_address_t));
+    }
+    beacon_req->ssidPresent = (query_params->ssid_len > 0);
+    if (beacon_req->ssidPresent) {
+        size_t ssid_copy_len = query_params->ssid_len;
+        if (ssid_copy_len >= sizeof(beacon_req->ssid)) {
+            ssid_copy_len = sizeof(beacon_req->ssid) - 1;
+        }
+        memcpy(beacon_req->ssid, query_params->ssid, ssid_copy_len);
+        beacon_req->ssid[ssid_copy_len] = '\0';
+    }
+    em_printfout("SSID Name: %s[%s]", beacon_req->ssid, util::mac_to_string(beacon_req->bssid).c_str());
+    beacon_req->reportingDetail = query_params->rprt_detail;
+    {
+        int total_ch = 0;
+        const int max_hal_ch = MAX_CHANNELS_REPORT; // channels[] size in wifi_ChannelReport_t
+        for (int i = 0; i < query_params->num_ap_channel_rprt && total_ch < max_hal_ch; i++) {
+            // All entries share the same op_class (single-band query); use the first.
+            if (i == 0) {
+                beacon_req->channelReport.opClass = query_params->ap_channel_rprt[i].ap_channel_op_class;
+            }
+            int num_ch = query_params->ap_channel_rprt[i].ap_channel_rprt_len - 1;
+            for (int j = 0; j < num_ch && total_ch < max_hal_ch; j++) {
+                uint8_t ch = query_params->ap_channel_rprt[i].ap_channel_list[j];
+                em_printfout("Ap Channel Report[%d] - OpClass: %d Channel: %d", i,
+                    beacon_req->channelReport.opClass, ch);
+                beacon_req->channelReport.channels[total_ch++] = ch;
+            }
+        }
+        em_printfout("Total channels accumulated into HAL channelReport: %d", total_ch);
+    }
+    beacon_req->channelReportPresent = (query_params->num_ap_channel_rprt > 0);
+    for (int i = 0; i < query_params->element_list.num_element_id; i++) {
+        beacon_req->requestedElementIDS.ids[i] = query_params->element_list.element_list[i];
+        em_printfout("Requested Element ID: %d", beacon_req->requestedElementIDS.ids[i]);
+    }
+
+    if((desc = get_bus_descriptor()) == NULL) {
+       em_printfout("descriptor is null");
+       return;
+    }
+
+    l_bus_data.data_type = bus_data_type_bytes;
+    l_bus_data.raw_data.bytes = (void *)&beacon_query;
+    l_bus_data.raw_data_len = sizeof(beacon_query_params_t);
+
+    if (is_mld) {
+        // For MLO STAs send one beacon query per affiliated link, using the
+        // link-level STA MAC and link-level AP BSSID so that OneWifi can
+        // resolve ap_index from the wifidb VAP map (which stores link BSSIDs,
+        // not the AP-MLD MAC).
+        bool any_sent = false;
+        for (unsigned int i = 0; i < m_data_model.get_num_assoc_sta_mld(); i++) {
+            em_assoc_sta_mld_info_t &mld =
+                m_data_model.m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+            if (memcmp(mld.mac_addr, query_params->sta_mac_addr, sizeof(mac_address_t)) != 0) {
+                continue;
+            }
+            // Use the MLD MAC as beacon request destination (addr1 in the
+            // 802.11 action frame).  In MTK MLO, hostapd registers the STA
+            // under its MLD MAC, so ap_get_sta() only finds it by MLD MAC.
+            // The MLD MAC is also the correct addr1: an MLO STA accepts
+            // frames addressed to its MLD MAC on any active link.
+            memcpy(beacon_query.sta_mac, query_params->sta_mac_addr, sizeof(mac_address_t));
+            // Prefer the affiliated BSSID that matches the STA's current active
+            // connection (sta->m_sta_info.bssid) so that the first query targets
+            // the correct link and not an inactive one (e.g. 2.4 GHz when the
+            // STA is only on 5/6 GHz).  This avoids wasting an ap_index lookup
+            // on an isolated hapd that will return "not connected".
+            int send_pick = 0;
+            for (int c = 0; c < mld.num_affiliated_sta; c++) {
+                if (memcmp(mld.affiliated_sta[c].bssid, sta->m_sta_info.bssid,
+                           sizeof(mac_address_t)) == 0) {
+                    send_pick = c;
+                    break;
+                }
+            }
+            for (int pass = 0; pass < mld.num_affiliated_sta; pass++) {
+                int c = (send_pick + pass) % mld.num_affiliated_sta;
+                memcpy(beacon_req->bssid, mld.affiliated_sta[c].bssid, sizeof(mac_address_t));
+                em_printfout("Sending Beacon Query for MLD link AP=%s MLD-STA=%s",
+                    util::mac_to_string(mld.affiliated_sta[c].bssid).c_str(),
+                    util::mac_to_string(query_params->sta_mac_addr).c_str());
+                rc = desc->bus_set_fn(&m_bus_hdl, "Device.WiFi.EM.BeaconQuery", &l_bus_data);
+                if (rc != 0) {
+                    em_printfout("Failed to send Beacon Query for MLD link AP=%s MLD-STA=%s rc=%d",
+                        util::mac_to_string(mld.affiliated_sta[c].bssid).c_str(),
+                        util::mac_to_string(query_params->sta_mac_addr).c_str(), rc);
+                } else {
+                    em_printfout("Successfully sent Beacon Query for MLD link AP=%s MLD-STA=%s",
+                        util::mac_to_string(mld.affiliated_sta[c].bssid).c_str(),
+                        util::mac_to_string(query_params->sta_mac_addr).c_str());
+                    any_sent = true;
+                    // One successful send is sufficient: in MTK MLO all per-link
+                    // queries end up routed through the same shared hapd and the
+                    // same physical link.  Additional queries are redundant and
+                    // produce spurious "not connected" errors from isolated hapds.
+                    break;
+                }
+            }
+            break; // found the MLD entry
+        }
+        if (!any_sent) {
+            em_printfout("Failed to send Beacon Query to any MLD link for STA %s",
+                util::mac_to_string(query_params->sta_mac_addr).c_str());
+        }
+    } else {
+        memcpy(beacon_query.sta_mac, query_params->sta_mac_addr, sizeof(mac_address_t));
+        if ((rc = desc->bus_set_fn(&m_bus_hdl, "Device.WiFi.EM.BeaconQuery", &l_bus_data)) != 0) {
+            em_printfout("Failed to send Beacon Query to bus rc=%d len=%u", rc, l_bus_data.raw_data_len);
+            return;
+        }
+        em_printfout("Successfully sent Beacon Query to bus");
     }
 }
 
@@ -792,11 +1339,11 @@ void em_agent_t::handle_beacon_report(em_bus_event_t *evt)
     unsigned int num = 0;
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
-        printf("analyze_beacon_report in progress\n");
-    } else if ((num = m_data_model.analyze_beacon_report(evt, pcmd)) == 0) {
-        printf("analyze_beacon_report failed\n");
+        em_printfout("analyze_beacon_report in progress");
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_beacon_report(evt, pcmd))) == 0) {
+        em_printfout("analyze_beacon_report failed");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
-        printf("submitted beacon report cmd for orch\n");
+        em_printfout("submitted beacon report cmd for orchestration");
     }
 }
 
@@ -806,7 +1353,7 @@ void em_agent_t::handle_ap_metrics_report(em_bus_event_t *evt)
     unsigned int num;
 
     // populate data model first
-    if ((num = m_data_model.analyze_ap_metrics_report(evt, pcmd)) == 0) {
+    if ((num = static_cast<unsigned int>(m_data_model.analyze_ap_metrics_report(evt, pcmd))) == 0) {
         em_printfout("analyze_ap_metrics_report failed");
         return;
     }
@@ -832,6 +1379,7 @@ void em_agent_t::handle_ap_metrics_report(em_bus_event_t *evt)
                 } else {
                     em_printfout("failed to allocate event for ap_metrics_report, dropping for radio %s",
                         util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                    pcmd[i]->deinit();
                     delete pcmd[i];
                     pcmd[i] = NULL;
                 }
@@ -841,6 +1389,7 @@ void em_agent_t::handle_ap_metrics_report(em_bus_event_t *evt)
         }
         // if no matching em was found, pcmd[i] still non-null here, clean it up
         if (pcmd[i] != NULL) {
+            pcmd[i]->deinit();
             delete pcmd[i];
             pcmd[i] = NULL;
         }
@@ -854,7 +1403,7 @@ void em_agent_t::handle_link_stats_report(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         em_printfout("analyze_link_report in progress");
-    } else if ((num = m_data_model.analyze_link_report(evt, pcmd)) == 0) {
+    } else if ((num = static_cast<unsigned int>(m_data_model.analyze_link_report(evt, pcmd))) == 0) {
         em_printfout("analyze_link_report failed");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
         em_printfout("Submitted Link Stats report cmd for orch");
@@ -941,6 +1490,10 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
             handle_set_policy(evt);
             break;
 
+        case em_bus_event_type_beacon_query:
+            send_beacon_query(evt);
+            break;
+
         case em_bus_event_type_beacon_report:
             handle_beacon_report(evt);
             break;
@@ -956,6 +1509,10 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
             handle_recv_assoc_status(evt);
             break;
 
+        case em_bus_event_type_connection_status:
+            handle_recv_connection_status(evt);
+            break;
+
         case em_bus_event_type_ap_metrics_report:
             handle_ap_metrics_report(evt);
             break;
@@ -966,6 +1523,14 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
 
         case em_bus_event_type_link_quality_report:
             handle_link_stats_report(evt);
+            break;
+
+        case em_bus_event_type_unassoc_sta_link_metrics_query:
+            handle_unassoc_sta_link_metrics_qry(evt);
+            break;
+
+        case em_bus_event_type_unassoc_sta_result:
+            handle_unassoc_sta_result(evt);
             break;
 
         default:
@@ -1045,7 +1610,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
 
     int vap_idx = -1;
 
-    for (int bss_idx = 0; bss_idx < m_data_model.m_num_bss; bss_idx++) {
+    for (unsigned int bss_idx = 0; bss_idx < m_data_model.m_num_bss; bss_idx++) {
         auto bss_info = m_data_model.get_bss_info(bss_idx);
         if (bss_info == nullptr) {
             continue;
@@ -1056,7 +1621,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
         if (op_class_info == nullptr) {
             continue;
         }
-        vap_idx = bss_info->vap_index;
+        vap_idx = static_cast<int>(bss_info->vap_index);
         // Found a matching BSS, no need to continue searching
         break;
     }
@@ -1077,7 +1642,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
     EM_ASSERT_NOT_NULL(action_frame, false, "action_frame is null");
 
     // Allocate memory for the action frame parameters, ieee80211 header and action frame body
-    action_frame_params_t *act_frame_params = (action_frame_params_t*) calloc(sizeof(action_frame_params_t) + action_frame_len, 1);
+    action_frame_params_t *act_frame_params = static_cast<action_frame_params_t *>(calloc(sizeof(action_frame_params_t) + action_frame_len, 1));
     EM_ASSERT_NOT_NULL(act_frame_params, false, "calloc failed");
 
     act_frame_params->ap_index = vap_idx;
@@ -1091,7 +1656,7 @@ bool em_agent_t::send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_f
 
     raw_data_t raw_act_frame;
     memset(&raw_act_frame, 0, sizeof(raw_data_t));
-    raw_act_frame.raw_data.bytes = (uint8_t *)act_frame_params;
+    raw_act_frame.raw_data.bytes = reinterpret_cast<uint8_t *>(act_frame_params);
     raw_act_frame.raw_data_len = sizeof(action_frame_params_t) + action_frame_len;
     raw_act_frame.data_type = bus_data_type_bytes;
 
@@ -1164,83 +1729,93 @@ void em_agent_t::input_listener()
     bus_init(&m_bus_hdl);
 
     if((desc = get_bus_descriptor()) == NULL) {
-        printf("%s:%d descriptor is null\n", __func__, __LINE__);
+        em_printfout("Error: descriptor is null");
     }
 
     if (desc->bus_open_fn(&m_bus_hdl, service_name) != 0) {
-        printf("%s:%d bus open failed\n",__func__, __LINE__);
+        em_printfout("Error: bus open failed");
         return;
     }
 
-    printf("%s:%d he_bus open success\n", __func__, __LINE__);
+    em_printfout("bus open success");
 
     memset(&data, 0, sizeof(raw_data_t));
 
     while ((bus_error_val = desc->bus_data_get_fn(&m_bus_hdl, WIFI_WEBCONFIG_INIT_DML_DATA, &data)) != bus_error_success) {
-        printf("%s:%d bus get failed, error:%d, ", __func__, __LINE__, bus_error_val);
+        em_printfout("Error: bus get failed, error: %d", bus_error_val);
 		usleep(RETRY_SLEEP_INTERVAL_IN_MS * 1000);
 		num_retry++;
-		printf("retrying %d\n", num_retry);
+		em_printfout("retrying %d", num_retry);
 
         if (num_retry % 5 == 0) {
             if (access(EM_CFG_FILE, F_OK) != -1) {
-                printf("Check that OneWifi is running.\n");
+                em_printfout("Check that OneWifi is running.");
             } else {
-                printf("EasymeshCfg.json does not exist. Generate via the unified-wifi-mesh CLI/TUI (if co-located) or by adding the `--interface` flag to the agent (if not)\n");
+                em_printfout("EasymeshCfg.json does not exist. Generate via the unified-wifi-mesh CLI/TUI (if co-located) or by adding the `--interface` flag to the agent (if not)");
             }
         }
     }
-    printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, (char *)data.raw_data.bytes);
+    em_printfout("Received data:\r\n%s\r\n", reinterpret_cast<char *>(data.raw_data.bytes));
 
-    g_agent.io_process(em_bus_event_type_dev_init, (unsigned char *)data.raw_data.bytes, data.raw_data_len);
+    g_agent.io_process(em_bus_event_type_dev_init, reinterpret_cast<unsigned char *>(data.raw_data.bytes), data.raw_data_len);
     free(data.raw_data.bytes);
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_DOC_DATA_NORTH, (void *)&em_agent_t::onewifi_cb, NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_DOC_DATA_NORTH, reinterpret_cast<void *>(&em_agent_t::onewifi_cb), NULL, 0) != 0) {
+        em_printfout("Error: bus get failed");
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_GET_ASSOC, (void *)&em_agent_t::sta_cb, NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_WEBCONFIG_GET_ASSOC, reinterpret_cast<void *>(&em_agent_t::sta_cb), NULL, 0) != 0) {
+        em_printfout("Error: bus get failed");
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.STALinkMetricsReport", (void *)&em_agent_t::assoc_stats_cb, NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.STALinkMetricsReport", reinterpret_cast<void *>(&em_agent_t::assoc_stats_cb), NULL, 0) != 0) {
+        em_printfout("Error: bus get failed");
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_EM_CHANNEL_SCAN_REPORT, (void *)&em_agent_t::channel_scan_cb, NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+    if (desc->bus_event_subs_fn(&m_bus_hdl, WIFI_EM_CHANNEL_SCAN_REPORT, reinterpret_cast<void *>(&em_agent_t::channel_scan_cb), NULL, 0) != 0) {
+        em_printfout("Error: bus get failed");
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.BeaconReport", (void *)&em_agent_t::beacon_report_cb, NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.BeaconReport", reinterpret_cast<void *>(&em_agent_t::beacon_report_cb), NULL, 0) != 0) {
+        em_printfout("Error: bus get failed");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.AssociationStatus", reinterpret_cast<void *>(&em_agent_t::association_status_cb), nullptr, 0) != 0) {
-        em_printfout("Failed to subscribe to 'Device.WiFi.EM.AssociationStatus'");
+        em_printfout("Error: Failed to subscribe to 'Device.WiFi.EM.AssociationStatus'");
+        return;
+    }
+
+    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.ReportConnectionStatus", reinterpret_cast<void *>(&em_agent_t::connection_status_cb), nullptr, 0) != 0) {
+        em_printfout("Error: Failed to subscribe to 'Device.WiFi.EM.ReportConnectionStatus'");
         return;
     }
 
     if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EC.BSSInfo", reinterpret_cast<void *>(&em_agent_t::bss_info_cb), nullptr, 0) != 0) {
-        em_printfout("Failed to subscribe to 'Device.WiFi.EC.BSSInfo', dynamic DPP channel list for Reconfiguration Announcement is not available");
+        em_printfout("Error: Failed to subscribe to 'Device.WiFi.EC.BSSInfo', dynamic DPP channel list for Reconfiguration Announcement is not available");
         // This is fine, not a fatal error
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.APMetricsReport", (void *)&em_agent_t::report_cb, NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+    if (desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.APMetricsReport", reinterpret_cast<void *>(&em_agent_t::report_cb), NULL, 0) != 0) {
+        em_printfout("Error: bus get failed");
         return;
     }
 
-    if (desc->bus_event_subs_fn(&m_bus_hdl,  WIFI_QUALITY_LINKREPORT, (void *)&em_agent_t::report_cb, NULL, 0) != 0) {
-        printf("%s:%d bus get failed\n", __func__, __LINE__);
+    if (desc->bus_event_subs_fn(&m_bus_hdl,  WIFI_QUALITY_LINKREPORT, reinterpret_cast<void *>(&em_agent_t::report_cb), NULL, 0) != 0) {
+        em_printfout("Error: bus get failed");
         return;
     }
 
-   if(desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.CSABeaconFrameRecieved", (void *)&em_agent_t::mgmt_csa_beacon_frame_cb, NULL, 0) != 0) {
+   if(desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.CSABeaconFrameRecieved", reinterpret_cast<void *>(&em_agent_t::mgmt_csa_beacon_frame_cb), NULL, 0) != 0) {
+        em_printfout("Error: bus get failed");
+        return;
+    }
+
+   if(desc->bus_event_subs_fn(&m_bus_hdl, "Device.WiFi.EM.NaStaResponse", (void *)&em_agent_t::unassoc_sta_link_metrics_cb, NULL, 0) != 0) {
         printf("%s:%d bus get failed\n",__func__,__LINE__);
         return;
     }
@@ -1248,108 +1823,183 @@ void em_agent_t::input_listener()
     io(NULL);
 }
 
-int em_agent_t::bss_info_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::unassoc_sta_link_metrics_cb(char *event_name, bus_data_prop_t *data, void *userData)
+{
+    (void)event_name;
+    (void)userData;
+
+    if ((data == NULL) || (data->value.raw_data.bytes == NULL))
+    {
+        em_printfout("%s:%d invalid input", __func__,  __LINE__);
+        return -1;
+    }
+
+    cJSON *json = cJSON_Parse((const char *)data->value.raw_data.bytes);
+
+    if (json == NULL) {
+        em_printfout("%s:%d JSON parse failed",  __func__,  __LINE__);
+        return -1;
+    }
+
+    cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
+
+    if ((subdoc_name == NULL) || (!cJSON_IsString(subdoc_name))) {
+        em_printfout("%s:%d SubDocName missing", __func__,  __LINE__);
+        cJSON_Delete(json);
+        return -1;
+    }
+
+    if (strcmp(subdoc_name->valuestring, "UnassocStaLinkMetricsResponse") != 0) {
+        em_printfout("%s:%d unexpected SubDocName=%s",__func__, __LINE__, subdoc_name->valuestring);
+        cJSON_Delete(json);
+        return -1;
+    }
+
+    cJSON *resp = cJSON_GetObjectItemCaseSensitive(json, "UnassocStaLinkMetricsResponse");
+    if ((resp == NULL) || (!cJSON_IsArray(resp))) {
+        em_printfout("%s:%d response array missing",__func__,__LINE__);
+        cJSON_Delete(json);
+        return -1;
+    }
+
+    char *str = cJSON_Print(json);
+    if (str != NULL) {
+        em_printfout("===== UNASSOC RESPONSE =====\n%s\n", str);
+        free(str);
+    }
+
+    g_agent.io_process(em_bus_event_type_unassoc_sta_result, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes),
+                                                                               data->value.raw_data_len);
+    cJSON_Delete(json);
+
+    return 1;
+}
+
+int em_agent_t::bss_info_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     if (data == nullptr) {
         em_printfout("NULL data from OneWifi callback!");
         return -1;
     }
-    g_agent.io_process(em_bus_event_type_bss_info, reinterpret_cast<unsigned char *>(data->raw_data.bytes), data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_bss_info, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     return 1;
 }
 
-int em_agent_t::association_status_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::association_status_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     if (data == nullptr) {
         em_printfout("NULL data from OneWiFi callback!");
         return -1;
     }
-    g_agent.io_process(em_bus_event_type_assoc_status, reinterpret_cast<unsigned char *>(data->raw_data.bytes), data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_assoc_status, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     return 1;
 }
 
-int em_agent_t::channel_scan_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::connection_status_cb(char *event_name, bus_data_prop_t *data, void *userData)
+{
+    (void)event_name;
+    (void)userData;
+
+    if (data == nullptr) {
+        em_printfout("NULL data from OneWiFi callback!");
+        return -1;
+    }
+
+    g_agent.io_process(em_bus_event_type_connection_status,
+                       reinterpret_cast<unsigned char *>(data->value.raw_data.bytes),
+                       data->value.raw_data_len);
+    return 1;
+}
+
+int em_agent_t::channel_scan_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
     cJSON *json, *channel_stats_arr;
 
-    json = cJSON_Parse((const char *)data->raw_data.bytes);
+    json = cJSON_Parse(reinterpret_cast<const char *>(data->value.raw_data.bytes));
     if (json != NULL) {
         channel_stats_arr = cJSON_GetObjectItem(json, "ChannelScanResponse");
         if ((channel_stats_arr == NULL) && (cJSON_IsObject(channel_stats_arr) == false)) {
+            cJSON_Delete(json);
             return -1;
         }
         if (cJSON_IsArray(channel_stats_arr) && cJSON_GetArraySize(channel_stats_arr) == 0) {
+            cJSON_Delete(json);
             return -1;
         }
+        cJSON_Delete(json);
     }
 
-    g_agent.io_process(em_bus_event_type_scan_result, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_scan_result, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     return 1;
 }
 
-int em_agent_t::report_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::report_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
-    //em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->raw_data.bytes);
+    //em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
     (void)userData;
 
     if (strncmp(event_name, "Device.WiFi.EM.APMetricsReport", sizeof("Device.WiFi.EM.APMetricsReport"))==0) {
-        g_agent.io_process(em_bus_event_type_ap_metrics_report, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_ap_metrics_report, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     } else if (strncmp(event_name, WIFI_QUALITY_LINKREPORT, sizeof(WIFI_QUALITY_LINKREPORT))==0) {
-        em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->raw_data.bytes);
-        cJSON *json = cJSON_Parse((const char *)data->raw_data.bytes);
+        //em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->raw_data.bytes);
+        cJSON *json = cJSON_Parse((const char *)data->value.raw_data.bytes);
         if (json != NULL) {
             cJSON *link_report_arr;
             cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
             if ((strcmp(subdoc_name->valuestring, "LinkReport") == 0)) {
-                em_printfout("Found SubDocName: LinkReport");
+                //em_printfout("Found SubDocName: LinkReport");
                 link_report_arr = cJSON_GetObjectItem(json, "LinkReport");
                 if ((link_report_arr == NULL) && (cJSON_IsObject(link_report_arr) == false)) {
+                    cJSON_Delete(json);
                     return 0;
                 }
                 if (cJSON_IsArray(link_report_arr) && cJSON_GetArraySize(link_report_arr) == 0) {
-                    em_printfout("LinkReport is NULL");
+                    //em_printfout("LinkReport is NULL");
+                    cJSON_Delete(json);
                     return -1;
                 }
+                em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
             }
+            cJSON_Delete(json);
         }
-        g_agent.io_process(em_bus_event_type_link_quality_report, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        //g_agent.io_process(em_bus_event_type_link_quality_report, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     }
 
     return 0;
 }
 
-int em_agent_t::beacon_report_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::beacon_report_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
-    //printf("%s:%d Received Frame data for event [%s] and data :\n%s\n", __func__, __LINE__, event_name, data->raw_data.bytes);
+    //printf("%s:%d Received Frame data for event [%s] and data :\n%s\n", __func__, __LINE__, event_name, data->value.raw_data.bytes);
     (void)userData;
 
-    g_agent.io_process(em_bus_event_type_beacon_report, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_beacon_report, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     return 0;
 }
 
-int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::mgmt_action_frame_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
-    em_printfout("Received Frame data for event [%s] and data of len: %d",event_name, data->raw_data_len);
+    em_printfout("Received Frame data for event [%s] and data of len: %d",event_name, data->value.raw_data_len);
 
-    EM_ASSERT_MSG_TRUE(data != NULL && data->raw_data.bytes != NULL && data->raw_data_len > 0, -1,
+    EM_ASSERT_MSG_TRUE(data != NULL && data->value.raw_data.bytes != NULL && data->value.raw_data_len > 0, -1,
                    "Invalid data in mgmt_action_frame_cb");
 
-    uint8_t* mgmt_frame_data = (uint8_t*)data->raw_data.bytes;
-    unsigned int mgmt_hdr_len = data->raw_data_len;
+    uint8_t* mgmt_frame_data = reinterpret_cast<uint8_t *>(data->value.raw_data.bytes);
+    unsigned int mgmt_hdr_len = data->value.raw_data_len;
 
     // The frequency (and other wifi data) is prepended to the action frame data
     mgmt_frame_data += sizeof(wifi_frame_t);
     mgmt_hdr_len -= sizeof(wifi_frame_t);
 
-    struct ieee80211_mgmt *mgmt_frame = (struct ieee80211_mgmt *)mgmt_frame_data;
+    struct ieee80211_mgmt *mgmt_frame = reinterpret_cast<struct ieee80211_mgmt *>(mgmt_frame_data);
     
     
 
-    //util::print_hex_dump(data->raw_data_len, (uint8_t*)data->raw_data.bytes);
+    //util::print_hex_dump(data->value.raw_data_len, reinterpret_cast<uint8_t *>(data->value.raw_data.bytes));
 
     //printf("Received Frame data for event %s \n", event_name);
     if (mgmt_frame->u.action.u.bss_tm_resp.action == WLAN_WNM_BTM_RESPONSE) {
@@ -1364,7 +2014,7 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *u
         if (!memcmp(mgmt_frame->u.action.u.vs_public_action.oui, wfa_oui, sizeof(wfa_oui))){
             // Push WFA action frame back to main thread
             // Push all data to pass frequency as well
-            g_agent.io_process(em_bus_event_type_recv_wfa_action_frame, reinterpret_cast<uint8_t*>(data->raw_data.bytes), data->raw_data_len);
+            g_agent.io_process(em_bus_event_type_recv_wfa_action_frame, reinterpret_cast<uint8_t*>(data->value.raw_data.bytes), data->value.raw_data_len);
         }
     }
 
@@ -1377,13 +2027,13 @@ int em_agent_t::mgmt_action_frame_cb(char *event_name, raw_data_t *data, void *u
     return 0;
 }
 
-int em_agent_t::assoc_stats_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::assoc_stats_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
-    //printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, (char *)data->raw_data.bytes);
+    //printf("%s:%d recv data:\r\n%s\r\n", __func__, __LINE__, reinterpret_cast<char *>(data->value.raw_data.bytes));
     cJSON *json, *assoc_stats_arr;
 
-    json = cJSON_Parse((const char *)data->raw_data.bytes);
+    json = cJSON_Parse(reinterpret_cast<const char *>(data->value.raw_data.bytes));
     if (json != NULL) {
         cJSON *subdoc_name = cJSON_GetObjectItemCaseSensitive(json, "SubDocName");
         if ((strcmp(subdoc_name->valuestring, "Easymesh STA link metrics") == 0)) {
@@ -1392,36 +2042,38 @@ int em_agent_t::assoc_stats_cb(char *event_name, raw_data_t *data, void *userDat
             printf("%s:%d Found SubDocName: AssociatedDeviceStats\n", __func__, __LINE__);
             assoc_stats_arr = cJSON_GetObjectItem(json, "AssociatedDeviceStats");
             if ((assoc_stats_arr == NULL) && (cJSON_IsObject(assoc_stats_arr) == false)) {
+                cJSON_Delete(json);
                 return -1;
             }
             if (cJSON_IsArray(assoc_stats_arr) && cJSON_GetArraySize(assoc_stats_arr) == 0) {
                 printf("%s:%d AssociatedDeviceStats is NULL\n", __func__, __LINE__);
+                cJSON_Delete(json);
                 return -1;
             }
         }
     }
 
-    g_agent.io_process(em_bus_event_type_sta_link_metrics, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_sta_link_metrics, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     cJSON_Delete(json);
 
     return 1;
 }
 
-void em_agent_t::sta_cb(char *event_name, raw_data_t *data, void *userData)
+void em_agent_t::sta_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
     (void)userData;
-    //printf("%s:%d Recv data from onewifi:\r\n%s\r\n", __func__, __LINE__, (char *)data->raw_data.bytes);
-    g_agent.io_process(em_bus_event_type_sta_list, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    //printf("%s:%d Recv data from onewifi:\r\n%s\r\n", __func__, __LINE__, reinterpret_cast<char *>(data->value.raw_data.bytes));
+    g_agent.io_process(em_bus_event_type_sta_list, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
 }
 
-void em_agent_t::onewifi_cb(char *event_name, raw_data_t *data, void *userData)
+void em_agent_t::onewifi_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
         (void)userData;
-	const char *json_data = (char *)data->raw_data.bytes;
+	const char *json_data = reinterpret_cast<char *>(data->value.raw_data.bytes);
 	cJSON *json = cJSON_Parse(json_data);
 
-	//printf("%s:%dRecv data from onewifi:\r\n%s\r\n", __func__, __LINE__, (char *)data->raw_data.bytes);
+	//printf("%s:%dRecv data from onewifi:\r\n%s\r\n", __func__, __LINE__, reinterpret_cast<char *>(data->value.raw_data.bytes));
 
 	if (json == NULL) {
 		em_printfout("Error parsing JSON");
@@ -1436,15 +2088,15 @@ void em_agent_t::onewifi_cb(char *event_name, raw_data_t *data, void *userData)
     em_printfout("Found SubDocName: %s", subdoc_name->valuestring);
     if ((strcmp(subdoc_name->valuestring, "private") == 0) || (strcmp(subdoc_name->valuestring, "Vap_6G") == 0) ||
         (strcmp(subdoc_name->valuestring, "Vap_5G") == 0) || (strcmp(subdoc_name->valuestring, "Vap_2.4G") == 0)) {
-        g_agent.io_process(em_bus_event_type_onewifi_private_cb, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_private_cb, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     } else if ((strcmp(subdoc_name->valuestring, "radio") == 0) || (strcmp(subdoc_name->valuestring, "radio_6G") == 0) ||
         (strcmp(subdoc_name->valuestring, "radio_5G") == 0) || (strcmp(subdoc_name->valuestring, "radio_2.4G") == 0)) {
-        g_agent.io_process(em_bus_event_type_onewifi_radio_cb, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_radio_cb, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     } else if ((strcmp(subdoc_name->valuestring, "mesh_sta") == 0) || 
                (strcmp(subdoc_name->valuestring, "mesh backhaul sta") == 0)) {
-        g_agent.io_process(em_bus_event_type_onewifi_mesh_sta_cb, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+        g_agent.io_process(em_bus_event_type_onewifi_mesh_sta_cb, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
 
     } else {
         em_printfout("SubDocName (%s) not matching private, mesh_sta, or radio", subdoc_name->valuestring);
@@ -1454,11 +2106,11 @@ void em_agent_t::onewifi_cb(char *event_name, raw_data_t *data, void *userData)
 
 }
 
-int em_agent_t::mgmt_csa_beacon_frame_cb(char *event_name, raw_data_t *data, void *userData)
+int em_agent_t::mgmt_csa_beacon_frame_cb(char *event_name, bus_data_prop_t *data, void *userData)
 {
-    printf("%s:%d Received Frame data for event [%s] and data of len:\n%d\n", __func__, __LINE__, event_name, data->raw_data_len);
+    printf("%s:%d Received Frame data for event [%s] and data of len:\n%d\n", __func__, __LINE__, event_name, data->value.raw_data_len);
 
-    g_agent.io_process(em_bus_event_type_recv_csa_beacon_frame, (unsigned char *)data->raw_data.bytes, data->raw_data_len);
+    g_agent.io_process(em_bus_event_type_recv_csa_beacon_frame, reinterpret_cast<unsigned char *>(data->value.raw_data.bytes), data->value.raw_data_len);
     return 1;
 }
 
@@ -1490,31 +2142,31 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 {
     em_raw_hdr_t *hdr;
     em_cmdu_t *cmdu;
-    em_interface_t intf;
     em_freq_band_t band = em_freq_band_unknown;
     dm_easy_mesh_t *dm;
     em_t *em = NULL;
     mac_address_t ruid;
-    em_profile_type_t profile;
     mac_addr_str_t mac_str1, mac_str2;
     bssid_t bss_mac;
-    mac_address_t client_mac;
     bool found = false;
     em_string_t al_mac_str;
     em_bss_info_t *em_bss = NULL;
+    em_t *tmp_em = NULL;
+    em_ap_mld_info_t *ap_mld_info = NULL;
+    unsigned int i = 0, j = 0;
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
     if (len < ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)))) {
         return NULL;
     }
    
-    hdr = (em_raw_hdr_t *)data;
+    hdr = reinterpret_cast<em_raw_hdr_t *>(data);
 
     if (hdr->type != htons(ETH_P_1905)) {
         return NULL;
     }
    
-    cmdu = (em_cmdu_t *)(data + sizeof(em_raw_hdr_t));
+    cmdu = reinterpret_cast<em_cmdu_t *>(data + sizeof(em_raw_hdr_t));
 
     switch (htons(cmdu->type)) {
 	case em_msg_type_autoconf_resp:
@@ -1529,7 +2181,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             return al_em;
         }
 
-		em = (em_t *)hash_map_get_first(m_em_map);
+		em = static_cast<em_t *>(hash_map_get_first(m_em_map));
 		while (em != NULL) {
 			if (!(em->is_al_interface_em())) {
 				if (em->is_matching_freq_band(&band) == true) {
@@ -1542,7 +2194,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 					}
 				}
 			}
-			em = (em_t *)hash_map_get_next(m_em_map, em);
+			em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
 		}
 		if (found == false) {
 			printf("%s:%d: Could not find em with matching band%d and expected state \n", __func__, __LINE__, band);
@@ -1565,12 +2217,12 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 		}
 		dm_easy_mesh_t::macbytes_to_string(ruid, al_mac_str);
 		strcat(al_mac_str, "_al");
-		if ((em = (em_t *)hash_map_get(m_em_map, al_mac_str)) != NULL) {
+		if ((em = static_cast<em_t *>(hash_map_get(m_em_map, al_mac_str))) != NULL) {
 			printf("%s:%d: Found existing AL MAC:%s\n", __func__, __LINE__, al_mac_str);
 		} else {
 			return NULL;
 		}
-		em = (em_t *)hash_map_get_first(m_em_map);
+		em = static_cast<em_t *>(hash_map_get_first(m_em_map));
 		while (em != NULL) {
 			if (!(em->is_al_interface_em())) {
 				if (em->is_matching_freq_band(&band) == true) {
@@ -1583,7 +2235,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 					}
 				}
 			}
-			em = (em_t *)hash_map_get_next(m_em_map, em);
+			em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
 		}
 		if (found == false) {
 			printf("%s:%d: Could not find em with matching band%d and expected state \n", __func__, __LINE__, band);
@@ -1597,7 +2249,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 			}
 
 			dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
-        	if ((em = (em_t *)hash_map_get(m_em_map, mac_str1)) != NULL) {
+         if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) != NULL) {
             	printf("%s:%d: Found existing radio:%s\n", __func__, __LINE__, mac_str1);
         	} else {
 				return NULL;
@@ -1610,7 +2262,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             em_string_t al_mac_str;
             dm_easy_mesh_t::macbytes_to_string(hdr->dst, al_mac_str);
             strcat(al_mac_str, "_al");
-            if ((em = (em_t *)hash_map_get(m_em_map, al_mac_str)) != NULL) {
+            if ((em = static_cast<em_t *>(hash_map_get(m_em_map, al_mac_str))) != NULL) {
                 em_printfout("Received query message, found al_mac agent:%s", al_mac_str);
             } else {
                 em_printfout("Discarding query message, al_mac agent:%s not found",
@@ -1630,7 +2282,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             }
 
             dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
-            if ((em = (em_t *)hash_map_get(m_em_map, mac_str1)) != NULL) {
+            if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) != NULL) {
                 if (em->is_al_interface_em() == false) {
                     printf("%s:%d: Received em_msg_type_channel_sel_req, found existing radio:%s\n", __func__, __LINE__, mac_str1);
                 } else {
@@ -1660,12 +2312,50 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             while (em != NULL) {
                 dm = em->get_data_model();
                 em_bss = dm->get_bss_info_with_mac(bss_mac);
-                if (memcmp(em_bss->ruid.mac, em->get_radio_interface_mac(), sizeof(bssid_t)) == 0) {
+                if ((em_bss != NULL) &&
+                    (memcmp(em_bss->ruid.mac, em->get_radio_interface_mac(), sizeof(bssid_t)) == 0)) {
                     printf("%s:%d: Received client cap query: found radio for bss:%s\n", __func__, __LINE__, mac_str1);
                     break;
                 }
                 em = static_cast<em_t *> (hash_map_get_next(m_em_map, em));
             }
+
+            if (em == NULL) {
+                // AP MLD MAC fallback: resolve affiliated link radio EM.
+                tmp_em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+                while (tmp_em != NULL) {
+                    dm = tmp_em->get_data_model();
+                    if ((dm != NULL) && (tmp_em->is_al_interface_em() == false)) {
+                        for (i = 0; i < dm->get_num_ap_mld(); i++) {
+                            ap_mld_info = &dm->m_ap_mld[i].m_ap_mld_info;
+                            if (memcmp(ap_mld_info->mac_addr, bss_mac, sizeof(mac_address_t)) != 0) {
+                                continue;
+                            }
+
+                            for (j = 0; j < ap_mld_info->num_affiliated_ap; j++) {
+                                if (memcmp(ap_mld_info->affiliated_ap[j].ruid.mac,
+                                           tmp_em->get_radio_interface_mac(),
+                                           sizeof(mac_address_t)) == 0) {
+                                    em = tmp_em;
+                                    em_printfout("Client cap: AP-MLD bssid=%s mapped to radio=%s",
+                                           util::mac_to_string(bss_mac).c_str(),
+                                           util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                                    break;
+                                }
+                            }
+                            if (em != NULL) {
+                                break;
+                            }
+                        }
+                    }
+
+                    if (em != NULL) {
+                        break;
+                    }
+                    tmp_em = static_cast<em_t *>(hash_map_get_next(m_em_map, tmp_em));
+                }
+            }
+
             if(em == NULL){
                 dm_easy_mesh_t::macbytes_to_string(bss_mac, mac_str2);
                 printf("%s:%d: Received client cap query: Could not find radio:%s of bss:%s\n", __func__, __LINE__, mac_str1, mac_str2);
@@ -1681,12 +2371,12 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case em_msg_type_assoc_sta_link_metrics_query:
             printf("\n%s:%d: Rcvd Assoc STA Link Metrics Query\n", __func__, __LINE__);
 
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == false)) {
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
             break;
 
@@ -1696,13 +2386,13 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 
         case em_msg_type_client_steering_req:
             printf("\n%s:%d: Rcvd Client steering request\n", __func__, __LINE__);
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == false)) {
                     //printf("%s:%d: Found em\n", __func__, __LINE__);
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
             break;
 
@@ -1717,7 +2407,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 			}
 
 			dm_easy_mesh_t::macbytes_to_string(ruid, mac_str1);
-        	if ((em = (em_t *)hash_map_get(m_em_map, mac_str1)) == NULL) {
+         if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) == NULL) {
 				return NULL;
 			}
 			
@@ -1726,13 +2416,13 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case  em_msg_type_ap_mld_config_req:
             printf("%s:%d: Received em_msg_type_ap_mld_config_req\n", __func__, __LINE__);
 
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == false)) {
                     //printf("%s:%d: Found em\n", __func__, __LINE__);
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
 
             break;
@@ -1742,22 +2432,49 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
         case em_msg_type_channel_pref_rprt:
         case em_msg_type_1905_ack:
         case em_msg_type_map_policy_config_req:
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == false)) {
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
             break;
 
 		case em_msg_type_channel_scan_rprt:
         case em_msg_type_beacon_metrics_rsp:
         case em_msg_type_ap_mld_config_resp:
-        case em_msg_type_beacon_metrics_query:
         case em_msg_type_ap_metrics_rsp:
             break;
 
+        case em_msg_type_beacon_metrics_query:
+            em_printfout(" Rcvd Beacon Metrics Query");
+            {
+                mac_address_t client_mac = {};
+                em_tlv_t *bmq_tlv = reinterpret_cast<em_tlv_t *>(data + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+                em_beacon_metrics_query_t *bmq = reinterpret_cast<em_beacon_metrics_query_t *>(bmq_tlv->value);
+                memcpy(client_mac, bmq->sta_mac_addr, sizeof(mac_address_t));
+                em_printfout("Beacon Metrics Query for STA: %s", util::mac_to_string(client_mac).c_str());
+
+                em = (em_t *)hash_map_get_first(m_em_map);
+                while (em != NULL) {
+                    if (!em->is_al_interface_em()) {
+                        dm = em->get_data_model();
+                        if (dm->get_first_sta(client_mac) != NULL) {
+                            em_printfout("Found em with STA %s associated", util::mac_to_string(client_mac).c_str());
+                            break;
+                        }
+                    }
+                    em = (em_t *)hash_map_get_next(m_em_map, em);
+                }
+            }
+            // If no em has the STA, fall back to al_em so handle_beacon_metrics_query
+            // can send a 1905 ACK with Error Code TLV (Reason 0x02) per spec 10.3.3.
+            if (em == NULL) {
+                em_printfout("STA not found for Beacon Metrics Query, falling back to al_em for error ACK");
+                em = al_em;
+            }
+            break;
         case em_msg_type_proxied_encap_dpp:
         case em_msg_type_direct_encap_dpp:
         case em_msg_type_chirp_notif:
@@ -1773,13 +2490,13 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             break;
 
         case em_msg_type_bh_sta_cap_query:
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
                 if ((em->is_al_interface_em() == true)) {
                     em_printfout("Rcvd bsta cap Query");
                     break;
                 }
-                em = (em_t *)hash_map_get_next(m_em_map, em);
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
             }
             break;
 
@@ -1787,18 +2504,32 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             break;
 
         case em_msg_type_client_assoc_ctrl_req:
-            em = (em_t *)hash_map_get_first(m_em_map);
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
             while (em != NULL) {
 	        if ((em->is_al_interface_em() == true)) {
 	            em_printfout("Rceived client assoc ctrl request from controller");
 	            break;
 	        }
-	        em = (em_t *)hash_map_get_next(m_em_map, em);
+	        em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
            }
            break;
 
+        case em_msg_type_unassoc_sta_link_metrics_query:
+           em = (em_t *)hash_map_get_first(m_em_map);
+           while (em != NULL) {
+                if ((em->is_al_interface_em() == false)) {
+                    break;
+                }
+                em = (em_t *)hash_map_get_next(m_em_map, em);
+            }
+            break;
+
+        case em_msg_type_unassoc_sta_link_metrics_rsp:
+            em_printfout("Sending Unassoc STA Link Metrics response");
+            break;
+
         default:
-            printf("%s:%d: Frame: %d not handled in agent\n", __func__, __LINE__, htons(cmdu->type));
+            em_printfout("Frame: %d not handled in agent", htons(cmdu->type));
             em = NULL;
             break;	
 	}
@@ -1950,6 +2681,7 @@ bool em_agent_t::try_start_dpp_onboarding()  {
 }
 
 em_agent_t::em_agent_t()
+    : m_orch(nullptr), m_data_model(), m_data_model_path{}, m_agent_cmd(nullptr), m_simulator(), m_bus_hdl{}
 {
 
 }
@@ -1977,7 +2709,7 @@ AlServiceAccessPoint* em_agent_t::al_sap_register(const std::string& data_socket
         }
         std::cout << std::dec << std::endl;
     } else {
-        std::cout << "Registration failed with error: " << (int)result << std::endl;
+        std::cout << "Registration failed with error: " << static_cast<int>(result) << std::endl;
     }
 
     return sap;

--- a/src/agent/em_cmd_agent.cpp
+++ b/src/agent/em_cmd_agent.cpp
@@ -42,19 +42,19 @@
 #include "em_cmd_agent.h"
 
 em_cmd_t em_cmd_agent_t::m_client_cmd_spec[] = {
-    em_cmd_t(em_cmd_type_none,em_cmd_params_t{0, {"", "", "", "", ""}, "none"}),
-    em_cmd_t(em_cmd_type_dev_init,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Network"}),
-    em_cmd_t(em_cmd_type_cfg_renew, em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Renew"}),
-    em_cmd_t(em_cmd_type_vap_config,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:BssConfig"}),
-    em_cmd_t(em_cmd_type_sta_list,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:StaList"}),
-    em_cmd_t(em_cmd_type_ap_cap_query,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:CapReport"}),
-    em_cmd_t(em_cmd_type_max,em_cmd_params_t{0, {"", "", "", "", ""}, "max"}),
+    em_cmd_t(em_cmd_type_none,em_cmd_params_t{0, {"", "", "", "", ""}, "none", nullptr}),
+    em_cmd_t(em_cmd_type_dev_init,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Network", nullptr}),
+    em_cmd_t(em_cmd_type_cfg_renew, em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Renew", nullptr}),
+    em_cmd_t(em_cmd_type_vap_config,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:BssConfig", nullptr}),
+    em_cmd_t(em_cmd_type_sta_list,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:StaList", nullptr}),
+    em_cmd_t(em_cmd_type_ap_cap_query,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:CapReport", nullptr}),
+    em_cmd_t(em_cmd_type_max,em_cmd_params_t{0, {"", "", "", "", ""}, "max", nullptr}),
 };
 
 int em_cmd_agent_t::execute(em_long_string_t result)
 {
-    int ret, lsock, dsock;
-    unsigned int sz = EM_MAX_EVENT_DATA_LEN, i, offset, iter;
+    int ret, lsock;
+    unsigned int sz = EM_MAX_EVENT_DATA_LEN;
     unsigned char *tmp;
 
     m_cmd.reset();
@@ -81,7 +81,7 @@ int em_cmd_agent_t::execute(em_long_string_t result)
 
         printf("%s:%d: Connection accepted from client\n", __func__, __LINE__);
 
-        tmp = (unsigned char *)get_event();
+        tmp = reinterpret_cast<unsigned char *>(get_event());
 
         if ((ret = recv(m_dsock, tmp, sizeof(em_event_t) + EM_MAX_EVENT_DATA_LEN, 0)) <= 0) {
             printf("%s:%d: listen error on socket, err:%d\n", __func__, __LINE__, errno);
@@ -113,7 +113,7 @@ int em_cmd_agent_t::send_result(em_cmd_out_status_t status)
     em_status_string_t str;
     unsigned char *tmp;
 
-    tmp = (unsigned char *)m_cmd.status_to_string(status, str);
+    tmp = reinterpret_cast<unsigned char *>(m_cmd.status_to_string(status, str));
 
     if ((ret = send(m_dsock, tmp, sizeof(em_status_string_t), 0)) <= 0) {
         printf("%s:%d: write error on socket, err:%d\n", __func__, __LINE__, errno);
@@ -129,7 +129,7 @@ em_event_t *em_cmd_agent_t::create_event(char *buff)
     // here is the entry point of RBUS subdocuments
     em_cmd_type_t   type = em_cmd_type_none;
     cJSON *obj, *child_obj;
-    char *tmp;
+    const char *tmp;
     em_cmd_t    *cmd;
     unsigned int idx;
     em_event_t *evt;
@@ -151,7 +151,7 @@ em_event_t *em_cmd_agent_t::create_event(char *buff)
             type = em_cmd_agent_t::m_client_cmd_spec[idx].get_type(); continue;
         }
 
-        tmp = (char *)cmd->get_arg();
+        tmp = cmd->get_arg();
 
         if ((child_obj = cJSON_GetObjectItem(obj, tmp)) != NULL) {
             break;
@@ -169,7 +169,8 @@ em_event_t *em_cmd_agent_t::create_event(char *buff)
         return NULL;
     }
 
-    evt = (em_event_t *)malloc(sizeof(em_event_t));
+    unsigned int buff_len = static_cast<unsigned int>(strlen(buff)) + 1;
+    evt = reinterpret_cast<em_event_t *>(malloc(sizeof(em_event_t) + buff_len));
     evt->type = em_event_type_bus;
     bevt = &evt->u.bevt;
 
@@ -199,22 +200,22 @@ em_event_t *em_cmd_agent_t::create_event(char *buff)
     }
 
     memcpy(&bevt->params, &cmd->m_param, sizeof(em_cmd_params_t));
-    memcpy(&bevt->u.subdoc.buff, buff, EM_MAX_EVENT_DATA_LEN);
-    bevt->data_len = strlen(buff) + 1;   
+    memcpy(&bevt->u.subdoc.buff, buff, buff_len);
+    bevt->data_len = buff_len;
     return evt;
 }
 
-em_cmd_agent_t::em_cmd_agent_t(em_cmd_t& obj)
+em_cmd_agent_t::em_cmd_agent_t(em_cmd_t& obj) : m_dsock(-1)
 {
     memcpy(&m_cmd.m_param, &obj.m_param, sizeof(em_cmd_params_t));
 }
 
-em_cmd_agent_t::em_cmd_agent_t(em_cmd_type_t type)
+em_cmd_agent_t::em_cmd_agent_t(em_cmd_type_t type) : m_dsock(-1)
 {
     memcpy(&m_cmd.m_param, &em_cmd_agent_t::m_client_cmd_spec[type].m_param, sizeof(em_cmd_params_t));
 }
 
-em_cmd_agent_t::em_cmd_agent_t()
+em_cmd_agent_t::em_cmd_agent_t() : m_dsock(-1)
 {
 
 }

--- a/src/agent/em_simulator.cpp
+++ b/src/agent/em_simulator.cpp
@@ -41,7 +41,7 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 	unsigned int i, j, k;
 	em_scan_result_t	scan_result;
 	dm_scan_result_t *res;
-	em_long_string_t key;
+	em_2xlong_string_t key;
 	mac_addr_str_t dev_mac_str, scanner_mac_str;
 	mac_address_t nbr_mac_base = {0x00, 0x01, 0x03, 0x04, 0x05, 0x06};
 
@@ -53,7 +53,7 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 
         for (j = 0; j < m_param.u.scan_params.op_class[i].num_channels; j++) {
 
-			strncpy(scan_result.id.net_id, dm.m_network.m_net_info.id, strlen(dm.m_network.m_net_info.id) + 1);
+			snprintf(scan_result.id.net_id, sizeof(scan_result.id.net_id), "%s", dm.m_network.m_net_info.id);
 			memcpy(scan_result.id.dev_mac, dm.m_device.m_device_info.id.dev_mac, sizeof(mac_address_t));
 			memcpy(scan_result.id.scanner_mac, m_param.u.scan_params.ruid, sizeof(mac_address_t));
 			scan_result.id.op_class = m_param.u.scan_params.op_class[i].op_class;
@@ -63,15 +63,15 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 			dm_easy_mesh_t::macbytes_to_string(dm.m_device.m_device_info.id.dev_mac, dev_mac_str);
 			dm_easy_mesh_t::macbytes_to_string(m_param.u.scan_params.ruid, scanner_mac_str);
 
-			snprintf(key, sizeof(em_long_string_t), "%s@%s@%s@%d@%d@%d", scan_result.id.net_id, dev_mac_str, scanner_mac_str,
+			snprintf(key, sizeof(em_2xlong_string_t), "%s@%s@%s@%d@%d@%d", scan_result.id.net_id, dev_mac_str, scanner_mac_str,
 				scan_result.id.op_class, scan_result.id.channel, scan_result.id.scanner_type);
 
-			if ((res = (dm_scan_result_t *)hash_map_get(dm.m_scan_result_map, key)) == NULL) {
+			if ((res = reinterpret_cast<dm_scan_result_t *>(hash_map_get(dm.m_scan_result_map, key))) == NULL) {
 				res = new dm_scan_result_t(&scan_result);
 				hash_map_put(dm.m_scan_result_map, strdup(key), res);
 			}
 			
-			strncpy(res->m_scan_result.id.net_id, dm.m_network.m_net_info.id, strlen(dm.m_network.m_net_info.id) + 1);
+			snprintf(res->m_scan_result.id.net_id, sizeof(res->m_scan_result.id.net_id), "%s", dm.m_network.m_net_info.id);
 			memcpy(res->m_scan_result.id.dev_mac, dm.m_device.m_device_info.intf.mac, sizeof(mac_address_t));
 			memcpy(res->m_scan_result.id.scanner_mac, m_param.u.scan_params.ruid, sizeof(mac_address_t));
 			res->m_scan_result.id.op_class = m_param.u.scan_params.op_class[i].op_class;
@@ -80,7 +80,7 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 
 			util::get_date_time_rfc3399(time_date, sizeof(time_date));
 
-			strncpy(res->m_scan_result.timestamp, time_date, strlen(time_date) + 1);
+			snprintf(res->m_scan_result.timestamp, sizeof(res->m_scan_result.timestamp), "%s", time_date);
 			res->m_scan_result.util = 20;
 			res->m_scan_result.noise = 10;
 
@@ -89,7 +89,7 @@ bool em_simulator_t::run(dm_easy_mesh_agent_t& dm)
 			for (k = 0; k < res->m_scan_result.num_neighbors; k++) {
 				nbr_mac_base[5]++;
 				memcpy(res->m_scan_result.neighbor[k].bssid, nbr_mac_base, sizeof(mac_address_t));
-				strncpy(res->m_scan_result.neighbor[k].ssid, "test", strlen("test") + 1);
+				snprintf(res->m_scan_result.neighbor[k].ssid, sizeof(res->m_scan_result.neighbor[k].ssid), "%s", "test");
 				res->m_scan_result.neighbor[k].signal_strength = 30;
 				res->m_scan_result.neighbor[k].bandwidth = WIFI_CHANNELBANDWIDTH_40MHZ;
 				res->m_scan_result.neighbor[k].bss_color = 0x8f;
@@ -127,8 +127,8 @@ void em_simulator_t::configure(dm_easy_mesh_agent_t& dm, em_scan_params_t *param
 }
 
 em_simulator_t::em_simulator_t()
+    : m_param{}, m_can_run_scan_res(false)
 {
-	m_can_run_scan_res = false;
 }
 
 em_simulator_t::~em_simulator_t()

--- a/src/cmd/em_cmd.cpp
+++ b/src/cmd/em_cmd.cpp
@@ -180,7 +180,10 @@ char *em_cmd_t::status_to_string(em_cmd_out_status_t status, char *str)
 
 void em_cmd_t::deinit()
 {
-    queue_destroy(m_em_candidates);
+    if (m_em_candidates != nullptr) {
+        queue_destroy(m_em_candidates);
+        m_em_candidates = nullptr;
+    }
     m_data_model.deinit();
 	//free(m_evt);
 }
@@ -462,6 +465,11 @@ void em_cmd_t::init()
             strncpy(m_name, "get_alarm_report", strlen("get_alarm_report") + 1);
             m_svc = em_service_type_ctrl;
             break;
+        
+	case em_cmd_type_unassoc_sta_query:
+            snprintf(m_name, sizeof(m_name), "%s", "unassoc_sta_query");
+            m_svc = em_service_type_ctrl;
+            break;
 
         default:
             snprintf(m_name, sizeof(m_name), "%s", "unknown");
@@ -489,6 +497,7 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_set_ssid)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_channel)
         BUS_EVENT_TYPE_2S(em_bus_event_type_set_channel)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_channel_select)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_bss)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_sta)
         BUS_EVENT_TYPE_2S(em_bus_event_type_steer_sta)
@@ -511,6 +520,9 @@ const char *em_cmd_t::get_bus_event_type_str(em_bus_event_type_t type)
         BUS_EVENT_TYPE_2S(em_bus_event_type_mld_reconfig)
         BUS_EVENT_TYPE_2S(em_bus_event_type_get_reset)
         BUS_EVENT_TYPE_2S(em_bus_event_type_link_quality_report)
+        BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_query)
+	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_link_metrics_query)
+	BUS_EVENT_TYPE_2S(em_bus_event_type_unassoc_sta_result)
        
         default:
            break;
@@ -588,6 +600,8 @@ const char *em_cmd_t::get_orch_op_str(dm_orch_type_t type)
         ORCH_TYPE_2S(dm_orch_type_policy_cfg)
         ORCH_TYPE_2S(dm_orch_type_mld_reconfig)
         ORCH_TYPE_2S(dm_orch_type_topo_publish)
+        ORCH_TYPE_2S(dm_orch_type_unassoc_sta_link_req_query)
+	ORCH_TYPE_2S(dm_orch_type_unassoc_sta_result)
 
         default:
            break;
@@ -644,6 +658,8 @@ const char *em_cmd_t::get_cmd_type_str(em_cmd_type_t type)
         CMD_TYPE_2S(em_cmd_type_ap_metrics_report)
         CMD_TYPE_2S(em_cmd_type_get_reset)
         CMD_TYPE_2S(em_cmd_type_get_link_quality_report)
+        CMD_TYPE_2S(em_cmd_type_unassoc_sta_query)
+	CMD_TYPE_2S(em_cmd_type_unassoc_sta_result)
 
         default:
            break;
@@ -790,6 +806,18 @@ em_cmd_type_t em_cmd_t::bus_2_cmd_type(em_bus_event_type_t etype)
             type = em_cmd_type_get_link_quality_report;
             break;
 
+      	case em_bus_event_type_unassoc_sta_query:
+            type = em_cmd_type_unassoc_sta_query;
+            break;
+
+      	case em_bus_event_type_unassoc_sta_result:
+            type = em_cmd_type_unassoc_sta_result;
+            break;
+
+        case em_bus_event_type_channel_select:
+            type = em_cmd_type_set_channel;
+            break;
+
         default:
             break;
     }
@@ -842,6 +870,14 @@ em_bus_event_type_t em_cmd_t::cmd_2_bus_event_type(em_cmd_type_t ctype)
             type = em_bus_event_type_get_reset;
             break;
 
+        case em_cmd_type_unassoc_sta_query:
+            type = em_bus_event_type_unassoc_sta_query;
+            break;
+
+        case em_cmd_type_unassoc_sta_result:
+            type = em_bus_event_type_unassoc_sta_result;
+            break;
+
         default:
             break;
     }
@@ -886,7 +922,7 @@ int em_cmd_t::dump_bus_event(em_bus_event_t *evt)
 }   
 
 em_cmd_t::em_cmd_t(em_cmd_type_t type, em_cmd_params_t param, dm_easy_mesh_t& dm)
-    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_db_cfg_type(db_cfg_type_none)
+    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_em_candidates(nullptr), m_db_cfg_type(db_cfg_type_none)
 {
     auto raw = static_cast<std::underlying_type_t<em_cmd_type_t>>(type);
     m_type = (raw >= static_cast<decltype(raw)>(em_cmd_type_max))
@@ -898,7 +934,7 @@ em_cmd_t::em_cmd_t(em_cmd_type_t type, em_cmd_params_t param, dm_easy_mesh_t& dm
 }
 
 em_cmd_t::em_cmd_t(em_cmd_type_t type, em_cmd_params_t param)
-    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_db_cfg_type(db_cfg_type_none)
+    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_em_candidates(nullptr), m_db_cfg_type(db_cfg_type_none)
 {
     auto raw = static_cast<std::underlying_type_t<em_cmd_type_t>>(type);
     m_type = (raw >= static_cast<decltype(raw)>(em_cmd_type_max))
@@ -909,7 +945,7 @@ em_cmd_t::em_cmd_t(em_cmd_type_t type, em_cmd_params_t param)
 }
 
 em_cmd_t::em_cmd_t()
-    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_db_cfg_type(db_cfg_type_none)
+    : m_type(em_cmd_type_none), m_svc(em_service_type_none), m_param{}, m_evt(NULL), m_em_candidates(nullptr), m_db_cfg_type(db_cfg_type_none)
 {
 	m_evt = static_cast<em_event_t *> (malloc(sizeof(em_event_t) + EM_MAX_EVENT_DATA_LEN));
 }

--- a/src/cmd/em_cmd_exec.cpp
+++ b/src/cmd/em_cmd_exec.cpp
@@ -411,7 +411,8 @@ int em_cmd_exec_t::init()
 
 em_cmd_exec_t::em_cmd_exec_t()
 {
-
+    m_ssl = NULL;
+    m_ssl_ctx = NULL;
 }
 
 em_cmd_exec_t::~em_cmd_exec_t()

--- a/src/cmd/em_cmd_unassoc_sta_query.cpp
+++ b/src/cmd/em_cmd_unassoc_sta_query.cpp
@@ -33,45 +33,41 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <cjson/cJSON.h>
-#include "em_cmd_em_config.h"
+#include "em_cmd_unassoc_sta_query.h"
 
-em_cmd_em_config_t::em_cmd_em_config_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
+em_cmd_unassoc_sta_query_t::em_cmd_unassoc_sta_query_t(em_cmd_params_t param, dm_easy_mesh_t& dm, em_unassoc_query_list_t *query)
 {
-    em_cmd_ctx_t ctx;;
+    em_cmd_ctx_t ctx;
 
-    m_type = em_cmd_type_em_config;
+    m_type = em_cmd_type_unassoc_sta_query;
+
     memcpy(&m_param, &param, sizeof(em_cmd_params_t));
 
-    memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+    memset(&m_query, 0, sizeof(em_unassoc_query_list_t));
+
+    if (query != NULL) {
+        memcpy(&m_query, query, sizeof(em_unassoc_query_list_t));
+    }
+
+    memset(reinterpret_cast<unsigned char *>(&m_orch_desc[0]), 0, EM_MAX_CMD * sizeof(em_orch_desc_t));
 
     m_orch_op_idx = 0;
-    m_num_orch_desc = 8;
-    m_orch_desc[0].op = dm_orch_type_bss_delete;
-    m_orch_desc[0].submit = false;
-    m_orch_desc[1].op = dm_orch_type_topo_sync;
-    m_orch_desc[1].submit = true;
-    m_orch_desc[2].op = dm_orch_type_ap_cap_query;
-    m_orch_desc[2].submit = true;
-    m_orch_desc[3].op = dm_orch_type_channel_pref;
-    m_orch_desc[3].submit = true;
-    //sending policy_cfg req before channel selection, since policy_cfg is per device
-    m_orch_desc[4].op = dm_orch_type_policy_cfg;
-    m_orch_desc[4].submit = true;
-    m_orch_desc[5].op = dm_orch_type_channel_sel;
-    m_orch_desc[5].submit = true;
-    // m_orch_desc[6].op = dm_orch_type_channel_scan_req;
-    // m_orch_desc[6].submit = true;
-    m_orch_desc[6].op = dm_orch_type_topo_update;
-    m_orch_desc[6].submit = false;
-    m_orch_desc[7].op = dm_orch_type_topo_publish;
-    m_orch_desc[7].submit = true;
 
-    strncpy(m_name, "em_config", strlen("em_config") + 1);
+    m_num_orch_desc = 1;
+
+    m_orch_desc[0].op = dm_orch_type_unassoc_sta_link_req_query;
+
+    m_orch_desc[0].submit = true;
+
+    strncpy(m_name, "unassoc_sta_query", sizeof(m_name) - 1);
+
     m_svc = em_service_type_ctrl;
+
     init(dm);
 
     memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+
     ctx.type = m_orch_desc[0].op;
+
     m_data_model.set_cmd_ctx(&ctx);
 }
-

--- a/src/cmd/em_cmd_unassoc_sta_result.cpp
+++ b/src/cmd/em_cmd_unassoc_sta_result.cpp
@@ -33,32 +33,33 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <cjson/cJSON.h>
-#include "em_cmd_sta_assoc.h"
+#include "em_cmd_unassoc_sta_result.h"
 
-em_cmd_sta_assoc_t::em_cmd_sta_assoc_t(em_cmd_params_t param, dm_easy_mesh_t& dm)
+em_cmd_unassoc_sta_result_t::em_cmd_unassoc_sta_result_t(em_cmd_params_t param,  dm_easy_mesh_t& dm)
 {
     em_cmd_ctx_t ctx;
 
-    m_type = em_cmd_type_sta_assoc;
+    m_type = em_cmd_type_unassoc_sta_result;
+
     memcpy(&m_param, &param, sizeof(em_cmd_params_t));
 
-	memset(reinterpret_cast<unsigned char *> (&m_orch_desc[0]), 0, EM_MAX_CMD*sizeof(em_orch_desc_t));
+    memset(reinterpret_cast<unsigned char *>(&m_orch_desc[0]), 0, EM_MAX_CMD * sizeof(em_orch_desc_t));
 
     m_orch_op_idx = 0;
-    m_num_orch_desc = 3;
-    m_orch_desc[0].op = dm_orch_type_topo_sync;
-    m_orch_desc[0].submit = true;
-    m_orch_desc[1].op = dm_orch_type_sta_cap;
-    m_orch_desc[1].submit = true;
-    m_orch_desc[2].op = dm_orch_type_topo_publish;
-    m_orch_desc[2].submit = true;
+    m_num_orch_desc = 1;
 
-    strncpy(m_name, "sta_assoc", strlen("sta_assoc") + 1);
-    m_svc = em_service_type_ctrl;
+    m_orch_desc[0].op = dm_orch_type_unassoc_sta_result;
+    m_orch_desc[0].submit = true;
+
+    strncpy(m_name, "unassoc_sta_result", sizeof(m_name) - 1);
+
+    m_svc = em_service_type_agent;
+
     init(dm);
 
     memset(&ctx, 0, sizeof(em_cmd_ctx_t));
+
     ctx.type = m_orch_desc[0].op;
+
     m_data_model.set_cmd_ctx(&ctx);
 }
-

--- a/src/ctrl/Makefile.am
+++ b/src/ctrl/Makefile.am
@@ -30,10 +30,12 @@ onewifi_em_ctrl_CPPFLAGS = \
     -I$(top_srcdir)/inc \
     -I$(top_srcdir)/src/utils \
     -I$(top_srcdir)/src/util \
-    -I$(top_srcdir)/src/util_crypto \
-    -DUNIT_TEST
+    -I$(top_srcdir)/src/util_crypto
 
-onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fsanitize=address -fsanitize=undefined #-Wconversion -Werror -O2
+onewifi_em_ctrl_CXXFLAGS = $(INCLUDEDIRS) -g -Wall -Wextra -pedantic -Wpedantic -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-aliasing -fno-common -Wctor-dtor-privacy -Wold-style-cast -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -pie -ftrapv -Wformat=2 -Wformat-security -Wuninitialized -Winit-self -Wsign-conversion -Weffc++ -Wno-unused-parameter -std=c++17 -fno-omit-frame-pointer #-Wconversion -Werror -O2
+if EM_ASAN_CTRL
+onewifi_em_ctrl_CXXFLAGS += -fsanitize=address -fsanitize=undefined
+endif
 
 onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/em/em.cpp \
@@ -93,6 +95,7 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
      $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
      $(top_srcdir)/src/cmd/em_cmd_bsta_cap.cpp \
+     $(top_srcdir)/src/cmd/em_cmd_unassoc_sta_query.cpp \
      $(top_srcdir)/src/ctrl/dm_easy_mesh_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_cmd_ctrl.cpp \
      $(top_srcdir)/src/ctrl/em_ctrl.cpp \
@@ -142,7 +145,11 @@ onewifi_em_ctrl_SOURCES =  \
      $(top_srcdir)/src/utils/timer.cpp
  
  
-onewifi_em_ctrl_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lrbus -fsanitize=address -fsanitize=undefined -lmariadb
+onewifi_em_ctrl_LDFLAGS = -lm -lpthread -ldl -luuid -lcjson -lssl -lcrypto -lrbus -lmariadb
+if EM_ASAN_CTRL
+onewifi_em_ctrl_LDFLAGS += -fsanitize=address -fsanitize=undefined
+endif
+
 onewifi_em_ctrl_LDADD = $(top_builddir)/src/al-sap/libalsap.la
 if EM_UNITTEST
 onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
@@ -216,8 +223,7 @@ onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
 	$(top_srcdir)/tests/test_l1_em_dev_test_ctrl.cpp \
 	$(top_srcdir)/src/al-sap/al_service_utils.cpp \
 	$(top_srcdir)/tests/test_l1_al_service_utils.cpp \
-	$(top_srcdir)/tests/test_l1_cjson_util.cpp \	
-	$(top_srcdir)/tests/test_l1_dm_easy_mesh_list.cpp \
+	$(top_srcdir)/tests/test_l1_cjson_util.cpp \
 	$(top_srcdir)/tests/test_l1_em_msg.cpp \
 	$(top_srcdir)/tests/test_l1_timer.cpp \
 	$(top_srcdir)/tests/test_l1_util.cpp \
@@ -226,14 +232,19 @@ onewifi_em_ctrl_test_SOURCES = $(onewifi_em_ctrl_SOURCES) \
 	$(top_srcdir)/tests/test_l1_ec_1905_encrypt_layer.cpp \
 	$(top_srcdir)/tests/test_l1_ec_enrollee.cpp \
 	$(top_srcdir)/tests/test_l1_ec_util.cpp \
-	$(top_srcdir)/tests/test_l1_em_ctrl.cpp \
 	$(top_srcdir)/tests/test_l1_dm_easy_mesh.cpp \
 	$(top_srcdir)/tests/test_l1_ec_pa_configurator.cpp \
-	$(top_srcdir)/tests/test_l1_ec_manager.cpp
+	$(top_srcdir)/tests/test_l1_ec_manager.cpp \
+	$(top_srcdir)/src/al-sap/al_service_registration_response.cpp \
+	$(top_srcdir)/tests/test_l1_em_ctrl.cpp \
+	$(top_srcdir)/tests/test_l1_dm_easy_mesh_list.cpp
+
 onewifi_em_ctrl_test_CPPFLAGS = $(onewifi_em_ctrl_CPPFLAGS) \
                                 -I$(PKG_CONFIG_SYSROOT_DIR)$(includedir)/gtest \
                                 -DTESTING
-onewifi_em_ctrl_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST
-onewifi_em_ctrl_test_LDFLAGS = -lcjson -lgtest -lgtest_main -lgmock -lpthread -lssl -lcrypto -lm -luuid -lssl -lrbus -lmariadb -fsanitize=address -fsanitize=undefined
-onewifi_em_ctrl_test_LDADD = $(top_builddir)/src/al-sap/libalsap.la $(onewifi_em_ctrl_LDADD)
-endif
+onewifi_em_ctrl_test_CXXFLAGS = $(INCLUDEDIRS) -g -DUNIT_TEST -fno-omit-frame-pointer
+onewifi_em_ctrl_test_CXXFLAGS += -fsanitize=address -fsanitize=undefined
+onewifi_em_ctrl_test_LDFLAGS = -lcjson -lgtest -lgtest_main -lgmock -lpthread -lssl -lcrypto -lm -luuid -lssl -lrbus -lmariadb
+onewifi_em_ctrl_test_LDFLAGS += -fsanitize=address -fsanitize=undefined
+onewifi_em_ctrl_test_LDADD = $(top_builddir)/src/al-sap/libalsap.la
+endif  # EM_UNITTEST

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -33,10 +33,12 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
+#include <stdlib.h>
 #include "dm_easy_mesh_ctrl.h"
 #include "dm_easy_mesh.h"
 #include "em_ctrl.h"
 #include "tr_181.h"
+#include "util.h"
 #include <cjson/cJSON.h>
 #include "em_cmd_exec.h"
 #include "em_cmd_reset.h"
@@ -57,10 +59,11 @@
 #include "em_cmd_get_mld_config.h"
 #include "em_cmd_mld_reconfig.h"
 #include "em_cmd_bsta_cap.h"
+#include "em_cmd_unassoc_sta_query.h"
 
 extern em_network_topo_t *g_network_topology;
 
-bus_error_t em_ctrl_t::cmd_setssid(const char *event_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
 {
     em_subdoc_info_t *subdoc = NULL;
     unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
@@ -74,7 +77,7 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *event_name, const bus_data_prop_t
     char HaulType[TR181_HAULTYPE_MAX_LEN + 1] = {0};
     size_t json_len = 0;
 
-    (void)event_name;
+    (void)method_name;
     (void)async_handle;
 
     if (!input_params) {
@@ -346,6 +349,1806 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *event_name, const bus_data_prop_t
     return bus_error_success;
 }
 
+bus_error_t em_ctrl_t::cmd_steerwifibh(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+{
+    (void)async_handle;
+    const char *name = method_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    const bus_data_prop_t *prop = NULL;
+    char target[TR181_BSSID_MAX_LEN + 1] = { 0 };
+    int channel = -1;
+    int timeout = -1;
+    em_subdoc_info_t *subdoc = NULL;
+    unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
+    cJSON *root = NULL, *json = NULL, *net_obj = NULL;
+    cJSON *dev_list = NULL, *dev_obj = NULL;
+    cJSON *steer_obj = NULL;
+    mac_addr_str_t mac_str;
+    char *json_buff = NULL;
+    size_t json_len = 0;
+    bus_error_t rc;
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        em_printfout("Invalid method name");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+    ++param;
+    if (strcmp("SteerWiFiBackhaul()", param) != 0) {
+        em_printfout("Invalid method");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_method;
+    }
+
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!em_ctrl) {
+        em_printfout("Controller not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_general;
+    }
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        em_printfout("Device not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_device_info_t *di = dm->get_device()->get_device_info();
+
+    /* Most of the parameters are mandatory, parse them */
+    for (prop = input_params; prop; prop = prop->next_data) {
+        if (strcmp(prop->name, "TargetBSS") == 0) {
+            if (!tr_181_t::tr181_copy_prop_string(prop, target, sizeof(target))) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "Channel") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &channel)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "TimeOut") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &timeout)) {
+                goto invalid;
+            }
+        } else {
+invalid:
+            em_printfout("Invalid parameter: %s", prop->name);
+            if (output_params) {
+                *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+            }
+            return bus_error_invalid_input;
+        }
+    }
+    /* Mandatory parameters: TargetBSS and TimeOut */
+    if (!target[0] || timeout < 0) {
+        em_printfout("Mandatory parameters missing");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+
+    /* Prepare subdoc to be processed with command */
+    subdoc = reinterpret_cast<em_subdoc_info_t *>(buff);
+    memset(subdoc, 0, sizeof(em_subdoc_info_t));
+    strncpy(subdoc->name, "SteerWiFiBackhaul", sizeof(subdoc->name) - 1);
+
+    /* Create json with root "wfa-dataelements:SteerWiFiBackhaul" and fill
+     * with necessary parameters we extract from path */
+    rc = bus_error_out_of_resources;
+    root = cJSON_CreateObject();
+    json = cJSON_CreateObject();
+    if (!root || !json) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(root, "wfa-dataelements:SteerWiFiBackhaul", json)) {
+        em_printfout("Add item failed");
+        cJSON_Delete(json);
+        goto cleanup;
+    }
+    /* Add Network parameters */
+    net_obj = cJSON_AddObjectToObject(json, "Network");
+    if (!net_obj) {
+        em_printfout("Add Network failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddStringToObject(net_obj, "ID", GLOBAL_NET_ID)) {
+        em_printfout("Add Network ID failed");
+        goto cleanup;
+    }
+    /* Add Device parameters */
+    dev_list = cJSON_AddArrayToObject(net_obj, "DeviceList");
+    if (!dev_list) {
+        em_printfout("Add DeviceList failed");
+        goto cleanup;
+    }
+    dev_obj = cJSON_CreateObject();
+    if (!dev_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(dev_list, dev_obj)) {
+        em_printfout("Add Device failed");
+        cJSON_Delete(dev_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(di->intf.mac, mac_str);
+    if (!cJSON_AddStringToObject(dev_obj, "ID", mac_str)) {
+        em_printfout("Add Device ID failed");
+        goto cleanup;
+    }
+    /* Add method parameters */
+    steer_obj = cJSON_CreateObject();
+    if (!steer_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(dev_obj, "SteerWiFiBackhaul", steer_obj)) {
+        em_printfout("Add SteerWiFiBackhaul failed");
+        cJSON_Delete(steer_obj);
+        goto cleanup;
+    }
+    /* TODO: Validity check of parameters? */
+    if (!cJSON_AddStringToObject(steer_obj, "TargetBSS", target)) {
+        em_printfout("Add TargetBSS failed");
+        goto cleanup;
+    }
+    if (channel > 0) {
+        if (!cJSON_AddNumberToObject(steer_obj, "Channel", channel)) {
+            em_printfout("Add Channel failed");
+            goto cleanup;
+        }
+    }
+    if (!cJSON_AddNumberToObject(steer_obj, "TimeOut", timeout)) {
+        em_printfout("Add TimeOut failed");
+        goto cleanup;
+    }
+
+    /* Convert JSON back to string and store in subdoc buffer. */
+    json_buff = cJSON_PrintUnformatted(root);
+    if (!json_buff) {
+        em_printfout("Create output buffer failed");
+        rc = bus_error_out_of_resources;
+        goto cleanup;
+    }
+    /* Ensure updated JSON fits in buffer. */
+    json_len = strlen(json_buff);
+    if (json_len >= EM_IO_BUFF_SZ) {
+        em_printfout("Buffer too big for subdoc");
+        free(json_buff);
+        rc = bus_error_invalid_input;
+        goto cleanup;
+    }
+    memcpy(subdoc->buff, json_buff, json_len);
+    subdoc->buff[json_len] = '\0';
+
+    // uncomment below line to log the updated JSON before sending to DM; can be helpful for debugging.
+    /*
+    cJSON *json_obj;
+    json_obj = cJSON_Parse(subdoc->buff);
+    if (json_obj) {
+        char *new_json = cJSON_Print(json_obj);
+        em_printfout("Updated and formatted JSON:\n%s", new_json);
+        free(new_json);
+        cJSON_Delete(json_obj);
+    } else {
+        em_printfout("Invalid JSON in subdoc->buff");
+    }
+    */
+
+    //em_ctrl->io_process(em_bus_event_type_steer_wifi_backhaul, subdoc->buff, json_len);
+    free(json_buff);
+    cJSON_Delete(root);
+
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Success");
+    }
+
+    return bus_error_success;
+
+cleanup:
+    cJSON_Delete(root);
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+    }
+    return rc;
+}
+
+bus_error_t em_ctrl_t::cmd_channelscan(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+{
+    (void)async_handle;
+    const char *name = method_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    const bus_data_prop_t *prop = NULL;
+    char ch_list[TR181_CHLIST_MAX_LEN + 1] = { 0 };
+    int op_class = -1;
+    em_subdoc_info_t *subdoc = NULL;
+    unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
+    cJSON *root = NULL, *json = NULL, *net_obj = NULL;
+    cJSON *dev_list = NULL, *dev_obj = NULL;
+    cJSON *radio_list = NULL, *radio_obj = NULL;
+    cJSON *chscan_arr = NULL, *chscan_obj = NULL;
+    cJSON *chlist_arr = NULL, *chlist_obj = NULL;
+    mac_addr_str_t mac_str;
+    char *json_buff = NULL;
+    size_t json_len = 0;
+    bus_error_t rc;
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        em_printfout("Invalid method name");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+    ++param;
+    if (strcmp("ChannelScanRequest()", param) != 0) {
+        em_printfout("Invalid method");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_method;
+    }
+
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!em_ctrl) {
+        em_printfout("Controller not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_general;
+    }
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        em_printfout("Device not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_device_info_t *di = dm->get_device()->get_device_info();
+
+    /* Extract radio instance (numeric or alias), find the radio dm object
+     * for that instance, and finally get info struct for radio dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_radio_t *radio = dm_ctrl->get_dm_radio(dm, instance, is_num);
+    if (radio == NULL) {
+        em_printfout("Radio not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_radio_info_t *ri = radio->get_radio_info();
+
+    /* Input parameters are optional, parse if any */
+    for (prop = input_params; prop; prop = prop->next_data) {
+        if (strcmp(prop->name, "OpClass") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &op_class)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "ChannelList") == 0) {
+            if (!tr_181_t::tr181_copy_prop_string(prop, ch_list, sizeof(ch_list))) {
+                goto invalid;
+            }
+        } else if ((strcmp(prop->name, "ScanType") == 0) ||
+                   (strcmp(prop->name, "DwellTime") == 0) ||
+                   (strcmp(prop->name, "DFSDwellTime") == 0) ||
+                   (strcmp(prop->name, "HomeTime") == 0)) {
+            continue;
+        } else {
+invalid:
+            em_printfout("Invalid parameter: %s", prop->name);
+            if (output_params) {
+                *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+            }
+            return bus_error_invalid_input;
+        }
+    }
+    /* Mandatory parameters: OpClass and ChannelList is any one of them is provided */
+    if ((op_class > 0 && !ch_list[0]) || (ch_list[0] && op_class < 0)) {
+        em_printfout("Mandatory parameters missing");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+
+    /* Prepare subdoc to be processed with command */
+    subdoc = reinterpret_cast<em_subdoc_info_t *>(buff);
+    memset(subdoc, 0, sizeof(em_subdoc_info_t));
+    strncpy(subdoc->name, "ChannelScanRequest", sizeof(subdoc->name) - 1);
+
+    /* Create json with root "wfa-dataelements:ChannelScanRequest" and fill
+     * with necessary parameters we extract from path */
+    rc = bus_error_out_of_resources;
+    root = cJSON_CreateObject();
+    json = cJSON_CreateObject();
+    if (!root || !json) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(root, "wfa-dataelements:ChannelScanRequest", json)) {
+        em_printfout("Add item failed");
+        cJSON_Delete(json);
+        goto cleanup;
+    }
+    /* Add Network parameters */
+    net_obj = cJSON_AddObjectToObject(json, "Network");
+    if (!net_obj) {
+        em_printfout("Add Network failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddStringToObject(net_obj, "ID", GLOBAL_NET_ID)) {
+        em_printfout("Add Network ID failed");
+        goto cleanup;
+    }
+    /* Add Device parameters */
+    dev_list = cJSON_AddArrayToObject(net_obj, "DeviceList");
+    if (!dev_list) {
+        em_printfout("Add DeviceList failed");
+        goto cleanup;
+    }
+    dev_obj = cJSON_CreateObject();
+    if (!dev_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(dev_list, dev_obj)) {
+        em_printfout("Add Device failed");
+        cJSON_Delete(dev_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(di->intf.mac, mac_str);
+    if (!cJSON_AddStringToObject(dev_obj, "ID", mac_str)) {
+        em_printfout("Add Device ID failed");
+        goto cleanup;
+    }
+    /* Add Radio parameters */
+    radio_list = cJSON_AddArrayToObject(dev_obj, "RadioList");
+    if (!radio_list) {
+        em_printfout("Add RadioList failed");
+        goto cleanup;
+    }
+    radio_obj = cJSON_CreateObject();
+    if (!radio_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(radio_list, radio_obj)) {
+        em_printfout("Add Radio failed");
+        cJSON_Delete(radio_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(ri->id.ruid, mac_str);
+    if (!cJSON_AddStringToObject(radio_obj, "ID", mac_str)) {
+        em_printfout("Add Radio ID failed");
+        goto cleanup;
+    }
+    /* Add method parameters */
+    chscan_arr = cJSON_AddArrayToObject(radio_obj, "ChannelScanParameters");
+    if (!chscan_arr) {
+        em_printfout("Add ChannelScanParameters failed");
+        goto cleanup;
+    }
+    chscan_obj = cJSON_CreateObject();
+    if (!chscan_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(chscan_arr, chscan_obj)) {
+        em_printfout("Add item failed");
+        cJSON_Delete(chscan_obj);
+        goto cleanup;
+    }
+    if (op_class > 0) {
+        /* TODO: Validity check of parameters? */
+        if (!cJSON_AddNumberToObject(chscan_obj, "Class", op_class)) {
+            em_printfout("Add OpClass failed");
+            goto cleanup;
+        }
+        chlist_arr = cJSON_AddArrayToObject(chscan_obj, "ChannelList");
+        if (!chlist_arr) {
+            em_printfout("Add ChannelList failed");
+            goto cleanup;
+        }
+        std::string chlist_str = ch_list;
+        std::vector<std::string> channels = util::split_by_delim(chlist_str, ',');
+        for (unsigned int i = 0; i < channels.size(); i++) {
+            char *ep = NULL;
+            int channel = static_cast<int> (std::strtol(channels[i].c_str(), &ep, 10));
+            if (ep == channels[i].c_str() || *ep != '\0') {
+                em_printfout("Invalid channel");
+                goto cleanup;
+            }
+            chlist_obj = cJSON_CreateNumber(channel);
+            if (!chlist_obj) {
+                em_printfout("Create number failed");
+                goto cleanup;
+            }
+            if (!cJSON_AddItemToArray(chlist_arr, chlist_obj)) {
+                em_printfout("Add item failed");
+                cJSON_Delete(chlist_obj);
+                goto cleanup;
+            }
+        }
+    }
+
+    /* Convert JSON back to string and store in subdoc buffer. */
+    json_buff = cJSON_PrintUnformatted(root);
+    if (!json_buff) {
+        em_printfout("Create output buffer failed");
+        rc = bus_error_out_of_resources;
+        goto cleanup;
+    }
+    /* Ensure updated JSON fits in buffer. */
+    json_len = strlen(json_buff);
+    if (json_len >= EM_IO_BUFF_SZ) {
+        em_printfout("Buffer too big for subdoc");
+        free(json_buff);
+        rc = bus_error_invalid_input;
+        goto cleanup;
+    }
+    memcpy(subdoc->buff, json_buff, json_len);
+    subdoc->buff[json_len] = '\0';
+
+    // uncomment below line to log the updated JSON before sending to DM; can be helpful for debugging.
+    /*
+    cJSON *json_obj;
+    json_obj = cJSON_Parse(subdoc->buff);
+    if (json_obj) {
+        char *new_json = cJSON_Print(json_obj);
+        em_printfout("Updated and formatted JSON:\n%s", new_json);
+        free(new_json);
+        cJSON_Delete(json_obj);
+    } else {
+        em_printfout("Invalid JSON in subdoc->buff");
+    }
+    */
+
+    em_ctrl->io_process(em_bus_event_type_scan_channel, subdoc->buff, json_len);
+    free(json_buff);
+    cJSON_Delete(root);
+
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Success");
+    }
+
+    return bus_error_success;
+
+cleanup:
+    cJSON_Delete(root);
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+    }
+    return rc;
+}
+
+bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+{
+    (void)async_handle;
+    const char *name = method_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    const bus_data_prop_t *prop = NULL;
+    em_subdoc_info_t *subdoc = NULL;
+    unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
+    cJSON *root = NULL, *json = NULL, *net_obj = NULL;
+    cJSON *dev_list = NULL, *dev_obj = NULL, *radio_list = NULL, *radio_obj = NULL;
+    cJSON *class_arr = NULL, *class_obj = NULL;
+    cJSON *channel_list_obj = NULL, *channel_pref_obj = NULL;
+    mac_addr_str_t mac_str;
+    char *json_buff = NULL;
+    size_t json_len = 0;
+    bus_error_t rc = bus_error_success;
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        em_printfout("Invalid method name");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+    ++param;
+    if (strcmp("ChannelSelectionRequest()", param) != 0) {
+        em_printfout("Invalid method");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_method;
+    }
+
+    // Lookup controller and get the DM instance for this device/radio path
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!em_ctrl) {
+        em_printfout("Controller not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_general;
+    }
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl->get_dm_ctrl();
+
+    // Skip the static network prefix and parse the device instance from the TR-181 path
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        em_printfout("Device not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_radio_t *radio = dm_ctrl->get_dm_radio(dm, instance, is_num);
+    if (radio == NULL) {
+        em_printfout("Radio not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+
+    em_device_info_t *di = dm->get_device()->get_device_info();
+    em_radio_info_t *ri = radio->get_radio_info();
+
+    // Data structures used to collect nested Class.N.* channel preference input
+    struct channel_info {
+        bool have_channel;
+        bool have_pref;
+        int channel;
+        int preference;
+    };
+
+    struct class_info {
+        int instance_index;
+        bool have_op_class;
+        int op_class;
+        int max_channel_index;
+        channel_info channels[MAX_CHANSEL_CHANNELS];
+    };
+
+    class_info classes[MAX_CHANSEL_CLASSES];
+    int num_classes = 0;
+
+    // Initialize or reset a class_info slot
+    auto clear_class = [&](class_info &cls) {
+        cls.instance_index = -1;
+        cls.have_op_class = false;
+        cls.op_class = -1;
+        cls.max_channel_index = -1;
+        for (int i = 0; i < MAX_CHANSEL_CHANNELS; i++) {
+            cls.channels[i].have_channel = false;
+            cls.channels[i].have_pref = false;
+            cls.channels[i].channel = -1;
+            cls.channels[i].preference = -1;
+        }
+    };
+
+    // Find an existing class_info by instance index, or allocate a new one
+    auto find_or_create_class_by_instance = [&](int instance_index) -> class_info* {
+        for (int i = 0; i < num_classes; i++) {
+            if (classes[i].instance_index == instance_index) {
+                return &classes[i];
+            }
+        }
+        if (num_classes >= MAX_CHANSEL_CLASSES) {
+            return NULL;
+        }
+        clear_class(classes[num_classes]);
+        classes[num_classes].instance_index = instance_index;
+        classes[num_classes].have_op_class = false;
+        classes[num_classes].max_channel_index = -1;
+        num_classes++;
+        return &classes[num_classes - 1];
+    };
+
+    // Parse incoming TR-181 parameters and populate class/channel structures
+    for (prop = input_params; prop; prop = prop->next_data) {
+        char prop_name[BUS_MAX_NAME_LENGTH];
+        snprintf(prop_name, sizeof(prop_name), "%s", prop->name);
+
+        char *tokens[6] = { NULL };
+        char *saveptr = NULL;
+        int token_count = 0;
+        char *tok = strtok_r(prop_name, ".", &saveptr);
+        while (tok != NULL && token_count < 6) {
+            tokens[token_count++] = tok;
+            tok = strtok_r(NULL, ".", &saveptr);
+        }
+
+        // Only nested Class.N.* properties are valid for ChannelSelectionRequest()
+        if (token_count >= 2 && strcmp(tokens[0], "Class") == 0) {
+            char *end = NULL;
+            long class_index_l = strtol(tokens[1], &end, 10);
+            if (end == tokens[1] || *end != '\0' || class_index_l < 0 || class_index_l >= MAX_CHANSEL_CLASSES) {
+                em_printfout("Invalid class index in '%s'", prop->name);
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+            int class_index = static_cast<int>(class_index_l);
+            class_info *cls = find_or_create_class_by_instance(class_index);
+            if (!cls) {
+                em_printfout("Too many classes");
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+
+            if (token_count == 3 && strcmp(tokens[2], "OpClass") == 0) {
+                // Parse Class.N.OpClass
+                if (!tr_181_t::tr181_get_prop_int(prop, &cls->op_class)) {
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+                cls->have_op_class = true;
+            } else if (token_count == 5 && strcmp(tokens[2], "Channel") == 0) {
+                // Parse Class.N.Channel.M.Channel or Class.N.Channel.M.Preference
+                char *end = NULL;
+                long channel_idx_l = strtol(tokens[3], &end, 10);
+                if (end == tokens[3] || *end != '\0' || channel_idx_l < 0 || channel_idx_l >= MAX_CHANSEL_CHANNELS) {
+                    em_printfout("Invalid channel index in '%s'", prop->name);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+                int channel_idx = static_cast<int>(channel_idx_l);
+                if (strcmp(tokens[4], "Channel") == 0) {
+                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_idx].channel)) {
+                        rc = bus_error_invalid_input;
+                        goto finish;
+                    }
+                    cls->channels[channel_idx].have_channel = true;
+                    if (channel_idx > cls->max_channel_index) {
+                        cls->max_channel_index = channel_idx;
+                    }
+                } else if (strcmp(tokens[4], "Preference") == 0) {
+                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_idx].preference)) {
+                        rc = bus_error_invalid_input;
+                        goto finish;
+                    }
+                    cls->channels[channel_idx].have_pref = true;
+                } else {
+                    em_printfout("Invalid parameter: %s", prop->name);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+            } else {
+                em_printfout("Invalid parameter: %s", prop->name);
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+        } else {
+            em_printfout("Invalid parameter: %s", prop->name);
+            rc = bus_error_invalid_input;
+            goto finish;
+        }
+    }
+
+    // Fail if there were no nested class definitions in the request
+    if (num_classes == 0) {
+        em_printfout("Mandatory parameters missing: expected nested Class.N.* entries");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+
+    // Build the EM control subdocument and JSON payload for ChannelSelectionRequest
+    subdoc = reinterpret_cast<em_subdoc_info_t *>(buff);
+    memset(subdoc, 0, sizeof(em_subdoc_info_t));
+    strncpy(subdoc->name, "ChannelSelectionRequest", sizeof(subdoc->name) - 1);
+
+    root = cJSON_CreateObject();
+    json = cJSON_CreateObject();
+    if (!root || !json) {
+        em_printfout("Create object failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    if (!cJSON_AddItemToObject(root, "wfa-dataelements:ChannelSelectionRequest", json)) {
+        em_printfout("Add item failed");
+        cJSON_Delete(json);
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    // Create the Network/Device/Radio container structure for the payload
+    net_obj = cJSON_AddObjectToObject(json, "Network");
+    if (!net_obj) {
+        em_printfout("Add Network failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    if (!cJSON_AddStringToObject(net_obj, "ID", GLOBAL_NET_ID)) {
+        em_printfout("Add Network ID failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    dev_list = cJSON_AddArrayToObject(net_obj, "DeviceList");
+    if (!dev_list) {
+        em_printfout("Add DeviceList failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    dev_obj = cJSON_CreateObject();
+    if (!dev_obj) {
+        em_printfout("Create device object failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    if (!cJSON_AddItemToArray(dev_list, dev_obj)) {
+        em_printfout("Add Device failed");
+        cJSON_Delete(dev_obj);
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    dm_easy_mesh_t::macbytes_to_string(di->intf.mac, mac_str);
+    if (!cJSON_AddStringToObject(dev_obj, "ID", mac_str)) {
+        em_printfout("Add Device ID failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    radio_list = cJSON_AddArrayToObject(dev_obj, "RadioList");
+    if (!radio_list) {
+        em_printfout("Add RadioList failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    radio_obj = cJSON_CreateObject();
+    if (!radio_obj) {
+        em_printfout("Create radio object failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    if (!cJSON_AddItemToArray(radio_list, radio_obj)) {
+        em_printfout("Add Radio failed");
+        cJSON_Delete(radio_obj);
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+    dm_easy_mesh_t::macbytes_to_string(ri->id.ruid, mac_str);
+    if (!cJSON_AddStringToObject(radio_obj, "ID", mac_str)) {
+        em_printfout("Add Radio ID failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    // Add the radio-level ChannelSelectionRequest array
+    class_arr = cJSON_AddArrayToObject(radio_obj, "ChannelSelectionRequest");
+    if (!class_arr) {
+        em_printfout("Add ChannelSelectionRequest failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    if (num_classes > 0) {
+        // Convert each parsed class entry into JSON with ChannelList and ChannelPrefList
+        for (int i = 0; i < num_classes; i++) {
+            class_info &cls = classes[i];
+            if (!cls.have_op_class || cls.max_channel_index < 0) {
+                em_printfout("Incomplete class entry");
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+
+            class_obj = cJSON_CreateObject();
+            if (!class_obj) {
+                em_printfout("Create class object failed");
+                rc = bus_error_out_of_resources;
+                goto finish;
+            }
+            if (!cJSON_AddItemToArray(class_arr, class_obj)) {
+                em_printfout("Add class object failed");
+                cJSON_Delete(class_obj);
+                rc = bus_error_out_of_resources;
+                goto finish;
+            }
+            if (!cJSON_AddNumberToObject(class_obj, "Class", cls.op_class)) {
+                em_printfout("Add Class failed");
+                rc = bus_error_out_of_resources;
+                goto finish;
+            }
+
+            channel_list_obj = cJSON_AddArrayToObject(class_obj, "ChannelList");
+            channel_pref_obj = cJSON_AddArrayToObject(class_obj, "ChannelPrefList");
+            if (!channel_list_obj || !channel_pref_obj) {
+                em_printfout("Add ChannelList or ChannelPrefList failed");
+                rc = bus_error_out_of_resources;
+                goto finish;
+            }
+
+            for (int idx = 0; idx <= cls.max_channel_index; idx++) {
+                if (!cls.channels[idx].have_channel) {
+                    continue;
+                }
+                if (!cls.channels[idx].have_pref) {
+                    em_printfout("Missing Preference for channel index %d", idx);
+                    rc = bus_error_invalid_input;
+                    goto finish;
+                }
+                cJSON_AddItemToArray(channel_list_obj, cJSON_CreateNumber(cls.channels[idx].channel));
+                cJSON_AddItemToArray(channel_pref_obj, cJSON_CreateNumber(cls.channels[idx].preference));
+            }
+        }
+    }
+
+    // Serialize the final JSON payload and send it to the EM control bus
+    json_buff = cJSON_PrintUnformatted(root);
+    if (!json_buff) {
+        em_printfout("Print JSON failed");
+        rc = bus_error_out_of_resources;
+        goto finish;
+    }
+
+    json_len = strlen(json_buff) + 1;
+    if (json_len > EM_IO_BUFF_SZ) {
+        em_printfout("JSON payload too large");
+        rc = bus_error_invalid_input;
+        goto finish;
+    }
+    memcpy(subdoc->buff, json_buff, json_len);
+
+    em_printfout("Sending ChannelSelectionRequest with JSON payload len %zu:\n", json_len - 1);
+    em_ctrl->io_process(em_bus_event_type_channel_select, subdoc->buff, json_len);
+    free(json_buff);
+    cJSON_Delete(root);
+
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Success");
+    }
+
+    // Request processed successfully
+    return bus_error_success;
+
+finish:
+    // Common cleanup for failure paths
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+    }
+    if (json_buff) free(json_buff);
+    if (root) cJSON_Delete(root);
+    return rc;
+}
+
+bus_error_t em_ctrl_t::cmd_clientsteer(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+{
+    (void)async_handle;
+    const char *name = method_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    const bus_data_prop_t *prop = NULL;
+    char target[TR181_BSSID_MAX_LEN + 1] = { 0 };
+    char requestmode[TR181_REQMODE_MAX_LEN + 1] = { 0 };
+    bool imminent = false, imminent_set = false;
+    bool bridged = false, bridged_set = false;
+    bool link = false, link_set = false;
+    int opportunity = -1;
+    int timer = -1;
+    int op_class = -1;
+    int channel = -1;
+    em_subdoc_info_t *subdoc = NULL;
+    unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
+    cJSON *root = NULL, *json = NULL, *net_obj = NULL;
+    cJSON *dev_list = NULL, *dev_obj = NULL;
+    cJSON *radio_list = NULL, *radio_obj = NULL;
+    cJSON *bss_list = NULL, *bss_obj = NULL;
+    cJSON *sta_list = NULL, *sta_obj = NULL;
+    cJSON *steer_obj = NULL, *request_obj = NULL;
+    mac_addr_str_t mac_str;
+    char *json_buff = NULL;
+    size_t json_len = 0;
+    bus_error_t rc;
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        em_printfout("Invalid method name");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+    ++param;
+    if (strcmp("ClientSteer()", param) != 0) {
+        em_printfout("Invalid method");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_method;
+    }
+
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!em_ctrl) {
+        em_printfout("Controller not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_general;
+    }
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        em_printfout("Device not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_device_info_t *di = dm->get_device()->get_device_info();
+
+    /* Extract radio instance (numeric or alias), find the radio dm object
+     * for that instance, and finally get info struct for radio dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_radio_t *radio = dm_ctrl->get_dm_radio(dm, instance, is_num);
+    if (radio == NULL) {
+        em_printfout("Radio not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_radio_info_t *ri = radio->get_radio_info();
+
+    /* Extract bss instance (numeric or alias), find the bss dm object
+     * for that instance, and finally get info struct for bss dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_bss_t *bss = dm_ctrl->get_dm_bss(dm, ri, instance, is_num);
+    if (bss == NULL) {
+        em_printfout("BSS not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_bss_info_t *bi = bss->get_bss_info();
+
+    /* Extract sta instance (numeric or alias), find the sta dm object
+     * for that instance, and finally get info struct for sta dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_sta_t *sta = dm_ctrl->get_dm_sta(dm, bi, instance, is_num);
+    if (sta == NULL) {
+        em_printfout("STA not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_sta_info_t *si = sta->get_sta_info();
+
+    /* Most of the parameters are mandatory, parse them */
+    for (prop = input_params; prop; prop = prop->next_data) {
+        if (strcmp(prop->name, "TargetBSSID") == 0) {
+            if (!tr_181_t::tr181_copy_prop_string(prop, target, sizeof(target))) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "RequestMode") == 0) {
+            if (!tr_181_t::tr181_copy_prop_string(prop, requestmode, sizeof(requestmode))) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "BTMDisassociationImminent") == 0) {
+            if (!tr_181_t::tr181_get_prop_bool(prop, &imminent)) {
+                goto invalid;
+            }
+            imminent_set = true;
+        } else if (strcmp(prop->name, "BTMAbridged") == 0) {
+            if (!tr_181_t::tr181_get_prop_bool(prop, &bridged)) {
+                goto invalid;
+            }
+            bridged_set = true;
+        } else if (strcmp(prop->name, "LinkRemovalImminent") == 0) {
+            if (!tr_181_t::tr181_get_prop_bool(prop, &link)) {
+                goto invalid;
+            }
+            link_set = true;
+        } else if (strcmp(prop->name, "SteeringOpportunityWindow") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &opportunity)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "BTMDisassociationTimer") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &timer)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "TargetBSSOperatingClass") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &op_class)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "TargetBSSChannel") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &channel)) {
+                goto invalid;
+            }
+        } else {
+invalid:
+            em_printfout("Invalid parameter: %s", prop->name);
+            if (output_params) {
+                *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+            }
+            return bus_error_invalid_input;
+        }
+    }
+    /* Mandatory parameters: TargetBSSID, RequestMode, BTMDisassociationImminent, BTMAbridged,
+     *   BTMDisassociationTimer, TargetBSSOperatingClass, TargetBSSChannel and
+     *   SteeringOpportunityWindow if RequestMode is Steering_Opportunity */
+    if (!target[0] || !requestmode[0] || !imminent_set || !bridged_set ||
+        timer < 0  || op_class < 0    || channel < 0   ||
+        (strcasecmp(requestmode, "Steering_Opportunity") == 0 && opportunity < 0)) {
+        em_printfout("Mandatory parameters missing");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+
+    /* Prepare subdoc to be processed with command */
+    subdoc = reinterpret_cast<em_subdoc_info_t *>(buff);
+    memset(subdoc, 0, sizeof(em_subdoc_info_t));
+    strncpy(subdoc->name, "ClientSteer", sizeof(subdoc->name) - 1);
+
+    /* Create json with root "wfa-dataelements:ClientSteer" and fill
+     * with necessary parameters we extract from path */
+    rc = bus_error_out_of_resources;
+    root = cJSON_CreateObject();
+    json = cJSON_CreateObject();
+    if (!root || !json) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(root, "wfa-dataelements:ClientSteer", json)) {
+        em_printfout("Add item failed");
+        cJSON_Delete(json);
+        goto cleanup;
+    }
+    /* Add Network parameters */
+    net_obj = cJSON_AddObjectToObject(json, "Network");
+    if (!net_obj) {
+        em_printfout("Add Network failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddStringToObject(net_obj, "ID", GLOBAL_NET_ID)) {
+        em_printfout("Add Network ID failed");
+        goto cleanup;
+    }
+    /* Add Device parameters */
+    dev_list = cJSON_AddArrayToObject(net_obj, "DeviceList");
+    if (!dev_list) {
+        em_printfout("Add DeviceList failed");
+        goto cleanup;
+    }
+    dev_obj = cJSON_CreateObject();
+    if (!dev_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(dev_list, dev_obj)) {
+        em_printfout("Add Device failed");
+        cJSON_Delete(dev_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(di->intf.mac, mac_str);
+    if (!cJSON_AddStringToObject(dev_obj, "ID", mac_str)) {
+        em_printfout("Add Device ID failed");
+        goto cleanup;
+    }
+    /* Add Radio parameters */
+    radio_list = cJSON_AddArrayToObject(dev_obj, "RadioList");
+    if (!radio_list) {
+        em_printfout("Add RadioList failed");
+        goto cleanup;
+    }
+    radio_obj = cJSON_CreateObject();
+    if (!radio_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(radio_list, radio_obj)) {
+        em_printfout("Add Radio failed");
+        cJSON_Delete(radio_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(ri->id.ruid, mac_str);
+    if (!cJSON_AddStringToObject(radio_obj, "ID", mac_str)) {
+        em_printfout("Add Radio ID failed");
+        goto cleanup;
+    }
+    /* Add BSS parameters */
+    bss_list = cJSON_AddArrayToObject(radio_obj, "BSSList");
+    if (!bss_list) {
+        em_printfout("Add BSSList failed");
+        goto cleanup;
+    }
+    bss_obj = cJSON_CreateObject();
+    if (!bss_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(bss_list, bss_obj)) {
+        em_printfout("Add BSS failed");
+        cJSON_Delete(bss_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(bi->bssid.mac, mac_str);
+    if (!cJSON_AddStringToObject(bss_obj, "BSSID", mac_str)) {
+        em_printfout("Add BSSID failed");
+        goto cleanup;
+    }
+    /* Add STA parameters */
+    sta_list = cJSON_AddArrayToObject(bss_obj, "STAList");
+    if (!sta_list) {
+        em_printfout("Add STAList failed");
+        goto cleanup;
+    }
+    sta_obj = cJSON_CreateObject();
+    if (!sta_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(sta_list, sta_obj)) {
+        em_printfout("Add STA failed");
+        cJSON_Delete(sta_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(si->id, mac_str);
+    if (!cJSON_AddStringToObject(sta_obj, "MACAddress", mac_str)) {
+        em_printfout("Add MACAddress failed");
+        goto cleanup;
+    }
+    /* Currently not used, but let's add it anyway */
+    if (!cJSON_AddBoolToObject(sta_obj, "Associated", si->associated)) {
+        em_printfout("Add Associated failed");
+        goto cleanup;
+    }
+    /* Add method parameters */
+    steer_obj = cJSON_CreateObject();
+    if (!steer_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(sta_obj, "ClientSteer", steer_obj)) {
+        em_printfout("Add ClientSteer failed");
+        cJSON_Delete(steer_obj);
+        goto cleanup;
+    }
+    /* TODO: Validity check of parameters? */
+    if (!cJSON_AddStringToObject(steer_obj, "TargetBSSID", target)) {
+        em_printfout("Add TargetBSSID failed");
+        goto cleanup;
+    }
+    request_obj = cJSON_AddObjectToObject(steer_obj, "RequestMode");
+    if (!request_obj) {
+        em_printfout("Add RequestMode failed");
+        goto cleanup;
+    }
+    /* Analyze command steer, later, checks for extra object in RequestMode,
+       request_mode of em_cmd_steer_params_t expects 0 or 1. So why using
+       an extra object, instead of adding the number value? */
+    em_steering_req_mode_t mode;
+    if (strcasecmp(requestmode, "Steering_Opportunity") == 0) {
+        mode = em_steering_req_mode_opportunity;
+    } else if (strcasecmp(requestmode, "Steering_Mandate") == 0) {
+        mode = em_steering_req_mode_mandate;
+    } else {
+        em_printfout("Invalid request mode");
+        goto cleanup;
+    }
+    if (!cJSON_AddNumberToObject(request_obj, requestmode, mode)) {
+        em_printfout("Add number failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddBoolToObject(steer_obj, "BTMDisassociationImminent", imminent)) {
+        em_printfout("Add BTMDisassociationImminent failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddBoolToObject(steer_obj, "BTMAbridged", bridged)) {
+        em_printfout("Add BTMAbridged failed");
+        goto cleanup;
+    }
+    if (link_set) {
+        if (!cJSON_AddBoolToObject(steer_obj, "LinkRemovalImminent", link)) {
+            em_printfout("Add LinkRemovalImminent failed");
+            goto cleanup;
+        }
+    }
+    if (opportunity > 0) {
+        if (!cJSON_AddNumberToObject(steer_obj, "SteeringOpportunityWindow", opportunity)) {
+            em_printfout("Add SteeringOpportunityWindow failed");
+            goto cleanup;
+        }
+    }
+    if (!cJSON_AddNumberToObject(steer_obj, "BTMDisassociationTimer", timer)) {
+        em_printfout("Add BTMDisassociationTimer failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddNumberToObject(steer_obj, "TargetBSSOperatingClass", op_class)) {
+        em_printfout("Add TargetBSSOperatingClass failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddNumberToObject(steer_obj, "TargetBSSChannel", channel)) {
+        em_printfout("Add TargetBSSChannel failed");
+        goto cleanup;
+    }
+
+    /* Convert JSON back to string and store in subdoc buffer. */
+    json_buff = cJSON_PrintUnformatted(root);
+    if (!json_buff) {
+        em_printfout("Create output buffer failed");
+        rc = bus_error_out_of_resources;
+        goto cleanup;
+    }
+    /* Ensure updated JSON fits in buffer. */
+    json_len = strlen(json_buff);
+    if (json_len >= EM_IO_BUFF_SZ) {
+        em_printfout("Buffer too big for subdoc");
+        free(json_buff);
+        rc = bus_error_invalid_input;
+        goto cleanup;
+    }
+    memcpy(subdoc->buff, json_buff, json_len);
+    subdoc->buff[json_len] = '\0';
+
+    // uncomment below line to log the updated JSON before sending to DM; can be helpful for debugging.
+    /*
+    cJSON *json_obj;
+    json_obj = cJSON_Parse(subdoc->buff);
+    if (json_obj) {
+        char *new_json = cJSON_Print(json_obj);
+        em_printfout("Updated and formatted JSON:\n%s", new_json);
+        free(new_json);
+        cJSON_Delete(json_obj);
+    } else {
+        em_printfout("Invalid JSON in subdoc->buff");
+    }
+    */
+
+    em_ctrl->io_process(em_bus_event_type_steer_sta, subdoc->buff, json_len);
+    free(json_buff);
+    cJSON_Delete(root);
+
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Success");
+    }
+
+    return bus_error_success;
+
+cleanup:
+    cJSON_Delete(root);
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+    }
+    return rc;
+}
+
+bus_error_t em_ctrl_t::cmd_disassociate(const char *method_name, const bus_data_prop_t *input_params, bus_data_prop_t **output_params, void *async_handle)
+{
+    (void)async_handle;
+    const char *name = method_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    em_subdoc_info_t *subdoc = NULL;
+    unsigned char buff[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ];
+    cJSON *root = NULL, *json = NULL, *net_obj = NULL;
+    cJSON *dev_list = NULL, *dev_obj = NULL;
+    cJSON *radio_list = NULL, *radio_obj = NULL;
+    cJSON *bss_list = NULL, *bss_obj = NULL;
+    cJSON *sta_list = NULL, *sta_obj = NULL;
+    cJSON *disassoc_obj = NULL;
+    mac_addr_str_t mac_str;
+    char *json_buff = NULL;
+    size_t json_len = 0;
+    const bus_data_prop_t *prop = NULL;
+    int timer = -1;
+    int reason = -1;
+    bool silent = false, silent_set = false;
+    bus_error_t rc;
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        em_printfout("Invalid method name");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+    ++param;
+    if (strcmp("Disassociate()", param) != 0) {
+        em_printfout("Invalid method");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_method;
+    }
+
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!em_ctrl) {
+        em_printfout("Controller not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_general;
+    }
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        em_printfout("Device not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_device_info_t *di = dm->get_device()->get_device_info();
+
+    /* Extract radio instance (numeric or alias), find the radio dm object
+     * for that instance, and finally get info struct for radio dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_radio_t *radio = dm_ctrl->get_dm_radio(dm, instance, is_num);
+    if (radio == NULL) {
+        em_printfout("Radio not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_radio_info_t *ri = radio->get_radio_info();
+
+    /* Extract bss instance (numeric or alias), find the bss dm object
+     * for that instance, and finally get info struct for bss dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_bss_t *bss = dm_ctrl->get_dm_bss(dm, ri, instance, is_num);
+    if (bss == NULL) {
+        em_printfout("BSS not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_bss_info_t *bi = bss->get_bss_info();
+
+    /* Extract sta instance (numeric or alias), find the sta dm object
+     * for that instance, and finally get info struct for sta dm object */
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_sta_t *sta = dm_ctrl->get_dm_sta(dm, bi, instance, is_num);
+    if (sta == NULL) {
+        em_printfout("STA not found");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_namespace;
+    }
+    em_sta_info_t *si = sta->get_sta_info();
+
+    /* Most of the parameters are mandatory, parse them */
+    for (prop = input_params; prop; prop = prop->next_data) {
+        if (strcmp(prop->name, "DisassociationTimer") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &timer)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "ReasonCode") == 0) {
+            if (!tr_181_t::tr181_get_prop_int(prop, &reason)) {
+                goto invalid;
+            }
+        } else if (strcmp(prop->name, "Silent") == 0) {
+            if (!tr_181_t::tr181_get_prop_bool(prop, &silent)) {
+                goto invalid;
+            }
+            silent_set = true;
+        } else {
+invalid:
+            em_printfout("Invalid parameter: %s", prop->name);
+            if (output_params) {
+                *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+            }
+            return bus_error_invalid_input;
+        }
+    }
+    /* Mandatory parameters: DisassociationTimer and ReasonCode. */
+    if (timer < 0 || reason < 0) {
+        em_printfout("Mandatory parameters missing");
+        if (output_params) {
+            *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+        }
+        return bus_error_invalid_input;
+    }
+
+    /* Prepare subdoc to be processed with command */
+    subdoc = reinterpret_cast<em_subdoc_info_t *>(buff);
+    memset(subdoc, 0, sizeof(em_subdoc_info_t));
+    strncpy(subdoc->name, "Disassociate", sizeof(subdoc->name) - 1);
+
+    /* Create json with root "wfa-dataelements:Disassociate" and fill
+     * with necessary parameters we extract from path */
+    rc = bus_error_out_of_resources;
+    root = cJSON_CreateObject();
+    json = cJSON_CreateObject();
+    if (!root || !json) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(root, "wfa-dataelements:Disassociate", json)) {
+        em_printfout("Add item failed");
+        cJSON_Delete(json);
+        goto cleanup;
+    }
+    /* Add Network parameters */
+    net_obj = cJSON_AddObjectToObject(json, "Network");
+    if (!net_obj) {
+        em_printfout("Add Network failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddStringToObject(net_obj, "ID", GLOBAL_NET_ID)) {
+        em_printfout("Add Network ID failed");
+        goto cleanup;
+    }
+    /* Add Device parameters */
+    dev_list = cJSON_AddArrayToObject(net_obj, "DeviceList");
+    if (!dev_list) {
+        em_printfout("Add DeviceList failed");
+        goto cleanup;
+    }
+    dev_obj = cJSON_CreateObject();
+    if (!dev_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(dev_list, dev_obj)) {
+        em_printfout("Add Device failed");
+        cJSON_Delete(dev_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(di->intf.mac, mac_str);
+    if (!cJSON_AddStringToObject(dev_obj, "ID", mac_str)) {
+        em_printfout("Add Device ID failed");
+        goto cleanup;
+    }
+    /* Add Radio parameters */
+    radio_list = cJSON_AddArrayToObject(dev_obj, "RadioList");
+    if (!radio_list) {
+        em_printfout("Add RadioList failed");
+        goto cleanup;
+    }
+    radio_obj = cJSON_CreateObject();
+    if (!radio_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(radio_list, radio_obj)) {
+        em_printfout("Add Radio failed");
+        cJSON_Delete(radio_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(ri->id.ruid, mac_str);
+    if (!cJSON_AddStringToObject(radio_obj, "ID", mac_str)) {
+        em_printfout("Add Radio ID failed");
+        goto cleanup;
+    }
+    /* Add BSS parameters */
+    bss_list = cJSON_AddArrayToObject(radio_obj, "BSSList");
+    if (!bss_list) {
+        em_printfout("Add BSSList failed");
+        goto cleanup;
+    }
+    bss_obj = cJSON_CreateObject();
+    if (!bss_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(bss_list, bss_obj)) {
+        em_printfout("Add BSS failed");
+        cJSON_Delete(bss_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(bi->bssid.mac, mac_str);
+    if (!cJSON_AddStringToObject(bss_obj, "BSSID", mac_str)) {
+        em_printfout("Add BSSID failed");
+        goto cleanup;
+    }
+    /* Add STA parameters */
+    sta_list = cJSON_AddArrayToObject(bss_obj, "STAList");
+    if (!sta_list) {
+        em_printfout("Add STAList failed");
+        goto cleanup;
+    }
+    sta_obj = cJSON_CreateObject();
+    if (!sta_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToArray(sta_list, sta_obj)) {
+        em_printfout("Add STA failed");
+        cJSON_Delete(sta_obj);
+        goto cleanup;
+    }
+    dm_easy_mesh_t::macbytes_to_string(si->id, mac_str);
+    if (!cJSON_AddStringToObject(sta_obj, "MACAddress", mac_str)) {
+        em_printfout("Add MACAddress failed");
+        goto cleanup;
+    }
+    /* Currently not used, but let's add it anyway */
+    if (!cJSON_AddBoolToObject(sta_obj, "Associated", si->associated)) {
+        em_printfout("Add Associated failed");
+        goto cleanup;
+    }
+    /* Add method parameters */
+    disassoc_obj = cJSON_CreateObject();
+    if (!disassoc_obj) {
+        em_printfout("Create object failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(sta_obj, "Disassociate", disassoc_obj)) {
+        em_printfout("Add Disassociate failed");
+        cJSON_Delete(disassoc_obj);
+        goto cleanup;
+    }
+    /* TODO: Validity check of parameters? */
+    if (!cJSON_AddNumberToObject(disassoc_obj, "DisassociationTimer", timer)) {
+        em_printfout("Add DisassociationTimer failed");
+        goto cleanup;
+    }
+    if (!cJSON_AddNumberToObject(disassoc_obj, "ReasonCode", reason)) {
+        em_printfout("Add ReasonCode failed");
+        goto cleanup;
+    }
+    if (silent_set) {
+        if (!cJSON_AddBoolToObject(disassoc_obj, "Silent", silent)) {
+            em_printfout("Add Silent failed");
+            goto cleanup;
+        }
+    }
+
+    /* Convert JSON back to string and store in subdoc buffer. */
+    json_buff = cJSON_PrintUnformatted(root);
+    if (!json_buff) {
+        em_printfout("Create output buffer failed");
+        rc = bus_error_out_of_resources;
+        goto cleanup;
+    }
+    /* Ensure updated JSON fits in buffer. */
+    json_len = strlen(json_buff);
+    if (json_len >= EM_IO_BUFF_SZ) {
+        em_printfout("Buffer too big for subdoc");
+        free(json_buff);
+        rc = bus_error_invalid_input;
+        goto cleanup;
+    }
+    memcpy(subdoc->buff, json_buff, json_len);
+    subdoc->buff[json_len] = '\0';
+
+    // uncomment below line to log the updated JSON before sending to DM; can be helpful for debugging.
+    /*
+    cJSON *json_obj;
+    json_obj = cJSON_Parse(subdoc->buff);
+    if (json_obj) {
+        char *new_json = cJSON_Print(json_obj);
+        em_printfout("Updated and formatted JSON:\n%s", new_json);
+        free(new_json);
+        cJSON_Delete(json_obj);
+    } else {
+        em_printfout("Invalid JSON in subdoc->buff");
+    }
+    */
+
+    em_ctrl->io_process(em_bus_event_type_disassoc_sta, subdoc->buff, json_len);
+    free(json_buff);
+    cJSON_Delete(root);
+
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Success");
+    }
+
+    return bus_error_success;
+
+cleanup:
+    cJSON_Delete(root);
+    if (output_params) {
+        *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+    }
+    return rc;
+}
+
+int dm_easy_mesh_ctrl_t::analyze_unassoc_sta_metrics_query(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    int num = 0;
+    em_cmd_t *tmp = NULL;
+    em_subdoc_info_t *subdoc = NULL;
+
+    cJSON *obj = NULL;
+    cJSON *wfa_obj = NULL;
+
+    cJSON *al_mac_obj = NULL;
+    cJSON *query_list = NULL;
+
+    char wfa[128] = {0};
+
+    subdoc = &evt->u.subdoc;
+    if (subdoc == NULL) {
+        em_printfout("subdoc NULL");
+        return 0;
+    }
+
+    obj = cJSON_Parse(subdoc->buff);
+    if (obj == NULL) {
+        em_printfout("JSON parse failed");
+        return 0;
+    }
+
+    snprintf(wfa, sizeof(wfa), "wfa-dataelements:UnassocSTAQuery");
+
+    wfa_obj = cJSON_GetObjectItem(obj, wfa);
+
+    if (wfa_obj == NULL) {
+        em_printfout("Missing wfa object");
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    al_mac_obj = cJSON_GetObjectItem(wfa_obj, "AlMac");
+
+    query_list = cJSON_GetObjectItem(wfa_obj, "UnassocStaQueryList");
+
+    if ((al_mac_obj == NULL) || (query_list == NULL) || (!cJSON_IsArray(query_list))) {
+        em_printfout("Missing mandatory params");
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    em_cmd_params_t params = evt->params;
+
+    const char *al_mac_str = cJSON_GetStringValue(al_mac_obj);
+    if (al_mac_str == NULL) {
+        em_printfout("%s:%d: AlMac is not a string", __func__, __LINE__);
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    char al_mac_buf[32] = {0};
+    strncpy(al_mac_buf, al_mac_str, sizeof(al_mac_buf) - 1);
+
+    dm_easy_mesh_t::string_to_macbytes(al_mac_buf, params.u.unassoc_sta_query_params.al_mac);
+
+    dm_easy_mesh_t dm = *this;
+
+    em_unassoc_query_list_t query;
+    memset(&query, 0, sizeof(query));
+
+    int opclass_count = cJSON_GetArraySize(query_list);
+
+    if (opclass_count > EM_MAX_OP_CLASS) {
+        opclass_count = EM_MAX_OP_CLASS;
+    }
+
+    query.num_opclass = static_cast<uint8_t>(opclass_count);
+
+    for (int i = 0; i < opclass_count; i++) {
+
+        cJSON *opclass_obj = cJSON_GetArrayItem(query_list, i);
+
+        if (opclass_obj == NULL) {
+            continue;
+        }
+
+        cJSON *opclass_val = cJSON_GetObjectItem(opclass_obj, "opclass");
+
+        cJSON *channels_array = cJSON_GetObjectItem(opclass_obj, "channels");
+
+        if ((opclass_val == NULL) || (channels_array == NULL) || (!cJSON_IsArray(channels_array))) {
+            continue;
+        }
+
+        auto &op = query.opclass_list[i];
+
+        op.op_class = static_cast<uint8_t>(opclass_val->valueint);
+
+        int channel_count = cJSON_GetArraySize(channels_array);
+
+        if (channel_count > EM_MAX_CHANNELS_PER_OPCLASS) {
+            channel_count = EM_MAX_CHANNELS_PER_OPCLASS;
+        }
+
+        op.num_channels = static_cast<uint8_t>(channel_count);
+
+        for (int j = 0; j < channel_count; j++) {
+
+            cJSON *channel_obj = cJSON_GetArrayItem(channels_array, j);
+
+            if (channel_obj == NULL) {
+                continue;
+            }
+
+            cJSON *channel_val = cJSON_GetObjectItem(channel_obj, "channel");
+            cJSON *sta_array = cJSON_GetObjectItem(channel_obj, "sta_macs");
+
+            if ((channel_val == NULL) || (sta_array == NULL) || (!cJSON_IsArray(sta_array))) {
+                continue;
+            }
+
+            auto &ch = op.channel_list[j];
+
+            ch.channel = static_cast<uint8_t>(channel_val->valueint);
+
+            int sta_count = cJSON_GetArraySize(sta_array);
+
+            if (sta_count > EM_MAX_STA_PER_CHANNEL) {
+                sta_count = EM_MAX_STA_PER_CHANNEL;
+            }
+
+            ch.num_sta = static_cast<uint8_t>(sta_count);
+
+            for (int k = 0; k < sta_count; k++) {
+                cJSON *sta_obj = cJSON_GetArrayItem(sta_array, k);
+
+                if ((sta_obj == NULL) || (sta_obj->valuestring == NULL)) {
+                    continue;
+                }
+
+                dm_easy_mesh_t::string_to_macbytes(sta_obj->valuestring, ch.sta_list[k]);
+            }
+        }
+    }
+
+    pcmd[num] = new em_cmd_unassoc_sta_query_t(params, dm, &query);
+
+    if (pcmd[num] == NULL) {
+        cJSON_Delete(obj);
+        return 0;
+    }
+
+    tmp = pcmd[num];
+    num++;
+
+    while ((pcmd[num] =
+            tmp->clone_for_next()) != NULL) {
+
+        tmp = pcmd[num];
+        num++;
+    }
+
+    cJSON_Delete(obj);
+
+    em_printfout("Returning successfully from analyze_unassoc_sta_metrics_query");
+
+    return num;
+}
+
 int dm_easy_mesh_ctrl_t::analyze_sta_link_metrics(em_cmd_t *pcmd[])
 {
     int num = 0;
@@ -364,7 +2167,6 @@ int dm_easy_mesh_ctrl_t::analyze_sta_link_metrics(em_cmd_t *pcmd[])
 
     return num;
 }
-
 
 int dm_easy_mesh_ctrl_t::analyze_config_renew(em_bus_event_t *evt, em_cmd_t *pcmd[])
 {
@@ -408,13 +2210,12 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     dm_easy_mesh_t  dm, *pdm;
     em_cmd_t *tmp;
     dm_bss_t *pbss;
-    bool radio_matched = false, found;
-    em_sta_info_t sta_info;
+    bool radio_matched = false, found = false;
     em_orch_desc_t desc;
-    em_2xlong_string_t	key;
+    mac_address_t fallback_ruid = {0};
 
     if (evt == NULL) {
-        printf("%s:%d: NULL event\n", __func__, __LINE__);
+        em_printfout("NULL event");
         return -1;
     }
 
@@ -434,54 +2235,120 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     strncpy(evt->params.u.args.args[3], (params->assoc.assoc_event == 1)?"Assoc":"Disassoc", len);
     pdm = get_data_model(GLOBAL_NET_ID, params->dev);
     if (pdm == NULL) {
-        printf("%s:%d: Could not find data model for dev: %s\n", __func__, __LINE__, dev_mac_str);
+        em_printfout("Could not find data model for dev: %s", dev_mac_str);
         return -1;
     }
 
     pdm->set_topo_state(true);
 
-    for (i = 0; i < pdm->get_num_radios(); i++) {
-        found = true;
-        pbss = pdm->get_bss(pdm->get_radio_info(i)->id.ruid, params->assoc.bssid);
-        if (pbss == NULL) {
-            found = false;
-            continue;
+    bool is_ap_mld = pdm->is_ap_mld_mac(params->assoc.bssid);
+
+    if (is_ap_mld == false) {
+        em_printfout("bssid=%s is not AP-MLD MAC, using direct BSS lookup for STA assoc event", bss_mac_str);
+        found = false;
+        for (i = 0; i < pdm->get_num_radios(); i++) {
+            pbss = pdm->get_bss(pdm->get_radio_info(i)->id.ruid, params->assoc.bssid);
+            if (pbss != NULL) {
+                found = true;
+                break;
+            }
         }
-        break;
-    }
-    if (found == false) {
-        printf("%s:%d: Could not find bss: %s\n", __func__, __LINE__, bss_mac_str);
-        return -1;
-    }
 
-    dm_easy_mesh_t::macbytes_to_string(pbss->m_bss_info.ruid.mac, radio_mac_str);
+        if (found == true) {
+            dm_easy_mesh_t::macbytes_to_string(pbss->m_bss_info.ruid.mac, radio_mac_str);
 
-    // confirm that the radio is on this device
-    for (i = 0; i < pdm->m_num_radios; i++) {
-        if (memcmp(pbss->m_bss_info.ruid.mac, pdm->m_radio[i].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
-            radio_matched = true;
-            break;
+            // confirm that the radio is on this device
+            for (i = 0; i < pdm->m_num_radios; i++) {
+                    if (memcmp(pbss->m_bss_info.ruid.mac, pdm->m_radio[i].m_radio_info.intf.mac,
+                           sizeof(mac_address_t)) == 0) {
+                    radio_matched = true;
+                    break;
+                }
+            }
+
+            if (radio_matched == false) {
+                em_printfout("Could not find bss: %s on radio: %s", bss_mac_str, radio_mac_str);
+                return -1;
+            }
+        }
+    } else {
+        em_printfout("bssid=%s is AP-MLD MAC, resolving to affiliated radio for STA assoc event", bss_mac_str);
+        if (pdm->resolve_ap_mld_to_fallback_ruid(params->assoc.bssid, fallback_ruid)) {
+            dm_easy_mesh_t::macbytes_to_string(fallback_ruid, radio_mac_str);
+            em_printfout("Resolved AP-MLD bssid=%s to radio=%s for STA assoc event",
+                bss_mac_str, radio_mac_str);
+            found = true;
         }
     }
-
-    if (radio_matched == false) {
-        printf("%s:%d: Could not find bss: %s on radio: %s\n", __func__, __LINE__, bss_mac_str, radio_mac_str);
-        return -1;
-    }
-
-    memcpy(sta_info.id, params->assoc.cli_mac_address, sizeof(mac_address_t));
-    memcpy(sta_info.bssid, params->assoc.bssid, sizeof(mac_address_t));
-    memcpy(sta_info.radiomac, pbss->m_bss_info.ruid.mac, sizeof(mac_address_t));
 
     pcmd[num] = new em_cmd_sta_assoc_t(evt->params, dm);
     tmp = pcmd[num];
     num++;
 
-    snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
-    if ((get_sta(key) != NULL) && (params->assoc.assoc_event == false)){
+    bool is_assoc = (params->assoc.assoc_event == true) ? true : false;
+    // Before processing the topology update, clear the associated flag for all
+    // consolidated map entries matching this STA MAC — on both assoc and disassoc.
+    // This ensures stale multi-link entries (AP-MLD or direct-BSS) are cleaned up
+    // before the new state is applied.
+    bool sta_exists = false;
+    for (dm_sta_t *iter = static_cast<dm_sta_t *>(hash_map_get_first(pdm->m_sta_map));
+        iter != NULL;
+        iter = static_cast<dm_sta_t *>(hash_map_get_next(pdm->m_sta_map, iter))) {
+        if (memcmp(iter->m_sta_info.id, params->assoc.cli_mac_address, sizeof(mac_address_t)) == 0) {
+            sta_exists = true;
+            // STA is "known" only if we already have its capability data
+            bool new_sta_exists = (iter->m_sta_info.cap[0] != '\0' ||
+                      iter->m_sta_info.ht_cap[0] != '\0' ||
+                      iter->m_sta_info.vht_cap[0] != '\0');
+                      em_printfout("sta found is m_sta_map %s, sta_exists=%d, new_sta_exists=%d", sta_mac_str, sta_exists, new_sta_exists);
+            sta_exists = new_sta_exists;
+            break;
+        }
+    }
+
+        for (dm_sta_t *iter = static_cast<dm_sta_t *>(hash_map_get_first(pdm->m_sta_assoc_map));
+        iter != NULL;
+        iter = static_cast<dm_sta_t *>(hash_map_get_next(pdm->m_sta_assoc_map, iter))) {
+        if (memcmp(iter->m_sta_info.id, params->assoc.cli_mac_address, sizeof(mac_address_t)) == 0) {
+            em_printfout("sta found is m_assoc_map %s ", sta_mac_str);
+        }
+    }
+
+    if (is_assoc == false) {
         desc.op = dm_orch_type_topo_update;
         desc.submit = false;
         pcmd[num - 1]->override_op(0, &desc);
+        desc.op = dm_orch_type_topo_publish;
+        desc.submit = true;
+        pcmd[num - 1]->override_op(1, &desc);
+        pcmd[num - 1]->m_num_orch_desc = 2;
+    } else {
+        if (sta_exists == true) {
+            desc.op = dm_orch_type_topo_update;
+            desc.submit = false;
+            pcmd[num - 1]->override_op(0, &desc);
+            desc.op = dm_orch_type_topo_publish;
+            desc.submit = true;
+            pcmd[num - 1]->override_op(1, &desc);
+            pcmd[num - 1]->m_num_orch_desc = 2;
+            em_printfout("STA info already present in data model, skipping topology query. Do a topology update + publish for STA assoc event");
+        } else {
+            // sta_exists = false;
+            if ((found == true) && (is_ap_mld == false)) {
+                            // BSS is directly resolvable for a non-MLO client — topology query not needed;
+                // skip dm_orch_type_topo_sync and go straight to client capability query + publish.
+                // Also check if sta info is already present in the data model, if yes then we can go straight to topology update + publish.
+                //new mlo client
+                em_printfout("------ >>>>>> New non-mlo STA identified Send a cap query....");
+                desc.op = dm_orch_type_sta_cap;
+                desc.submit = true;
+                pcmd[num - 1]->override_op(0, &desc);
+                desc.op = dm_orch_type_topo_publish;
+                desc.submit = true;
+                pcmd[num - 1]->override_op(1, &desc);
+                pcmd[num - 1]->m_num_orch_desc = 2;
+            }
+        }
     }
 
     while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
@@ -898,10 +2765,12 @@ int dm_easy_mesh_ctrl_t::analyze_set_policy(em_bus_event_t *evt, em_cmd_t *pcmd[
     int policy_changed = 0;
 
     subdoc = &evt->u.subdoc;
+    dm.init();
 
     em_printfout("Received SetPolicy event: \n%s", subdoc->buff);
     do {
         dm.reset();
+        policy_changed = 0;
 
         if ((ret = dm.decode_config(subdoc, "SetPolicy", i, &num_devices)) < 0) {
             em_printfout("Failed to decode SetPolicy config: %d", ret);
@@ -914,11 +2783,78 @@ int dm_easy_mesh_ctrl_t::analyze_set_policy(em_bus_event_t *evt, em_cmd_t *pcmd[
 
         dev_dm = get_data_model(GLOBAL_NET_ID, dm.m_device.m_device_info.intf.mac);
         if (dev_dm != NULL) {
-            //compare if policy has changed for this device, create cmd only if a policy chnage is detected
-            for (unsigned int j = 0; j < dev_dm->get_num_policy(); j++) {
-                if ((dev_dm->m_policy[j] == dm.m_policy[j]) == false) {
+            // Expand broadcast radio MAC (ff:ff:ff:ff:ff:ff) in per-radio policy entries
+            // (radio_metrics_rep and steering_param) into one entry per actual radio.
+            static const mac_address_t bcast_mac = {0xff,0xff,0xff,0xff,0xff,0xff};
+            unsigned int orig_num = dm.get_num_policy();
+            for (unsigned int k = 0; k < orig_num; k++) {
+                if (dm.m_policy[k].m_policy.id.type != em_policy_id_type_radio_metrics_rep &&
+                    dm.m_policy[k].m_policy.id.type != em_policy_id_type_steering_param) continue;
+                if (memcmp(dm.m_policy[k].m_policy.id.radio_mac, bcast_mac, sizeof(mac_address_t)) != 0) continue;
+                // Replace this broadcast entry with per-radio copies
+                em_policy_t tmpl;
+                memcpy(&tmpl, &dm.m_policy[k].m_policy, sizeof(em_policy_t));
+                // Overwrite index k with first radio, append remaining radios at end
+                bool first = true;
+                for (unsigned int r = 0; r < dev_dm->get_num_radios(); r++) {
+                    if (first) {
+                        memcpy(dm.m_policy[k].m_policy.id.radio_mac,
+                               dev_dm->m_radio[r].m_radio_info.intf.mac, sizeof(mac_address_t));
+                        first = false;
+                    } else {
+                        unsigned int index = dm.get_num_policy();
+                        if (index >= EM_MAX_POLICIES) {
+                            em_printfout("Warning: policy array full (%u), skipping per-radio expansion for radio %u",
+                                EM_MAX_POLICIES, r);
+                            break;
+                        }
+                        memcpy(&dm.m_policy[index].m_policy, &tmpl, sizeof(em_policy_t));
+                        memcpy(dm.m_policy[index].m_policy.id.radio_mac,
+                               dev_dm->m_radio[r].m_radio_info.intf.mac, sizeof(mac_address_t));
+                        dm.set_num_policy(index + 1);
+                    }
+                }
+                // Don't break — there may be broadcast entries of both types
+            }
+
+            // Compare each incoming policy by type against the existing dm.
+            // Compact dm.m_policy[] in-place to only keep changed/new entries so
+            // that the command carries only what actually changed
+            unsigned int write_idx = 0;
+            for (unsigned int k = 0; k < dm.get_num_policy(); k++) {
+                // Use full equality (operator== does memcmp on em_policy_t) so this works
+                // generically for all policy types, including multi-entry types like
+                // backhaul_bss_config and radio metrics that are keyed by BSSID/radio MAC.
+                bool changed = true;
+                for (unsigned int j = 0; j < dev_dm->get_num_policy(); j++) {
+                    if (dev_dm->m_policy[j] == dm.m_policy[k]) {
+                        changed = false;
+                        break;
+                    }
+                }
+                if (changed) {
+                    if (write_idx != k) {
+                        dm.m_policy[write_idx] = dm.m_policy[k];
+                    }
+                    write_idx++;
                     policy_changed++;
-                    break;
+                }
+            }
+            dm.set_num_policy(write_idx);
+            if (write_idx > 0) {
+                static const char * const s_policy_type_names[] = {
+                    "steering_local", "steering_btm", "steering_param",
+                    "ap_metrics_rep", "radio_metrics_rep", "default_8021q_settings",
+                    "traffic_separation", "channel_scan", "unsuccess_assoc",
+                    "backhaul_bss_config", "qos_mgt", "alarm_threshold",
+                    "client_filters", "unknown"
+                };
+                em_printfout("Changed policies for device %s (%u):", mac_str, write_idx);
+                for (unsigned int p = 0; p < write_idx; p++) {
+                    em_policy_id_type_t t = dm.m_policy[p].m_policy.id.type;
+                    unsigned int ti = (static_cast<unsigned int>(t) < static_cast<unsigned int>(em_policy_id_type_unknown))
+                                      ? static_cast<unsigned int>(t) : static_cast<unsigned int>(em_policy_id_type_unknown);
+                    em_printfout("  [%u] %s", p, s_policy_type_names[ti]);
                 }
             }
         } else {
@@ -941,10 +2877,22 @@ int dm_easy_mesh_ctrl_t::analyze_set_policy(em_bus_event_t *evt, em_cmd_t *pcmd[
         }
         radio = m_data_model_list.get_first_radio(dm.m_network.m_net_info.id, dm.m_device.m_device_info.intf.mac);
         while (radio != NULL) {
-            memcpy(dm.m_radio[dm.m_num_radios].m_radio_info.intf.mac, radio->m_radio_info.intf.mac, sizeof(mac_address_t));
+            if (dm.m_num_radios >= EM_MAX_RADIO_PER_AGENT) {
+                em_printfout("SetPolicy Radio overflow guard triggered | device=%s num_radios=%u max_allowed=%u",
+                    mac_str, dm.m_num_radios, EM_MAX_RADIO_PER_AGENT);
+                break;
+            }
+            memcpy(dm.m_radio[dm.m_num_radios].m_radio_info.intf.mac,
+                radio->m_radio_info.intf.mac, sizeof(mac_address_t));
             dm.m_num_radios++;
-            radio = m_data_model_list.get_next_radio(dm.m_network.m_net_info.id, dm.m_device.m_device_info.intf.mac, radio);
+            radio = m_data_model_list.get_next_radio(dm.m_network.m_net_info.id,
+                dm.m_device.m_device_info.intf.mac, radio);
         }
+
+        if (dm.m_num_radios == 0) {
+            em_printfout("No radios found for device %s while processing set_policy", mac_str);
+        }
+
         dm.set_db_cfg_param(db_cfg_type_policy_list_update, "");
         pcmd[num] = new em_cmd_set_policy_t(evt->params, dm);
         num++;
@@ -966,23 +2914,24 @@ int dm_easy_mesh_ctrl_t::analyze_scan_channel(em_bus_event_t *evt, em_cmd_t *pcm
     dm_easy_mesh_t dm, *pdm;
     em_cmd_t *tmp;
     unsigned int num = 0, num_devices = 0, i = 0;
-        
+
     subdoc = &evt->u.subdoc;
-        
+
     if ((ret = dm.decode_config(subdoc, "ChannelScanRequest", i, &num_devices)) < 0) {
+        em_printfout("Decode config for channel scan failed");
         return ret;
     } 
-        
-    assert(dm.get_num_op_class() == EM_MAX_BANDS);
-        
+
+    //methods don't have multiple op_classes (yet)
+    //assert(dm.get_num_op_class() == EM_MAX_BANDS);
+
     pdm = m_data_model_list.get_first_dm();
     while (pdm != NULL) {
         pdm->set_channels_list(dm.m_op_class, dm.get_num_op_class());
-    
         pdm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
+
         pdm = m_data_model_list.get_next_dm(pdm);
     }
-
 
     pcmd[num] = new em_cmd_scan_channel_t(evt->params, dm);
     tmp = pcmd[num];
@@ -994,7 +2943,102 @@ int dm_easy_mesh_ctrl_t::analyze_scan_channel(em_bus_event_t *evt, em_cmd_t *pcm
     }
 
     return static_cast<int> (num);
+}
 
+int dm_easy_mesh_ctrl_t::analyze_channel_select(em_bus_event_t *evt, em_cmd_t *pcmd[])
+{
+    int ret;
+    em_subdoc_info_t *subdoc;
+    dm_easy_mesh_t dm, *pdm;
+    em_cmd_t *tmp;
+    unsigned int num = 0, num_devices = 0, i = 0, j = 0;
+    dm_op_class_t *updated_oclass, *current_oclass;
+    mac_addr_str_t mac_str;
+    std::vector<std::string> delete_invalid_opclass_ids;
+
+    subdoc = &evt->u.subdoc;
+    em_printfout("Received tr181 Channel Selection event");
+
+    if ((ret = dm.decode_config(subdoc, "ChannelSelectionRequest", i, &num_devices)) < 0) {
+        em_printfout("Decode config for set channel select failed");
+        return ret;
+    }
+
+    // Lets process radio channel preference report and schedule channel selection request
+    // print all opclasses and channels received in the event for debugging purpose
+    em_printfout("Number of opclasses received in the event: %d", dm.get_num_op_class());
+    for (i = 0; i < dm.get_num_op_class(); i++) {
+        updated_oclass = &dm.m_op_class[i];
+        dm_easy_mesh_t::macbytes_to_string(updated_oclass->m_op_class_info.id.ruid, mac_str);
+        em_printfout("Radio: %s, OpClass: %d, Type: %d, NumChannels: %d", mac_str,
+                     updated_oclass->m_op_class_info.id.op_class, updated_oclass->m_op_class_info.id.type, updated_oclass->m_op_class_info.num_channels);
+        for (j = 0; j < updated_oclass->m_op_class_info.num_channels; j++)
+        {
+            // Update preference values to Easymesh Standard
+            updated_oclass->m_op_class_info.channel_pref[j] = static_cast<unsigned char>(updated_oclass->m_op_class_info.channel_pref[j] << EM_CH_PREF_SHIFT);
+            em_printfout("Channel: %d, Preference: %d", updated_oclass->m_op_class_info.channels[j], updated_oclass->m_op_class_info.channel_pref[j]);
+
+        }
+    }
+
+    pdm = m_data_model_list.get_first_dm();
+    while (pdm != NULL) {
+        if (memcmp(dm.m_device.m_device_info.intf.mac, pdm->get_device_info()->intf.mac, sizeof(mac_address_t)) != 0) {
+            pdm = m_data_model_list.get_next_dm(pdm);
+            continue;
+        }
+        break;
+    }
+
+    if (pdm == NULL) {
+        em_printfout("No matching DM found for device MAC in ChannelSelectionRequest event");
+        return 0;
+    }
+
+    // Assuming that the opclass list received in the event is only for one radio,
+    // invalidating the opclasses for that radio based on RUID match
+    // Create list of invalid opclasses id's to delete it from DB
+    {
+        updated_oclass = &dm.m_op_class[0];
+        for (j = 0; j < pdm->get_num_op_class(); j++)
+        {
+            current_oclass = &pdm->m_op_class[j];
+            if (current_oclass->m_op_class_info.id.type == em_op_class_type_anticipated &&
+                memcmp(current_oclass->m_op_class_info.id.ruid, updated_oclass->m_op_class_info.id.ruid, sizeof(mac_address_t)) == 0)
+            {
+                current_oclass->m_op_class_info.pref_valid = EM_CH_PREF_ENTRY_INVALID;
+                std::string opclass_id = util::mac_to_string(current_oclass->m_op_class_info.id.ruid) + "@" +
+                                         std::to_string(static_cast<unsigned int>(current_oclass->m_op_class_info.id.type)) + "@" +
+                                         std::to_string(static_cast<unsigned int>(current_oclass->m_op_class_info.id.op_class));
+                em_printfout("Marking opclass with id: %s for deletion from DB", opclass_id.c_str());
+                delete_invalid_opclass_ids.push_back(opclass_id);
+            }
+        }
+    }
+    // Invalidated all the OPCLASSES belonging to the particular radio
+    // Update data model and db with new opclass info received in the event
+    pdm->set_channels_list(dm.m_op_class, dm.get_num_op_class());
+
+    // Delete invalid row of anticipated type from db
+    for (const auto &del_id : delete_invalid_opclass_ids) {
+        dm_op_class_list_t::delete_row(m_db_client, del_id.c_str());
+    }
+
+    // Update db with new opclasses received in the event
+    pdm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
+
+    // Queue the channel selection command to trigger the channel selection
+    // Explicitly set num_args to 0 to make sure command is handled properly in build_candidates()
+    evt->params.u.args.num_args = 0;
+    pcmd[num] = new em_cmd_set_channel_t(evt->params, dm);
+    tmp = pcmd[num];
+    num++;
+    while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
+        tmp = pcmd[num];
+        num++;
+    }
+
+    return static_cast<int> (num);
 }
 
 int dm_easy_mesh_ctrl_t::analyze_set_channel(em_bus_event_t *evt, em_cmd_t *pcmd[])
@@ -1019,8 +3063,7 @@ int dm_easy_mesh_ctrl_t::analyze_set_channel(em_bus_event_t *evt, em_cmd_t *pcmd
        	return ret;
    	}
 
-	assert(dm.get_num_op_class() == EM_MAX_BANDS);
-
+	// Fewer bands than EM_MAX_BANDS is valid; empty/invalid input is handled by decode_config above.
 	evt->params.u.args.num_args = 0;
 
 	// Reset pref_valid for all anticipated operating classes before update
@@ -1130,8 +3173,11 @@ int dm_easy_mesh_ctrl_t::analyze_set_channel(em_bus_event_t *evt, em_cmd_t *pcmd
 		pdm->set_db_cfg_param(db_cfg_type_op_class_list_update, "");
 		pdm = m_data_model_list.get_next_dm(pdm);
 	}
-	
 
+	if (evt->params.u.args.num_args == 0) {
+        em_printfout("No change detected in channel or preference, skipping command generation");
+        return 0;
+    }
    	pcmd[num] = new em_cmd_set_channel_t(evt->params, dm);
    	tmp = pcmd[num];
    	num++;
@@ -1780,7 +3826,7 @@ int dm_easy_mesh_ctrl_t::get_channel_config(cJSON *parent, char *key, em_get_cha
             if (reason == em_get_channel_list_reason_set_anticipated) {
                 channel_list_obj = cJSON_AddArrayToObject(radio_obj, "AnticipatedChannelPreference");
                 snprintf(op_key, sizeof(op_key), "%s@%d@%d", tmp, em_op_class_type_anticipated, 0);
-                dm_op_class_list_t::get_config(op_class_list_obj, op_key);
+                dm_op_class_list_t::get_config(channel_list_obj, op_key);
             }
             op_class_list_obj = cJSON_AddArrayToObject(radio_obj, "CurrentOperatingClasses");
             snprintf(op_key, sizeof(op_key), "%s@%d@%d", tmp, em_op_class_type_current, 0);
@@ -1918,10 +3964,14 @@ int dm_easy_mesh_ctrl_t::get_device_config(cJSON *parent, char *key, bool summar
 
 int dm_easy_mesh_ctrl_t::get_network_config(cJSON *parent, char *key)
 {
-	// get the data from topology
-	m_topology->encode(parent);
-	//em_printfout("Network Topology Json:\n%s",cJSON_Print(parent));
-	return 0;
+    // get the data from topology
+    cJSON *net_obj;
+
+    net_obj = cJSON_AddObjectToObject(parent, "Network");
+    dm_network_list_t::get_config(net_obj, key, true);
+    m_topology->encode(net_obj);
+    //em_printfout("Network Topology Json:\n%s",cJSON_Print(parent));
+    return 0;
 }
 
 int dm_easy_mesh_ctrl_t::get_mld_config(cJSON *parent, char *key)
@@ -2292,7 +4342,7 @@ int dm_easy_mesh_ctrl_t::update_tables(dm_easy_mesh_t *dm)
             hash_map_remove(dm->m_sta_assoc_map, key);
             delete tmp;
         }
-            
+
 		dm->reset_db_cfg_type(db_cfg_type_sta_list_update);
     }
 
@@ -2492,7 +4542,7 @@ dm_device_t *dm_easy_mesh_ctrl_t::get_dm_dev(mac_address_t dev_mac, mac_address_
     return NULL;
 }
 
-dm_radio_t* dm_easy_mesh_ctrl_t::get_dm_radio(dm_easy_mesh_t *dm, char *instance, bool is_num)
+dm_radio_t *dm_easy_mesh_ctrl_t::get_dm_radio(dm_easy_mesh_t *dm, char *instance, bool is_num)
 {
     dm_radio_t *radio = NULL;
 
@@ -2700,6 +4750,16 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_get(char *event_name, raw_data_t *p_data
 bus_error_t dm_easy_mesh_ctrl_t::curops_tget(char *event_name, raw_data_t *p_data)
 {
     return bus_get_cb_fwd(event_name, p_data, curops_tget_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::capops_get(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, capops_get_inner);
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::capops_tget(char *event_name, raw_data_t *p_data)
+{
+    return bus_get_cb_fwd(event_name, p_data, capops_tget_inner);
 }
 
 bus_error_t dm_easy_mesh_ctrl_t::bss_get(char *event_name, raw_data_t *p_data)
@@ -3458,6 +5518,38 @@ char* dm_easy_mesh_ctrl_t::get_vht_caps_str(em_ap_vht_cap_t *vht, char *buf, siz
     return buf;
 }
 
+char* dm_easy_mesh_ctrl_t::get_supported_standards_str(wifi_ieee80211Variant_t variant, char *buf, size_t buf_size)
+{
+    if (!buf || buf_size == 0)
+        return nullptr;
+
+    buf[0] = '\0';
+    size_t len = 0;
+
+    auto append = [&](const char* s) {
+        size_t slen = strlen(s);
+        size_t needed = (len == 0) ? slen : (slen + 1);
+        if (len + needed + 1 > buf_size) return;
+        if (len != 0) {
+            buf[len++] = ',';
+        }
+        memcpy(buf + len, s, slen);
+        len += slen;
+        buf[len] = '\0';
+    };
+
+    if (variant & WIFI_80211_VARIANT_A)  append("a");
+    if (variant & WIFI_80211_VARIANT_B)  append("b");
+    if (variant & WIFI_80211_VARIANT_G)  append("g");
+    if (variant & WIFI_80211_VARIANT_N)  append("n");
+    if (variant & WIFI_80211_VARIANT_AC) append("ac");
+    if (variant & WIFI_80211_VARIANT_AX) append("ax");
+    if (variant & WIFI_80211_VARIANT_BE) append("be");
+    if (variant & WIFI_80211_VARIANT_BN) append("bn");
+
+    return buf;
+}
+
 bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     (void) user_data;
@@ -3512,7 +5604,7 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p
     } else if (strcmp(param, "Noise") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, static_cast<unsigned int> (ri->noise));
     } else if (strcmp(param, "Utilization") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, ri->utilization);
+        rc = dm_ctrl->raw_data_set(p_data, static_cast<unsigned int> (ri->utilization));
     } else if (strcmp(param, "Transmit") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, 0U);
     } else if (strcmp(param, "ReceiveSelf") == 0) {
@@ -3522,7 +5614,22 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p
     } else if (strcmp(param, "ChipsetVendor") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, ri->chip_vendor);
     } else if (strcmp(param, "CurrentOperatingClassProfileNumberOfEntries") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, 0U);
+        unsigned int curop_count = 0;
+        for (unsigned int i = 0; i < dm->get_num_op_class(); i++) {
+            dm_op_class_t *op_class = dm->get_op_class(i);
+            if (op_class == NULL) {
+                continue;
+            }
+            em_op_class_info_t *oci = op_class->get_op_class_info();
+            if (oci->id.type != em_op_class_type_current) {
+                continue;
+            }
+            if (memcmp(ri->id.ruid, oci->id.ruid, sizeof(oci->id.ruid)) != 0) {
+                continue;
+            }
+            curop_count++;
+        }
+        rc = dm_ctrl->raw_data_set(p_data, curop_count);
     } else if (strcmp(param, "BSSNumberOfEntries") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, ri->number_of_bss);
     } else {
@@ -3575,6 +5682,7 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_params(dm_easy_mesh_t *dm, const cha
 {
     char path[512];
     char caps_str[MAX_CAPS_STR_LEN] = { 0 };
+    char supported_standards[MAX_STDLEN] = { 0 };
     bus_error_t rc = bus_error_success;
     dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
 
@@ -3594,12 +5702,27 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_params(dm_easy_mesh_t *dm, const cha
 #endif
         dm_ctrl->property_append_tail(property, root, idx, "Enabled", ri->enabled);
         dm_ctrl->property_append_tail(property, root, idx, "Noise", static_cast<unsigned int> (ri->noise));
-        dm_ctrl->property_append_tail(property, root, idx, "Utilization", ri->utilization);
+        dm_ctrl->property_append_tail(property, root, idx, "Utilization", static_cast<unsigned int> (ri->utilization));
         dm_ctrl->property_append_tail(property, root, idx, "Transmit", 0U);
         dm_ctrl->property_append_tail(property, root, idx, "ReceiveSelf", 0U);
         dm_ctrl->property_append_tail(property, root, idx, "ReceiveOther", 0U);
         dm_ctrl->property_append_tail(property, root, idx, "ChipsetVendor", ri->chip_vendor);
-        dm_ctrl->property_append_tail(property, root, idx, "CurrentOperatingClassProfileNumberOfEntries", 0U);
+        unsigned int curop_count = 0;
+        for (unsigned int i = 0; i < dm->get_num_op_class(); i++) {
+            dm_op_class_t *op_class = dm->get_op_class(i);
+            if (op_class == NULL) {
+                continue;
+            }
+            em_op_class_info_t *oci = op_class->get_op_class_info();
+            if (oci->id.type != em_op_class_type_current) {
+                continue;
+            }
+            if (memcmp(ri->id.ruid, oci->id.ruid, sizeof(oci->id.ruid)) != 0) {
+                continue;
+            }
+            curop_count++;
+        }
+        dm_ctrl->property_append_tail(property, root, idx, "CurrentOperatingClassProfileNumberOfEntries", curop_count);
         dm_ctrl->property_append_tail(property, root, idx, "BSSNumberOfEntries", ri->number_of_bss);
 
         dm_sta_t *bh_sta = dm_ctrl->get_dm_bh_sta(dm, radio);
@@ -3614,22 +5737,43 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_params(dm_easy_mesh_t *dm, const cha
             }
         }
 
+        unsigned int capop_count = 0;
+        for (unsigned int i = 0; i < dm->get_num_op_class(); i++) {
+            dm_op_class_t *op_class = dm->get_op_class(i);
+            if (op_class == NULL) {
+                continue;
+            }
+            em_op_class_info_t *oci = op_class->get_op_class_info();
+            if (oci->id.type != em_op_class_type_capability) {
+                continue;
+            }
+            if (memcmp(ri->id.ruid, oci->id.ruid, sizeof(oci->id.ruid)) != 0) {
+                continue;
+            }
+            capop_count++;
+        }
+
         dm_radio_cap_t *radio_cap = dm->get_radio_cap(ri->id.ruid);
         if (radio_cap != NULL) {
             em_radio_cap_info_t *rci = radio_cap->get_radio_cap_info();
+            dm_ctrl->get_supported_standards_str(rci->mode, supported_standards, sizeof(supported_standards));
+            dm_ctrl->property_append_tail(property, root, idx, "X_AIRTIES_OperatingStandards", supported_standards);
             dm_ctrl->get_ht_caps_str(&rci->ht_cap, caps_str, sizeof(caps_str));
             dm_ctrl->property_append_tail(property, root, idx, "Capabilities.HTCapabilities", caps_str);
             dm_ctrl->get_vht_caps_str(&rci->vht_cap, caps_str, sizeof(caps_str));
             dm_ctrl->property_append_tail(property, root, idx, "Capabilities.VHTCapabilities", caps_str);
-            dm_ctrl->property_append_tail(property, root, idx, "Capabilities.CapableOperatingClassProfileNumberOfEntries", 0U);
+            dm_ctrl->property_append_tail(property, root, idx, "Capabilities.CapableOperatingClassProfileNumberOfEntries", capop_count);
         } else {
             dm_ctrl->property_append_tail(property, root, idx, "Capabilities.HTCapabilities", "");
             dm_ctrl->property_append_tail(property, root, idx, "Capabilities.VHTCapabilities", "");
-            dm_ctrl->property_append_tail(property, root, idx, "Capabilities.CapableOperatingClassProfileNumberOfEntries", 0U);
+            dm_ctrl->property_append_tail(property, root, idx, "Capabilities.CapableOperatingClassProfileNumberOfEntries", capop_count);
         }
 
         snprintf(path, sizeof(path) - 1, "%s%d.CurrentOperatingClassProfile.", root, idx);
         dm_ctrl->curops_tget_params(dm, path, ri, property);
+
+        snprintf(path, sizeof(path) - 1, "%s%d.Capabilities.CapableOperatingClassProfile.", root, idx);
+        dm_ctrl->capops_tget_params(dm, path, ri, property);
 
         snprintf(path, sizeof(path) - 1, "%s%d.Capabilities.WiFi6APRole.", root, idx);
         dm_ctrl->wf6ap_tget_params(dm, path, ri, property, idx);
@@ -3708,6 +5852,7 @@ bus_error_t dm_easy_mesh_ctrl_t::rcaps_get_inner(char *event_name, raw_data_t *p
     const char *param;
     char caps_str[MAX_CAPS_STR_LEN] = { 0 };
     char instance[MAX_INSTANCE_LEN] = { 0 };
+    char supported_standards[MAX_STDLEN] = { 0 };
     bool is_num;
     int radio_instance = 0;
     bus_error_t rc;
@@ -3744,6 +5889,26 @@ bus_error_t dm_easy_mesh_ctrl_t::rcaps_get_inner(char *event_name, raw_data_t *p
     em_radio_info_t *ri = radio->get_radio_info();
 
     dm_radio_cap_t *radio_cap = dm->get_radio_cap(ri->id.ruid);
+
+    if (strcmp(param, "CapableOperatingClassProfileNumberOfEntries") == 0) {
+        unsigned int capop_count = 0;
+        for (unsigned int i = 0; i < dm->get_num_op_class(); i++) {
+            dm_op_class_t *op_class = dm->get_op_class(i);
+            if (op_class == NULL) {
+                continue;
+            }
+            em_op_class_info_t *oci = op_class->get_op_class_info();
+            if (oci->id.type != em_op_class_type_capability) {
+                continue;
+            }
+            if (memcmp(ri->id.ruid, oci->id.ruid, sizeof(oci->id.ruid)) != 0) {
+                continue;
+            }
+            capop_count++;
+        }
+        return dm_ctrl->raw_data_set(p_data, capop_count);
+    }
+
     if (radio_cap == NULL) {
         em_printfout("radio_cap is NULL\n");
         return bus_error_invalid_input;
@@ -3756,8 +5921,9 @@ bus_error_t dm_easy_mesh_ctrl_t::rcaps_get_inner(char *event_name, raw_data_t *p
     } else if (strcmp(param, "VHTCapabilities") == 0) {
         dm_ctrl->get_vht_caps_str(&rci->vht_cap, caps_str, sizeof(caps_str));
         rc = dm_ctrl->raw_data_set(p_data, caps_str);
-    } else if (strcmp(param, "CapableOperatingClassProfileNumberOfEntries") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, 0U);
+    } else if (strcmp(param, "X_AIRTIES_OperatingStandards") == 0) {
+        dm_ctrl->get_supported_standards_str(rci->mode, supported_standards, sizeof(supported_standards));
+        rc = dm_ctrl->raw_data_set(p_data, supported_standards);
     } else {
         em_printfout("Invalid param: %s", param);
         rc = bus_error_invalid_input;
@@ -4330,6 +6496,244 @@ bus_error_t dm_easy_mesh_ctrl_t::curops_tget_params(dm_easy_mesh_t *dm, const ch
     return rc;
 }
 
+/* Build a comma-separated list string of the non-operable channels of a
+ * CapableOperatingClassProfile entry (e.g. "36,40,44,48"). */
+char* dm_easy_mesh_ctrl_t::get_capop_nonoper_str(em_op_class_info_t *oci, char *buf, size_t buf_len)
+{
+    size_t off = 0;
+
+    if (buf == NULL || buf_len == 0) {
+        return buf;
+    }
+
+    buf[0] = '\0';
+    for (unsigned int i = 0; i < oci->num_channels && i < EM_MAX_CHANNELS_IN_LIST; i++) {
+        int n = snprintf(buf + off, buf_len - off, "%s%u",
+                         (i == 0) ? "" : ",", oci->channels[i]);
+        if (n < 0 || static_cast<size_t>(n) >= buf_len - off) {
+            break;
+        }
+        off += static_cast<size_t>(n);
+    }
+
+    return buf;
+}
+
+dm_op_class_t* dm_easy_mesh_ctrl_t::get_dm_capop(dm_easy_mesh_t *dm, dm_radio_t *radio, int instance)
+{
+    int ocnt = 0;
+    em_radio_info_t *ri = radio->get_radio_info();
+
+    for (unsigned int i = 0; i < dm->get_num_op_class(); i++) {
+        dm_op_class_t *op_class = dm->get_op_class(i);
+        if (op_class == NULL) {
+            continue;
+        }
+        em_op_class_info_t *oci = op_class->get_op_class_info();
+        if (oci->id.type != em_op_class_type_capability) {
+            continue;
+        }
+        if (memcmp(ri->id.ruid, oci->id.ruid, sizeof(oci->id.ruid)) != 0) {
+            continue;
+        }
+        ++ocnt;
+        if (ocnt == instance) {
+            return op_class;
+        }
+    }
+
+    return NULL;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::capops_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *param;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    int radio_instance = 0, capop_class_instance = 0;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+
+    param = strrchr(name, '.');
+    if (param == NULL) {
+        return bus_error_invalid_input;
+    }
+    ++param;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
+    if (radio_instance < 1 || static_cast<unsigned int>(radio_instance) > dm->get_num_radios()) {
+        em_printfout("invalid radio instance %d\n", radio_instance);
+        return bus_error_invalid_input;
+    }
+    dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
+
+    /* Skip the "Capabilities." segment so the instance is taken from the
+     * CapableOperatingClassProfile table and not the Capabilities object. */
+    name = strstr(name, "CapableOperatingClassProfile.");
+    if (name == NULL) {
+        em_printfout("invalid CapableOperatingClassProfile path\n");
+        return bus_error_invalid_input;
+    }
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    capop_class_instance = is_num ? atoi(instance) : 0;
+    dm_op_class_t *op_class = dm_ctrl->get_dm_capop(dm, radio, capop_class_instance);
+    if (op_class == NULL) {
+        em_printfout("op_class is NULL\n");
+        return bus_error_invalid_input;
+    }
+    em_op_class_info_t *oci = op_class->get_op_class_info();
+
+    if (strcmp(param, "Class") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, oci->op_class);
+    } else if (strcmp(param, "MaxTxPower") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, oci->max_tx_power);
+    } else if (strcmp(param, "NumberOfNonOperChan") == 0) {
+        rc = dm_ctrl->raw_data_set(p_data, std::min(oci->num_channels,
+                                                    static_cast<unsigned int>(EM_MAX_CHANNELS_IN_LIST)));
+    } else if (strcmp(param, "NonOperable") == 0) {
+        char nonoper[512];
+        dm_ctrl->get_capop_nonoper_str(oci, nonoper, sizeof(nonoper));
+        rc = dm_ctrl->raw_data_set(p_data, nonoper);
+    } else {
+        em_printfout("Invalid param: %s\n", param);
+        rc = bus_error_invalid_input;
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::capops_tget_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    (void) user_data;
+    const char *name = event_name;
+    const char *root = name;
+    bus_data_prop_t *property = NULL;
+    char instance[MAX_INSTANCE_LEN] = { 0 };
+    bool is_num;
+    int radio_instance = 0;
+    bus_error_t rc;
+
+    if (!name || !p_data) {
+        return bus_error_invalid_input;
+    }
+    if (*(name + (strlen(name) - 1)) != '.') {
+        /* Only partial paths are valid */
+        return bus_error_invalid_operation;
+    }
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+
+    /* Extract device instance (numeric or alias) and find the dm object for
+     * that device instance */
+    name += sizeof(DATAELEMS_NETWORK);
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    dm_easy_mesh_t *dm = dm_ctrl->get_dm_easy_mesh(instance, is_num);
+    if (dm == NULL) {
+        printf("device not found\n");
+        return bus_error_invalid_namespace;
+    }
+
+    name = dm_ctrl->get_table_instance(name, instance, MAX_INSTANCE_LEN, &is_num);
+    radio_instance = is_num ? atoi(instance) : 0;
+    if (radio_instance < 1 || static_cast<unsigned int>(radio_instance) > dm->get_num_radios()) {
+        em_printfout("invalid radio instance %d\n", radio_instance);
+        return bus_error_invalid_input;
+    }
+    dm_radio_t *radio = &dm->m_radio[radio_instance - 1];
+    em_radio_info_t *ri = radio->get_radio_info();
+
+    rc = dm_ctrl->capops_tget_params(dm, root, ri, &property);
+    if (rc == bus_error_success && property) {
+        dm_ctrl->raw_data_set(p_data, property);
+    }
+
+    return rc;
+}
+
+bus_error_t dm_easy_mesh_ctrl_t::capops_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property)
+{
+    bus_error_t rc = bus_error_success;
+
+    dm_easy_mesh_ctrl_t *dm_ctrl = em_ctrl_t::get_em_ctrl_instance()->get_dm_ctrl();
+    unsigned int idx = 0;
+    for (unsigned int i = 0; i < dm->get_num_op_class(); i++) {
+        dm_op_class_t *op_class = dm->get_op_class(i);
+        if (op_class == NULL) {
+            continue;
+        }
+        em_op_class_info_t *oci = op_class->get_op_class_info();
+        if (oci->id.type != em_op_class_type_capability) {
+            continue;
+        }
+        if (memcmp(ri->id.ruid, oci->id.ruid, sizeof(oci->id.ruid)) != 0) {
+            continue;
+        }
+        ++idx;
+
+        char nonoper[512];
+        dm_ctrl->get_capop_nonoper_str(oci, nonoper, sizeof(nonoper));
+
+        dm_ctrl->property_append_tail(property, root, idx, "Class", oci->op_class);
+        dm_ctrl->property_append_tail(property, root, idx, "MaxTxPower", oci->max_tx_power);
+        dm_ctrl->property_append_tail(property, root, idx, "NumberOfNonOperChan",
+                                      std::min(oci->num_channels,
+                                               static_cast<unsigned int>(EM_MAX_CHANNELS_IN_LIST)));
+        dm_ctrl->property_append_tail(property, root, idx, "NonOperable", nonoper);
+    }
+
+    return rc;
+}
+
+dm_bss_t *dm_easy_mesh_ctrl_t::get_dm_bss(dm_easy_mesh_t *dm, em_radio_info_t *ri, char *instance, bool is_num)
+{
+    unsigned int bcnt = 0;
+    unsigned int idx = 0;
+    mac_address_t mac = { 0 };
+
+    if (is_num) {
+        idx = static_cast<unsigned int>(atoi(instance));
+    } else {
+        dm_easy_mesh_t::string_to_macbytes(instance, mac);
+    }
+
+    for (unsigned int i = 0; i < dm->get_num_bss(); i++) {
+        dm_bss_t *bss = dm->get_bss(i);
+        em_bss_info_t *bi = bss->get_bss_info();
+        if (memcmp(ri->id.ruid, bi->ruid.mac, sizeof(mac_address_t)) == 0) {
+            ++bcnt;
+        }
+        if (is_num) {
+            if (bcnt == idx) {
+                return bss;
+            }
+        } else {
+            if (memcmp(mac, bi->bssid.mac, sizeof(mac_address_t)) == 0) {
+                return bss;
+            }
+        }
+    }
+
+    return NULL;
+}
+
 dm_sta_t* dm_easy_mesh_ctrl_t::get_dm_sta(dm_easy_mesh_t *dm, em_bss_info_t *bi, int instance)
 {
     int scnt = 0;
@@ -4579,6 +6983,42 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_tget_params(dm_easy_mesh_t *dm, const char 
     }
 
     return rc;
+}
+
+dm_sta_t *dm_easy_mesh_ctrl_t::get_dm_sta(dm_easy_mesh_t *dm, em_bss_info_t *bi, char *instance, bool is_num)
+{
+    unsigned int scnt = 0;
+    unsigned int idx = 0;
+    mac_address_t mac = { 0 };
+
+    if (is_num) {
+        idx = static_cast<unsigned int>(atoi(instance));
+    } else {
+        dm_easy_mesh_t::string_to_macbytes(instance, mac);
+    }
+
+    dm_sta_t *sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
+    while (sta != NULL) {
+        em_sta_info_t *si = sta->get_sta_info();
+        if (si->associated == 0 ||
+            memcmp(bi->bssid.mac, si->bssid, sizeof(mac_address_t)) != 0) {
+            sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+            continue;
+        }
+        ++scnt;
+        if (is_num) {
+            if (scnt == idx) {
+                return sta;
+            }
+        } else {
+            if (memcmp(mac, si->id, sizeof(mac_address_t)) == 0) {
+                return sta;
+            }
+        }
+        sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+    }
+
+    return NULL;
 }
 
 bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
@@ -5618,7 +8058,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     em_sta_info_t *si = NULL;
     while (sta != NULL) {
         si = sta->get_sta_info();
-        if (si->associated && memcmp(asi->mac_addr, si->id, sizeof(mac_addr_t)) != 0) {
+        if (si->associated && memcmp(asi->link_addr, si->id, sizeof(mac_addr_t)) != 0) {
             break;
         }
         sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
@@ -5626,7 +8066,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     }
 
     if (strcmp(param, "MACAddress") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, asi->mac_addr);
+        rc = dm_ctrl->raw_data_set(p_data, asi->link_addr);
     } else if (strcmp(param, "BSSID") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, asi->bssid);
     } else if (strcmp(param, "BytesSent") == 0) {
@@ -5723,14 +8163,14 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_tget_params(dm_easy_mesh_t *dm, const ch
         em_sta_info_t *si = NULL;
         while (sta != NULL) {
             si = sta->get_sta_info();
-            if (si->associated && memcmp(asi->mac_addr, si->id, sizeof(mac_addr_t)) != 0) {
+            if (si->associated && memcmp(asi->link_addr, si->id, sizeof(mac_addr_t)) != 0) {
                 break;
             }
             sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
             si = NULL;
         }
 
-        dm_ctrl->property_append_tail(property, root, idx, "MACAddress", asi->mac_addr);
+        dm_ctrl->property_append_tail(property, root, idx, "MACAddress", asi->link_addr);
         dm_ctrl->property_append_tail(property, root, idx, "BSSID", asi->bssid);
         dm_ctrl->property_append_tail(property, root, idx, "BytesSent", si ? si->bytes_tx : 0);
         dm_ctrl->property_append_tail(property, root, idx, "BytesReceived", si ? si->bytes_rx : 0);

--- a/src/ctrl/em_cmd_ctrl.cpp
+++ b/src/ctrl/em_cmd_ctrl.cpp
@@ -86,6 +86,7 @@ int em_cmd_ctrl_t::execute(char *result)
 
         if (SSL_accept(m_ssl) <= 0) {
             SSL_free(m_ssl);
+            m_ssl = NULL;
             close(dsock);
             continue;
         }
@@ -156,6 +157,7 @@ int em_cmd_ctrl_t::send_result(em_cmd_out_status_t status)
 	sd = SSL_get_fd(m_ssl);
 	SSL_shutdown(m_ssl);
 	SSL_free(m_ssl);
+	m_ssl = NULL;
 	close(sd);
 
 	free(str);

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -102,6 +102,13 @@ void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
     }
 }
 
+// Non-positive analyze_*() result: 0/NO_CHANGE is a no-op, any other negative is an error.
+static em_cmd_out_status_t status_for_noncmd(int num)
+{
+    return (num == 0 || num == EM_PARSE_ERR_NO_CHANGE) ?
+        em_cmd_out_status_no_change : em_cmd_out_status_invalid_input;
+}
+
 void em_ctrl_t::handle_client_steer(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
@@ -109,8 +116,8 @@ void em_ctrl_t::handle_client_steer(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_steer(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_command_steer(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -125,8 +132,8 @@ void em_ctrl_t::handle_client_disassoc(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_disassoc(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_command_disassoc(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -141,8 +148,8 @@ void em_ctrl_t::handle_client_btm(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_btm(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_command_btm(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -157,14 +164,30 @@ void em_ctrl_t::handle_start_dpp(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_dpp_start(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_dpp_start(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
         m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
     } 
 
+}
+
+void em_ctrl_t::handle_channel_select(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    int num;
+
+    if (m_orch->is_cmd_type_in_progress(evt) == true) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
+    } else if ((num = m_data_model.analyze_channel_select(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
+    } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_success);
+    } else {
+        m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+    }
 }
 
 void em_ctrl_t::handle_set_channel_list(em_bus_event_t *evt)
@@ -174,8 +197,8 @@ void em_ctrl_t::handle_set_channel_list(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_channel(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_set_channel(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -191,8 +214,8 @@ void em_ctrl_t::handle_scan_channel_list(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_scan_channel(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_scan_channel(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -208,8 +231,8 @@ void em_ctrl_t::handle_set_policy(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_policy(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_set_policy(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -254,8 +277,8 @@ void em_ctrl_t::handle_set_radio(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_radio(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_set_radio(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -291,8 +314,8 @@ void em_ctrl_t::handle_remove_device(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_remove_device(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_remove_device(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -362,8 +385,8 @@ void em_ctrl_t::handle_reset(em_bus_event_t *evt)
 	
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_reset(evt, pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_reset(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -379,8 +402,8 @@ void em_ctrl_t::handle_mld_reconfig(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_mld_reconfig(pcmd)) == 0) {
-        m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
+    } else if ((num = m_data_model.analyze_mld_reconfig(pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
     } else {
@@ -396,6 +419,22 @@ void em_ctrl_t::handle_radio_metrics_req()
 void em_ctrl_t::handle_ap_metrics_req()
 {
 
+}
+
+void em_ctrl_t::handle_unassoc_sta_metrics_query(em_bus_event_t *evt)
+{
+    em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
+    int num;
+
+    if (m_orch->is_cmd_type_in_progress(evt) == true) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
+    } else if ((num = m_data_model.analyze_unassoc_sta_metrics_query(evt, pcmd)) <= 0) {
+        m_ctrl_cmd->send_result(status_for_noncmd(num));
+    } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
+        m_ctrl_cmd->send_result(em_cmd_out_status_success);
+    } else {
+        m_ctrl_cmd->send_result(em_cmd_out_status_not_ready);
+    }
 }
 
 void em_ctrl_t::handle_client_metrics_req()
@@ -571,6 +610,10 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
             handle_set_channel_list(evt);
             break;
 
+        case em_bus_event_type_channel_select:
+            handle_channel_select(evt);
+            break;
+
         case em_bus_event_type_scan_channel:
             handle_scan_channel_list(evt);
             break;
@@ -622,7 +665,11 @@ void em_ctrl_t::handle_bus_event(em_bus_event_t *evt)
         case em_bus_event_type_link_quality_report:
            handle_link_stats_alarm_report(evt);
            break;
-	
+
+	case em_bus_event_type_unassoc_sta_query:
+           handle_unassoc_sta_metrics_query(evt);
+           break;
+
         default:
             break;
     }
@@ -789,11 +836,10 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
     bssid_t	bssid;
     dm_bss_t *bss;
     em_profile_type_t profile;
-    em_2xlong_string_t key;
     unsigned int i;
-    bool found;
-    mac_addr_str_t mac_str1, mac_str2, dev_mac_str, radio_mac_str;
+    mac_addr_str_t mac_str1 = {0}, mac_str2 = {0};
     em_commit_info_t dm_commit;
+    mac_address_t fallback_ruid = {0};
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
     if (len < ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)))) {
@@ -886,52 +932,38 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
                 em_printfout("Could not find radio:%s", mac_str1);
                 return NULL;
             }
+            em_printfout("topo_resp: routed to radio %s state:%s", mac_str1, em_t::state_2_str(em->get_state()));
+            // For topo_resp: the radio ID in the message may not be the radio
+            // that sent the query (e.g. sta_assoc dispatches only one radio to
+            // topo_sync_pending). Fall back to whichever radio in the same AL
+            // is in topo_sync_pending so process_msg() state guard passes.
+            // if (htons(cmdu->type) == em_msg_type_topo_resp &&
+            //     em->get_state() != em_state_ctrl_topo_sync_pending) {
+            //     std::vector<em_t *> al_radios;
+            //     get_all_em_for_al_mac(em->get_data_model()->get_agent_al_interface_mac(), al_radios);
+            //     for (auto *r : al_radios) {
+            //         if (r->get_state() == em_state_ctrl_topo_sync_pending) {
+            //             em_printfout("topo_resp: rerouting from radio %s (state:%s) to radio %s (topo_sync_pending)",
+            //                 mac_str1,
+            //                 em_t::state_2_str(em->get_state()),
+            //                 util::mac_to_string(r->get_radio_interface_mac()).c_str());
+            //             em = r;
+            //             break;
+            //         }
+            //     }
+            // }
             break;
 
         case em_msg_type_topo_notif:
         case em_msg_type_client_cap_rprt:
         case em_msg_type_ap_metrics_rsp:
-           if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
+        case em_msg_type_failed_conn:
+            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
                     len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_bss_id(&bssid) == false) {
                 printf("%s:%d: Could not find bss id in msg:0x%04x\n", __func__, __LINE__, htons(cmdu->type));
                 return NULL;
             }
-
-            if ((dm = get_data_model(GLOBAL_NET_ID, const_cast<const unsigned char *> (hdr->src))) == NULL) {
-                printf("%s:%d: Can not find data model\n", __func__, __LINE__);
-            }
-
-            for (i = 0; i < dm->get_num_radios(); i++) {
-                found = true;
-                dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (dm->get_radio_info(i)->id.dev_mac), dev_mac_str);
-                dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (dm->get_radio_info(i)->id.ruid), radio_mac_str);
-                dm_easy_mesh_t::macbytes_to_string(bssid, mac_str1);
-                snprintf(key, sizeof (em_2xlong_string_t), "%s@%s@%s@%s@", dm->get_radio_info(i)->id.net_id, dev_mac_str, radio_mac_str, mac_str1);
-
-                if ((bss = dm->get_bss(dm->get_radio_info(i)->id.ruid, bssid)) == NULL) {
-                    found = false;
-                    continue;
-                }
-                break;
-            }
-
-            if (found == false) {
-                printf("%s:%d: Could not find bss:%s from data model, for radio: %s\n", __func__, __LINE__, mac_str1, radio_mac_str);
-                return NULL;
-            }
-              
-            dm_easy_mesh_t::macbytes_to_string(bss->m_bss_info.ruid.mac, mac_str1);
-            if ((em = static_cast<em_t *> (hash_map_get(m_em_map, mac_str1))) == NULL) {
-                printf("%s:%d: Could not find radio:%s\n", __func__, __LINE__, mac_str1);
-                return NULL;
-            } else {
-                dm_easy_mesh_t::macbytes_to_string(bssid, mac_str1);
-                mac_addr_str_t mac;
-                dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac);
-                //printf("%s:%d: Em radio id: %s\n", __func__, __LINE__, mac);
-                //printf("%s:%d: Found em for msg type: %d, key for bss[%s]: %s\n", __func__, __LINE__, htons(cmdu->type), mac_str1, key);
-            }
-
+            em = al_em;
             break;
 
         case em_msg_type_autoconf_resp:
@@ -941,6 +973,7 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
         case em_msg_type_channel_sel_req:
         case em_msg_type_client_cap_query:
         case em_msg_type_assoc_sta_link_metrics_query:
+        case em_msg_type_unassoc_sta_link_metrics_query:	    
         case em_msg_type_beacon_metrics_query:
         case em_msg_type_client_steering_req:
         case em_msg_type_client_assoc_ctrl_req:
@@ -1043,6 +1076,16 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
             }
             break;
 
+	case em_msg_type_unassoc_sta_link_metrics_rsp:
+            em = static_cast<em_t *>(hash_map_get_first(m_em_map));
+            while (em != NULL) {
+                if ((em->is_al_interface_em() == false) && 
+	          (memcmp(em->get_data_model()->get_agent_al_interface_mac(), hdr->src, sizeof(mac_address_t)) == 0)) {
+                    break;
+                }
+                em = static_cast<em_t *>(hash_map_get_next(m_em_map, em));
+            }
+            break;
 
         default:
             printf("%s:%d: Frame: 0x%04x not handled in controller\n", __func__, __LINE__, htons(cmdu->type));
@@ -1091,6 +1134,21 @@ void em_ctrl_t::start_complete()
             { bus_data_type_string, false, 0, 0, 0, NULL } },
         { const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_SETSSID_CMD), bus_element_type_method,
             { NULL, NULL , NULL, NULL, NULL, tr_181_t::setssid_handler}, slow_speed, ZERO_TABLE,
+            { bus_data_type_property, false, 0, 0, 0, NULL } },
+        { const_cast<char*>(DE_MAPDEVBH_STEERWIFIBH), bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, tr_181_t::steerwifibh_handler}, slow_speed, ZERO_TABLE,
+            { bus_data_type_property, false, 0, 0, 0, NULL } },
+        { const_cast<char*>(DE_RADIO_CHSCANREQ), bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, tr_181_t::channelscan_handler}, slow_speed, ZERO_TABLE,
+            { bus_data_type_property, false, 0, 0, 0, NULL } },
+        { const_cast<char*>(DE_RADIO_CHSELREQ), bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, tr_181_t::channelselect_handler}, slow_speed, ZERO_TABLE,
+            { bus_data_type_property, false, 0, 0, 0, NULL } },
+        { const_cast<char*>(DE_STA_CLIENTSTEER), bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, tr_181_t::clientsteer_handler}, slow_speed, ZERO_TABLE,
+            { bus_data_type_property, false, 0, 0, 0, NULL } },
+        { const_cast<char*>(DE_STAMAP_DISASSOC), bus_element_type_method,
+            { NULL, NULL , NULL, NULL, NULL, tr_181_t::disassociate_handler}, slow_speed, ZERO_TABLE,
             { bus_data_type_property, false, 0, 0, 0, NULL } }
         };
 

--- a/src/ctrl/em_network_topo.cpp
+++ b/src/ctrl/em_network_topo.cpp
@@ -144,14 +144,15 @@ em_network_topo_t *em_network_topo_t::find_topology_by_bh_associated(dm_easy_mes
 	}
 	// From the bss info obtained, find the appropriate em_network_topo_t containing this bss
 	// and return that topology object.
+	// bss->id.bssid  = local bSTA interface MAC (used to locate the parent topology node)
+	// bss->bssid.mac = upstream AP BSSID the bSTA is associated to (shown in Backhaul.MACAddress)
 	mac_address_t bss_mac;
 	memcpy(bss_mac, bss->id.bssid, sizeof(mac_address_t));
 	if (dm->is_controller() == false) {
-		// Update the backhaul of the dm object with the bss mac address
-		memcpy(dm->m_device.m_device_info.backhaul_mac.mac, bss_mac, sizeof(mac_address_t));
+		// Set BackhaulMACAddress to the upstream AP BSSID, not the local bSTA MAC
+		memcpy(dm->m_device.m_device_info.backhaul_mac.mac, bss->bssid.mac, sizeof(mac_address_t));
 		dm->m_device.m_device_info.backhaul_mac.media = em_media_type_ieee80211ac_5;
-		// check if backhaul mac is 00:00:00:00:00:00, then change the media type to em_media_type_ieee8023ab
-		if (memcmp(bss_mac, ZERO_MAC_ADDR, sizeof(mac_address_t)) == 0) {
+		if (memcmp(bss->bssid.mac, ZERO_MAC_ADDR, sizeof(mac_address_t)) == 0) {
 			dm->m_device.m_device_info.backhaul_mac.media = em_media_type_ieee8023ab;
 		}
 	}

--- a/src/ctrl/tr_181/wfa_data_model/Data_Elements_JSON_Schema_v3.0.json
+++ b/src/ctrl/tr_181/wfa_data_model/Data_Elements_JSON_Schema_v3.0.json
@@ -3059,6 +3059,12 @@
                                             "type": "integer",
                                             "minimum": -127,
                                             "maximum": 127
+                                        },
+                                        "X_AIRTIES_OperatingStandards": {
+                                            "type": "string",
+                                            "description": "List of 802.11 standards in operation for this radio instance",
+                                            "enum": ["a", "b", "g", "n", "ac", "ax", "be", "bn"]
+                                        }
                                         }
                                     }
                                 }

--- a/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181.cpp
@@ -135,9 +135,15 @@ int tr_181_t::wfa_set_bus_callbackfunc_pointers(const char *full_namespace, bus_
         ELEMENT(DE_RADIO_CHIPVENDOR,       CALLBACK_GETTER(radio_get)),
         ELEMENT(DE_RADIO_CURROPNOE,        CALLBACK_GETTER(radio_get)),
         ELEMENT(DE_RADIO_BSSNOE,           CALLBACK_GETTER(radio_get)),
+        ELEMENT(DE_RADIO_XAIRTIES_OPERSTANDARDS, CALLBACK_GETTER(rcaps_get)),
         ELEMENT(DE_RCAPS_HTCAPS,           CALLBACK_GETTER(rcaps_get)),
         ELEMENT(DE_RCAPS_VHTCAPS,          CALLBACK_GETTER(rcaps_get)),
         ELEMENT(DE_RCAPS_CAPOPNOE,         CALLBACK_GETTER(rcaps_get)),
+        ELEMENT(DE_CAPOP_TABLE,            CALLBACK_GETTER(capops_tget)),
+        ELEMENT(DE_CAPOP_CLASS,            CALLBACK_GETTER(capops_get)),
+        ELEMENT(DE_CAPOP_MAXTXPOWER,       CALLBACK_GETTER(capops_get)),
+        ELEMENT(DE_CAPOP_NONOPERABLE,      CALLBACK_GETTER(capops_get)),
+        ELEMENT(DE_CAPOP_NONOPCNT,         CALLBACK_GETTER(capops_get)),
         ELEMENT(DE_CAPS_WF6AP,             CALLBACK_GETTER(wf6ap_tget)),
         ELEMENT(DE_WF6AP_HE160,            CALLBACK_GETTER(wf6ap_get)),
         ELEMENT(DE_WF6AP_HE8080,           CALLBACK_GETTER(wf6ap_get)),
@@ -595,12 +601,23 @@ bus_error_t tr_181_t::radio_get(char *event_name, raw_data_t *p_data, bus_user_d
     return bus_error_general;
 }
 
-bus_error_t tr_181_t::bss_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+bus_error_t tr_181_t::radio_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
 
     if (em_ctrl != NULL) {
-        return em_ctrl->get_dm_ctrl()->bss_get(event_name, p_data);
+        return em_ctrl->get_dm_ctrl()->radio_tget(event_name, p_data);
+    }
+    
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::rbhsta_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->rbhsta_get(event_name, p_data);
     }
     
     return bus_error_general;
@@ -679,38 +696,38 @@ bus_error_t tr_181_t::curops_tget(char *event_name, raw_data_t *p_data, bus_user
     if (em_ctrl != NULL) {
         return em_ctrl->get_dm_ctrl()->curops_tget(event_name, p_data);
     }
-    
+
     return bus_error_general;
 }
 
-bus_error_t tr_181_t::sta_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+bus_error_t tr_181_t::capops_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
 
     if (em_ctrl != NULL) {
-        return em_ctrl->get_dm_ctrl()->sta_get(event_name, p_data);
+        return em_ctrl->get_dm_ctrl()->capops_get(event_name, p_data);
     }
-    
+
     return bus_error_general;
 }
 
-bus_error_t tr_181_t::radio_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+bus_error_t tr_181_t::capops_tget(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
 
     if (em_ctrl != NULL) {
-        return em_ctrl->get_dm_ctrl()->radio_tget(event_name, p_data);
+        return em_ctrl->get_dm_ctrl()->capops_tget(event_name, p_data);
     }
-    
+
     return bus_error_general;
 }
 
-bus_error_t tr_181_t::rbhsta_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+bus_error_t tr_181_t::bss_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
 
     if (em_ctrl != NULL) {
-        return em_ctrl->get_dm_ctrl()->rbhsta_get(event_name, p_data);
+        return em_ctrl->get_dm_ctrl()->bss_get(event_name, p_data);
     }
     
     return bus_error_general;
@@ -722,6 +739,17 @@ bus_error_t tr_181_t::bss_tget(char *event_name, raw_data_t *p_data, bus_user_da
 
     if (em_ctrl != NULL) {
         return em_ctrl->get_dm_ctrl()->bss_tget(event_name, p_data);
+    }
+    
+    return bus_error_general;
+}
+
+bus_error_t tr_181_t::sta_get(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    em_ctrl_t *em_ctrl = em_ctrl_t::get_em_ctrl_instance();
+
+    if (em_ctrl != NULL) {
+        return em_ctrl->get_dm_ctrl()->sta_get(event_name, p_data);
     }
     
     return bus_error_general;

--- a/src/ctrl/tr_181/wfa_data_model/tr_181_helper.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181_helper.cpp
@@ -163,14 +163,33 @@ bus_data_prop_t *tr_181_t::tr181_set_status_output_prop(const char *status)
 }
 
 // Populate output_data with a "Status" property containing the given status string.
-void tr_181_t::tr181_set_status_output(raw_data_t *output_data, const char *status)
+void tr_181_t::tr181_set_status_output(bus_data_prop_t *output_data, const char *status)
 {
-    if (!output_data) return;
-    bus_data_prop_t *prop = tr181_set_status_output_prop(status);
-    if (!prop) return;
-    output_data->data_type = bus_data_type_property;
-    output_data->raw_data.bytes = prop;
-    output_data->raw_data_len = sizeof(bus_data_prop_t);
+    if (!output_data || !status) {
+        return;
+    }
+
+    bus_data_prop_t *prop = output_data;
+    memset(prop, 0, sizeof(*prop));
+
+    size_t name_len = strnlen("Status", sizeof(prop->name) - 1U);
+    memcpy(prop->name, "Status", name_len);
+    prop->name[name_len] = '\0';
+    prop->name_len = static_cast<uint32_t>(name_len);
+    prop->is_data_set = true;
+    prop->status = bus_error_success;
+    prop->ref_count = 1;
+
+    size_t value_len = strlen(status);
+    prop->value.data_type = bus_data_type_string;
+    prop->value.raw_data.bytes = malloc(value_len + 1U);
+    if (!prop->value.raw_data.bytes) {
+        prop->is_data_set = false;
+        prop->ref_count = 0;
+        return;
+    }
+    memcpy(prop->value.raw_data.bytes, status, value_len + 1U);
+    prop->value.raw_data_len = static_cast<unsigned int>(value_len + 1U);
 }
 
 // Copy a string property value into a destination buffer, ensuring proper type and null-termination.
@@ -196,5 +215,45 @@ bool tr_181_t::tr181_copy_prop_string(const bus_data_prop_t *prop, char *dst, si
 
     memcpy(dst, src, len);
     dst[len] = '\0';
+    return true;
+}
+
+bool tr_181_t::tr181_get_prop_int(const bus_data_prop_t *prop, int *value)
+{
+    if (!prop || !value) {
+        return false;
+    }
+
+    if (prop->value.data_type == bus_data_type_int8) {
+        *value = static_cast<int>(prop->value.raw_data.i8);
+    } else if (prop->value.data_type == bus_data_type_uint8) {
+        *value = static_cast<int>(prop->value.raw_data.u8);
+    } else if (prop->value.data_type == bus_data_type_int16) {
+        *value = static_cast<int>(prop->value.raw_data.i16);
+    } else if (prop->value.data_type == bus_data_type_uint16) {
+        *value = static_cast<int>(prop->value.raw_data.u16);
+    } else if (prop->value.data_type == bus_data_type_int32) {
+        *value = prop->value.raw_data.i32;
+    } else if (prop->value.data_type == bus_data_type_uint32) {
+        *value = static_cast<int>(prop->value.raw_data.u32);
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+bool tr_181_t::tr181_get_prop_bool(const bus_data_prop_t *prop, bool *value)
+{
+    if (!prop || !value) {
+        return false;
+    }
+
+    if (prop->value.data_type == bus_data_type_boolean) {
+        *value = prop->value.raw_data.b;
+    } else {
+        return false;
+    }
+
     return true;
 }

--- a/src/ctrl/tr_181/wfa_data_model/tr_181_method.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181_method.cpp
@@ -18,13 +18,11 @@
 #include "em_ctrl.h"
 #include "tr_181.h"
 
-bus_error_t tr_181_t::setssid_handler(const char *method_name, raw_data_t *input_data, raw_data_t *output_data, void *async_handle)
+bus_error_t tr_181_t::setssid_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
 {
-    // Suppress unused parameter warning if async_handle is not used
-    (void)async_handle;
-
     // Standardize input pointer checks
-    if (!input_data || input_data->raw_data_len == 0) {
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
         em_printfout("Invalid input_data or missing input_props");
         if (output_data) {
             tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
@@ -32,10 +30,16 @@ bus_error_t tr_181_t::setssid_handler(const char *method_name, raw_data_t *input
         return bus_error_invalid_input;
     }
 
-    bus_data_prop_t *input_props = static_cast<bus_data_prop_t *>(input_data->raw_data.bytes);
+    bus_data_prop_t *input_props = input_data;
     bus_data_prop_t *output_props = NULL;
 
-    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_data->raw_data_len);
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
     // Log all chained input properties
     for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
         em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
@@ -54,9 +58,276 @@ bus_error_t tr_181_t::setssid_handler(const char *method_name, raw_data_t *input
     bus_error_t rc = ctrl->cmd_setssid(event, input_props, output_data ? &output_props : NULL, async_handle);
 
     if (output_data && output_props) {
-        output_data->data_type = bus_data_type_property;
-        output_data->raw_data.bytes = output_props;
-        output_data->raw_data_len = sizeof(bus_data_prop_t);
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
+    }
+
+    return rc;
+}
+
+bus_error_t tr_181_t::steerwifibh_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
+{
+    // Standardize input pointer checks
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
+        em_printfout("Invalid input_data or missing input_props");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_data_prop_t *input_props = input_data;
+    bus_data_prop_t *output_props = NULL;
+
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
+    // Log all chained input properties
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
+    }
+
+    em_ctrl_t *ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!ctrl) {
+        em_printfout("Controller unavailable");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: controller unavailable");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_error_t rc = ctrl->cmd_steerwifibh(method_name, input_props, output_data ? &output_props : NULL, async_handle);
+
+    if (output_data && output_props) {
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
+    }
+
+    return rc;
+}
+
+bus_error_t tr_181_t::channelscan_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
+{
+    // Standardize input pointer checks
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
+        em_printfout("Invalid input_data or missing input_props");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_data_prop_t *input_props = input_data;
+    bus_data_prop_t *output_props = NULL;
+
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
+    // Log all chained input properties
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
+    }
+
+    em_ctrl_t *ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!ctrl) {
+        em_printfout("Controller unavailable");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: controller unavailable");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_error_t rc = ctrl->cmd_channelscan(method_name, input_props, output_data ? &output_props : NULL, async_handle);
+
+    if (output_data && output_props) {
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
+    }
+
+    return rc;
+}
+
+bus_error_t tr_181_t::channelselect_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
+{
+    // Standardize input pointer checks
+    em_printfout("Entered channelselect_handler");
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
+        em_printfout("Invalid input_data or missing input_props");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_data_prop_t *input_props = input_data;
+    bus_data_prop_t *output_props = NULL;
+
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
+    // Log all chained input properties
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
+    }
+
+    em_ctrl_t *ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!ctrl) {
+        em_printfout("Controller unavailable");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: controller unavailable");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_error_t rc = ctrl->cmd_channelselect(method_name, input_props, output_data ? &output_props : NULL, async_handle);
+
+    if (output_data && output_props) {
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
+    }
+    em_printfout("Exiting channelselect_handler with rc=%d", rc);
+
+    return rc;
+}
+
+bus_error_t tr_181_t::clientsteer_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
+{
+    // Standardize input pointer checks
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
+        em_printfout("Invalid input_data or missing input_props");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_data_prop_t *input_props = input_data;
+    bus_data_prop_t *output_props = NULL;
+
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
+    // Log all chained input properties
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
+    }
+
+    em_ctrl_t *ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!ctrl) {
+        em_printfout("Controller unavailable");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: controller unavailable");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_error_t rc = ctrl->cmd_clientsteer(method_name, input_props, output_data ? &output_props : NULL, async_handle);
+
+    if (output_data && output_props) {
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
+    }
+
+    return rc;
+}
+
+bus_error_t tr_181_t::disassociate_handler(const char *method_name, bus_data_prop_t *input_data,
+    bus_data_prop_t *output_data, void *async_handle)
+{
+    // Standardize input pointer checks
+    if (!input_data || (!input_data->is_data_set && input_data->next_data == NULL)) {
+        em_printfout("Invalid input_data or missing input_props");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: missing input_props");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_data_prop_t *input_props = input_data;
+    bus_data_prop_t *output_props = NULL;
+
+    uint32_t input_count = 0;
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        if (p->is_data_set) {
+            input_count++;
+        }
+    }
+    em_printfout("Method='%s' input_len=%u", method_name ? method_name : "(null)", input_count);
+    // Log all chained input properties
+    for (bus_data_prop_t *p = input_props; p; p = p->next_data) {
+        em_printfout("Prop='%s' type=%d len=%u", p->name, p->value.data_type, p->value.raw_data_len);
+    }
+
+    em_ctrl_t *ctrl = em_ctrl_t::get_em_ctrl_instance();
+    if (!ctrl) {
+        em_printfout("Controller unavailable");
+        if (output_data) {
+            tr_181_t::tr181_set_status_output(output_data, "Failure: controller unavailable");
+        }
+        return bus_error_invalid_input;
+    }
+
+    bus_error_t rc = ctrl->cmd_disassociate(method_name, input_props, output_data ? &output_props : NULL, async_handle);
+
+    if (output_data && output_props) {
+        *output_data = *output_props;
+        output_data->ref_count = 1;
+
+        for (bus_data_prop_t *p = output_data->next_data; p; p = p->next_data) {
+            p->ref_count = 1;
+        }
+
+        free(output_props);
     }
 
     return rc;

--- a/src/dm/dm_assoc_sta_mld.cpp
+++ b/src/dm/dm_assoc_sta_mld.cpp
@@ -56,8 +56,14 @@ void dm_assoc_sta_mld_t::operator = (const dm_assoc_sta_mld_t& obj)
     this->m_assoc_sta_mld_info.nstr = obj.m_assoc_sta_mld_info.nstr;
     this->m_assoc_sta_mld_info.emlsr = obj.m_assoc_sta_mld_info.emlsr;
     this->m_assoc_sta_mld_info.emlmr = obj.m_assoc_sta_mld_info.emlmr;
-    this->m_assoc_sta_mld_info.num_affiliated_sta = obj.m_assoc_sta_mld_info.num_affiliated_sta;
-    memcpy(&this->m_assoc_sta_mld_info.affiliated_sta,&obj.m_assoc_sta_mld_info.affiliated_sta,sizeof(em_affiliated_sta_info_t));
+    this->m_assoc_sta_mld_info.num_affiliated_sta = (obj.m_assoc_sta_mld_info.num_affiliated_sta > EM_MAX_AP_MLD)
+                                                    ? EM_MAX_AP_MLD : obj.m_assoc_sta_mld_info.num_affiliated_sta;
+    for (unsigned int i = 0; i < this->m_assoc_sta_mld_info.num_affiliated_sta; i++) {
+        memcpy(&this->m_assoc_sta_mld_info.affiliated_sta[i].bssid,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].bssid, sizeof(mac_address_t));
+        memcpy(&this->m_assoc_sta_mld_info.affiliated_sta[i].link_addr,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].link_addr, sizeof(mac_address_t));
+    }
 }
 
 bool dm_assoc_sta_mld_t::operator == (const dm_assoc_sta_mld_t& obj)
@@ -71,7 +77,14 @@ bool dm_assoc_sta_mld_t::operator == (const dm_assoc_sta_mld_t& obj)
     ret += !(this->m_assoc_sta_mld_info.emlsr == obj.m_assoc_sta_mld_info.emlsr);
     ret += !(this->m_assoc_sta_mld_info.emlmr == obj.m_assoc_sta_mld_info.emlmr);
     ret += !(this->m_assoc_sta_mld_info.num_affiliated_sta == obj.m_assoc_sta_mld_info.num_affiliated_sta);
-    ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta,&obj.m_assoc_sta_mld_info.affiliated_sta,sizeof(em_affiliated_ap_info_t)) != 0);
+    unsigned int num_sta = (this->m_assoc_sta_mld_info.num_affiliated_sta > EM_MAX_AP_MLD)
+                           ? EM_MAX_AP_MLD : this->m_assoc_sta_mld_info.num_affiliated_sta;
+    for (unsigned int i = 0; i < num_sta; i++) {
+        ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].bssid,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].bssid, sizeof(mac_address_t)) != 0);
+        ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].link_addr,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].link_addr, sizeof(mac_address_t)) != 0);
+    }
 
     if (ret > 0)
         return false;

--- a/src/dm/dm_bss.cpp
+++ b/src/dm/dm_bss.cpp
@@ -50,6 +50,11 @@ int dm_bss_t::decode(const cJSON *obj, void *parent_id)
         dm_easy_mesh_t::name_from_mac_address(&m_bss_info.bssid.mac, m_bss_info.bssid.name);
     }
 
+    if ((tmp = cJSON_GetObjectItem(obj, "MLDAddr")) != NULL) {
+        snprintf(mac_str, sizeof(mac_str), "%s", cJSON_GetStringValue(tmp));
+        dm_easy_mesh_t::string_to_macbytes(mac_str, m_bss_info.mld_mac);
+    }
+    
     if ((tmp = cJSON_GetObjectItem(obj, "UnicastBytesSent")) != NULL) {
         m_bss_info.unicast_bytes_sent = static_cast<unsigned int> (tmp->valuedouble);
     }
@@ -308,6 +313,7 @@ void dm_bss_t::operator = (const dm_bss_t& obj)
     this->m_bss_info.r2_disallowed = obj.m_bss_info.r2_disallowed;
     this->m_bss_info.multi_bssid = obj.m_bss_info.multi_bssid;
     this->m_bss_info.transmitted_bssid = obj.m_bss_info.transmitted_bssid;
+    memcpy(&this->m_bss_info.eht_ops, &obj.m_bss_info.eht_ops, sizeof(em_eht_operations_bss_t));
     memcpy(this->m_bss_info.vendor_elements, obj.m_bss_info.vendor_elements, sizeof(this->m_bss_info.vendor_elements));
     this->m_bss_info.vendor_elements_len = obj.m_bss_info.vendor_elements_len;
     this->m_bss_info.connect_status = obj.m_bss_info.connect_status;
@@ -352,6 +358,7 @@ bool dm_bss_t::operator == (const dm_bss_t& obj)
     ret += !(this->m_bss_info.r2_disallowed == obj.m_bss_info.r2_disallowed);
     ret += !(this->m_bss_info.multi_bssid == obj.m_bss_info.multi_bssid);
     ret += !(this->m_bss_info.transmitted_bssid == obj.m_bss_info.transmitted_bssid);
+    ret += (memcmp(&this->m_bss_info.eht_ops, &obj.m_bss_info.eht_ops, sizeof(em_eht_operations_bss_t)) != 0);
     ret += (memcmp(this->m_bss_info.vendor_elements, obj.m_bss_info.vendor_elements, sizeof(this->m_bss_info.vendor_elements)) != 0);
     ret += !(this->m_bss_info.vendor_elements_len == obj.m_bss_info.vendor_elements_len);
     ret += !(this->m_bss_info.connect_status == obj.m_bss_info.connect_status);

--- a/src/dm/dm_bsta_mld.cpp
+++ b/src/dm/dm_bsta_mld.cpp
@@ -58,7 +58,13 @@ void dm_bsta_mld_t::operator = (const dm_bsta_mld_t& obj)
     this->m_bsta_mld_info.emlsr = obj.m_bsta_mld_info.emlsr;
     this->m_bsta_mld_info.emlmr = obj.m_bsta_mld_info.emlmr;
     this->m_bsta_mld_info.num_affiliated_bsta = obj.m_bsta_mld_info.num_affiliated_bsta;
-    memcpy(&this->m_bsta_mld_info.affiliated_bsta,&obj.m_bsta_mld_info.affiliated_bsta,sizeof(em_affiliated_bsta_info_t));
+    for (unsigned int i = 0; i < this->m_bsta_mld_info.num_affiliated_bsta; i++) {
+        this->m_bsta_mld_info.affiliated_bsta[i].mac_addr_valid = obj.m_bsta_mld_info.affiliated_bsta[i].mac_addr_valid;
+        memcpy(&this->m_bsta_mld_info.affiliated_bsta[i].ruid.mac,
+            &obj.m_bsta_mld_info.affiliated_bsta[i].ruid.mac, sizeof(mac_address_t));
+        memcpy(&this->m_bsta_mld_info.affiliated_bsta[i].mac_addr,
+            &obj.m_bsta_mld_info.affiliated_bsta[i].mac_addr, sizeof(mac_address_t));
+    }
 }
 
 
@@ -75,7 +81,13 @@ bool dm_bsta_mld_t::operator == (const dm_bsta_mld_t& obj)
     ret += !(this->m_bsta_mld_info.emlsr == obj.m_bsta_mld_info.emlsr);
     ret += !(this->m_bsta_mld_info.emlmr == obj.m_bsta_mld_info.emlmr);
     ret += !(this->m_bsta_mld_info.num_affiliated_bsta == obj.m_bsta_mld_info.num_affiliated_bsta);
-    ret += (memcmp(&this->m_bsta_mld_info.affiliated_bsta,&obj.m_bsta_mld_info.affiliated_bsta,sizeof(em_affiliated_ap_info_t)) != 0);
+    for (unsigned int i = 0; i < this->m_bsta_mld_info.num_affiliated_bsta; i++) {
+        ret += !(this->m_bsta_mld_info.affiliated_bsta[i].mac_addr_valid == obj.m_bsta_mld_info.affiliated_bsta[i].mac_addr_valid);
+        ret += (memcmp(&this->m_bsta_mld_info.affiliated_bsta[i].ruid.mac,
+            &obj.m_bsta_mld_info.affiliated_bsta[i].ruid.mac, sizeof(mac_address_t)) != 0);
+        ret += (memcmp(&this->m_bsta_mld_info.affiliated_bsta[i].mac_addr,
+            &obj.m_bsta_mld_info.affiliated_bsta[i].mac_addr, sizeof(mac_address_t)) != 0);
+    }
 
     if (ret > 0)
         return false;
@@ -85,6 +97,10 @@ bool dm_bsta_mld_t::operator == (const dm_bsta_mld_t& obj)
 
 dm_bsta_mld_t::dm_bsta_mld_t(em_bsta_mld_info_t *bsta_mld_info)
 {
+    memset(&m_bsta_mld_info, 0, sizeof(em_bsta_mld_info_t));
+    if (bsta_mld_info == nullptr) {
+        return;
+    }
     memcpy(&m_bsta_mld_info, bsta_mld_info, sizeof(em_bsta_mld_info_t));
 }
 

--- a/src/dm/dm_device_list.cpp
+++ b/src/dm/dm_device_list.cpp
@@ -46,11 +46,20 @@ int dm_device_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
     em_device_info_t *info;
     char *net_id = static_cast<char *> (parent);
     cJSON *obj;
-	
+    em_interface_t *ctrl_intf = nullptr;
+    dm_easy_mesh_ctrl_t *ctrl_dm = dynamic_cast<dm_easy_mesh_ctrl_t *>(this);
+    if (ctrl_dm != nullptr) {
+        ctrl_intf = ctrl_dm->get_ctrl_al_interface(net_id);
+    }
+
     pdev = get_first_device();
     while (pdev != NULL) {
         info = pdev->get_device_info();
         if (strncmp(info->id.net_id, net_id, strlen(net_id)) == 0) {
+            if (ctrl_intf != nullptr && memcmp(info->id.dev_mac, ctrl_intf->mac, sizeof(mac_address_t)) == 0) {
+                pdev = get_next_device(pdev);
+                continue;
+            }
             obj = cJSON_CreateObject();
 
             pdev->encode(obj, summary);
@@ -245,7 +254,7 @@ bool dm_device_list_t::search_db(db_client_t& db_client, void *ctx, void *key)
 
 int dm_device_list_t::sync_db(db_client_t& db_client, void *ctx)
 {
-    em_device_info_t info;
+    em_device_info_t info = {};
     mac_addr_str_t	mac;
     em_long_string_t   str;
     int rc = 0;
@@ -302,7 +311,7 @@ int dm_device_list_t::sync_db(db_client_t& db_client, void *ctx)
 
 bool dm_device_list_t::compare_db(db_client_t& db_client, const dm_device_t& sta)
 {
-    em_device_info_t info;
+    em_device_info_t info = {};
     mac_addr_str_t mac;
     em_long_string_t   str;
     db_query_t    query;

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -105,14 +105,25 @@ dm_easy_mesh_t& dm_easy_mesh_t::operator = (dm_easy_mesh_t const& obj)
         m_ap_mld[i] = obj.m_ap_mld[i];
     }
 
-    sta = static_cast<dm_sta_t *> (hash_map_get_first(obj.m_sta_map));
-    while (sta != NULL) {
-        dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
-        dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
-        dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
-        snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
-        hash_map_put(m_sta_map, strdup(key), new dm_sta_t(*sta));
-        sta = static_cast<dm_sta_t *> (hash_map_get_next(obj.m_sta_map, sta));
+    m_num_assoc_sta_mld = obj.m_num_assoc_sta_mld;
+    for (unsigned int i = 0; i < EM_MAX_ASSOC_STA_MLD; i++) {
+        m_assoc_sta_mld[i] = obj.m_assoc_sta_mld[i];
+    }
+
+    if (m_sta_map == NULL) {
+        m_sta_map = hash_map_create();
+    }
+
+    if (obj.m_sta_map != NULL && m_sta_map != NULL) {
+        sta = static_cast<dm_sta_t *> (hash_map_get_first(obj.m_sta_map));
+        while (sta != NULL) {
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
+            dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
+            snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
+            hash_map_put(m_sta_map, strdup(key), new dm_sta_t(*sta));
+            sta = static_cast<dm_sta_t *> (hash_map_get_next(obj.m_sta_map, sta));
+        }
     }
 
     m_em = obj.m_em;
@@ -445,7 +456,7 @@ int dm_easy_mesh_t::encode_config_reset(em_subdoc_info_t *subdoc, const char *ke
 	formatted_json = cJSON_Print(parent_obj);
 
     //printf("%s:%d: %s\n", __func__, __LINE__, formatted_json);
-    snprintf(subdoc->buff, EM_IO_BUFF_SZ, "%s", formatted_json);
+    snprintf(subdoc->buff, EM_MAX_EVENT_DATA_LEN, "%s", formatted_json);
     cJSON_free(formatted_json);
     cJSON_Delete(parent_obj);
 
@@ -764,6 +775,9 @@ int dm_easy_mesh_t::decode_config(em_subdoc_info_t *subdoc, const char *str, uns
     } else if (strncmp(str, "SetAnticipatedChannelPreference", strlen("SetAnticipatedChannelPreference")) == 0) {
         snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
         return decode_config_set_channel(subdoc, key, index, num);
+    } else if (strncmp(str, "ChannelSelectionRequest", strlen("ChannelSelectionRequest")) == 0) {
+        snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
+        return decode_config_set_channel(subdoc, key, index, num);
     } else if (strncmp(str, "ChannelScanRequest", strlen("ChannelScanRequest")) == 0) {
         snprintf(key, sizeof(em_long_string_t), "wfa-dataelements:%s", str);
         return decode_config_set_channel(subdoc, key, index, num);
@@ -973,6 +987,7 @@ int dm_easy_mesh_t::decode_config_set_policy(em_subdoc_info_t *subdoc, const cha
 	cJSON *parent_obj, *net_obj, *net_obj_id, *dev_arr_obj, *dev_obj, *dev_obj_id, *policy_obj; 
 	cJSON *ap_metrics_obj, *scan_obj, *radio_metrics_arr_obj, *radio_steer_arr_obj, *local_steer_obj, *btm_steer_obj;
 	cJSON *backhaul_obj, *radio_id_obj, *radio_metrics_obj, *radio_steer_obj;
+	cJSON *traffic_sep_obj, *unsuccess_assoc_obj, *qos_mgt_obj, *def_8021q_obj;
 	unsigned int num_devices = 0;
 	int i;
 	char *dev_mac_str, *net_id;
@@ -1102,14 +1117,20 @@ int dm_easy_mesh_t::decode_config_set_policy(em_subdoc_info_t *subdoc, const cha
         m_num_policy++;
     }
 
-    if ((local_steer_obj = cJSON_GetObjectItem(policy_obj, "Local Steering Disallowed Policy")) != NULL) {
+    // "Steering Policies" wrapper (groups local/BTM disallowed + radio steering params)
+    cJSON *steer_policies_obj = cJSON_GetObjectItem(policy_obj, "Steering Policies");
+    cJSON *steer_local_parent = steer_policies_obj ? steer_policies_obj : policy_obj;
+    cJSON *steer_btm_parent   = steer_policies_obj ? steer_policies_obj : policy_obj;
+    cJSON *steer_param_parent = steer_policies_obj ? steer_policies_obj : policy_obj;
+
+    if ((local_steer_obj = cJSON_GetObjectItem(steer_local_parent, "Local Steering Disallowed Policy")) != NULL) {
         snprintf(parent, sizeof(em_long_string_t), "%s@%s@00:00:00:00:00:00@%d", net_id, dev_mac_str,
                     em_policy_id_type_steering_local);
         m_policy[m_num_policy].decode(local_steer_obj, parent, em_policy_id_type_steering_local);
         m_num_policy++;
     }
 
-    if ((btm_steer_obj = cJSON_GetObjectItem(policy_obj, "BTM Steering Disallowed Policy")) != NULL) {
+    if ((btm_steer_obj = cJSON_GetObjectItem(steer_btm_parent, "BTM Steering Disallowed Policy")) != NULL) {
         snprintf(parent, sizeof(em_long_string_t), "%s@%s@00:00:00:00:00:00@%d", net_id, dev_mac_str,
                     em_policy_id_type_steering_btm);
         m_policy[m_num_policy].decode(btm_steer_obj, parent, em_policy_id_type_steering_btm);
@@ -1117,10 +1138,13 @@ int dm_easy_mesh_t::decode_config_set_policy(em_subdoc_info_t *subdoc, const cha
     }
 
     if ((backhaul_obj = cJSON_GetObjectItem(policy_obj, "Backhaul BSS Configuration Policy")) != NULL) {
-        snprintf(parent, sizeof(em_long_string_t), "%s@%s@00:00:00:00:00:00@%d", net_id, dev_mac_str,
-                    em_policy_id_type_backhaul_bss_config);
-        m_policy[m_num_policy].decode(backhaul_obj, parent, em_policy_id_type_backhaul_bss_config);
-        m_num_policy++;
+        for (i = 0; i < cJSON_GetArraySize(backhaul_obj); i++) {
+            cJSON *backhaul_item_obj = cJSON_GetArrayItem(backhaul_obj, i);
+            snprintf(parent, sizeof(em_long_string_t), "%s@%s@00:00:00:00:00:00@%d", net_id, dev_mac_str,
+                        em_policy_id_type_backhaul_bss_config);
+            m_policy[m_num_policy].decode(backhaul_item_obj, parent, em_policy_id_type_backhaul_bss_config);
+            m_num_policy++;
+        }
     }
 
     if ((scan_obj = cJSON_GetObjectItem(policy_obj, "Channel Scan Reporting Policy")) != NULL) {
@@ -1130,129 +1154,287 @@ int dm_easy_mesh_t::decode_config_set_policy(em_subdoc_info_t *subdoc, const cha
         m_num_policy++;
     }
 
+    if ((unsuccess_assoc_obj = cJSON_GetObjectItem(policy_obj, "Unsuccessful Association Policy")) != NULL) {
+        snprintf(parent, sizeof(em_long_string_t), "%s@%s@00:00:00:00:00:00@%d", net_id, dev_mac_str,
+                    em_policy_id_type_unsuccess_assoc);
+        m_policy[m_num_policy].decode(unsuccess_assoc_obj, parent, em_policy_id_type_unsuccess_assoc);
+        m_num_policy++;
+    }
+
+    if ((qos_mgt_obj = cJSON_GetObjectItem(policy_obj, "QoS Management Policy")) != NULL) {
+        snprintf(parent, sizeof(em_long_string_t), "%s@%s@00:00:00:00:00:00@%d", net_id, dev_mac_str,
+                    em_policy_id_type_qos_mgt);
+        m_policy[m_num_policy].decode(qos_mgt_obj, parent, em_policy_id_type_qos_mgt);
+        m_num_policy++;
+    }
+
+    if ((def_8021q_obj = cJSON_GetObjectItem(policy_obj, "Default 802.1Q Settings Policy")) != NULL) {
+        snprintf(parent, sizeof(em_long_string_t), "%s@%s@00:00:00:00:00:00@%d", net_id, dev_mac_str,
+                    em_policy_id_type_default_8021q_settings);
+        m_policy[m_num_policy].decode(def_8021q_obj, parent, em_policy_id_type_default_8021q_settings);
+        m_num_policy++;
+    }
+
+    if ((traffic_sep_obj = cJSON_GetObjectItem(policy_obj, "Traffic Separation Policy")) != NULL) {
+        snprintf(parent, sizeof(em_long_string_t), "%s@%s@00:00:00:00:00:00@%d", net_id, dev_mac_str,
+                    em_policy_id_type_traffic_separation);
+        m_policy[m_num_policy].decode(traffic_sep_obj, parent, em_policy_id_type_traffic_separation);
+        m_num_policy++;
+    }
+
     if ((radio_metrics_arr_obj = cJSON_GetObjectItem(policy_obj, "Radio Specific Metrics Policy")) != NULL) {
         for (i = 0; i < cJSON_GetArraySize(radio_metrics_arr_obj); i++) {
             radio_metrics_obj = cJSON_GetArrayItem(radio_metrics_arr_obj, i);
             radio_id_obj = cJSON_GetObjectItem(radio_metrics_obj, "ID");
-            if (radio_id_obj != NULL) {
-                mac_addr_t mac;
-                dm_easy_mesh_t::string_to_macbytes(cJSON_GetStringValue(radio_id_obj), mac);
-                memcpy(m_policy[m_num_policy].m_policy.id.radio_mac, mac, sizeof(mac_addr_t));
+            const char *radio_id_str = cJSON_GetStringValue(radio_id_obj);
+            if (radio_id_str == NULL || strcmp(radio_id_str, "00:00:00:00:00:00") == 0) {
+                continue; // skip null entries
             }
-            snprintf(parent, sizeof(em_long_string_t), "%s@%s@%s@%d", net_id, dev_mac_str, cJSON_GetStringValue(radio_id_obj),
+            snprintf(parent, sizeof(em_long_string_t), "%s@%s@%s@%d", net_id, dev_mac_str, radio_id_str,
                         em_policy_id_type_radio_metrics_rep);
             m_policy[m_num_policy].decode(radio_metrics_obj, parent, em_policy_id_type_radio_metrics_rep);
             m_num_policy++;
         }
     }
 
-    if ((radio_steer_arr_obj = cJSON_GetObjectItem(policy_obj, "Radio Steering Parameters")) != NULL) {
+    if ((radio_steer_arr_obj = cJSON_GetObjectItem(steer_param_parent, "Radio Steering Parameters")) != NULL) {
         for (i = 0; i < cJSON_GetArraySize(radio_steer_arr_obj); i++) {
             radio_steer_obj = cJSON_GetArrayItem(radio_steer_arr_obj, i);
             radio_id_obj = cJSON_GetObjectItem(radio_steer_obj, "ID");
-            snprintf(parent, sizeof(em_long_string_t), "%s@%s@%s@%d", net_id, dev_mac_str, cJSON_GetStringValue(radio_id_obj),
+            const char *id_str = cJSON_GetStringValue(radio_id_obj);
+            if (id_str == NULL || strcmp(id_str, "00:00:00:00:00:00") == 0) {
+                continue; // skip null entries
+            }
+            snprintf(parent, sizeof(em_long_string_t), "%s@%s@%s@%d", net_id, dev_mac_str, id_str,
                         em_policy_id_type_steering_param);
             m_policy[m_num_policy].decode(radio_steer_obj, parent, em_policy_id_type_steering_param);
             m_num_policy++;
         }
     }
 
+    cJSON_Delete(parent_obj);
+
     return 0;
 }
 
 int dm_easy_mesh_t::decode_config_set_channel(em_subdoc_info_t *subdoc, const char *key, unsigned int index, unsigned int *num)
 {
-    cJSON *parent_obj, *net_obj, *net_obj_id; 
-    cJSON *target_arr_obj, *target_obj, *channel_arr_obj, *channel_pref_arry_obj;
+#define KEY_CHANNEL_ANTICIPATED "wfa-dataelements:SetAnticipatedChannelPreference"
+#define KEY_CHANNEL_SCANREQUEST "wfa-dataelements:ChannelScanRequest"
+#define KEY_CHANNEL_SELECTION "wfa-dataelements:ChannelSelectionRequest"
+    cJSON *parent_obj = NULL;
+    cJSON *wrapper_obj, *net_obj, *net_id_obj;
+    cJSON *dev_arr_obj, *dev_obj, *dev_id_obj;
+    cJSON *radio_arr_obj, *radio_obj, *radio_id_obj;
+    cJSON *target_arr_obj, *target_obj;
+    cJSON *channel_arr_obj, *channel_pref_arry_obj;
     int i, j, arr_size;
-    char *net_id;
-	em_long_string_t	target_key;	
-	em_op_class_type_t	type = em_op_class_type_none;
+    char *net_id, *dev_id, *radio_id;
+    em_long_string_t target_key;
+    em_op_class_type_t type = em_op_class_type_none;
+
+    if (key == NULL) {
+        em_printfout("Wrapper key is missing");
+        return EM_PARSE_ERR_GEN;
+    }
+    /* This function aims to collect op_classes and channel list for those op_classes for
+     * different type of requests. That data will be used later to fill TLV values for those
+     * requests. In addition to "Channel Scan" and "Anticipated Channel Preference", "Set
+     * Channel" is also handled here. But there is no em_op_class_type to represent "Set
+     * Channel", and this causes an error while parsing "ChanPrefList" later. Furthermore,
+     * "Anticipated Channel Preference" request is not handled later in the code, only "Set
+     * Channel" and "Channel Scan" are handled. */
+    if (strncmp(key, KEY_CHANNEL_ANTICIPATED, strlen(KEY_CHANNEL_ANTICIPATED)) == 0) {
+        snprintf(target_key, sizeof(em_long_string_t), "AnticipatedChannelPreference");
+        type = em_op_class_type_anticipated;
+    } else if (strncmp(key, KEY_CHANNEL_SCANREQUEST, strlen(KEY_CHANNEL_SCANREQUEST)) == 0) {
+        snprintf(target_key, sizeof(em_long_string_t), "ChannelScanParameters");
+        type = em_op_class_type_scan_param;
+    } else if (strncmp(key, KEY_CHANNEL_SELECTION, strlen(KEY_CHANNEL_SELECTION)) == 0) {
+        snprintf(target_key, sizeof(em_long_string_t), "ChannelSelectionRequest");
+        type = em_op_class_type_selection;
+    } else {
+        em_printfout("Invalid wrapper key: '%s'", key);
+        return EM_PARSE_ERR_GEN;
+    }
 
     parent_obj = cJSON_Parse(subdoc->buff);
     if (parent_obj == NULL) {
-        printf("%s:%d: Failed to parse: %s\n", __func__, __LINE__, subdoc->buff);
+        em_printfout("Failed to parse: %s", subdoc->buff);
         return EM_PARSE_ERR_GEN;
     }
 
-    if ((net_obj = cJSON_GetObjectItem(parent_obj, key)) == NULL) {
-        printf("%s:%d: Failed to parse: %s\n", __func__, __LINE__, subdoc->buff);
+    /* Get 'Network' under provided wrapper and extract Network ID */
+    if ((wrapper_obj = cJSON_GetObjectItem(parent_obj, key)) == NULL) {
+        em_printfout("Key '%s' not found in buffer: %s", key, subdoc->buff);
         cJSON_Delete(parent_obj);
         return EM_PARSE_ERR_GEN;
     }
-
-    if ((net_obj = cJSON_GetObjectItem(net_obj, "Network")) == NULL) {
-        printf("%s:%d: Failed to parse: %s\n", __func__, __LINE__, subdoc->buff);
+    if ((net_obj = cJSON_GetObjectItem(wrapper_obj, "Network")) == NULL) {
+        em_printfout("'Network' not found in wrapper: %s", subdoc->buff);
         cJSON_Delete(parent_obj);
         return EM_PARSE_ERR_GEN;
     }
-
-    if ((net_obj_id = cJSON_GetObjectItem(net_obj, "ID")) == NULL) {
-        printf("%s:%d: Network ID not present\n", __func__, __LINE__);
+    if ((net_id_obj = cJSON_GetObjectItem(net_obj, "ID")) == NULL) {
+        em_printfout("'ID' not found in Network: %s", subdoc->buff);
         cJSON_Delete(parent_obj);
         return EM_PARSE_ERR_NET_ID;
     }
-
-    if ((net_id = cJSON_GetStringValue(net_obj_id)) == NULL) {
-        printf("%s:%d: Network ID not present\n", __func__, __LINE__);
+    if ((net_id = cJSON_GetStringValue(net_id_obj)) == NULL) {
+        em_printfout("Network ID is invalid: %s", subdoc->buff);
         cJSON_Delete(parent_obj);
         return EM_PARSE_ERR_NET_ID;
     }
+    snprintf(m_network.m_net_info.id, sizeof(em_long_string_t), "%s", net_id);
 
-	if (strncmp(key, "wfa-dataelements:SetAnticipatedChannelPreference", strlen("wfa-dataelements:SetAnticipatedChannelPreference")) == 0) {
-		snprintf(target_key, sizeof(em_long_string_t), "AnticipatedChannelPreference");
-		type = em_op_class_type_anticipated;
-	} else if (strncmp(key, "wfa-dataelements:ChannelScanRequest", strlen("wfa-dataelements:ChannelScanRequest")) == 0) {
-		snprintf(target_key, sizeof(em_long_string_t), "ChannelScanParameters");
-		type = em_op_class_type_scan_param;
-	}
+    /* Get 'DeviceList' under 'Network' and extract Device ID (MAC) */
+    if ((dev_arr_obj = cJSON_GetObjectItem(net_obj, "DeviceList")) == NULL) {
+        em_printfout("'DeviceList' not found in Network: %s", subdoc->buff);
+        cJSON_Delete(parent_obj);
+        return EM_PARSE_ERR_GEN;
+    }
+    *num = static_cast<unsigned int> (cJSON_GetArraySize(dev_arr_obj));
+    if (index >= *num) {
+        em_printfout("Invalid input index: %d, number of devices: %d", index, *num);
+        cJSON_Delete(parent_obj);
+        return EM_PARSE_ERR_GEN;
+    }
+    if ((dev_obj = cJSON_GetArrayItem(dev_arr_obj, static_cast<int> (index))) == NULL) {
+        em_printfout("Invalid input index: %d", index);
+        cJSON_Delete(parent_obj);
+        return EM_PARSE_ERR_GEN;
+    }
+    if ((dev_id_obj = cJSON_GetObjectItem(dev_obj, "ID")) == NULL) {
+        em_printfout("'ID' not found in Device: %s", subdoc->buff);
+        cJSON_Delete(parent_obj);
+        return EM_PARSE_ERR_GEN;
+    }
+    if ((dev_id = cJSON_GetStringValue(dev_id_obj)) == NULL) {
+        em_printfout("Device ID is invalid: %s", subdoc->buff);
+        cJSON_Delete(parent_obj);
+        return EM_PARSE_ERR_GEN;
+    }
+    dm_easy_mesh_t::string_to_macbytes(dev_id, m_device.m_device_info.intf.mac);
 
-	if ((target_arr_obj = cJSON_GetObjectItem(net_obj, target_key)) == NULL) {
-		cJSON_Delete(parent_obj);
-        printf("%s:%d: %s not present\n", __func__, __LINE__, target_key);
-        return -1;
+    /* "Channel Scan" is for radio, so is "Set Channel". "Set Anticipated Channel Preference"
+     * is for device. There is also a clash here. */
+    if (type == em_op_class_type_scan_param || type == em_op_class_type_selection) {
+        /* Get 'RadioList' under 'Device' and extract Radio ID (MAC) */
+        if ((radio_arr_obj = cJSON_GetObjectItem(dev_obj, "RadioList")) == NULL) {
+            em_printfout("'RadioList' not found in Device: %s", subdoc->buff);
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
+        if ((radio_obj = cJSON_GetArrayItem(radio_arr_obj, 0)) == NULL) {
+            em_printfout("Invalid input index: %d", index);
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
+        if ((radio_id_obj = cJSON_GetObjectItem(radio_obj, "ID")) == NULL) {
+            em_printfout("'ID' not found in Radio: %s", subdoc->buff);
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
+        if ((radio_id = cJSON_GetStringValue(radio_id_obj)) == NULL) {
+            em_printfout("Radio ID is invalid: %s", subdoc->buff);
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
+        m_num_radios = 1;
+        dm_easy_mesh_t::string_to_macbytes(radio_id, m_radio[0].m_radio_info.intf.mac);
 
-	}	
+        if ((target_arr_obj = cJSON_GetObjectItem(radio_obj, target_key)) == NULL) {
+            em_printfout("'%s' not found in Radio", target_key);
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
+    } else {
+        // Anticipated preference is carried at Network scope; Set/Scan at device scope
+        cJSON *src_obj = (type == em_op_class_type_anticipated) ? net_obj : dev_obj;
+        if ((target_arr_obj = cJSON_GetObjectItem(src_obj, target_key)) == NULL) {
+            em_printfout("'%s' not found in %s", target_key,
+                         (type == em_op_class_type_anticipated) ? "Network" : "Device");
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
+    }
 
-	m_num_opclass = 0;
-	arr_size = cJSON_GetArraySize(target_arr_obj);
-	for (i = 0; i < arr_size; i++) {
-		if ((target_obj = cJSON_GetArrayItem(target_arr_obj, i)) == NULL) {
-			cJSON_Delete(parent_obj);
-        	printf("%s:%d: %s not present\n", __func__, __LINE__, target_key);
-        	return -1;
-    	}
+    m_num_opclass = 0;
+    arr_size = cJSON_GetArraySize(target_arr_obj); // may be 0 for scan
+    for (i = 0; i < arr_size && m_num_opclass < EM_MAX_OPCLASS; i++) {
+        if ((target_obj = cJSON_GetArrayItem(target_arr_obj, i)) == NULL) {
+            em_printfout("Invalid input index: %d", i);
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
 
-		memset(&m_op_class[m_num_opclass].m_op_class_info, 0, sizeof(em_op_class_info_t));   
+        memset(&m_op_class[m_num_opclass].m_op_class_info, 0, sizeof(em_op_class_info_t));
 
-		m_op_class[m_num_opclass].m_op_class_info.id.type = type;
-		m_op_class[m_num_opclass].m_op_class_info.op_class = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetObjectItem(target_obj, "Class")));
-		m_op_class[m_num_opclass].m_op_class_info.id.op_class = m_op_class[m_num_opclass].m_op_class_info.op_class;
+        // Presently only Anticipated opclass is being used as valid.
+        // Support of type selection will be used in upcoming updates
+        m_op_class[m_num_opclass].m_op_class_info.id.type =
+            (type == em_op_class_type_selection) ? em_op_class_type_anticipated : type;
 
-		if ((channel_arr_obj = cJSON_GetObjectItem(target_obj, "ChannelList")) == NULL) {
-			cJSON_Delete(parent_obj);
-        	printf("%s:%d: %s not present\n", __func__, __LINE__, target_key);
-        	return -1;
-		}
+        cJSON *class_num_obj = cJSON_GetObjectItem(target_obj, "Class");
+        if (!cJSON_IsNumber(class_num_obj)) {
+            em_printfout("Class not present");
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
+        m_op_class[m_num_opclass].m_op_class_info.op_class =
+            static_cast<unsigned int>(cJSON_GetNumberValue(class_num_obj));
+        m_op_class[m_num_opclass].m_op_class_info.id.op_class =
+            m_op_class[m_num_opclass].m_op_class_info.op_class;
 
-		if ((channel_pref_arry_obj = cJSON_GetObjectItem(target_obj, "ChannelPrefList")) == NULL) {
-			cJSON_Delete(parent_obj);
-			em_printfout("Error: %s not present\n", target_key);
-			return -1;
-		}
+        if ((channel_arr_obj = cJSON_GetObjectItem(target_obj, "ChannelList")) == NULL) {
+            em_printfout("ChannelList not present");
+            cJSON_Delete(parent_obj);
+            return EM_PARSE_ERR_GEN;
+        }
 
-		m_op_class[m_num_opclass].m_op_class_info.num_channels = 0;
+        m_op_class[m_num_opclass].m_op_class_info.num_channels = 0;
+        if (type != em_op_class_type_scan_param) {
 
-		for (j = 0; j < cJSON_GetArraySize(channel_arr_obj); j++) {
-			m_op_class[m_num_opclass].m_op_class_info.channels[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_arr_obj, j)));
-			m_op_class[m_num_opclass].m_op_class_info.channel_pref[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_pref_arry_obj, j)));
-			m_op_class[m_num_opclass].m_op_class_info.num_channels++;
-		}
-		m_num_opclass++;
-	}	
-	
+            // For TR181 request belongs to only one radio, so copying same for all opclass entries as ID
+            if (type == em_op_class_type_selection) {
+                memcpy(m_op_class[m_num_opclass].m_op_class_info.id.ruid, m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t));
+            }
+
+            if ((channel_pref_arry_obj = cJSON_GetObjectItem(target_obj, "ChannelPrefList")) == NULL) {
+                em_printfout("ChannelPrefList not present");
+                cJSON_Delete(parent_obj);
+                return EM_PARSE_ERR_GEN;
+            }
+            if (cJSON_GetArraySize(channel_pref_arry_obj) != cJSON_GetArraySize(channel_arr_obj)) {
+                em_printfout("ChannelPrefList size is not equal to ChannelList");
+                cJSON_Delete(parent_obj);
+                return EM_PARSE_ERR_GEN;
+            }
+            for (j = 0; j < cJSON_GetArraySize(channel_arr_obj) &&
+                        m_op_class[m_num_opclass].m_op_class_info.num_channels < EM_MAX_CHANNELS_IN_LIST; j++) {
+                m_op_class[m_num_opclass].m_op_class_info.channels[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_arr_obj, j)));
+                m_op_class[m_num_opclass].m_op_class_info.channel_pref[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_pref_arry_obj, j)));
+                m_op_class[m_num_opclass].m_op_class_info.num_channels++;
+            }
+        } else {
+            for (j = 0; j < cJSON_GetArraySize(channel_arr_obj) &&
+                        m_op_class[m_num_opclass].m_op_class_info.num_channels < EM_MAX_CHANNELS_IN_LIST; j++) {
+                m_op_class[m_num_opclass].m_op_class_info.channels[m_op_class[m_num_opclass].m_op_class_info.num_channels] = static_cast<unsigned int> (cJSON_GetNumberValue(cJSON_GetArrayItem(channel_arr_obj, j)));
+                m_op_class[m_num_opclass].m_op_class_info.num_channels++;
+            }
+        }
+
+        m_num_opclass++;
+    }
+
+    if ((type == em_op_class_type_anticipated || type == em_op_class_type_selection) && m_num_opclass == 0) {
+        em_printfout("OpClass list is empty");
+        cJSON_Delete(parent_obj);
+        return EM_PARSE_ERR_NO_CHANGE;
+    }
+
     cJSON_Delete(parent_obj);
-    //printf("%s:%d: End\n", __func__, __LINE__);
+
     return 0;
 }
 
@@ -2037,16 +2219,16 @@ dm_radio_cap_t *dm_easy_mesh_t::get_radio_cap(mac_address_t mac)
     return NULL;
 }
 
-dm_radio_cap_t *dm_easy_mesh_t::get_radio_cap(int index)
+dm_radio_cap_t *dm_easy_mesh_t::get_radio_cap(unsigned int index)
 {
-    if ((index < 0) || (index >= EM_MAX_BANDS)) {
+    if (index >= EM_MAX_BANDS) {
         return nullptr;
     }
 
     return &m_radio_cap[index];
 }
 
-em_radio_cap_info_t *dm_easy_mesh_t::get_radio_cap_info(int index)
+em_radio_cap_info_t *dm_easy_mesh_t::get_radio_cap_info(unsigned int index)
 {
     dm_radio_cap_t *cap = get_radio_cap(index);
     return cap ? cap->get_radio_cap_info() : nullptr;
@@ -2151,6 +2333,46 @@ void dm_easy_mesh_t::print_config()
             m_radio_cap[i].get_radio_cap_info()->he_cap.mu_beamformer_cap,
             m_radio_cap[i].get_radio_cap_info()->he_cap.su_beamformer_cap
         );
+        em_printfout("VHT Cap: RUID:%s TXRX_MCS:[0x%04x 0x%04x] "
+            "GI support: 160MHz:%d 80MHz:%d Max RX streams:%d Max TX streams:%d "
+            "MU Beamformer:%d SU Beamformer:%d 160MHz:%d 80+80MHz:%d",
+            util::mac_to_string(m_radio_cap[i].get_radio_cap_info()->ruid.mac).c_str(),
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.sprt_tx_mcs,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.sprt_rx_mcs,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.gi_sprt_160mhz,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.gi_sprt_80mhz,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.max_sprt_rx_streams,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.max_sprt_tx_streams,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.mu_beamformer_cap,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.su_beamformer_cap,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.sprt_160mhz,
+            m_radio_cap[i].get_radio_cap_info()->vht_cap.sprt_80_80_mhz
+        );
+        em_printfout("HT Cap: RUID:%s 40MHz:%d GI 40MHz:%d GI 20MHz:%d Max RX streams:%d Max TX streams:%d",
+            util::mac_to_string(m_radio_cap[i].get_radio_cap_info()->ruid.mac).c_str(),
+            m_radio_cap[i].get_radio_cap_info()->ht_cap.ht_sprt_40mhz,
+            m_radio_cap[i].get_radio_cap_info()->ht_cap.gi_sprt_40mhz,
+            m_radio_cap[i].get_radio_cap_info()->ht_cap.gi_sprt_20mhz,
+            m_radio_cap[i].get_radio_cap_info()->ht_cap.max_sprt_rx_streams,
+            m_radio_cap[i].get_radio_cap_info()->ht_cap.max_sprt_tx_streams
+        );
+        em_printfout("Channel scan cap: RUID:%s boot only:%d min scan interval:%u scan impact:%u",
+            util::mac_to_string(m_radio_cap[i].get_radio_cap_info()->ruid.mac).c_str(),
+            m_radio_cap[i].get_radio_cap_info()->ch_scan.boot_only,
+            m_radio_cap[i].get_radio_cap_info()->ch_scan.min_scan_interval,
+            m_radio_cap[i].get_radio_cap_info()->ch_scan.scan_impact
+        );
+        for (size_t k = 0; k < m_radio_cap[i].get_radio_cap_info()->ch_scan.op_classes_num; k++) {
+            const em_scan_cap_op_class_info_t *oc = &m_radio_cap[i].get_radio_cap_info()->ch_scan.op_classes[k];
+            char ch_buf[256] = {0};
+            int  ch_buf_pos  = 0;
+            for (unsigned char ci = 0; ci < oc->num && ch_buf_pos < static_cast<int>(sizeof(ch_buf)) - 5; ci++) {
+                ch_buf_pos += snprintf(ch_buf + ch_buf_pos, sizeof(ch_buf) - static_cast<size_t>(ch_buf_pos),
+                                       "%d ", oc->channels.channel[ci]);
+            }
+            em_printfout("ch_scan op_class[%zu]: op_class=%d num_channels=%d channels=[%s]",
+                k, oc->op_class, oc->num, oc->num > 0 ? ch_buf : "all");
+        }
     }
 }
 
@@ -2230,6 +2452,8 @@ em_e4_table_t dm_easy_mesh_t::m_e4_table[] = {
 	//Row with center channels
 	{ 137, em_freq_band_6, 320, false, 6, {31, 63, 95, 127, 159, 191} }
 };
+
+const size_t dm_easy_mesh_t::m_e4_table_size = sizeof(dm_easy_mesh_t::m_e4_table) / sizeof(dm_easy_mesh_t::m_e4_table[0]);
 
 int dm_easy_mesh_t::get_beaconchannel_by_bandwidth(int center_channel, int bandwidth)
 {
@@ -2334,6 +2558,30 @@ std::vector<int>  dm_easy_mesh_t::get_channel_list_by_op_class(int op_class)
         }
     }
     return channels;
+}
+
+int dm_easy_mesh_t::get_primary_channel_op_class(int op_class)
+{
+    size_t n = sizeof(m_e4_table) / sizeof(m_e4_table[0]);
+    // Find this op_class in the table
+    for (size_t i = 0; i < n; ++i) {
+        if (m_e4_table[i].op_class != op_class) continue;
+        // Already a 20 MHz primary-channel op_class?
+        if (m_e4_table[i].has_beaconchannel && m_e4_table[i].channel_spacing == 20) {
+            return op_class;
+        }
+        // Find first 20 MHz primary-channel op_class for the same band
+        em_freq_band_t band = m_e4_table[i].band;
+        for (size_t j = 0; j < n; ++j) {
+            if (m_e4_table[j].band == band &&
+                m_e4_table[j].has_beaconchannel &&
+                m_e4_table[j].channel_spacing == 20) {
+                return m_e4_table[j].op_class;
+            }
+        }
+        break;
+    }
+    return op_class; // not found – return as-is
 }
 
 em_bss_info_t *dm_easy_mesh_t::get_bss_info_with_mac(mac_address_t mac)
@@ -2663,6 +2911,22 @@ dm_sta_t *dm_easy_mesh_t::find_sta(mac_address_t sta_mac, bssid_t bssid)
     return NULL;
 }
 
+dm_sta_t *dm_easy_mesh_t::find_sta(mac_address_t sta_mac)
+{
+    for (unsigned int i = 0; i < get_num_bss(); i++) {
+        auto *bss = get_bss_info(i);
+        if (bss == NULL) {
+            continue;
+        }
+
+        auto *sta = find_sta(sta_mac, bss->bssid.mac);
+        if (sta != NULL) {
+            return sta;
+        }
+    }
+    return NULL;
+}
+
 dm_sta_t *dm_easy_mesh_t::get_first_sta(mac_address_t sta_mac)
 {
     dm_sta_t *sta;
@@ -2781,6 +3045,17 @@ int dm_easy_mesh_t::get_num_bss_for_associated_sta(mac_address_t sta_mac)
     return num_bssids;
 }
 
+bool dm_easy_mesh_t::is_sta_mld(mac_address_t sta_mac)
+{
+    for (unsigned int i = 0; i < m_num_assoc_sta_mld; i++) {
+        if (memcmp(sta_mac, m_assoc_sta_mld[i].m_assoc_sta_mld_info.mac_addr, sizeof(mac_address_t)) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void dm_easy_mesh_t::clone_hash_maps(dm_easy_mesh_t& obj)
 {
     mac_addr_str_t  sta_mac_str, bss_mac_str, radio_mac_str;
@@ -2839,6 +3114,7 @@ void dm_easy_mesh_t::deinit()
 		snprintf(key, sizeof(em_2xlong_string_t), "%s@%s@%s@%d@%d@%d", tmp_res->m_scan_result.id.net_id, dev_mac_str, scanner_mac_str,
 					tmp_res->m_scan_result.id.op_class, tmp_res->m_scan_result.id.channel, tmp_res->m_scan_result.id.scanner_type);
 		hash_map_remove(m_scan_result_map, key);
+        delete tmp_res;
 	}
 
 	hash_map_destroy(m_scan_result_map);	
@@ -2900,7 +3176,6 @@ void dm_easy_mesh_t::set_policy(dm_policy_t policy)
 	dm_policy_t *ppolicy;
 	bool found_match = false;
 	bool temp = 0;
-
     for (i = 0; i < m_num_policy; i++) {
         ppolicy = &m_policy[i];
         temp = ((strncmp(policy.m_policy.id.net_id, ppolicy->m_policy.id.net_id, strlen(policy.m_policy.id.net_id)) == 0) &&
@@ -3130,6 +3405,80 @@ em_ap_mld_info_t *dm_easy_mesh_t::get_ap_mld_frm_bssid(mac_address_t bss_id)
     return NULL;
 }
 
+bool dm_easy_mesh_t::is_ap_mld_mac(const mac_address_t mac)
+{
+    const em_ap_mld_info_t *ap_mld_info = NULL;
+
+    if (mac == NULL) {
+        return false;
+    }
+
+    for (unsigned int i = 0; i < m_num_ap_mld; i++) {
+        ap_mld_info = &m_ap_mld[i].m_ap_mld_info;
+        if (!ap_mld_info->mac_addr_valid) {
+            continue;
+        }
+        if (memcmp(ap_mld_info->mac_addr, mac, sizeof(mac_address_t)) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool dm_easy_mesh_t::resolve_ap_mld_to_fallback_ruid(const mac_address_t ap_mld_mac, mac_address_t fallback_ruid)
+{
+    em_ap_mld_info_t *ap_mld_info = NULL;
+    unsigned int i, j;
+
+    if ((ap_mld_mac == NULL) || (fallback_ruid == NULL)) {
+        return false;
+    }
+
+    for (i = 0; i < m_num_ap_mld; i++) {
+        ap_mld_info = &m_ap_mld[i].m_ap_mld_info;
+        if (!ap_mld_info->mac_addr_valid) {
+            continue;
+        }
+        if (memcmp(ap_mld_info->mac_addr, ap_mld_mac, sizeof(mac_address_t)) != 0) {
+            continue;
+        }
+
+        em_printfout("resolve_ap_mld_to_fallback_ruid: ap_mld=%s num_affiliated_ap=%d num_bss=%d",
+            util::mac_to_string(ap_mld_mac).c_str(), ap_mld_info->num_affiliated_ap, m_num_bss);
+
+        // Use the first valid affiliated AP's RUID as fallback.
+        for (j = 0; j < ap_mld_info->num_affiliated_ap; j++) {
+            mac_addr_str_t aff_mac_str, stored_ruid_str, bss_ruid_str;
+            dm_easy_mesh_t::macbytes_to_string(ap_mld_info->affiliated_ap[j].mac_addr, aff_mac_str);
+            dm_easy_mesh_t::macbytes_to_string(ap_mld_info->affiliated_ap[j].ruid.mac, stored_ruid_str);
+            em_printfout("  affiliated_ap[%d]: mac=%s valid=%d stored_ruid=%s",
+                j, aff_mac_str,
+                ap_mld_info->affiliated_ap[j].mac_addr_valid,
+                stored_ruid_str);
+            // Cross-check: find this BSSID in m_bss[] and log its ruid
+            for (unsigned int k = 0; k < m_num_bss; k++) {
+                if (memcmp(m_bss[k].m_bss_info.bssid.mac,
+                           ap_mld_info->affiliated_ap[j].mac_addr,
+                           sizeof(mac_address_t)) == 0) {
+                    dm_easy_mesh_t::macbytes_to_string(m_bss[k].m_bss_info.ruid.mac, bss_ruid_str);
+                    em_printfout("    m_bss[%d] bssid=%s ruid=%s", k, aff_mac_str, bss_ruid_str);
+                }
+            }
+            if (!ap_mld_info->affiliated_ap[j].mac_addr_valid) {
+                continue;
+            }
+            memcpy(fallback_ruid, ap_mld_info->affiliated_ap[j].ruid.mac, sizeof(mac_address_t));
+            em_printfout("  returning stored_ruid=%s for affiliated_ap[%d]",
+                stored_ruid_str, j);
+            return true;
+        }
+        return false;
+    }
+
+    return false;
+}
+
 void dm_easy_mesh_t::update_ap_mld_info(em_ap_mld_info_t *ap_mld_info)
 {
 
@@ -3213,8 +3562,98 @@ void dm_easy_mesh_t::update_bsta_mld_info(em_bsta_mld_info_t *bsta_mld_info)
 
 void dm_easy_mesh_t::update_assoc_sta_mld_info(em_assoc_sta_mld_info_t *assoc_sta_mld_info)
 {
-    // TODO: Implement ASSOC MLD info update logic
-    em_printfout("Enter");
+    em_assoc_sta_mld_info_t *target_mld = NULL;
+    em_affiliated_sta_info_t *input_sta = NULL;                             
+    em_affiliated_sta_info_t *target_aff_sta = NULL;                        
+    unsigned int i, j, k;
+
+    // Find existing assoc STA MLD entry by STA MLD MAC address
+    for (i = 0; i < m_num_assoc_sta_mld; i++) {
+        if (memcmp(m_assoc_sta_mld[i].m_assoc_sta_mld_info.mac_addr, assoc_sta_mld_info->mac_addr,
+                sizeof(mac_address_t)) == 0) {
+            target_mld = &m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+            break;
+        }
+    }
+
+    // If not found, create a new entry
+    if (!target_mld) {
+        if (m_num_assoc_sta_mld >= EM_MAX_ASSOC_STA_MLD) {
+            em_printfout("Max assoc STA MLD entries reached");
+            return;
+        }
+
+        target_mld = &m_assoc_sta_mld[m_num_assoc_sta_mld].m_assoc_sta_mld_info;
+        memset(target_mld, 0, sizeof(em_assoc_sta_mld_info_t));
+        m_num_assoc_sta_mld++;
+    }
+
+    // Update top-level MLD fields
+    memcpy(target_mld->mac_addr, assoc_sta_mld_info->mac_addr, sizeof(mac_address_t));
+    memcpy(target_mld->ap_mld_mac_addr, assoc_sta_mld_info->ap_mld_mac_addr, sizeof(mac_address_t));
+    target_mld->str   = assoc_sta_mld_info->str;
+    target_mld->nstr  = assoc_sta_mld_info->nstr;
+    target_mld->emlsr = assoc_sta_mld_info->emlsr;
+    target_mld->emlmr = assoc_sta_mld_info->emlmr;
+
+    // Update affiliated STA entries, keyed by BSSID.
+    // Keep this incremental because some callers may feed one affiliated link per update.
+    for (j = 0; j < assoc_sta_mld_info->num_affiliated_sta; j++) {
+        input_sta = &assoc_sta_mld_info->affiliated_sta[j];
+        target_aff_sta = NULL;
+        bool aff_sta_found = false;
+
+        for (k = 0; k < target_mld->num_affiliated_sta; k++) {
+            if (memcmp(target_mld->affiliated_sta[k].bssid, input_sta->bssid,
+                    sizeof(mac_address_t)) == 0) {
+                target_aff_sta = &target_mld->affiliated_sta[k];
+                aff_sta_found = true;
+                break;
+            }
+        }
+
+        if (!aff_sta_found) {
+            if (target_mld->num_affiliated_sta >= EM_MAX_AP_MLD) {
+                em_printfout("Max affiliated STAs reached for assoc STA MLD");
+                continue;
+            }
+
+            target_aff_sta = &target_mld->affiliated_sta[target_mld->num_affiliated_sta];
+            memset(target_aff_sta, 0, sizeof(em_affiliated_sta_info_t));
+            target_mld->num_affiliated_sta++;
+        }
+
+        memcpy(target_aff_sta->bssid, input_sta->bssid, sizeof(mac_address_t));
+        memcpy(target_aff_sta->link_addr, input_sta->link_addr, sizeof(mac_address_t));
+    }
+}
+
+void dm_easy_mesh_t::remove_assoc_sta_mld_info(mac_address_t sta_mld_mac)
+{
+    unsigned int found_idx = m_num_assoc_sta_mld; // sentinel: not found
+    unsigned int i;
+
+    for (i = 0; i < m_num_assoc_sta_mld; i++) {
+        if (memcmp(m_assoc_sta_mld[i].m_assoc_sta_mld_info.mac_addr, sta_mld_mac,
+                sizeof(mac_address_t)) == 0) {
+            found_idx = i;
+            break;
+        }
+    }
+
+    if (found_idx == m_num_assoc_sta_mld) {
+        return; // not found
+    }
+
+    // Compact the array: shift entries after found_idx one position left.
+    for (unsigned int i = found_idx; i < m_num_assoc_sta_mld - 1; i++) {
+        m_assoc_sta_mld[i] = m_assoc_sta_mld[i + 1];
+    }
+
+    // Zero out the vacated last slot and decrement count.
+    //memset(&m_assoc_sta_mld[m_num_assoc_sta_mld - 1], 0, sizeof(dm_assoc_sta_mld_t));
+    m_assoc_sta_mld[m_num_assoc_sta_mld - 1].init();
+    m_num_assoc_sta_mld--;
 }
 
 void dm_easy_mesh_t::reset_db_cfg_type(db_cfg_type_t type) 

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -371,6 +371,43 @@ void dm_easy_mesh_list_t::put_radio(const char *key, const dm_radio_t *radio)
         pradio = dm->get_radio(dm->get_num_radios() - 1);
     }
     *pradio = *radio;
+
+    // Create default per-radio policies (radio_metrics_rep and steering_param) for newly discovered radios.
+    if (dm != NULL) {
+        bool has_radio_metrics = false, has_steering_param = false;
+        for (unsigned int p = 0; p < dm->get_num_policy(); p++) {
+            if (memcmp(dm->m_policy[p].m_policy.id.radio_mac, pradio->m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                if (dm->m_policy[p].m_policy.id.type == em_policy_id_type_radio_metrics_rep) has_radio_metrics = true;
+                if (dm->m_policy[p].m_policy.id.type == em_policy_id_type_steering_param) has_steering_param = true;
+            }
+        }
+        if (!has_radio_metrics) {
+            em_policy_t rm_default = {};
+            strncpy(rm_default.id.net_id, "OneWifiMesh", sizeof(rm_default.id.net_id) - 1);
+            rm_default.id.type = em_policy_id_type_radio_metrics_rep;
+            rm_default.policy = em_steering_policy_type_disallowed;
+            rm_default.util_threshold = 60;
+            rm_default.rcpi_threshold = 120;
+            rm_default.rcpi_hysteresis = 5;
+            rm_default.sta_traffic_stats = true;
+            rm_default.sta_link_metric = true;
+            dm_policy_t rp(rm_default);
+            memcpy(rp.m_policy.id.radio_mac, pradio->m_radio_info.intf.mac, sizeof(mac_address_t));
+            dm->set_policy(rp);
+        }
+        if (!has_steering_param) {
+            em_policy_t sp_default = {};
+            strncpy(sp_default.id.net_id, "OneWifiMesh", sizeof(sp_default.id.net_id) - 1);
+            sp_default.id.type = em_policy_id_type_steering_param;
+            sp_default.policy = em_steering_policy_type_rcpi_allowed;
+            sp_default.util_threshold = 60;
+            sp_default.rcpi_threshold = 120;
+            dm_policy_t sp(sp_default);
+            memcpy(sp.m_policy.id.radio_mac, pradio->m_radio_info.intf.mac, sizeof(mac_address_t));
+            dm->set_policy(sp);
+        }
+    }
+
     em_printfout("Radio dev_id is:%s", util::mac_to_string(pradio->m_radio_info.id.dev_mac).c_str());
     if ((em = m_mgr->create_node(&pradio->m_radio_info.intf, static_cast<em_freq_band_t> (pradio->m_radio_info.media_data.band), dm, false,
             em_profile_type_3, em_service_type_ctrl)) != NULL) {
@@ -701,8 +738,8 @@ void dm_easy_mesh_list_t::put_sta(const char *key, const dm_sta_t *sta)
     }
 
     if ((psta = static_cast<dm_sta_t *> (hash_map_get(dm->m_sta_map, key))) != NULL) {
-        //printf("%s:%d: STA:%s already present on BSS:%s of radio:%s dm:%p dm_mac:%s\n", __func__, __LINE__,
-        //    sta_mac_str, bssid_str, radio_mac_str, dm, util::mac_to_string(dm->m_device.m_device_info.intf.mac).c_str());
+        em_printfout("%s:%d: STA:%s already present on BSS:%s of radio:%s dm:%p dm_mac:%s\n", __func__, __LINE__,
+           sta_mac_str, bssid_str, radio_mac_str, dm, util::mac_to_string(dm->m_device.m_device_info.intf.mac).c_str());
         memcpy(&psta->m_sta_info, &sta->m_sta_info, sizeof(em_sta_info_t));
         return;
     }
@@ -710,8 +747,8 @@ void dm_easy_mesh_list_t::put_sta(const char *key, const dm_sta_t *sta)
     psta = new dm_sta_t(*sta);
     hash_map_put(dm->m_sta_map, strdup(key), psta);
 
-    //printf("%s:%d: STA:%s added to BSS:%s of radio:%s dm:%p dm_mac:%s\n", __func__, __LINE__,
-    //        sta_mac_str, bssid_str, radio_mac_str, dm, util::mac_to_string(dm->m_device.m_device_info.intf.mac).c_str());
+    em_printfout("%s:%d: STA:%s added to BSS:%s of radio:%s dm:%p dm_mac:%s\n", __func__, __LINE__,
+           sta_mac_str, bssid_str, radio_mac_str, dm, util::mac_to_string(dm->m_device.m_device_info.intf.mac).c_str());
 }
 
 dm_network_ssid_t *dm_easy_mesh_list_t::get_first_network_ssid()
@@ -1026,8 +1063,12 @@ dm_op_class_t *dm_easy_mesh_list_t::get_first_pre_set_op_class_by_type(em_op_cla
 
 	for (i = 0; i < dm->get_num_op_class(); i++) {
 		op_class = &dm->m_op_class[i];
-		if (op_class->m_op_class_info.id.type == type) {
-			return op_class;
+        // Make sure PRESET opclasses should not include the radio level anticipated opclasses
+		if (op_class->m_op_class_info.id.type == type ) {
+                if (type != em_op_class_type_anticipated ||
+                    memcmp(op_class->m_op_class_info.id.ruid, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                    return op_class;
+                }
 		}
 	}	
 
@@ -1050,7 +1091,10 @@ dm_op_class_t *dm_easy_mesh_list_t::get_next_pre_set_op_class_by_type(em_op_clas
 		pop_class = &dm->m_op_class[i];
 
 		if ((return_next == true) && (pop_class->m_op_class_info.id.type == type)) {
-			return pop_class;
+            if (type != em_op_class_type_anticipated ||
+                memcmp(pop_class->m_op_class_info.id.ruid, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                return pop_class;
+            }
 		}
 
 		if ((pop_class->m_op_class_info.id.type == type) &&
@@ -1200,26 +1244,29 @@ dm_policy_t *dm_easy_mesh_list_t::get_policy(const char *key)
 	dm_policy_t::parse_dev_radio_mac_from_key(key, &id);
 	dm_easy_mesh_t::macbytes_to_string(id.dev_mac, dev_mac_str);
 	dm_easy_mesh_t::macbytes_to_string(id.radio_mac, radio_mac_str);
-	//printf("%s:%d: Net id: %s\tdev: %s\tradio: %s\tType: %d\n", __func__, __LINE__, id.net_id, dev_mac_str, radio_mac_str, id.type);
+	em_printfout("%s:%d: Net id: %s\tdev: %s\tradio: %s\tType: %d\n", __func__, __LINE__, id.net_id, dev_mac_str, radio_mac_str, id.type);
 	dm_easy_mesh_t::macbytes_to_string(id.dev_mac, dev_mac_str);
 
 	if ((dm = get_data_model(id.net_id, id.dev_mac)) == NULL) {
-		printf("%s:%d: Could not find data model for Network: %s and dev: %s\n", __func__, __LINE__, id.net_id, dev_mac_str);
+		em_printfout("Could not find data model for Network: %s and dev: %s\n", id.net_id, dev_mac_str);
 		return NULL;
 	} 
 
 	for (i = 0; i < dm->get_num_policy(); i++) {
 		policy = &dm->m_policy[i];
+        em_printfout("compare with policy[%d]: Net id: %s[%s]\tdev: %s[%s]\tradio: %s[%s]\tType: %d[%d]\n", i, policy->m_policy.id.net_id, id.net_id,
+            util::mac_to_string(policy->m_policy.id.dev_mac).c_str(), dev_mac_str,
+            util::mac_to_string(policy->m_policy.id.radio_mac).c_str(), radio_mac_str, policy->m_policy.id.type, id.type);
 		if ((strncmp(policy->m_policy.id.net_id, id.net_id, strlen(id.net_id)) == 0) && 
 				(memcmp(policy->m_policy.id.dev_mac, id.dev_mac, sizeof(mac_address_t)) == 0) && 
 				(memcmp(policy->m_policy.id.radio_mac, id.radio_mac, sizeof(mac_address_t)) == 0) && 
 				(policy->m_policy.id.type == id.type)) {
-			//printf("%s:%d: Policy found for key: %s\n", __func__, __LINE__, key);
+			em_printfout("%s:%d: Policy found for key: %s\n", __func__, __LINE__, key);
 			return policy;
 		}
 	}
 
-	printf("%s:%d: Policy not found for key: %s\n", __func__, __LINE__, key);
+	em_printfout("Policy not found for key: %s\n", key);
 	return NULL;
 }
 
@@ -1523,38 +1570,43 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
     dm_network_t *net, *pnet;
     dm_device_t *dev;
     dm_network_ssid_t *net_ssid, *pnet_ssid;
+	// Per-radio policies (radio_metrics_rep, steering_param) are NOT initialized here.
+	// They are created with real radio MACs in put_radio() when radios are discovered.
 	const em_policy_t	em_policy[] = {
 						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-							em_policy_id_type_ap_metrics_rep}, 0, {}, em_steering_policy_type_unknown, 
-							0, 0, 5, 0, false, false, false, "", false, false, false, {0, 0},
-							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
-						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
-							em_policy_id_type_radio_metrics_rep}, 0, {}, em_steering_policy_type_unknown, 
-							60, 120, 0, 5, true, true, false, "", false, false, false, {0, 0},
-							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
+							em_policy_id_type_ap_metrics_rep}, 0, {}, em_steering_policy_type_disallowed,
+							0, 0, 5, 0, false, false, false, "", false, {}, false, false, false, 0, {0, 0},
+                            {0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}, {}, {}, {}, {}},
 						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-							em_policy_id_type_steering_local}, 1, {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}, 
-							em_steering_policy_type_unknown, 
-							0, 0, 0, 0, false, false, false, "", false, false, false, {0, 0},
-							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
+							em_policy_id_type_steering_local}, 1, {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+							em_steering_policy_type_disallowed,
+							0, 0, 0, 0, false, false, false, "", false, {}, false, false, false, 0, {0, 0},
+                            {0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}, {}, {}, {}, {}},
 						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-							em_policy_id_type_steering_btm}, 1, {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}, 
-							em_steering_policy_type_unknown, 
-							0, 0, 0, 0, false, false, false, "", false, false, false, {0, 0},
-							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
-						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
-							em_policy_id_type_steering_param}, 1, {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}, 
-							em_steering_policy_type_rcpi_allowed, 
-							60, 120, 0, 0, false, false, false, "", false, false, false, {0, 0},
-							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
+							em_policy_id_type_steering_btm}, 1, {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+							em_steering_policy_type_disallowed,
+							0, 0, 0, 0, false, false, false, "", false, {}, false, false, false, 0, {0, 0},
+                            {0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}, {}, {}, {}, {}},
 						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-							em_policy_id_type_channel_scan}, 0, {}, em_steering_policy_type_unknown,
-							0, 0, 0, 0, false, false, false, "", false, false, false, {0, 0},
-							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
+							em_policy_id_type_channel_scan}, 0, {}, em_steering_policy_type_disallowed,
+							0, 0, 0, 0, false, false, false, "", false, {}, false, false, false, 0, {0, 0},
+                            {0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}, {}, {}, {}, {}},
 						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-							em_policy_id_type_default_8021q_settings}, 0, {}, em_steering_policy_type_unknown,
-							0, 0, 0, 0, false, false, false, "", false, false, false, {1, 2},
-							{0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}},
+							em_policy_id_type_default_8021q_settings}, 0, {}, em_steering_policy_type_disallowed,
+							0, 0, 0, 0, false, false, false, "", false, {}, false, false, false, 0, {1, 2},
+                            {0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}, {}, {}, {}, {}},
+						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+							em_policy_id_type_unsuccess_assoc}, 0, {}, em_steering_policy_type_disallowed,
+							0, 0, 0, 0, false, false, false, "", false, {}, false, false, false, 0, {0, 0},
+                            {0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}, {}, {}, {}, {}},
+						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+							em_policy_id_type_backhaul_bss_config}, 0, {}, em_steering_policy_type_disallowed,
+							0, 0, 0, 0, false, false, false, "", false, {}, false, false, false, 0, {0, 0},
+                            {0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}, {}, {}, {}, {}},
+						{{"OneWifiMesh", {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+							em_policy_id_type_qos_mgt}, 0, {}, em_steering_policy_type_disallowed,
+							0, 0, 0, 0, false, false, false, "", false, {}, false, false, false, 0, {0, 0},
+                            {0, {{0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}, {0, "", 0}}}, {}, {}, {}, {}, {}, {}},
 					};
     unsigned int i;
     bool colocated = false;
@@ -1567,14 +1619,15 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
 		dm_op_class_t({{{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, em_op_class_type_scan_param, 135}, 135, 0, 0, 0, 1, {1}, {0}, EM_CH_PREF_ENTRY_VALID, 0, 0, 0})
 									};
 	dm_policy_t	policy[] = {
-								dm_policy_t(em_policy[0]), dm_policy_t(em_policy[1]), 
-								dm_policy_t(em_policy[2]), dm_policy_t(em_policy[3]), 
+								dm_policy_t(em_policy[0]), dm_policy_t(em_policy[1]),
+								dm_policy_t(em_policy[2]), dm_policy_t(em_policy[3]),
 								dm_policy_t(em_policy[4]), dm_policy_t(em_policy[5]),
-								dm_policy_t(em_policy[6])
-						};
-	
+								dm_policy_t(em_policy[6]), dm_policy_t(em_policy[7])
+							};
+
     dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (al_intf->mac), mac_str);
     snprintf(key, sizeof(em_short_string_t), "%s@%s", net_id, mac_str);
+
 
     dm = new dm_easy_mesh_t();
     dm->init();
@@ -1611,6 +1664,7 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
     memcpy(dev->m_device_info.intf.mac, al_intf->mac, sizeof(mac_address_t));
     strncpy(dev->m_device_info.id.net_id, net_id, strlen(net_id) + 1);
 	if (controller == true) {
+		memcpy(dev->m_device_info.id.dev_mac, al_intf->mac, sizeof(mac_address_t));
 		dev->m_device_info.id.media = dm->m_network.m_net_info.media;
 		//TODO: Monitor Checks
 		//memcpy(dev->m_device_info.backhaul_mac.mac, al_intf->mac, sizeof(mac_address_t));

--- a/src/dm/dm_op_class_list.cpp
+++ b/src/dm/dm_op_class_list.cpp
@@ -43,7 +43,7 @@
 int dm_op_class_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
 {
     dm_op_class_t *pop_class;
-    cJSON *obj, *non_op_arr, *anticipated_arr, *channel_arr;
+    cJSON *obj, *non_op_arr, *anticipated_arr, *anticipated_pref_list, *channel_arr;
     unsigned int i;
     em_op_class_id_t id;
     em_op_class_info_t *info;
@@ -86,7 +86,16 @@ int dm_op_class_list_t::get_config(cJSON *obj_arr, void *parent, bool summary)
 			anticipated_arr = cJSON_AddArrayToObject(obj, "ChannelList");
 			for (i = 0; i < pop_class->m_op_class_info.num_channels; i++) {
             	cJSON_AddItemToArray(anticipated_arr, cJSON_CreateNumber(pop_class->m_op_class_info.channels[i]));
-        	}
+            }
+            if (id.type == em_op_class_type_anticipated) {
+                if (pop_class->m_op_class_info.pref_valid) {
+                    anticipated_pref_list = cJSON_AddArrayToObject(obj, "ChannelPrefList");
+                    for (i = 0; i < pop_class->m_op_class_info.num_channels; i++) {
+                        cJSON_AddItemToArray(anticipated_pref_list, cJSON_CreateNumber(pop_class->m_op_class_info.channel_pref[i]));
+                    }
+                }
+
+            }
     	}
 		cJSON_AddItemToArray(obj_arr, obj);
 		pop_class = get_next_op_class(pop_class);

--- a/src/dm/dm_policy.cpp
+++ b/src/dm/dm_policy.cpp
@@ -54,11 +54,21 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
 		if ((sta_arr_obj = cJSON_GetObjectItem(obj, "Disallowed STA")) == NULL) {
 			return 0;
 		}
+		static const mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 		for (i = 0; i < cJSON_GetArraySize(sta_arr_obj); i++) {
+			if (m_policy.num_sta >= EM_MAX_STA_PER_STEER_POLICY) {
+				break;
+			}
 			tmp = cJSON_GetArrayItem(sta_arr_obj, i);
-			dm_easy_mesh_t::string_to_macbytes(cJSON_GetStringValue(cJSON_GetObjectItem(tmp, "MAC")), 
-					m_policy.sta_mac[m_policy.num_sta]);
-			m_policy.num_sta++;	
+			char *mac_str = cJSON_GetStringValue(tmp);
+			if (mac_str == NULL) {
+				continue;
+			}
+			dm_easy_mesh_t::string_to_macbytes(mac_str, m_policy.sta_mac[m_policy.num_sta]);
+			if (memcmp(m_policy.sta_mac[m_policy.num_sta], null_mac, sizeof(mac_address_t)) == 0) {
+				continue;
+			}
+			m_policy.num_sta++;
 		}
 	} else if (type == em_policy_id_type_steering_param) {
 		if ((tmp = cJSON_GetObjectItem(obj, "Steering Policy")) != NULL) {
@@ -97,7 +107,7 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
             m_policy.sta_status = tmp->valuedouble;
         }
 	} else if (type == em_policy_id_type_default_8021q_settings) {
-		if ((tmp = cJSON_GetObjectItem(obj, "Primay VLAN ID")) != NULL) {
+		if ((tmp = cJSON_GetObjectItem(obj, "Primary VLAN ID")) != NULL) {
 			m_policy.def_8021q_settings.primary_vid = static_cast<unsigned short>(tmp->valuedouble);
 		}
 		if ((tmp = cJSON_GetObjectItem(obj, "Default PCP")) != NULL) {
@@ -107,7 +117,52 @@ int dm_policy_t::decode(const cJSON *obj, void *parent_id, em_policy_id_type_t t
     	if ((tmp = cJSON_GetObjectItem(obj, "Report Independent Channel Scans")) != NULL) {
    			m_policy.independent_scan_report = tmp->valuedouble;
     	}
-    } else if (type == em_policy_id_type_alarm_threshold) {
+    } else if (type == em_policy_id_type_unsuccess_assoc) {
+		if ((tmp = cJSON_GetObjectItem(obj, "Report Unsuccessful Associations")) != NULL) {
+			m_policy.report_unassoc_sta = static_cast<bool>(tmp->valueint);
+		}
+		if ((tmp = cJSON_GetObjectItem(obj, "Maximum Reporting Rate")) != NULL) {
+			m_policy.max_reporting_rate = static_cast<unsigned int>(tmp->valuedouble);
+		}
+	} else if (type == em_policy_id_type_backhaul_bss_config) {
+        if ((tmp = cJSON_GetObjectItem(obj, "BSSID")) != NULL) {
+			if (m_policy.num_backhaul_bss_config < EM_MAX_BSS_PER_RADIO) {
+				unsigned int slot = m_policy.num_backhaul_bss_config;
+				dm_easy_mesh_t::string_to_macbytes(cJSON_GetStringValue(tmp), m_policy.backhaul_bss_config[slot].bssid);
+				if ((tmp = cJSON_GetObjectItem(obj, "Profile-1 bSTA Disallowed")) != NULL) {
+					m_policy.backhaul_bss_config[slot].b_profile_1_sta_disallowed = static_cast<bool>(tmp->valueint);
+				}
+				if ((tmp = cJSON_GetObjectItem(obj, "Profile-2 bSTA Disallowed")) != NULL) {
+					m_policy.backhaul_bss_config[slot].b_profile_2_sta_disallowed = static_cast<bool>(tmp->valueint);
+				}
+				m_policy.num_backhaul_bss_config++;
+			}
+		}
+	} else if (type == em_policy_id_type_qos_mgt) {
+		if (m_policy.num_qos_mgt < EM_MAX_STA_PER_AGENT) {
+			unsigned int slot = m_policy.num_qos_mgt;
+			cJSON *mac_arr_obj;
+			if ((mac_arr_obj = cJSON_GetObjectItem(obj, "MSCS Disallowed STA List")) != NULL) {
+				for (i = 0; i < static_cast<int>(cJSON_GetArraySize(mac_arr_obj)) &&
+						m_policy.qos_mgt[slot].num_mscs < EM_MAX_MSC_PER_TRAFFIC_SEPAR; i++) {
+					tmp = cJSON_GetArrayItem(mac_arr_obj, i);
+					dm_easy_mesh_t::string_to_macbytes(cJSON_GetStringValue(tmp),
+							m_policy.qos_mgt[slot].msc_mac[m_policy.qos_mgt[slot].num_mscs]);
+					m_policy.qos_mgt[slot].num_mscs++;
+				}
+			}
+			if ((mac_arr_obj = cJSON_GetObjectItem(obj, "SCS Disallowed STA List")) != NULL) {
+				for (i = 0; i < static_cast<int>(cJSON_GetArraySize(mac_arr_obj)) &&
+						m_policy.qos_mgt[slot].num_scs < EM_MAX_SCS_PER_TRAFFIC_SEPAR; i++) {
+					tmp = cJSON_GetArrayItem(mac_arr_obj, i);
+					dm_easy_mesh_t::string_to_macbytes(cJSON_GetStringValue(tmp),
+							m_policy.qos_mgt[slot].sc_mac[m_policy.qos_mgt[slot].num_scs]);
+					m_policy.qos_mgt[slot].num_scs++;
+				}
+			}
+			m_policy.num_qos_mgt++;
+		}
+	} else if (type == em_policy_id_type_alarm_threshold) {
         if ((tmp = cJSON_GetObjectItem(obj, "Collection Start Time")) != NULL) {
             snprintf(m_policy.link_stats_alarm_cfg.collection_start_time, sizeof(em_long_string_t), "%s", cJSON_GetStringValue(tmp));
         }
@@ -151,18 +206,20 @@ void dm_policy_t::encode(cJSON *obj, em_policy_id_type_t id)
 {
     unsigned int i;
 	mac_addr_str_t	dev_mac_str, radio_mac_str, sta_mac_str;
-	cJSON *sta_arr_obj, *sta_obj;
+	cJSON *sta_arr_obj;
 
 	dm_easy_mesh_t::macbytes_to_string(m_policy.id.dev_mac, dev_mac_str);
 	dm_easy_mesh_t::macbytes_to_string(m_policy.id.radio_mac, radio_mac_str);
 
 	if ((id == em_policy_id_type_steering_local) || (id == em_policy_id_type_steering_btm)) {
+		static const mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 		sta_arr_obj = cJSON_AddArrayToObject(obj, "Disallowed STA");
 		for (i = 0; i < m_policy.num_sta; i++) {
-			sta_obj = cJSON_CreateObject();
+			if (memcmp(m_policy.sta_mac[i], null_mac, sizeof(mac_address_t)) == 0) {
+				continue;
+			}
 			dm_easy_mesh_t::macbytes_to_string(m_policy.sta_mac[i], sta_mac_str);
-			cJSON_AddStringToObject(sta_obj, "MAC", sta_mac_str);
-			cJSON_AddItemToArray(sta_arr_obj, sta_obj);
+			cJSON_AddItemToArray(sta_arr_obj, cJSON_CreateString(sta_mac_str));
 		}
 
 	} else if (id == em_policy_id_type_steering_param) {
@@ -185,13 +242,30 @@ void dm_policy_t::encode(cJSON *obj, em_policy_id_type_t id)
 	} else if (id == em_policy_id_type_channel_scan) {
 		cJSON_AddNumberToObject(obj, "Report Independent Channel Scans", m_policy.independent_scan_report);
 	} else if (id == em_policy_id_type_unsuccess_assoc) {
-
+        cJSON_AddBoolToObject(obj, "Report Unsuccessful Associations", m_policy.report_unassoc_sta);
+        cJSON_AddNumberToObject(obj, "Maximum Reporting Rate", m_policy.max_reporting_rate);
 	} else if (id == em_policy_id_type_backhaul_bss_config) {
-
-	} else if (id == em_policy_id_type_unsuccess_assoc) {
-
+		for (unsigned int b = 0; b < m_policy.num_backhaul_bss_config; b++) {
+			cJSON *item = cJSON_CreateObject();
+			dm_easy_mesh_t::macbytes_to_string(m_policy.backhaul_bss_config[b].bssid, sta_mac_str);
+			cJSON_AddStringToObject(item, "BSSID", sta_mac_str);
+			cJSON_AddBoolToObject(item, "Profile-1 bSTA Disallowed", m_policy.backhaul_bss_config[b].b_profile_1_sta_disallowed);
+			cJSON_AddBoolToObject(item, "Profile-2 bSTA Disallowed", m_policy.backhaul_bss_config[b].b_profile_2_sta_disallowed);
+			cJSON_AddItemToArray(obj, item);
+		}
 	} else if (id == em_policy_id_type_qos_mgt) {
-
+		for (unsigned int q = 0; q < m_policy.num_qos_mgt; q++) {
+			cJSON *mscs_arr = cJSON_AddArrayToObject(obj, "MSCS Disallowed STA List");
+			for (i = 0; i < m_policy.qos_mgt[q].num_mscs; i++) {
+				dm_easy_mesh_t::macbytes_to_string(m_policy.qos_mgt[q].msc_mac[i], sta_mac_str);
+				cJSON_AddItemToArray(mscs_arr, cJSON_CreateString(sta_mac_str));
+			}
+			cJSON *scs_arr = cJSON_AddArrayToObject(obj, "SCS Disallowed STA List");
+			for (i = 0; i < m_policy.qos_mgt[q].num_scs; i++) {
+				dm_easy_mesh_t::macbytes_to_string(m_policy.qos_mgt[q].sc_mac[i], sta_mac_str);
+				cJSON_AddItemToArray(scs_arr, cJSON_CreateString(sta_mac_str));
+			}
+		}
 	}
 }
 
@@ -199,21 +273,7 @@ bool dm_policy_t::operator == (const dm_policy_t& obj)
 {
     int ret = 0;
 
-    ret += (memcmp(&this->m_policy.id.dev_mac, &obj.m_policy.id.dev_mac, sizeof(mac_address_t)) != 0);
-    ret += (memcmp(&this->m_policy.id.radio_mac, &obj.m_policy.id.radio_mac, sizeof(mac_address_t)) != 0);
-    ret += !(this->m_policy.interval == obj.m_policy.interval);
-    ret += !(this->m_policy.independent_scan_report == obj.m_policy.independent_scan_report);
-    ret += !(this->m_policy.rcpi_threshold == obj.m_policy.rcpi_threshold);
-    ret += !(this->m_policy.rcpi_hysteresis == obj.m_policy.rcpi_hysteresis);
-    ret += !(this->m_policy.util_threshold == obj.m_policy.util_threshold);
-    ret += !(this->m_policy.sta_traffic_stats == obj.m_policy.sta_traffic_stats);
-    ret += !(this->m_policy.sta_link_metric == obj.m_policy.sta_link_metric);
-    ret += !(this->m_policy.sta_status == obj.m_policy.sta_status);
-    ret += (strncmp(this->m_policy.managed_sta_marker, obj.m_policy.managed_sta_marker, strlen(this->m_policy.managed_sta_marker)) != 0);
-    ret += (memcmp(&this->m_policy.def_8021q_settings, &obj.m_policy.def_8021q_settings, sizeof(em_8021q_settings_policy_t)) != 0);
-    ret += (memcmp(&this->m_policy.traffic_separ, &obj.m_policy.traffic_separ, sizeof(em_traffic_separation_policy_t)) != 0);
-    ret += (memcmp(&m_policy.link_stats_alarm_cfg, &obj.m_policy.link_stats_alarm_cfg, sizeof(em_link_stats_alarm_cfg_t)) != 0);
-    ret += (memcmp(&m_policy.client_filters, &obj.m_policy.client_filters, sizeof(em_client_filters_cfg_t)) != 0);
+    ret += (memcmp(&m_policy, &obj.m_policy, sizeof(em_policy_t)) != 0);
 
     return (ret > 0) ? false:true;
 }
@@ -221,27 +281,7 @@ bool dm_policy_t::operator == (const dm_policy_t& obj)
 void dm_policy_t::operator = (const dm_policy_t& obj)
 {
     if (this == &obj) { return; }
-	memcpy(&this->m_policy.id.net_id, &obj.m_policy.id.net_id, sizeof(mac_address_t));
-    memcpy(&this->m_policy.id.dev_mac, &obj.m_policy.id.dev_mac, sizeof(mac_address_t));
-    memcpy(&this->m_policy.id.radio_mac, &obj.m_policy.id.radio_mac, sizeof(mac_address_t));
-    m_policy.id.type = obj.m_policy.id.type;
-    m_policy.num_sta = obj.m_policy.num_sta;
-    for(unsigned int i = 0; i < m_policy.num_sta; i++) {
-        memcpy(this->m_policy.sta_mac[i], obj.m_policy.sta_mac[i], sizeof(mac_address_t));
-    }
-    m_policy.policy = obj.m_policy.policy;
-    this->m_policy.interval = obj.m_policy.interval;
-    this->m_policy.independent_scan_report = obj.m_policy.independent_scan_report;
-    this->m_policy.rcpi_threshold = obj.m_policy.rcpi_threshold;
-    this->m_policy.rcpi_hysteresis = obj.m_policy.rcpi_hysteresis;
-    this->m_policy.util_threshold = obj.m_policy.util_threshold;
-    this->m_policy.sta_traffic_stats = obj.m_policy.sta_traffic_stats;
-    this->m_policy.sta_link_metric = obj.m_policy.sta_link_metric;
-    this->m_policy.sta_status = obj.m_policy.sta_status;
-    strncpy(this->m_policy.managed_sta_marker, obj.m_policy.managed_sta_marker, sizeof(em_long_string_t));
-    memcpy(&this->m_policy.def_8021q_settings, &obj.m_policy.def_8021q_settings, sizeof(em_8021q_settings_policy_t));
-    memcpy(&m_policy.link_stats_alarm_cfg, &obj.m_policy.link_stats_alarm_cfg, sizeof(em_link_stats_alarm_cfg_t));
-    memcpy(&m_policy.client_filters, &obj.m_policy.client_filters, sizeof(em_client_filters_cfg_t));
+    memcpy(&m_policy, &obj.m_policy, sizeof(em_policy_t));
 }
 
 int dm_policy_t::parse_dev_radio_mac_from_key(const char *key, em_policy_id_t *id)

--- a/src/dm/dm_policy_list.cpp
+++ b/src/dm/dm_policy_list.cpp
@@ -42,12 +42,16 @@
 int dm_policy_list_t::get_config(cJSON *parent_obj, void *parent, bool summary)
 {
     dm_policy_t *policy;
-	cJSON *obj, *radio_metrics_arr_obj, *radio_steer_arr_obj;
+	cJSON *obj, *radio_metrics_arr_obj, *radio_steer_arr_obj, *steering_policies_obj;
 	mac_addr_str_t radio_mac_str;
 	mac_address_t dev_mac;
 	mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 	dm_easy_mesh_t::string_to_macbytes(static_cast<char *>(parent), dev_mac);
+
+	// Create the Steering Policies wrapper up front so it can be populated in both loops.
+	steering_policies_obj = cJSON_CreateObject();
+	cJSON_AddItemToObject(parent_obj, "Steering Policies", steering_policies_obj);
 
 	// first report the global policies for the device, for global the radio id will be NULL
     policy = static_cast<dm_policy_t *>(get_first_policy());
@@ -66,10 +70,10 @@ int dm_policy_list_t::get_config(cJSON *parent_obj, void *parent, bool summary)
 
 		if (policy->m_policy.id.type == em_policy_id_type_steering_local) {
 			policy->encode(obj, em_policy_id_type_steering_local);
-			cJSON_AddItemToObject(parent_obj, "Local Steering Disallowed Policy", obj);
+			cJSON_AddItemToObject(steering_policies_obj, "Local Steering Disallowed Policy", obj);
 		} else if (policy->m_policy.id.type == em_policy_id_type_steering_btm) {
 			policy->encode(obj, em_policy_id_type_steering_btm);
-			cJSON_AddItemToObject(parent_obj, "BTM Steering Disallowed Policy", obj);
+			cJSON_AddItemToObject(steering_policies_obj, "BTM Steering Disallowed Policy", obj);
 		} else if (policy->m_policy.id.type == em_policy_id_type_ap_metrics_rep) {
 			policy->encode(obj, em_policy_id_type_ap_metrics_rep);
 			cJSON_AddItemToObject(parent_obj, "AP Metrics Reporting Policy", obj);
@@ -79,9 +83,36 @@ int dm_policy_list_t::get_config(cJSON *parent_obj, void *parent, bool summary)
         } else if (policy->m_policy.id.type == em_policy_id_type_channel_scan) {
 			policy->encode(obj, em_policy_id_type_channel_scan);
 			cJSON_AddItemToObject(parent_obj, "Channel Scan Reporting Policy", obj);
+		} else if (policy->m_policy.id.type == em_policy_id_type_unsuccess_assoc) {
+			policy->encode(obj, em_policy_id_type_unsuccess_assoc);
+			cJSON_AddItemToObject(parent_obj, "Unsuccessful Association Policy", obj);
 		} else if (policy->m_policy.id.type == em_policy_id_type_backhaul_bss_config) {
-			policy->encode(obj, em_policy_id_type_backhaul_bss_config);
-			cJSON_AddItemToObject(parent_obj, "Backhaul BSS Configuration Policy", obj);
+			dm_easy_mesh_ctrl_t *ctrl = dynamic_cast<dm_easy_mesh_ctrl_t *>(this);
+			dm_easy_mesh_t *dev_dm = ctrl ? ctrl->get_data_model(GLOBAL_NET_ID, dev_mac) : nullptr;
+			if (dev_dm != nullptr) {
+				policy->m_policy.num_backhaul_bss_config = 0;
+				for (unsigned int bi = 0; bi < dev_dm->m_num_bss && policy->m_policy.num_backhaul_bss_config < EM_MAX_BSS_PER_RADIO; bi++) {
+					em_bss_info_t *bss_info = dev_dm->m_bss[bi].get_bss_info();
+					if (bss_info == nullptr || bss_info->id.haul_type != em_haul_type_backhaul) {
+						continue;
+					}
+					if (memcmp(bss_info->bssid.mac, null_mac, sizeof(mac_address_t)) == 0) {
+						continue;
+					}
+
+					unsigned int cnt = policy->m_policy.num_backhaul_bss_config;
+					memcpy(policy->m_policy.backhaul_bss_config[cnt].bssid, bss_info->bssid.mac, sizeof(mac_address_t));
+					policy->m_policy.backhaul_bss_config[cnt].b_profile_1_sta_disallowed = bss_info->r1_disallowed;
+					policy->m_policy.backhaul_bss_config[cnt].b_profile_2_sta_disallowed = bss_info->r2_disallowed;
+					policy->m_policy.num_backhaul_bss_config++;
+				}
+			}
+			cJSON *arr = cJSON_CreateArray();
+			policy->encode(arr, em_policy_id_type_backhaul_bss_config);
+			cJSON_AddItemToObject(parent_obj, "Backhaul BSS Configuration Policy", arr);
+		} else if (policy->m_policy.id.type == em_policy_id_type_qos_mgt) {
+			policy->encode(obj, em_policy_id_type_qos_mgt);
+			cJSON_AddItemToObject(parent_obj, "QoS Management Policy", obj);
 		} else if (policy->m_policy.id.type == em_policy_id_type_alarm_threshold) {
             policy->encode(obj, em_policy_id_type_alarm_threshold);
             cJSON_AddItemToObject(parent_obj, "Algorithm Run Policy", obj);
@@ -92,11 +123,10 @@ int dm_policy_list_t::get_config(cJSON *parent_obj, void *parent, bool summary)
     }
 
 	// then report the policies of the radios of this device
-	
 	radio_metrics_arr_obj = cJSON_CreateArray();
 	cJSON_AddItemToObject(parent_obj, "Radio Specific Metrics Policy", radio_metrics_arr_obj);
 	radio_steer_arr_obj = cJSON_CreateArray();
-	cJSON_AddItemToObject(parent_obj, "Radio Steering Parameters", radio_steer_arr_obj);
+	cJSON_AddItemToObject(steering_policies_obj, "Radio Steering Parameters", radio_steer_arr_obj);
 
     policy = static_cast<dm_policy_t *>(get_first_policy());
     while (policy != NULL) {
@@ -105,6 +135,7 @@ int dm_policy_list_t::get_config(cJSON *parent_obj, void *parent, bool summary)
 	    	continue;
 		}
 
+		// Skip policies with null radio_mac — they are device-global, not radio-specific.
 		if (memcmp(policy->m_policy.id.radio_mac, null_mac, sizeof(mac_address_t)) == 0) {
 	    	policy = get_next_policy(policy);
 	    	continue;
@@ -119,7 +150,7 @@ int dm_policy_list_t::get_config(cJSON *parent_obj, void *parent, bool summary)
 			cJSON_AddItemToArray(radio_steer_arr_obj, obj);
 		} else if (policy->m_policy.id.type == em_policy_id_type_radio_metrics_rep) {
 			policy->encode(obj, em_policy_id_type_radio_metrics_rep);
-			cJSON_AddItemToArray(radio_metrics_arr_obj, obj);
+            cJSON_AddItemToArray(radio_metrics_arr_obj, obj);
 		}
 
 		policy = get_next_policy(policy);
@@ -175,12 +206,13 @@ dm_orch_type_t dm_policy_list_t::get_dm_orch_type(db_client_t& db_client, const 
             return dm_orch_type_db_insert;
         }
 
-        if (*ppolicy == policy) {
-            return dm_orch_type_db_update;
-        }
-
         return dm_orch_type_db_update;
     }  
+
+    // Not in memory — still check if the DB already has this row to avoid duplicates.
+    if (entry_exists_in_table(db_client, key) == true) {
+        return dm_orch_type_db_update;
+    }
 
     return dm_orch_type_db_insert;
 }
@@ -323,9 +355,11 @@ int dm_policy_list_t::sync_db(db_client_t& db_client, void *ctx)
 
     while (db_client.next_result(ctx)) {
         memset(&policy, 0, sizeof(em_policy_t));
+        memset(&id, 0, sizeof(id));
 
         db_client.get_string(ctx, str, 1);
 		dm_policy_t::parse_dev_radio_mac_from_key(str, &id);
+		strncpy(policy.id.net_id, id.net_id, sizeof(policy.id.net_id));
 		memcpy(policy.id.dev_mac, id.dev_mac, sizeof(mac_address_t));
 		memcpy(policy.id.radio_mac, id.radio_mac, sizeof(mac_address_t));
         policy.id.type = static_cast<em_policy_id_type_t>(db_client.get_number(ctx, 2));

--- a/src/dm/dm_radio_cap.cpp
+++ b/src/dm/dm_radio_cap.cpp
@@ -82,49 +82,15 @@ void dm_radio_cap_t::encode(cJSON *obj)
 */
 }
 
-bool dm_radio_cap_t::operator == (const dm_radio_cap_t& obj)
+bool dm_radio_cap_t::operator == (const dm_radio_cap_t& obj) const
 {
-    int ret = 0;
-    ret += (memcmp(&this->m_radio_cap_info.ruid.mac ,&obj.m_radio_cap_info.ruid.mac,sizeof(mac_address_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.ruid.name,&obj.m_radio_cap_info.ruid.name,sizeof(em_interface_name_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.ht_cap,&obj.m_radio_cap_info.ht_cap,sizeof(em_ap_ht_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.vht_cap,&obj.m_radio_cap_info.vht_cap,sizeof(em_ap_vht_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.he_cap,&obj.m_radio_cap_info.he_cap,sizeof(em_ap_he_cap_t)) != 0);
-    ret += !(this->m_radio_cap_info.num_op_classes == obj.m_radio_cap_info.num_op_classes);
-    ret += (memcmp(&this->m_radio_cap_info.wifi6_cap,&obj.m_radio_cap_info.wifi6_cap,sizeof(em_radio_wifi6_cap_data_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.wifi7_cap,&obj.m_radio_cap_info.wifi7_cap,sizeof(em_wifi7_agent_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.ch_scan,&obj.m_radio_cap_info.ch_scan,sizeof(em_channel_scan_cap_radio_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.radio_ad_cap,&obj.m_radio_cap_info.radio_ad_cap,sizeof(em_ap_radio_advanced_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.prof_2_ap_cap,&obj.m_radio_cap_info.prof_2_ap_cap,sizeof(em_profile_2_ap_cap_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.cac_cap,&obj.m_radio_cap_info.cac_cap,sizeof(em_cac_cap_radio_t)) != 0);
-    ret += (memcmp(&this->m_radio_cap_info.metric_interval,&obj.m_radio_cap_info.metric_interval,sizeof(em_metric_cltn_interval_t)) != 0);
-   
-     //em_util_info_print(EM_MGR, "%s:%d: MUH ret=%d\n", __func__, __LINE__,ret);
-
-     if (ret > 0)
-        return false;
-    else
-        return true;
-
+    return (memcmp(&this->m_radio_cap_info, &obj.m_radio_cap_info, sizeof(em_radio_cap_info_t)) == 0);
 }
 
 void dm_radio_cap_t::operator = (const dm_radio_cap_t& obj)
 {
     if (this == &obj) { return; }
-    memcpy(&this->m_radio_cap_info.ruid.mac ,&obj.m_radio_cap_info.ruid.mac,sizeof(mac_address_t));
-    memcpy(&this->m_radio_cap_info.ruid.name,&obj.m_radio_cap_info.ruid.name,sizeof(em_interface_name_t));
-    memcpy(&this->m_radio_cap_info.ht_cap,&obj.m_radio_cap_info.ht_cap,sizeof(em_ap_ht_cap_t));
-    memcpy(&this->m_radio_cap_info.vht_cap,&obj.m_radio_cap_info.vht_cap,sizeof(em_ap_vht_cap_t));
-    memcpy(&this->m_radio_cap_info.he_cap,&obj.m_radio_cap_info.he_cap,sizeof(em_ap_he_cap_t));
-    memcpy(&this->m_radio_cap_info.wifi6_cap,&obj.m_radio_cap_info.wifi6_cap,sizeof(em_radio_wifi6_cap_data_t));
-    memcpy(&this->m_radio_cap_info.wifi7_cap,&obj.m_radio_cap_info.wifi7_cap,sizeof(em_wifi7_agent_cap_t));
-    memcpy(&this->m_radio_cap_info.ch_scan,&obj.m_radio_cap_info.ch_scan,sizeof(em_channel_scan_cap_radio_t));
-    memcpy(&this->m_radio_cap_info.radio_ad_cap,&obj.m_radio_cap_info.radio_ad_cap,sizeof(em_ap_radio_advanced_cap_t));
-    memcpy(&this->m_radio_cap_info.prof_2_ap_cap,&obj.m_radio_cap_info.prof_2_ap_cap,sizeof(em_profile_2_ap_cap_t));
-    memcpy(&this->m_radio_cap_info.cac_cap,&obj.m_radio_cap_info.cac_cap,sizeof(em_cac_cap_radio_t));
-    memcpy(&this->m_radio_cap_info.metric_interval,&obj.m_radio_cap_info.metric_interval,sizeof(em_metric_cltn_interval_t));
-    this->m_radio_cap_info.num_op_classes = obj.m_radio_cap_info.num_op_classes;
-
+    memcpy(&this->m_radio_cap_info, &obj.m_radio_cap_info, sizeof(em_radio_cap_info_t));
 }
 
 dm_radio_cap_t::dm_radio_cap_t(em_radio_cap_info_t *radio_cap)

--- a/src/dm/dm_scan_result.cpp
+++ b/src/dm/dm_scan_result.cpp
@@ -252,8 +252,8 @@ bool dm_scan_result_t::has_same_id(em_scan_result_id_t *id)
 }
 
 dm_scan_result_t::dm_scan_result_t(em_scan_result_t *scan_result)
+    : m_scan_result{}
 {
-	memset(&m_scan_result, 0, sizeof(em_scan_result_t));
 	if (scan_result == nullptr) {
 		em_printfout("Error: scan_result is null");
 		return;
@@ -262,18 +262,20 @@ dm_scan_result_t::dm_scan_result_t(em_scan_result_t *scan_result)
 }
 
 dm_scan_result_t::dm_scan_result_t(const dm_scan_result_t& scan_result)
+    : m_scan_result{}
 {
     memcpy(&m_scan_result, &scan_result.m_scan_result, sizeof(em_scan_result_t));
 }
 
 dm_scan_result_t::dm_scan_result_t(const em_scan_result_t& scan_result)
+    : m_scan_result{}
 {
     memcpy(&m_scan_result, &scan_result, sizeof(em_scan_result_t));
 }
 
 dm_scan_result_t::dm_scan_result_t()
+    : m_scan_result{}
 {
-	memset(&m_scan_result, 0, sizeof(em_scan_result_t));
 }
 
 dm_scan_result_t::~dm_scan_result_t()

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -142,6 +142,10 @@ int dm_sta_t::decode(const cJSON *obj, void *parent_id)
         snprintf(m_sta_info.cellular_data_pref, sizeof(m_sta_info.cellular_data_pref), "%s", cJSON_GetStringValue(tmp));
     }
 
+    if ((tmp = cJSON_GetObjectItem(obj, "RMEnabledCapabilities")) != NULL) {
+        snprintf(m_sta_info.rm_cap, sizeof(m_sta_info.rm_cap), "%s", cJSON_GetStringValue(tmp));
+    }
+
     return 0;
 
 }
@@ -403,6 +407,13 @@ void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
 
     sta->m_sta_info.num_vendor_infos = 0;
 
+    /* The frame_body stores the full 802.11 (Re)Association Request frame body:
+     * capab_info (2B) + listen_interval (2B) + IEs. Skip the fixed fields. */
+    if (sta->m_sta_info.frame_body_len < 4) {
+        return;
+    }
+    offset = 4;
+
     while (offset < sta->m_sta_info.frame_body_len) {
         if (offset + 2 > sta->m_sta_info.frame_body_len) {
             printf("%s:%d: Insufficient data for tag header\n", __func__, __LINE__);
@@ -540,6 +551,24 @@ void dm_sta_t::decode_beacon_report(dm_sta_t *sta)
 
        ie += current_pkt_len;
    }
+}
+
+bool dm_sta_t::supports_beacon_measurement() const
+{
+    // IEEE 802.11 (RM Enabled Capabilities, Octet 1):
+    //   bit 4 = Beacon Passive measurement
+    //   bit 5 = Beacon Active measurement
+    //   bit 6 = Beacon Table measurement
+    // Mask 0x70 covers all three.
+    if (m_sta_info.rm_cap == nullptr || m_sta_info.rm_cap[0] == '\0') {
+        return false;
+    }
+    unsigned int byte0 = 0;
+    if (sscanf(m_sta_info.rm_cap, "%02x", &byte0) != 1) {
+        return false;
+    }
+    //return true if any of the three beacon measurement bits are set
+    return (byte0 & 0x70) != 0;
 }
 
 dm_sta_t::dm_sta_t(em_sta_info_t *sta)

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -48,7 +48,7 @@
 int em_capability_t::send_ap_cap_report_msg(unsigned char *dst, unsigned short msg_id)
 {
     unsigned char buff[MAX_EM_BUFF_SZ * EM_MAX_RADIO_PER_AGENT] = {0};
-    //char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
     unsigned short  msg_type = em_msg_type_ap_cap_rprt;
     unsigned int len = 0;
     em_cmdu_t *cmdu;
@@ -143,7 +143,7 @@ int em_capability_t::send_ap_cap_report_msg(unsigned char *dst, unsigned short m
         tlv->len = htons(static_cast<uint16_t>(sz));
         tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
         len += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
-#if 1
+
         // AP HE capabilities 17.2.10
         tlv = reinterpret_cast<em_tlv_t *>(tmp);
         tlv->type = em_tlv_type_he_cap;
@@ -152,20 +152,37 @@ int em_capability_t::send_ap_cap_report_msg(unsigned char *dst, unsigned short m
 
         tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
         len += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
-#endif
+
         // AP WiFi6 capabilities 17.2.72
         tlv = reinterpret_cast<em_tlv_t *>(tmp);
         tlv->type = em_tlv_type_ap_wifi6_cap;
         sz = static_cast<unsigned short>(em->create_wifi6_tlv(tlv->value));
         tlv->len = htons(static_cast<uint16_t>(sz));
-        tmp += (sizeof(em_tlv_t) + sz);
-        len += static_cast<unsigned int>(sizeof(em_tlv_t) + sz);
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+        len += static_cast<unsigned int>(sizeof(em_tlv_t) + static_cast<size_t>(sz));
+
+        // AP radio advanced capability tlv 17.2.52
+        sz = static_cast<unsigned short>(em->create_ap_radio_advanced_cap_tlv(tmp + sizeof(em_tlv_t)));
+        if (sz > 0) {
+            tlv = reinterpret_cast<em_tlv_t *>(tmp);
+            tlv->type = em_tlv_type_ap_radio_advanced_cap;
+            tlv->len = htons(static_cast<uint16_t>(sz));
+            tmp += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+            len += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+        }
+
+        // Airties Radio Capability TLV
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_vendor_specific;
+        sz = static_cast<unsigned short>(em->create_airties_radio_capability_tlv(tlv->value));
+        tlv->len = htons(static_cast<uint16_t>(sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
+        len += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
 
         em->set_state(em_state_agent_ap_cap_report);
     }
     em_radios.clear();
 
-#if 0
     // AP Channel Scan capabilities 17.2.38
     tlv = reinterpret_cast<em_tlv_t *>(tmp);
     tlv->type = em_tlv_type_channel_scan_cap;
@@ -217,19 +234,10 @@ int em_capability_t::send_ap_cap_report_msg(unsigned char *dst, unsigned short m
     // AP EHT Operations 17.2.103
     tlv = reinterpret_cast<em_tlv_t *>(tmp);
     tlv->type = em_tlv_eht_operations;
-    sz = static_cast<unsigned short>(em->create_eht_operations_tlv(tlv->value));
+    sz = static_cast<unsigned short>(create_eht_operations_tlv(tlv->value));
     tlv->len = htons(static_cast<uint16_t>(sz));
     tmp += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
     len += (sizeof(em_tlv_t) + static_cast<short unsigned int>(sz));
-
-    // One AP radio advanced capability tlv 17.2.52
-    tlv = reinterpret_cast<em_tlv_t *>(tmp);
-    tlv->type = em_tlv_type_ap_radio_advanced_cap;
-    sz = static_cast<unsigned short>(em->create_radioad_tlv(tlv->value));
-    tlv->len = htons(static_cast<uint16_t>(sz));
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
-#endif
 
     // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -239,18 +247,18 @@ int em_capability_t::send_ap_cap_report_msg(unsigned char *dst, unsigned short m
     tmp += (sizeof(em_tlv_t));
     len += static_cast<unsigned int>((sizeof(em_tlv_t)));
 
-    /*if (em_msg_t(em_msg_type_ap_cap_rprt, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("Topology Response msg failed validation in tnx end");
+    if (em_msg_t(em_msg_type_ap_cap_rprt, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("Error: AP Capability Report msg validation failed in tnx end");
 
         return -1;
-    }*/
+    }
 
     if (send_frame(buff, len)  < 0) {
-        em_printfout("AP capability report send failed, error:%d", errno);
+        em_printfout("Error: AP Capability Report msg send failed, error: %d", errno);
         return -1;
     }
     set_state(em_state_agent_ap_cap_report);
-    em_printfout("AP Cap report sent successfully, len[%d]", len);
+    em_printfout("AP Capability Report msg sent successfully, len[%d]", len);
     return static_cast<int> (len);
 }
 
@@ -312,17 +320,17 @@ int em_capability_t::send_client_cap_query()
     tmp += (sizeof (em_tlv_t));
     len += (sizeof (em_tlv_t));
     if (em_msg_t(em_msg_type_client_cap_query, em_profile_type_3, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        em_printfout("Capability Query msg failed validation in tnx end");
+        em_printfout("Error: Client Capability Query msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        em_printfout("Capability Query msg failed, error:%d", errno);
+        em_printfout("Error: Client Capability Query msg send failed, error: %d", errno);
         return -1;
     }
 
     m_cap_query_tx_cnt++;
-    em_printfout("Capability Query (%d) Send Successful for sta:%s", m_cap_query_tx_cnt, evt_param->u.args.args[2]);
+    em_printfout("Client Capability Query msg (%d) sent successfully for sta: %s", m_cap_query_tx_cnt, evt_param->u.args.args[2]);
 
     return static_cast<int> (len);
 }
@@ -342,10 +350,9 @@ short em_capability_t::create_client_cap_tlv(unsigned char *buff, mac_address_t 
         if (memcmp(dm_sta->get_sta_info()->id, sta, sizeof(mac_address_t)) == 0) {
             break;
         }
-        dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
+        dm_sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, dm_sta));
     }
 
-    //TODO; if dm_sta is null break; fill result 0?
     if(dm_sta == NULL) {
         return 0;
     }
@@ -390,7 +397,7 @@ short em_capability_t::create_error_code_tlv(unsigned char *buff, mac_address_t 
 
     memcpy(tmp, sta, sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
-    len += static_cast<short> (sizeof(unsigned char));
+    len += static_cast<short> (sizeof(mac_address_t));
 
     return len;
 }
@@ -509,17 +516,17 @@ int em_capability_t::send_client_cap_report_msg(mac_address_t sta, bssid_t bss, 
     len += (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_client_cap_rprt, em_profile_type_3, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        printf("%s:%d: Client capability report validation failed\n", __func__, __LINE__);
+        em_printfout("Error: Client Capability Report msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: Client Capablity report send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: Client Capability Report msg send failed, error: %d", errno);
         return -1;
     }
 
     dm_easy_mesh_t::macbytes_to_string(sta, mac_str);
-    printf("%s:%d: Client Capablity report Send Successful for sta:%s\n", __func__, __LINE__, mac_str);
+    em_printfout("Client Capability Report msg sent successfully for sta: %s", mac_str);
 
     return static_cast<int> (len);
 }
@@ -571,15 +578,15 @@ int em_capability_t::send_ap_cap_query_msg()
     len += static_cast<unsigned int> (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_ap_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
-        em_printfout("AP capability Query msg failed validation in tnx end");
+        em_printfout("Error: AP Capability Query msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, len)  < 0) {
-        em_printfout("%s:%d: AP capability Query send failed, error:%d", errno);
+        em_printfout("Error: AP Capability Query msg send failed, error: %d", errno);
         return -1;
     }
-    em_printfout("AP capability Query Sent for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
+    em_printfout("AP Capability Query msg sent successfully for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
 
     return 0;
 }
@@ -631,16 +638,16 @@ int em_capability_t::send_bsta_cap_query_msg()
     len += static_cast<unsigned int> (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_bh_sta_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("Backhaul Sta capability Query msg failed validation in tnx end\n");
+        em_printfout("Error: Backhaul Sta Capability Query msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, len)  < 0) {
-        printf("%s:%d: Backhaul Sta capability Query send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: Backhaul Sta Capability Query msg send failed, error: %d", errno);
         return -1;
     }
 
-    em_printfout("Backhaul Sta capability Query Sent for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
+    em_printfout("Backhaul Sta Capability Query msg sent successfully for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
 
     return 0;
 }
@@ -716,16 +723,16 @@ int em_capability_t::send_bsta_cap_report_msg(unsigned short msg_id)
     len += (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_bh_sta_cap_rprt, em_profile_type_3, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        em_printfout("Backhaul Sta capability report validation failed");
+        em_printfout("Error: Backhaul Sta Capability Report msg validation failed in tnx end");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        em_printfout("Backhaul Sta capability report send failed");
+        em_printfout("Error: Backhaul Sta Capability Report msg send failed");
         return -1;
     }
 
-    em_printfout("Backhaul Sta capability report Send Successful");
+    em_printfout("Backhaul Sta Capability Report msg sent successfully");
 
     return static_cast<int> (len);
 }
@@ -736,16 +743,25 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     em_tlv_t *tlv;
     em_sta_info_t sta_info;
     mac_addr_str_t sta_mac_str, bssid_str, radio_mac_str;
+    mac_addr_str_t link_bssid_str, link_radio_str;
     em_long_string_t	key;
     dm_easy_mesh_t  *dm;
+    em_assoc_sta_mld_info_t *assoc_info = NULL;
+    dm_bss_t *aff_bss = NULL;
+    dm_sta_t *existing_link_sta = NULL;
+    dm_sta_t *existing_sta = NULL;
+    em_sta_info_t link_sta_info;
+    em_long_string_t link_key;
     bool found_client_info = false;
     bool found_cap_report = false;
+    bool updated_any = false;
+    unsigned int i, j, k;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
 
     dm = get_data_model();
 
     if (em_msg_t(em_msg_type_client_cap_rprt, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("%s:%d:Client Capability query message validation failed\n",__func__,__LINE__);
+        em_printfout("Error: Client Capability Report msg validation failed");
         return -1;
     }
 
@@ -756,7 +772,23 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
             memset(&sta_info, 0, sizeof(em_sta_info_t));
             memcpy(sta_info.bssid, tlv->value, sizeof(mac_address_t));
             memcpy(sta_info.id, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
-            memcpy(sta_info.radiomac, get_radio_interface_mac(), sizeof(mac_address_t));
+            // Resolve the radio MAC from the BSSID so the key is correct regardless
+            // of which EM instance handled this message.
+            // First search this EM's DM, then walk all DMs if not found (the cap report
+            // may arrive on the controller's own EM whose DM doesn't hold agent BSSes).
+            bool radio_found = false;
+            for (unsigned int r = 0; r < dm->get_num_radios() && !radio_found; r++) {
+                dm_bss_t *bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, sta_info.bssid);
+                if (bss != NULL) {
+                    memcpy(sta_info.radiomac, bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+                    radio_found = true;
+                    em_printfout("client_cap_report: resolved radio %s for sta %s bssid %s",
+                        util::mac_to_string(sta_info.radiomac).c_str(),
+                        util::mac_to_string(sta_info.id).c_str(),
+                        util::mac_to_string(sta_info.bssid).c_str());
+                }
+            }
+
             found_client_info = true;
             break;
         }
@@ -766,8 +798,33 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     }
 
     if (found_client_info == false) {
-        printf("%s:%d: Could not find client info\n", __func__, __LINE__);
+        em_printfout("Error: Could not find client info");
         return -1;
+    }
+
+    if ((dm->get_bss(get_radio_interface_mac(), sta_info.bssid) == NULL) && dm->is_ap_mld_mac(sta_info.bssid)) {
+        em_printfout("Client cap: STA %s is affiliated with MLD BSSID %s, remapping to affiliated link BSSID",
+            util::mac_to_string(sta_info.id).c_str(), util::mac_to_string(sta_info.bssid).c_str());
+        assoc_info = NULL;
+        for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+            if (memcmp(dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info.mac_addr,
+                       sta_info.id,
+                       sizeof(mac_address_t)) == 0) {
+                assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+                break;
+            }
+        }
+
+        if (assoc_info != NULL) {
+            for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+                if (dm->get_bss(get_radio_interface_mac(), assoc_info->affiliated_sta[j].bssid) != NULL) {
+                    memcpy(sta_info.bssid, assoc_info->affiliated_sta[j].bssid, sizeof(mac_address_t));
+                    em_printfout("Client cap: remapped BSSID for STA %s -> %s",
+                        util::mac_to_string(sta_info.id).c_str(), util::mac_to_string(sta_info.bssid).c_str());
+                    break;
+                }
+            }
+        }
     }
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
@@ -791,22 +848,93 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     }
 
     if (found_cap_report == false) {
-        printf("%s:%d: Could not find client cap report\n", __func__, __LINE__);
+        em_printfout("Error: Could not find client cap report");
         return -1;
     }
 
     set_state(em_state_ctrl_sta_cap_confirmed);
 
+      // The cap report may be routed to a different radio than the one running
+    // the sta_assoc command (e.g. MLD: report arrives on 2.4GHz radio but
+    // sta_assoc was dispatched to 6GHz radio which is in sta_cap_pending).
+    // Set sta_cap_confirmed on any AL radio in sta_cap_pending so the
+    // orchestrator's fini check passes.
+    {
+        std::vector<em_t *> al_radios;
+        get_mgr()->get_all_em_for_al_mac(get_data_model()->get_agent_al_interface_mac(), al_radios);
+        for (auto *r : al_radios) {
+            if (r->get_state() == em_state_ctrl_sta_cap_pending) {
+                em_printfout("cap report: setting sta_cap_confirmed on radio %s (was sta_cap_pending)",
+                    util::mac_to_string(r->get_radio_interface_mac()).c_str());
+                r->set_state(em_state_ctrl_sta_cap_confirmed);
+            }
+        }
+    }
+
     dm_easy_mesh_t::macbytes_to_string(sta_info.id, sta_mac_str);
     dm_easy_mesh_t::macbytes_to_string(sta_info.bssid, bssid_str);
-    dm_easy_mesh_t::macbytes_to_string(get_radio_interface_mac(), radio_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(sta_info.radiomac, radio_mac_str);
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
 
-    if (hash_map_get(dm->m_sta_assoc_map, key) == NULL) {
-        hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
-        dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
-        em_printfout("New client updated to db: %s", key);
+    // For MLO STA, update all affiliated link rows.
+    for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+        assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+        if (memcmp(assoc_info->mac_addr, sta_info.id, sizeof(mac_address_t)) != 0) {
+            continue;
+        }
+
+        for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+            aff_bss = NULL;
+            link_sta_info = sta_info;
+            memcpy(link_sta_info.bssid, assoc_info->affiliated_sta[j].bssid, sizeof(mac_address_t));
+            for (k = 0; k < dm->get_num_radios(); k++) {
+                aff_bss = dm->get_bss(dm->get_radio_info(k)->id.ruid, link_sta_info.bssid);
+                if (aff_bss != NULL) {
+                    memcpy(link_sta_info.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+                    break;
+                }
+            }
+
+            if (aff_bss == NULL) {
+                em_printfout("Client cap DB skip link: unresolved BSSID %s for STA %s",
+                    util::mac_to_string(link_sta_info.bssid).c_str(),
+                    util::mac_to_string(link_sta_info.id).c_str());
+                continue;
+            }
+
+            dm_easy_mesh_t::macbytes_to_string(link_sta_info.bssid, link_bssid_str);
+            dm_easy_mesh_t::macbytes_to_string(link_sta_info.radiomac, link_radio_str);
+            snprintf(link_key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, link_bssid_str, link_radio_str);
+
+            existing_link_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, link_key));
+            if (existing_link_sta == NULL) {
+                hash_map_put(dm->m_sta_assoc_map, strdup(link_key), new dm_sta_t(&link_sta_info));
+                em_printfout("Client cap DB new link: %s len=%u assoc=%d",
+                        link_key, link_sta_info.frame_body_len, link_sta_info.associated);
+            } else {
+                memcpy(&existing_link_sta->m_sta_info, &link_sta_info, sizeof(em_sta_info_t));
+                em_printfout("Client cap DB update link: %s len=%u assoc=%d",
+                        link_key, link_sta_info.frame_body_len, link_sta_info.associated);
+            }
+            updated_any = true;
+        }
+        break;
     }
+
+    if (updated_any == false) {
+        existing_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, key));
+        if (existing_sta == NULL) {
+            hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
+            em_printfout("Client cap DB new: %s len=%u assoc=%d",
+                    key, sta_info.frame_body_len, sta_info.associated);
+        } else {
+            memcpy(&existing_sta->m_sta_info, &sta_info, sizeof(em_sta_info_t));
+            em_printfout("Client cap DB update: %s len=%u assoc=%d",
+                    key, sta_info.frame_body_len, sta_info.associated);
+        }
+    }
+
+    dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
     return 0;
 }
 
@@ -815,20 +943,61 @@ void em_capability_t::handle_client_cap_query(unsigned char *buff, unsigned int 
     mac_address_t sta;
     bssid_t bss;
     em_tlv_t *tlv;
+    em_cmdu_t *cmdu;
+    unsigned int tmp_len;
+    unsigned int tlv_sz;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
 
-    if (em_msg_t(em_msg_type_client_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
-        em_printfout("Client Capability query message validation failed");
+    if (buff == NULL) {
+        em_printfout("Client cap query: null buffer");
         return;
     }
 
-    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+    if (len < (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t) + sizeof(em_tlv_t))) {
+        em_printfout("Client cap query: short frame len=%u", len);
+        return;
+    }
+
+    cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
+
+    if (em_msg_t(em_msg_type_client_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("Error: Client Capability Query msg validation failed");
+        return;
+    }
+
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    tmp_len = len - static_cast<unsigned int>(sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+        if (tlv->type == em_tlv_type_client_info) {
+            break;
+        }
+        tlv_sz = static_cast<unsigned int>(sizeof(em_tlv_t) + htons(tlv->len));
+        if (tmp_len < tlv_sz) {
+            em_printfout("Client cap query: malformed tlv chain");
+            return;
+        }
+        tmp_len -= tlv_sz;
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + tlv_sz);
+    }
+
+    if (tlv->type != em_tlv_type_client_info) {
+        em_printfout("Client cap query: client_info tlv not found");
+        return;
+    }
+
+    if (htons(tlv->len) < (2 * sizeof(mac_address_t))) {
+        em_printfout("Client cap query: invalid client_info tlv len=%u", htons(tlv->len));
+        return;
+    }
 
     memcpy(bss, tlv->value, sizeof(bssid_t));
     memcpy(sta, tlv->value + sizeof(mac_address_t), sizeof(bssid_t));
 
-    send_client_cap_report_msg(sta, bss, ntohs(cmdu->id));
+    if (send_client_cap_report_msg(sta, bss, ntohs(cmdu->id)) < 0) {
+        em_printfout("Client cap report send failed for sta=%s",
+                util::mac_to_string(sta).c_str());
+    }
     set_state(em_state_agent_configured);
 }
 
@@ -838,100 +1007,178 @@ int em_capability_t::handle_bsta_cap_query(unsigned char *buff, unsigned int len
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
 
     if (em_msg_t(em_msg_type_bh_sta_cap_query, em_profile_type_3, buff, len).validate(errors) == 0) {
-        em_printfout("Backhaul Sta Capability query message validation failed");
+        em_printfout("Error: Backhaul Sta Capability Query msg validation failed");
         return -1;
     }
 
-    em_printfout("Backhaul Sta Capability query message rcvd");
+    em_printfout("Backhaul Sta Capability Query msg rcvd");
 
     send_bsta_cap_report_msg(ntohs(cmdu->id));
 
     return 0;
 }
 
-int em_capability_t::handle_bsta_radio_cap(unsigned char *buff, unsigned int len)
+int em_capability_t::handle_bsta_radio_cap(unsigned char *tlv_buff, unsigned int tlv_len)
 {
-    dm_easy_mesh_t *dm = get_data_model();
-    em_bh_sta_radio_cap_t *bsta_radio_cap = reinterpret_cast<em_bh_sta_radio_cap_t*>(buff);
-
-    em_printfout("Rcvd Backhaul STA Radio Capabilities received, sta mac: %s for radio: %s, mac present: %d",
-        util::mac_to_string(bsta_radio_cap->bsta_addr).c_str(),
-        util::mac_to_string(bsta_radio_cap->ruid).c_str(), bsta_radio_cap->bsta_mac_present);
-
-    //find device based on this radio
-    em_device_info_t *dev = dm->get_device_info();
-    if (dev == NULL) {
-        em_printfout("Could not find device in data model");
+    if (!tlv_buff)
+    {
         return -1;
     }
 
-    em_printfout("Update BSTA Cap for Device id: %s",
-        util::mac_to_string(dev->id.dev_mac).c_str());
+    if (!tlv_len || ((tlv_len != sizeof(em_bh_sta_radio_cap_t)) && (tlv_len != offsetof(em_bh_sta_radio_cap_t, bsta_addr))))
+    {
+        em_printfout("Error: Invalid TLV length:%d Must be %d or %d for bsta radio cap TLV",
+		     static_cast<int>(tlv_len),
+                     static_cast<int>(offsetof(em_bh_sta_radio_cap_t, bsta_addr)),
+                     static_cast<int>(sizeof(em_bh_sta_radio_cap_t)));
+        return -1;
+    }
 
+    em_bh_sta_radio_cap_t *bsta_radio_cap = reinterpret_cast<em_bh_sta_radio_cap_t*>(tlv_buff);
+    std::string ruid_str = util::mac_to_string(bsta_radio_cap->ruid);
+    em_printfout("Rcvd BSTA Cap, for radio: %s, mac present: %d",
+            ruid_str.c_str(),
+            bsta_radio_cap->bsta_mac_present);
+
+    if (tlv_len == offsetof(em_bh_sta_radio_cap_t, bsta_addr))
+    {
+        if (bsta_radio_cap->bsta_mac_present)
+        {
+            em_printfout("Error: bsta_mac_present is 1 when tlv_len is %d", static_cast<int>(offsetof(em_bh_sta_radio_cap_t, bsta_addr)));
+            return -1;
+        }
+        return 0;
+    }
+
+    if (!bsta_radio_cap->bsta_mac_present)
+    {
+        em_printfout("Error: bsta_mac_present is 0 when tlv_len is %d", static_cast<int>(sizeof(em_bh_sta_radio_cap_t)));
+        return -1;
+    }
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (!dm) {
+        em_printfout("Error: Could not find data model");
+        return -1;
+    }
+
+    em_device_info_t *dev = dm->get_device_info();
+    if (!dev)
+    {
+        em_printfout("Error: Could not find device in data model");
+        return -1;
+    }
+
+    em_printfout("Update BSTA Cap for Device id: %s", util::mac_to_string(dev->id.dev_mac).c_str());
     memcpy(dm->m_device.m_device_info.backhaul_sta, bsta_radio_cap->bsta_addr, sizeof(mac_address_t));
     dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
+    return 0;
+}
+
+int em_capability_t::handle_client_info(unsigned char *tlv_buff, unsigned int tlv_len)
+{
+    if (!tlv_buff) {
+        return -1;
+    }
+
+    if (tlv_len != sizeof(em_client_info_t)) {
+        em_printfout("Error: Invalid TLV length for client info TLV: received %u, expected %d", tlv_len, static_cast<int>(sizeof(em_client_info_t)));
+        return -1;
+    }
+
+    const em_client_info_t *client_info = reinterpret_cast<const em_client_info_t *>(tlv_buff);
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (!dm) {
+        em_printfout("Error: Could not find data model");
+        return -1;
+    }
+
+    if (dm->get_colocated() != true) {
+        // bssid is the upstream AP BSSID the bSTA is associated to (Backhaul.MACAddress)
+        memcpy(dm->m_device.m_device_info.backhaul_mac.mac, client_info->bssid, sizeof(mac_address_t));
+        dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
+    }
 
     return 0;
 }
 
-int em_capability_t::handle_bsta_cap_report(unsigned char *buff, unsigned int len)
+int em_capability_t::process_single_tlv_in_1905_message(unsigned char *pkt_buff, unsigned int pkt_len, em_tlv_type_t tlv_type,
+                                      int (em_capability_t::*handler)(unsigned char*, unsigned int))
 {
-    em_tlv_t *tlv;
-    unsigned int tmp_len;
-    dm_easy_mesh_t *dm;
+    em_tlv_t *tlv = NULL;
+    unsigned int header_len = sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t);
 
-    dm = get_data_model();
-
-    tlv =  reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    tmp_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-
-    em_printfout("Backhaul Sta Capability report message rcvd");
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type != em_tlv_type_bh_sta_radio_cap) {
-            tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-            tlv = reinterpret_cast <em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-            continue;
-        } else {
-            handle_bsta_radio_cap(tlv->value, tlv->len);
-            break;
-        }
-        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    em_device_info_t *dev = dm->get_device_info();
-    if (dev == NULL) {
-        em_printfout("Could not find device in data model");
+    if (!pkt_buff || !pkt_len || !handler) {
         return -1;
     }
 
-    tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    tmp_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_client_info) {
-            if(dm->get_colocated() != true ) {
-                em_printfout("Cap: Update backhaul mac for Device id(non-coloc): %s",
-                    util::mac_to_string(dev->id.dev_mac).c_str());
+    if (pkt_len <= header_len) {
+        return -1;
+    }
 
-                memcpy(dm->m_device.m_device_info.backhaul_mac.mac, tlv->value, sizeof(mac_address_t));
-                dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
-            } else {
-                em_printfout("Device is colocated, not updating backhaul mac for Device id: %s, backhaul mac in dm: %s",
-                    util::mac_to_string(dev->id.dev_mac).c_str(),
-                    util::mac_to_string(dm->m_device.m_device_info.backhaul_mac.mac).c_str());
+    em_tlv_t* tlvs_start = reinterpret_cast<em_tlv_t *>(pkt_buff + header_len);
+    unsigned int tlvs_len = pkt_len - header_len;
+
+    if (tlvs_len < sizeof(em_tlv_t)) {
+            return -1;
+    }
+
+    if (tlvs_start->type == em_tlv_type_eom) {
+            if (ntohs(tlvs_start->len) != 0) {
+                     return -1;
             }
+            return 0;
+    }
+
+    tlv = em_msg_t::get_first_tlv(tlvs_start, tlvs_len);
+
+    if (!tlv) {
+            return -1;
+    }
+
+    while (tlv != NULL) {
+        if (tlv->type == em_tlv_type_eom) {
             break;
         }
 
-        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        if (tlv->type == tlv_type) {
+            uint16_t tlv_len = ntohs(tlv->len);
+            return (this->*handler)(tlv->value, tlv_len);
+        }
+
+        tlv = em_msg_t::get_next_tlv(tlv, tlvs_start, tlvs_len);
     }
 
-    set_state(em_state_ctrl_configured);
-    em_printfout("Cap: Bsta Capability report proceesed, ctrl configured");
-
     return 0;
+}
+
+int em_capability_t::handle_bsta_cap_report(unsigned char *pkt_buff, unsigned int pkt_len)
+{
+    int ret = 0;
+
+    em_printfout("Backhaul Sta Capability report message rcvd");
+
+    ret = process_single_tlv_in_1905_message(pkt_buff, pkt_len,
+            em_tlv_type_bh_sta_radio_cap,
+            &em_capability_t::handle_bsta_radio_cap);
+
+    if (ret < 0)
+        em_printfout("Warning: failed to process bh_sta_radio_cap TLV, continuing");
+
+    ret = process_single_tlv_in_1905_message(pkt_buff, pkt_len,
+            em_tlv_type_client_info,
+            &em_capability_t::handle_client_info);
+
+    if (ret < 0)
+        return ret;
+
+    set_state(em_state_ctrl_configured);
+    em_printfout("Cap: Bsta Capability report processed, ctrl configured");
+
+    return ret;
 }
 
 int em_capability_t::handle_ap_radio_basic_cap(unsigned char *buff, unsigned int len)
@@ -1013,95 +1260,131 @@ int em_capability_t::handle_ap_radio_basic_cap(unsigned char *buff, unsigned int
 	return 0;
 }
 
-int em_capability_t::handle_eht_operations_tlv(unsigned char *buff)
+int em_capability_t::handle_channel_scan_cap_tlv(unsigned char *buff, unsigned int len)
 {
-    short len = 0;
-    unsigned int i = 0, j = 0, k = 0, l = 0;
-    unsigned char *tmp = buff;
-    unsigned char num_radios;
-    unsigned char num_bss = 0;
-    em_eht_operations_t eht_ops;
-    dm_easy_mesh_t *dm;
+    dm_easy_mesh_t *dm = get_data_model();
+    const unsigned char *tmp = buff;
+    unsigned int sz = 0;
 
-    dm = get_data_model();
-
-    // 32 octets are reserved for future use, so skip 32 octets
-    short reserved_octets = 32;
-    tmp += reserved_octets;
-    len += reserved_octets;
-
-    memcpy(&num_radios, tmp, sizeof(unsigned char));
-    
-    if (num_radios > EM_MAX_RADIO_PER_AGENT) {
-        em_printfout("Invalid num_radios=%d, max allowed=%d", num_radios, EM_MAX_RADIO_PER_AGENT);
+    if (len < 1) {
+        em_printfout("Channel scan cap TLV too short");
         return -1;
     }
-    
-    eht_ops.radios_num = num_radios;
-    tmp += sizeof(unsigned char);
-    len += static_cast<short> (sizeof(unsigned char));
 
-    for (i = 0; i < num_radios; i++) {
-        memcpy(&eht_ops.radios[i].ruid, tmp, sizeof(mac_address_t));
-        tmp += sizeof(mac_address_t);
-        len += static_cast<short> (sizeof(mac_address_t));
+    unsigned char num_radios_in_tlv = *tmp++;
+    sz++;
+    em_printfout("Channel scan cap TLV: num_radios=%d", num_radios_in_tlv);
 
-        memcpy(&num_bss, tmp, sizeof(unsigned char));
-        
-        if (num_bss > EM_MAX_BSS_PER_RADIO) {
-            em_printfout("Invalid num_bss=%d for radio %d, max allowed=%d", num_bss, i, EM_MAX_BSS_PER_RADIO);
+    // Fixed part of em_channel_scan_cap_radio_t that create_channelscan_tlv advances over.
+    static const size_t radio_hdr_sz = sizeof(em_channel_scan_cap_radio_t)
+                                       - sizeof(static_cast<em_channel_scan_cap_radio_t *>(nullptr)->op_classes);
+
+    for (unsigned char i = 0; i < num_radios_in_tlv; i++) {
+        if (sz + radio_hdr_sz > len) {
+            em_printfout("Channel scan cap TLV truncated at radio[%d] header (sz=%u, len=%u)", i, sz, len);
             return -1;
         }
-        
-        eht_ops.radios[i].bss_num = num_bss;
-        tmp += sizeof(unsigned char);
-        len += static_cast<short> (sizeof(unsigned char));
 
-        for(j = 0; j < num_bss; j++) {
-            memcpy(&eht_ops.radios[i].bss[j], tmp, sizeof(em_eht_operations_bss_t));
-            tmp += sizeof(em_eht_operations_bss_t);
-            len += static_cast<short> (sizeof(em_eht_operations_bss_t));
-        }
-        // 25 octets are reserved for future use in radio, so skip 25 octets
-        short radio_reserved_octets = 25;
-        tmp += radio_reserved_octets;
-        len += radio_reserved_octets;
-    }
+        const em_channel_scan_cap_radio_t *src =
+            reinterpret_cast<const em_channel_scan_cap_radio_t *>(tmp);
 
-    bool found_radio = false;
-    bool found_bss = false;
-    for (i = 0; i < eht_ops.radios_num; i++) {
-        for (j = 0; j < dm->get_num_radios(); j++) {
-            if (memcmp(eht_ops.radios[i].ruid, dm->m_radio[j].m_radio_info.id.dev_mac, sizeof(mac_address_t)) == 0) {
-                found_radio = true;
-                break;
-            }
-        }
-        if (found_radio == false) {
-            em_printfout("Radio with RUID %s not found in data model",
-                util::mac_to_string(eht_ops.radios[i].ruid).c_str());
-            return -1;
-        }
-        found_radio = false;
+        unsigned char num_op_classes = src->op_classes_num;
 
-        for(k = 0; k < eht_ops.radios[i].bss_num; k++) {
-            for(l = 0; l < dm->get_num_bss(); l++) {
-                if (memcmp(eht_ops.radios[i].bss[k].bssid, dm->m_bss[l].m_bss_info.bssid.mac, sizeof(mac_address_t)) == 0) {
-                    found_bss = true;
-                    break;
+        em_printfout("  Radio[%d] RUID=%s boot_only=%d scan_impact=%d "
+                     "min_scan_interval=%u num_op_classes=%d",
+            i, util::mac_to_string(src->ruid).c_str(),
+            src->boot_only, src->scan_impact, ntohl(src->min_scan_interval), num_op_classes);
+
+        tmp += radio_hdr_sz;
+        sz += static_cast<unsigned int>(radio_hdr_sz);
+
+        mac_address_t ruid;
+        memcpy(ruid, src->ruid, sizeof(mac_address_t));
+
+        dm_radio_cap_t *radio_cap = dm->get_radio_cap(ruid);
+        if (radio_cap == NULL) {
+            em_printfout("  Radio[%d]: no DM radio_cap for RUID %s, skipping",
+                i, util::mac_to_string(src->ruid).c_str());
+            // Skip all op class entries for this radio
+            for (unsigned char oi = 0; oi < num_op_classes; oi++) {
+                if (sz + 2 > len) {
+                    em_printfout("Channel scan cap TLV truncated skipping op_class");
+                    return -1;
                 }
+                tmp++;                   // op_class
+                unsigned char nc = *tmp++;
+                sz += 2;
+                if (sz + nc > len) {
+                    em_printfout("Channel scan cap TLV truncated at channel list");
+                    return -1;
+                }
+                tmp += nc;               // channel list
+                sz += nc;
             }
-            if (found_bss == false) {
-                em_printfout("BSS with BSSID %s not found in data model",
-                    util::mac_to_string(eht_ops.radios[i].bss[k].bssid).c_str());
+            continue;
+        }
+
+        em_radio_cap_info_t *cap_info = radio_cap->get_radio_cap_info();
+        if (cap_info == NULL) {
+            em_printfout("  Radio[%d]: cap_info NULL", i);
+            continue;
+        }
+
+        // Populate ch_scan to match the fields create_channelscan_tlv reads back out
+        memcpy(cap_info->ch_scan.ruid, ruid, sizeof(mac_address_t));
+        cap_info->ch_scan.boot_only         = src->boot_only;
+        cap_info->ch_scan.scan_impact       = src->scan_impact;
+        cap_info->ch_scan.reserved          = 0;
+        cap_info->ch_scan.min_scan_interval = ntohl(src->min_scan_interval);
+        cap_info->ch_scan.op_classes_num    = 0;
+
+        for (unsigned char oi = 0; oi < num_op_classes; oi++) {
+            if (sz + 2 > len) {
+                em_printfout("Channel scan cap TLV truncated at op_class[%d]", oi);
                 return -1;
             }
-            found_bss = false;
-            memcpy(&dm->m_bss[l].get_bss_info()->eht_ops, &eht_ops.radios[i].bss[k], sizeof(em_eht_operations_bss_t));
-        }
-    }
+            unsigned char op_class = *tmp++;
+            unsigned char num_chan  = *tmp++;
+            sz += 2;
 
+            em_printfout("    op_class[%d]: op_class=%d num_chan=%d", oi, op_class, num_chan);
+
+            if (sz + num_chan > len) {
+                em_printfout("Channel scan cap TLV truncated at channel list");
+                return -1;
+            }
+
+            if (oi < EM_MAX_OPCLASS) {
+                em_scan_cap_op_class_info_t *entry = &cap_info->ch_scan.op_classes[oi];
+                entry->op_class = op_class;
+                memset(entry->channels.channel, 0, EM_MAX_CHANNELS_IN_LIST);
+                unsigned char copy_n = (num_chan <= EM_MAX_CHANNELS_IN_LIST)
+                                       ? num_chan : EM_MAX_CHANNELS_IN_LIST;
+                entry->num      = copy_n;
+                memcpy(entry->channels.channel, tmp, copy_n);
+                cap_info->ch_scan.op_classes_num++;
+            }
+            tmp += num_chan;
+            sz += num_chan;
+        }
+        em_printfout("  Radio[%d]: stored %d op classes", i, cap_info->ch_scan.op_classes_num);
+    }
     return 0;
+}
+
+
+static wifi_ieee80211Variant_t airties_standards_to_variant(uint16_t std) {
+
+    wifi_ieee80211Variant_t variant = static_cast<wifi_ieee80211Variant_t>(0);
+    if (std & (1 << 15)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_A);
+    if (std & (1 << 14)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_B);
+    if (std & (1 << 13)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_G);
+    if (std & (1 << 12)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_N);
+    if (std & (1 << 11)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_AC);
+    if (std & (1 << 10)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_AX);
+    if (std & (1 <<  9)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_BE);
+    if (std & (1 <<  8)) variant = static_cast<wifi_ieee80211Variant_t>(variant | WIFI_80211_VARIANT_BN);
+    return variant;
 }
 
 int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
@@ -1127,7 +1410,7 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
         if (dm->get_num_radios() > 0) {
             em_printfout("handle_wifi6_cap_tlv: update dm_radio_cap's radio mac");
             for (unsigned int i = 0; i < dm->get_num_radios(); i++) {
-                dm_radio_cap = dm->get_radio_cap(static_cast<int>(i));
+                dm_radio_cap = dm->get_radio_cap(i);
                 if (dm_radio_cap != NULL) {
                     memcpy(dm_radio_cap->m_radio_cap_info.ruid.mac, dm->m_radio[i].m_radio_info.id.ruid, sizeof(mac_address_t));
                     em_printfout("handle_wifi6_cap_tlv: dm_radio_cap updated for MAC %s",
@@ -1222,34 +1505,36 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
             handle_wifi7_agent_cap_tlv(tlv->value);
         }
         else if (tlv->type == em_tlv_eht_operations){
-            handle_eht_operations_tlv(tlv->value);
+            handle_eht_operations_tlv(tlv->value, ntohs(tlv->len));
         }
         else if (tlv->type == em_tlv_type_channel_scan_cap){
-            em_channel_scan_cap_radio_t *scan = reinterpret_cast<em_channel_scan_cap_radio_t *>(tlv->value);
-            dm_radio_cap_t *radio_cap = dm->get_radio_cap(scan->ruid);
-            if (radio_cap != NULL){
-                em_radio_cap_info_t *cap_info = radio_cap->get_radio_cap_info();
-                if ((scan == NULL) && (cap_info == NULL)){
-                    em_printfout("No data Found");
-                    return 0;
-                }
-                memcpy(&cap_info->ch_scan, scan, sizeof(em_channel_scan_cap_radio_t));
-            }
+            em_printfout("Received Channel Scan Capabilities TLV (0xA5)");
+            handle_channel_scan_cap_tlv(tlv->value, ntohs(tlv->len));
         }
         else if (tlv->type == em_tlv_type_1905_layer_security_cap){
         }
         else if (tlv->type == em_tlv_type_cac_cap){
             em_cac_cap_t *cac = reinterpret_cast<em_cac_cap_t *>(tlv->value);
+            if (cac == nullptr) {
+                em_printfout("Invalid CAC TLV: null pointer");
+                return -1;
+            }
+
+            if (cac->radios_num > EM_MAX_RADIO_PER_AGENT) {
+                em_printfout("Invalid CAC TLV: radios_num=%u exceeds max=%u", cac->radios_num, EM_MAX_RADIO_PER_AGENT);
+                return -1;
+            }
+
             for (int idx = 0; idx < cac->radios_num; idx++)
             {
                 dm_radio_cap_t *radio_cap = dm->get_radio_cap(cac->radios[idx].ruid);
-                if ((cac != NULL) && (radio_cap != NULL)){
+                if (radio_cap != NULL){
                     em_radio_cap_info_t *cap_info = radio_cap->get_radio_cap_info();
                     if ((cap_info == NULL)){
                         em_printfout("No data Found");
                         return 0;
                     }
-                    memcpy(&cap_info->cac_cap, &cac->radios[0], sizeof(em_cac_cap_t));
+                    memcpy(&cap_info->cac_cap, &cac->radios[idx], sizeof(cap_info->cac_cap));
                 }
             }
         } else if (tlv->type == em_tlv_type_profile_2_ap_cap){
@@ -1298,18 +1583,55 @@ int em_capability_t::handle_ap_cap_report(unsigned char *buff, unsigned int len)
 
                 adv += sizeof(em_ap_radio_advanced_cap_t);
             }
-        }
+        } else if (tlv->type == em_tlv_type_vendor_specific) {
+            em_vendor_specific_v_t *vendor_tlv = reinterpret_cast<em_vendor_specific_v_t *> (tlv->value);
+            uint16_t value_len = ntohs(tlv->len);
+            dm_easy_mesh_t  *dm;
+            dm = get_data_model();
 
+            if (memcmp(vendor_tlv->vendor_oui, airties_vendor_oui, sizeof(airties_vendor_oui)) == 0) {
+                uint16_t tlv_id;
+                memcpy(&tlv_id, vendor_tlv->data, sizeof(tlv_id));
+                tlv_id = ntohs(tlv_id);
+                if (tlv_id == em_tlv_type_radio_capability) {
+                    if (value_len < sizeof(em_radio_capability_vendor_t) + sizeof(tlv_id) + sizeof(em_vendor_specific_v_t)) {
+                        em_printfout("Invalid TLV length for em_radio_capability_vendor_t");
+                        return -1;
+                    }
+                    em_printfout("Received Radio Capability TLV");
+                    em_radio_capability_vendor_t radio_capability;
+                    memcpy(&radio_capability, vendor_tlv->data + sizeof(tlv_id), sizeof(em_radio_capability_vendor_t));
+                    mac_address_t mac;
+                    memcpy(mac, radio_capability.interface_mac, sizeof(mac_address_t));
+                    uint16_t supported_standards;
+                    memcpy(&supported_standards,
+                           radio_capability.supported_standards,
+                           sizeof(supported_standards));
+                    supported_standards = ntohs(supported_standards);
+
+                    dm_radio_cap_t *radio_cap = dm->get_radio_cap(mac);
+                    if (radio_cap) {
+                        em_radio_cap_info_t *cap_info = radio_cap->get_radio_cap_info();
+                        if (cap_info) {
+                            cap_info->mode = airties_standards_to_variant(supported_standards);
+                        }
+                    }
+                    em_printfout("Parsed Radio Capability TLV - MAC:%s standards:0x%04x",
+                                 util::mac_to_string(mac).c_str(),
+                                 supported_standards);
+                }
+            }
+        }
         tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
         tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
     }
 
     /*if (em_msg_t(em_msg_type_ap_cap_rprt, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("%s:%d:AP Capability report message validation failed\n",__func__,__LINE__);
+        em_printfout("Error: AP Capability Report msg validation failed");
         return -1;
     }*/
 
-    em_printfout("AP Capability report message rcvd for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
+    em_printfout("AP Capability Report msg rcvd for radio: %s", util::mac_to_string(get_radio_interface_mac()).c_str());
 
     return 0;
 }
@@ -1318,6 +1640,7 @@ void em_capability_t::process_msg(unsigned char *data, unsigned int len)
 {
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (data + sizeof(em_raw_hdr_t));
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(data);
+    std::vector<em_t *> em_radios;
 
     switch (htons(cmdu->type)) {
         case em_msg_type_ap_cap_query:
@@ -1362,8 +1685,13 @@ void em_capability_t::process_msg(unsigned char *data, unsigned int len)
                 }
                 break;
             case em_msg_type_client_cap_rprt:
-                if (get_service_type() == em_service_type_ctrl){
-                    handle_client_cap_report(data, len);
+                em_radios.clear();
+                get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
+                for (auto &em : em_radios) {
+                    if (get_service_type() == em_service_type_ctrl){
+                        em->handle_client_cap_report(data, len);
+                        break;
+                    }
                 }
                 break;
 
@@ -1417,11 +1745,23 @@ void em_capability_t::process_ctrl_state()
             break;
 
         case em_state_ctrl_sta_cap_pending:
-            send_client_cap_query();
+            {
+                // Only one radio per AL needs to send the Client Capability Query.
+                // Use the same front-radio guard as em_state_ctrl_ap_cap_query_pending.
+                std::vector<em_t *> em_radios;
+                get_mgr()->get_all_em_for_al_mac(get_data_model()->get_agent_al_interface_mac(), em_radios);
+                if (this == em_radios.front()) {
+                    send_client_cap_query();
+                }
+            }
+            break;
+
+        case em_state_ctrl_topo_sync_pending:
+            // Handled by em_configuration_t::process_ctrl_state() for sta_assoc.
             break;
 
         default:
-            printf("%s:%d: unhandled case %s\n", __func__, __LINE__, em_t::state_2_str(get_state()));
+            em_printfout("unhandled case %s", em_t::state_2_str(get_state()));
             break;
     }
 }

--- a/src/em/channel/em_channel.cpp
+++ b/src/em/channel/em_channel.cpp
@@ -44,6 +44,13 @@
 #include "em_cmd_exec.h"
 #include "util.h"
 
+/*
+ * Bit mask for BSS Color + BSS Load Present field in Channel Scan Report Message.
+ * Defined as constexpr for type safety and limited to this file as it is an
+ * internal implementation detail.
+ */
+constexpr unsigned char BSS_COLOR_BSS_LOAD_PRESENT = 0x80;
+
 short em_channel_t::create_channel_pref_tlv_agent(unsigned char *buff, unsigned int index)
 {
     short len = 0;
@@ -220,22 +227,13 @@ short em_channel_t::create_channel_scan_req_tlv(unsigned char *buff)
 short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
 {
     short len = 0;
-    unsigned int i, j;
     em_channel_pref_t *pref;
     em_channel_pref_op_class_t *pref_op_class;
-    dm_easy_mesh_t *dm;
-    dm_op_class_t *op_class;
     unsigned char *tmp;
     unsigned char pref_bits = 0xee;
     unsigned int num_of_channel = 0;
     em_channels_list_t *channel_list;
 
-    //Stores a merged list of index of Anticipated entries for Global, Device or Radio ID
-    unsigned int merged_anticipated_opclass_idx[EM_MAX_OPCLASS] = {0};
-    bool merged_anticipated_is_ruid_based[EM_MAX_OPCLASS] = {0};
-    unsigned int merged_anticipated_opclass_count = 0;
-
-    dm = get_data_model();
     pref = reinterpret_cast<em_channel_pref_t *> (buff);
     memcpy(pref->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
     pref_op_class = pref->op_classes;
@@ -244,100 +242,61 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
     tmp = reinterpret_cast<unsigned char *> (pref_op_class);
     len += static_cast<short unsigned int> (sizeof(em_channel_pref_t));
 
-    em_printfout("[CHANNEL_SEL] radio %s Creating channel preference TLV\n",
+    em_printfout("[CHANNEL_SEL] radio %s Creating channel preference TLV",
                  util::mac_to_string(pref->ruid).c_str());
 
-    for (i = 0; i < dm->m_num_opclass; i++) {
-        op_class = &dm->m_op_class[i];
+    // Map for opclass with list of channels and their preference
+    std::map<unsigned char, std::map<unsigned char, unsigned char>> opclass_channel_prefs;
 
-        // Only handle anticipated entries for RUID, Device or for Global address for the Radio band
-        if (((op_class->m_op_class_info.id.type == em_op_class_type_anticipated) &&
-            ((memcmp(op_class->m_op_class_info.id.ruid, pref->ruid, sizeof(mac_address_t)) == 0) ||
-            (((memcmp(op_class->m_op_class_info.id.ruid, EM_GLOBAL_MAC_ADDRESS, sizeof(mac_address_t)) == 0) ||
-            (memcmp(op_class->m_op_class_info.id.ruid, dm->get_device()->get_dev_interface_mac(), sizeof(mac_address_t)) == 0)) &&
-            get_band() == dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int>(op_class->m_op_class_info.id.op_class))))) == false) {
-            continue;
-        }
+    // Fill the map with OPCLASS/Channels in E4 table with default preference
+    fill_map_with_opclass_channel_prefs(opclass_channel_prefs);
 
-        // Create a merged list of anticipated entries for Global, Device and RUID
-        // Assumes, only one entry for an OPCLASS for Global, Device or RUID
-        // If entry for same OPCLASS exists for both Global, Device and RUID, RUID is stored in the merged list
-        unsigned char class_num = op_class->m_op_class_info.op_class;
-        bool is_current_entry_ruid_based =
-            (memcmp(op_class->m_op_class_info.id.ruid, pref->ruid, sizeof(mac_address_t)) == 0);
+    // Update the map to remove non-operable opclass/channels reported by the Agent
+    update_map_with_agent_capability_preference(pref->ruid, opclass_channel_prefs);
 
-        // Find current op_class entry in the merged array
-        int merged_idx = -1;
-        for (j = 0; j < merged_anticipated_opclass_count; j++) {
-            if (dm->m_op_class[merged_anticipated_opclass_idx[j]].m_op_class_info.op_class == class_num) {
-                merged_idx = static_cast<int>(j);
-                break;
-            }
-        }
+    // Update map with the anticipated preferences in data model
+    bool anticipated_configured = update_map_with_ctrl_anticipated(pref->ruid, opclass_channel_prefs);
+    if (!anticipated_configured) {
+        em_printfout("[CHANNEL_SEL] no anticipated preferences found for radio %s, sending empty TLV",
+                     util::mac_to_string(pref->ruid).c_str());
 
-        if (merged_idx == -1) {
-            // New op-class entry
-            if (merged_anticipated_opclass_count >= EM_MAX_OPCLASS) {
-                em_printfout("Merged op-classes exceeded limit\n");
-                continue;
-            }
-            merged_anticipated_opclass_idx[merged_anticipated_opclass_count] = i;
-            merged_anticipated_is_ruid_based[merged_anticipated_opclass_count] = is_current_entry_ruid_based;
-            merged_anticipated_opclass_count++;
-            em_printfout("Initializing merged new op-class %d (RUID-based: %d)\n",
-                        class_num, is_current_entry_ruid_based);
-        } else {
-            // Op-class already exists
-            bool existing_is_ruid_based = merged_anticipated_is_ruid_based[merged_idx];
-
-            // Existing is Global MAC-based or Device-based, new is RUID-based so REPLACE existing
-            if (!existing_is_ruid_based && is_current_entry_ruid_based) {
-                em_printfout("Op-class %d: Replacing Global MAC-based with RUID-based entry\n",
-                            class_num);
-                merged_anticipated_opclass_idx[merged_idx] = i;
-                merged_anticipated_is_ruid_based[merged_idx] = true;
-                continue;
-            }
-        }
+        // No anticipated opclasses configured
+        // Send empty TLV with no opclasses
+        return len;
     }
 
-    // Create TLVs from merged anticipated op-classes
-    for (i = 0; i < merged_anticipated_opclass_count; i++) {
-        dm_op_class_t *merged_op_class = &dm->m_op_class[merged_anticipated_opclass_idx[i]];
-        em_op_class_info_t &merged_op = merged_op_class->m_op_class_info;
+    /*
+     * Add Channel preference TLV for each opclass from the map opclass_channel_prefs:
+     * - Consider opclass applicable for the band
+     * - Group channels by pref_byte
+     */
+    for (const auto &oc_pair : opclass_channel_prefs) {
+        unsigned char opclass = oc_pair.first;
+        em_freq_band_t oc_band = dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int>(opclass));
+        if (oc_band != get_band())
+            continue;
 
-        // Get list of Non-operable channels for the RUID OPClass
-        std::vector<unsigned char> non_oper_channels = get_non_operable_channels(
-            merged_op.op_class, merged_op.id.ruid);
-
-        // Group operable channels by preference bits, skip non-operable channels for agent
+        /* Group channels by preference */
         std::map<unsigned char, std::vector<unsigned char>> channels_per_pref;
-
-        for (j = 0; j < merged_op.num_channels; j++) {
-            bool is_anticipated_channel_non_operable_by_agent =
-                std::find(non_oper_channels.begin(),non_oper_channels.end(),
-                          merged_op.channels[j]) != non_oper_channels.end();
-            if (is_anticipated_channel_non_operable_by_agent) {
-                em_printfout("Channel %d in Op-Class %d is marked non-operable by agent, skipping this channel\n",
-                             merged_op.channels[j], merged_op.op_class);
-                continue; // Skip channels non-operable for agent
-            }
-            // Assign the preference value for channels
-            pref_bits = merged_op.channel_pref[j];
-            channels_per_pref[pref_bits].push_back(merged_op.channels[j]);;
+        for (const auto &ch_pair : oc_pair.second) {
+            channels_per_pref[ch_pair.second].push_back(ch_pair.first);
         }
 
         // Create TLV entries for each group of channels with the same preference bits
         for (auto& pair : channels_per_pref) {
             pref_bits = pair.first;
             auto& channels = pair.second;
-            if ((static_cast<unsigned char>(pref_bits) >> 4) >= EM_CH_PREF_MAX) {
-                em_printfout("Preference bits 0x%02x exceed max allowed value, skipping channels in Op-Class %d\n",
-                             pref_bits, merged_op.op_class);
+
+            if (channels.empty())
+                continue;
+
+            if ((static_cast<unsigned char>(pref_bits) >> EM_CH_PREF_SHIFT) >= EM_CH_PREF_MAX) {
+                em_printfout("Preference bits 0x%02x exceed max allowed value, skipping channels in Op-Class %d",
+                             pref_bits, opclass);
                 continue; // Skip if preference bits exceed max allowed value
             }
 
-            pref_op_class->op_class = static_cast<unsigned char>(merged_op.op_class);
+            pref_op_class->op_class = static_cast<unsigned char>(opclass);
             num_of_channel = channels.size();
             channel_list = &pref_op_class->channels;
 
@@ -357,8 +316,193 @@ short em_channel_t::create_channel_pref_tlv(unsigned char *buff)
             pref->op_classes_num++;
         }
     }
-
     return len;
+}
+
+// Fill the map with opclass/channel from m_e4_table with default preference
+void em_channel_t::fill_map_with_opclass_channel_prefs(std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs)
+{
+    em_service_type_t service_type = get_service_type();
+    unsigned char default_pref = ((service_type == em_service_type_ctrl) ? CTRL_DEFAULT_CH_PREF : AGENT_DEFAULT_CH_PREF) << EM_CH_PREF_SHIFT;
+
+    opclass_channel_prefs.clear();
+
+    size_t table_sz = dm_easy_mesh_t::m_e4_table_size;
+    for (size_t idx = 0; idx < table_sz; ++idx) {
+        em_e4_table_t *entry = &dm_easy_mesh_t::m_e4_table[idx];
+        unsigned char opclass = static_cast<unsigned char>(entry->op_class);
+        for (int ch = 0; ch < entry->num_channels; ++ch) {
+            unsigned char channel = static_cast<unsigned char>(entry->channels[ch]);
+            // Assign default preference
+            opclass_channel_prefs[opclass][channel] = default_pref;
+        }
+    }
+}
+
+void em_channel_t::update_map_with_agent_capability_preference(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    unsigned int i, j;
+
+    // Mark non-operable channels and add supported operating classes from Agent's Capability Report
+    std::set<unsigned int> supported_opclasses;
+    for (i = 0; i < dm->get_num_op_class(); i++) {
+        dm_op_class_t *op_class = &dm->m_op_class[i];
+        em_op_class_info_t *info = &op_class->m_op_class_info;
+
+        if ((info->id.type == em_op_class_type_capability) &&
+            (memcmp(info->id.ruid, ruid, sizeof(mac_address_t)) == 0)) {
+            unsigned int opclass = info->op_class;
+            supported_opclasses.insert(opclass);
+
+            // Mark non-operable channels in the supported opclass with preference 0
+            for (j = 0; j < info->num_channels; j++) {
+                unsigned int channel = info->channels[j];
+                if (opclass_channel_prefs.find(opclass) != opclass_channel_prefs.end()) {
+                    opclass_channel_prefs[opclass][channel] = EM_CH_PREF_NON_OPERABLE;
+                }
+            }
+        }
+    }
+
+    // Update non-operable/operable preference from Agent's Preference Report
+    for (i = 0; i < dm->get_num_op_class(); i++) {
+
+        dm_op_class_t *op_class = &dm->m_op_class[i];
+        em_op_class_info_t *info = &op_class->m_op_class_info;
+        if ((info->id.type == em_op_class_type_preference) &&
+            (info->pref_valid == EM_CH_PREF_ENTRY_VALID) &&
+            (memcmp(info->id.ruid, ruid, sizeof(mac_address_t)) == 0)) {
+
+            for (j = 0; j < info->num_channels; j++) {
+                unsigned char channel = static_cast<unsigned char>(info->channels[j]);
+                unsigned char pref = static_cast<unsigned char> (info->channel_pref[j]);
+                unsigned char pref_value = pref >> EM_CH_PREF_SHIFT;
+
+                // Update preference, it overrides operable/non-operable pref from Capability report
+                pref = pref_value ? (CTRL_DEFAULT_CH_PREF << EM_CH_PREF_SHIFT) : pref;
+                opclass_channel_prefs[static_cast<unsigned char>(info->op_class)][channel] = pref;
+            }
+        }
+    }
+
+    // Remove unsupported opclasses from the map
+    for (auto& oc_pair : opclass_channel_prefs) {
+        unsigned int opclass = oc_pair.first;
+        if (supported_opclasses.find(opclass) == supported_opclasses.end()) {
+            // Opclass not present in AP Capability Report.
+            opclass_channel_prefs.erase(opclass);
+            break;
+        }
+    }
+}
+
+bool em_channel_t::update_map_with_ctrl_anticipated(const unsigned char *ruid, std::map<unsigned char, std::map<unsigned char, unsigned char>> &opclass_channel_prefs)
+{
+    unsigned int i, j;
+    bool anticipated_config_updated = false;
+
+    if (ruid == NULL)
+        return false;
+
+    dm_easy_mesh_t *dm = get_data_model();
+    if (!dm)
+        return false;
+
+    // Create a merged list of indexes of Anticipated entries for Global/Device or Radio ID
+    unsigned int merged_anticipated_opclass_idx[EM_MAX_OPCLASS] = {0};
+    bool merged_anticipated_is_ruid_based[EM_MAX_OPCLASS] = {0};
+    unsigned int merged_anticipated_opclass_count = 0;
+
+    for (i = 0; i < dm->m_num_opclass; ++i) {
+        dm_op_class_t *dm_opclass = &dm->m_op_class[i];
+        em_op_class_info_t &info = dm_opclass->m_op_class_info;
+
+        // Only handle anticipated entries for RUID, Device or for Global address for the Radio band
+        // Checking pref_valid flag to determine if the entry is valid for anticipated preference
+        if (((info.id.type == em_op_class_type_anticipated && info.pref_valid == EM_CH_PREF_ENTRY_VALID) &&
+             ((memcmp(info.id.ruid, ruid, sizeof(mac_address_t)) == 0) ||
+             (((memcmp(info.id.ruid, EM_GLOBAL_MAC_ADDRESS, sizeof(mac_address_t)) == 0) ||
+             (memcmp(info.id.ruid, dm->get_device()->get_dev_interface_mac(), sizeof(mac_address_t)) == 0)) &&
+             (get_band() == dm_easy_mesh_t::get_freq_band_by_op_class(static_cast<int>(info.op_class)))))) == false) {
+             continue;
+        }
+
+        // Create a merged list of anticipated entries for Global, Device and RUID
+        // Assumes, only one entry for an OPCLASS for Global, Device or RUID
+        // If entry for same OPCLASS exists for both Global/Device and RUID, RUID is stored in the merged list
+        unsigned char class_num = info.op_class;
+        bool is_current_entry_ruid_based =
+            (memcmp(info.id.ruid, ruid, sizeof(mac_address_t)) == 0);
+
+        // Find current op_class entry in the merged array
+        int merged_idx = -1;
+        for (j = 0; j < merged_anticipated_opclass_count; j++) {
+            if (dm->m_op_class[merged_anticipated_opclass_idx[j]].m_op_class_info.op_class == class_num) {
+                merged_idx = static_cast<int>(j);
+                break;
+            }
+        }
+
+        if (merged_idx == -1) {
+            // New op-class entry
+            if (merged_anticipated_opclass_count >= EM_MAX_OPCLASS) {
+                em_printfout("Merged op-classes exceeded limit");
+                continue;
+            }
+            merged_anticipated_opclass_idx[merged_anticipated_opclass_count] = i;
+            merged_anticipated_is_ruid_based[merged_anticipated_opclass_count] = is_current_entry_ruid_based;
+            merged_anticipated_opclass_count++;
+            em_printfout("Adding op-class %d (RUID-based: %d) to merged list",
+                        class_num, is_current_entry_ruid_based);
+        } else {
+            // Op-class already exists
+            bool existing_is_ruid_based = merged_anticipated_is_ruid_based[merged_idx];
+
+            // Existing is Global MAC-based or Device-based, new is RUID-based so REPLACE existing
+            if (!existing_is_ruid_based && is_current_entry_ruid_based) {
+                em_printfout("Op-class %d: Replacing Global MAC-based with RUID-based entry",
+                            class_num);
+                merged_anticipated_opclass_idx[merged_idx] = i;
+                merged_anticipated_is_ruid_based[merged_idx] = true;
+                continue;
+            }
+        }
+    }
+
+    // Update the map with preferences from merged list
+    for (i = 0; i < merged_anticipated_opclass_count; i++) {
+
+        dm_op_class_t *dm_opclass = &dm->m_op_class[merged_anticipated_opclass_idx[i]];
+        em_op_class_info_t &info = dm_opclass->m_op_class_info;
+
+        // Opclass shall be present in map if supported by agent
+        unsigned char opclass = static_cast<unsigned char>(info.op_class);
+        if (opclass_channel_prefs.find(opclass) == opclass_channel_prefs.end()) {
+            em_printfout("Unsupported anticipated entry for opclass %u", opclass);
+            continue;
+        }
+
+        for (unsigned int ch_idx = 0; ch_idx < info.num_channels; ++ch_idx) {
+            unsigned char channel = static_cast<unsigned char>(info.channels[ch_idx]);
+            unsigned char pref_byte = info.channel_pref[ch_idx];
+
+            // Update if channel entry exists and pref is non-zero
+            if (opclass_channel_prefs[opclass].find(channel) == opclass_channel_prefs[opclass].end()) {
+                em_printfout("Unsupported anticipated entry for opclass %u ch %u", opclass, channel);
+                continue;
+            }
+
+            if ((opclass_channel_prefs[opclass][channel] >> EM_CH_PREF_SHIFT) != 0) {
+                unsigned char before = opclass_channel_prefs[opclass][channel];
+                opclass_channel_prefs[opclass][channel] = pref_byte;
+                em_printfout("Updated anticipated preference for opclass %u ch %u pref: 0x%02x -> 0x%02x",
+                            opclass, channel, before, pref_byte);
+                anticipated_config_updated = true;
+            }
+        }
+    }
+    return anticipated_config_updated;
 }
 
 std::vector<unsigned char> em_channel_t::get_non_operable_channels(unsigned char op_class, const unsigned char *ruid)
@@ -614,32 +758,48 @@ short em_channel_t::create_channel_scan_res_tlv(unsigned char *buff, unsigned in
             default:
                 break;
 
-		}	
+		}
 		
-		memcpy(tmp, &nbr->bss_color, sizeof(unsigned char));
-		len += static_cast<short unsigned int> (sizeof(unsigned char));
-		tmp += sizeof(unsigned char);
-	
-		memcpy(tmp, &nbr->channel_util, sizeof(unsigned char));
-		len += static_cast<short unsigned int> (sizeof(unsigned char));
-		tmp += sizeof(unsigned char);
+            unsigned char bss_color_byte = 0;
+            /* bits 0-5: actual BSS color */
+            bss_color_byte = (nbr->bss_color & 0x3F);
 
-		param = htons(nbr->sta_count);	
-		memcpy(tmp, &param, sizeof(unsigned short));
-		len += static_cast<short unsigned int> (sizeof(unsigned short));
-		tmp += sizeof(unsigned short);
-	
-	}			
+            /* bit 7: BSS Load presence */
+            if (nbr->bss_load_element_present) {
+                bss_color_byte |= BSS_COLOR_BSS_LOAD_PRESENT;
+            }
+		
+            memcpy(tmp, &bss_color_byte, sizeof(unsigned char));
+            len += static_cast<short unsigned int> (sizeof(unsigned char));
+            tmp += sizeof(unsigned char);
+	    
+            if (nbr->bss_load_element_present) {
+                memcpy(tmp, &nbr->channel_util, sizeof(unsigned char));
+                len += static_cast<short unsigned int> (sizeof(unsigned char));
+                tmp += sizeof(unsigned char);
 
-	memcpy(tmp, &scan_res->m_scan_result.aggr_scan_duration, sizeof(unsigned int));
-	len += static_cast<short unsigned int> (sizeof(unsigned int));
-	tmp += sizeof(unsigned int);
-	
-	memcpy(tmp, &scan_res->m_scan_result.scan_type, sizeof(unsigned char));
+                param = htons(nbr->sta_count);
+                memcpy(tmp, &param, sizeof(unsigned short));
+                len += static_cast<short unsigned int> (sizeof(unsigned short));
+                tmp += sizeof(unsigned short);
+            }
+	}
+   
+        unsigned int duration = htonl(scan_res->m_scan_result.aggr_scan_duration);
+        memcpy(tmp, &duration, sizeof(duration));
+        len += static_cast<short unsigned int> (sizeof(unsigned int));
+        tmp += sizeof(unsigned int);
+
+
+        unsigned char encoded_scan_type = 0;
+        if (scan_res->m_scan_result.scan_type == EM_SCAN_TYPE_ACTIVE) {
+            encoded_scan_type |= EM_SCAN_TYPE_BIT;
+        }
+        memcpy(tmp, &encoded_scan_type, sizeof(unsigned char));
 	len += static_cast<short unsigned int> (sizeof(unsigned char));
 	tmp += sizeof(unsigned char);
 
-    return len;
+        return len;
 }
 
 
@@ -661,6 +821,7 @@ int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
 
     dm = get_data_model();
 
+    em_printfout("  ------>>> Sending channel scan report message starting from index %u", start_idx);
     memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
     len += sizeof(mac_address_t);
@@ -703,6 +864,8 @@ int em_channel_t::send_channel_scan_report_msg(unsigned int *last_index)
         if(memcmp(get_radio_interface_mac(), scan_res->m_scan_result.id.scanner_mac, sizeof(mac_address_t)) == 0) { 
             tlv = reinterpret_cast<em_tlv_t *> (tmp);
             tlv->type = em_tlv_type_channel_scan_rslt;
+    em_printfout("create_channel_scan_res_tlv");
+
             sz = create_channel_scan_res_tlv(tlv->value, i);
             tlv->len = htons(static_cast<short unsigned int> (sz));
 
@@ -1610,87 +1773,6 @@ int em_channel_t::handle_channel_pref_tlv_ctrl(unsigned char *buff, unsigned int
     return 0;
 }
 
-int em_channel_t::handle_eht_operations_tlv_ctrl(unsigned char *buff, unsigned int len)
-{
-    unsigned int tmp_len = 0;
-    unsigned int i = 0, j = 0, k = 0, l = 0;
-    unsigned char *tmp = buff;
-    dm_easy_mesh_t  *dm;
-    em_eht_operations_bss_t  *eht_ops_bss;
-    mac_address_t ruid, bss;
-    bool found_radio = false, found_bss = false;
-
-    unsigned char num_radios;
-    unsigned char num_bss;
-
-    // 32 octets are reserved for future use, so skip 32 octets
-    unsigned int reserved_octets = 32;
-    tmp += reserved_octets;
-    tmp_len += reserved_octets;
-
-    memcpy(&num_radios, tmp, sizeof(unsigned char));
-    tmp += sizeof(unsigned char);
-    tmp_len += sizeof(unsigned char);
-
-    dm = get_data_model();
-//  Remove assert since channnel report is per radio
-//  assert(num_radios == dm->get_num_radios());
-
-    for (i = 0; i < num_radios; i++) {
-        memcpy(&ruid, tmp, sizeof(mac_address_t));
-        tmp += sizeof(mac_address_t);
-        tmp_len += sizeof(mac_address_t);
-
-        for (j = 0; j < dm->get_num_radios(); j++) {
-            if (memcmp(ruid, dm->m_radio[j].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
-                found_radio = true;
-                break;
-            }
-
-            if (found_radio == false) {
-                // do not update anything and retrun error
-                return -1;
-            }
-        }
-
-        found_radio = false;
-        memcpy(&num_bss, tmp, sizeof(unsigned char));
-        tmp += sizeof(unsigned char);
-        tmp_len += sizeof(unsigned char);
-
-        for(k = 0; k < num_bss; k++) {
-            memcpy(&bss, tmp, sizeof(mac_address_t));
-            tmp += sizeof(mac_address_t);
-            tmp_len += sizeof(mac_address_t);
-
-            for(l = 0; l < dm->get_num_bss(); l++) {
-                if (memcmp(bss, dm->m_bss[l].m_bss_info.bssid.mac, sizeof(mac_address_t)) == 0) {
-                    found_bss = true;
-                    break;
-                }
-
-                if (found_bss == false) {
-                    // do not update anything and retrun error
-                    return -1;
-                }
-            }
-
-            found_bss = false;
-            eht_ops_bss = &dm->m_bss[l].get_bss_info()->eht_ops;
-            memcpy(eht_ops_bss, tmp, sizeof(em_eht_operations_bss_t));
-            tmp += sizeof(em_eht_operations_bss_t);
-            tmp_len += sizeof(em_eht_operations_bss_t);
-        }
-        // 25 octets are reserved for future use in radio, so skip 25 octets
-        unsigned int radio_reserved_octets = 25;
-        tmp += radio_reserved_octets;
-        tmp_len += radio_reserved_octets;
-    }
-    assert(tmp_len == len);
-
-    return 0;
-}
-
 
 int em_channel_t::handle_channel_pref_rprt(unsigned char *buff, unsigned int len)
 {
@@ -1726,7 +1808,7 @@ int em_channel_t::handle_channel_pref_rprt(unsigned char *buff, unsigned int len
             handle_channel_pref_tlv_ctrl(tlv->value, htons(tlv->len));
         }
         if (tlv->type == em_tlv_eht_operations) {
-            handle_eht_operations_tlv_ctrl(tlv->value, htons(tlv->len));
+            handle_eht_operations_tlv(tlv->value, htons(tlv->len));
             break;
         }
 
@@ -1762,6 +1844,7 @@ int em_channel_t::handle_channel_pref_tlv(unsigned char *buff, op_class_channel_
             }
 
             // Check for any earlier entries with same OPCLASS
+            entry_found = false;
             for (j = 0; j < op_class->num; j++) {
                 if (op_class->op_class_info[j].op_class == static_cast<unsigned int> (channel_pref->op_class)) {
 
@@ -1820,59 +1903,6 @@ int em_channel_t::handle_channel_pref_tlv(unsigned char *buff, op_class_channel_
         }
     }
     return 0;
-}
-
-int em_channel_t::handle_eht_operations_tlv(unsigned char *buff, em_eht_operations_t *eht_ops)
-{
-	int len = 0;
-	int i = 0, j = 0;
-	unsigned char *tmp = buff;
-
-	unsigned char num_radios;
-	unsigned char num_bss;
-
-    // 32 octets are reserved for future use, so skip 32 octets
-    int reserved_octets = 32;
-    tmp += reserved_octets;
-    len += reserved_octets;
-
-	memcpy(&num_radios, tmp, sizeof(unsigned char));
-	eht_ops->radios_num = num_radios;
-	tmp += sizeof(unsigned char);
-	len += static_cast<int> (sizeof(unsigned char));
-
-	if (num_radios > EM_MAX_RADIO_PER_AGENT) {
-		printf("%s:%d Invalid radios count \n", __func__, __LINE__);
-		return -1;
-	}
-
-	for (i = 0; i < num_radios; i++) {
-		memcpy(&eht_ops->radios[i].ruid, tmp, sizeof(mac_address_t));
-		tmp += sizeof(mac_address_t);
-		len += static_cast<int> (sizeof(mac_address_t));
-
-		memcpy(&num_bss, tmp, sizeof(unsigned char));
-		eht_ops->radios[i].bss_num = num_bss;
-		tmp += sizeof(unsigned char);
-		len += static_cast<int> (sizeof(unsigned char));
-
-		if (num_bss > EM_MAX_BSS_PER_RADIO) {
-			printf("%s:%d Invalid bss count \n", __func__, __LINE__);
-			continue;
-		}
-
-		for(j = 0; j < num_bss; j++) {
-			memcpy(&eht_ops->radios[i].bss[j], tmp, sizeof(em_eht_operations_bss_t));
-			tmp += sizeof(em_eht_operations_bss_t);
-			len += static_cast<int> (sizeof(em_eht_operations_bss_t));
-		}
-        // 25 octets are reserved for future use in radio, so skip 25 octets
-        int radio_reserved_octets = 25;
-        tmp += radio_reserved_octets;
-        len += radio_reserved_octets;
-	}
-
-	return 0;
 }
 
 int em_channel_t::handle_channel_pref_query(unsigned char *buff, unsigned int len)
@@ -2072,8 +2102,18 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
 	mac_addr_str_t bssid_str;
 
 	scan_res->m_scan_result.scan_status = res->scan_status;
-	strncpy(scan_res->m_scan_result.timestamp, res->timestamp, static_cast<size_t>(res->timestamp_len + 1));
+	if (res->scan_status != 0) {
+            em_printfout("%s:%d scan failed with status=%u", __func__, __LINE__, res->scan_status);
+            scan_res->m_scan_result.timestamp[0] = '\0';
+            scan_res->m_scan_result.util = 0;
+            scan_res->m_scan_result.noise = 0;
+            scan_res->m_scan_result.num_neighbors = 0;
+            scan_res->m_scan_result.aggr_scan_duration = 0;
+            scan_res->m_scan_result.scan_type = 0;
+	    return;
+	}
 
+	strncpy(scan_res->m_scan_result.timestamp, res->timestamp, static_cast<size_t>(res->timestamp_len + 1));
 	tmp = reinterpret_cast<unsigned char *> (res) + sizeof(em_channel_scan_result_t) + res->timestamp_len;
 	
 	memcpy(&scan_res->m_scan_result.util, tmp, sizeof(unsigned char));
@@ -2096,12 +2136,18 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
         memcpy(nbr->bssid, tmp, sizeof(mac_address_t));
         tmp += sizeof(mac_address_t);
 
+        unsigned char original_ssid_len;
+
         memcpy(&ssid_len, tmp, sizeof(unsigned char));
         tmp += sizeof(unsigned char);
+        original_ssid_len = ssid_len;
 
-        strncpy(nbr->ssid, reinterpret_cast<char *> (tmp), static_cast<size_t>(ssid_len + 1));
+        if (ssid_len > static_cast<unsigned char>(sizeof(ssid_t) - 1)) {
+            ssid_len = static_cast<unsigned char>(sizeof(ssid_t) - 1);
+        }
+        strncpy(nbr->ssid, reinterpret_cast<char *> (tmp), static_cast<size_t>(ssid_len));
         nbr->ssid[ssid_len] = '\0';
-        tmp += ssid_len;
+        tmp += original_ssid_len;
 
         memcpy(&nbr->signal_strength, tmp, sizeof(unsigned char));
         tmp += sizeof(unsigned char);
@@ -2117,32 +2163,45 @@ void em_channel_t::fill_scan_result(dm_scan_result_t *scan_res, em_channel_scan_
         } else if (strncmp(bandwidth, "40", strlen("40")) == 0) {
             nbr->bandwidth = WIFI_CHANNELBANDWIDTH_40MHZ;
         } else if (strncmp(bandwidth, "80", strlen("80")) == 0) {
-            nbr->bandwidth = WIFI_CHANNELBANDWIDTH_40MHZ;
+            nbr->bandwidth = WIFI_CHANNELBANDWIDTH_80MHZ;
         } else if (strncmp(bandwidth, "160", strlen("160")) == 0) {
             nbr->bandwidth = WIFI_CHANNELBANDWIDTH_160MHZ;
         } else if (strncmp(bandwidth, "320", strlen("320")) == 0) {
             nbr->bandwidth = WIFI_CHANNELBANDWIDTH_320MHZ;
         }
 
-        memcpy(&nbr->bss_color, tmp, sizeof(unsigned char));
+        unsigned char bss_color_byte;
+        memcpy(&bss_color_byte, tmp, sizeof(unsigned char));
         tmp += sizeof(unsigned char);
+     
+        /* Extract only actual BSS color (bits 0-5) */
+        nbr->bss_color = bss_color_byte & 0x3F;
 
-        memcpy(&nbr->channel_util, tmp, sizeof(unsigned char));
-        tmp += sizeof(unsigned char);
+	if (bss_color_byte & BSS_COLOR_BSS_LOAD_PRESENT) {
+            nbr->bss_load_element_present = true;
+            memcpy(&nbr->channel_util, tmp, sizeof(unsigned char));
+            tmp += sizeof(unsigned char);
+	    
+	    memcpy(&nbr->sta_count, tmp, sizeof(unsigned short));
+            nbr->sta_count = ntohs(nbr->sta_count);
+	    tmp += sizeof(unsigned short);
+	} else {
+            nbr->bss_load_element_present = false;
+            nbr->channel_util = 0;
+            nbr->sta_count = 0;
+        }
 
-        memcpy(&nbr->sta_count, tmp, sizeof(unsigned short));
-		nbr->sta_count = htons(nbr->sta_count);
-        tmp += sizeof(unsigned short);
-
-		dm_easy_mesh_t::macbytes_to_string(nbr->bssid, bssid_str);
-		//printf("%s:%d: bssid: %s\tssid: %s\trssi: %d\tbandwidth: %s\tutil: %d\tcount: %d\n", __func__, __LINE__,
-		//			bssid_str, nbr->ssid, nbr->signal_strength, bandwidth, nbr->channel_util, nbr->sta_count);	
+	dm_easy_mesh_t::macbytes_to_string(nbr->bssid, bssid_str);
     }
 
-    memcpy(&scan_res->m_scan_result.aggr_scan_duration, tmp, sizeof(unsigned int));
+    unsigned int val;
+    memcpy(&val, tmp, sizeof(unsigned int));
+    scan_res->m_scan_result.aggr_scan_duration = ntohl(val);
     tmp += sizeof(unsigned int);
 
-    memcpy(&scan_res->m_scan_result.scan_type, tmp, sizeof(unsigned char));
+    unsigned char encoded_scan_type;
+    memcpy(&encoded_scan_type, tmp, sizeof(unsigned char));
+    scan_res->m_scan_result.scan_type = (encoded_scan_type & EM_SCAN_TYPE_BIT) ? EM_SCAN_TYPE_ACTIVE : EM_SCAN_TYPE_PASSIVE;
     tmp += sizeof(unsigned char);
 
 }
@@ -2161,36 +2220,40 @@ int em_channel_t::handle_channel_scan_rprt(unsigned char *buff, unsigned int len
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tlv_len = static_cast<int> (len - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)));
 
-    while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
-		if (tlv->type == em_tlv_type_channel_scan_rslt) {
-			res = reinterpret_cast<em_channel_scan_result_t *> (tlv->value);
-			
-			strncpy(id.net_id, dm->m_network.m_net_info.id, sizeof(em_long_string_t));	
-			memcpy(id.dev_mac, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t));
+    while ((tlv->type != em_tlv_type_eom) && (tlv_len > 0)) {
+        uint16_t value_len = ntohs(tlv->len);
+
+        if (tlv_len < static_cast<int>(sizeof(em_tlv_t) + value_len)) {
+            break; // malformed TLV, stop parsing
+        }
+	    
+        if (tlv->type == em_tlv_type_channel_scan_rslt) {
+            res = reinterpret_cast<em_channel_scan_result_t *> (tlv->value);
+
+            strncpy(id.net_id, dm->m_network.m_net_info.id, sizeof(em_long_string_t));	
+            memcpy(id.dev_mac, dm->m_device.m_device_info.intf.mac, sizeof(mac_address_t));
             memcpy(id.scanner_mac, res->ruid, sizeof(mac_address_t));
             id.op_class = res->op_class;
             id.channel = res->channel;
-			id.scanner_type = em_scanner_type_radio;
+            id.scanner_type = em_scanner_type_radio;
 
-			if ((scan_res = dm->find_matching_scan_result(&id)) == NULL) {
-				scan_res = dm->create_new_scan_result(&id);
-			}
+            if ((scan_res = dm->find_matching_scan_result(&id)) == NULL) {
+                scan_res = dm->create_new_scan_result(&id);
+            }
+            fill_scan_result(scan_res, res);
+        }
 
-			fill_scan_result(scan_res, res);
-		}
+	if (tlv->type == em_tlv_type_timestamp) {
+            ; 
+        }
 
-        if (tlv->type == em_tlv_type_timestamp) {
-       		; 
-		}
-
-        tlv_len -= static_cast<int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tlv_len -= static_cast<int> (sizeof(em_tlv_t) + value_len);
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + value_len);
     }
         
-	dm->set_db_cfg_param(db_cfg_type_scan_result_list_update, "");
-
-
-	return 0;
+    dm->set_db_cfg_param(db_cfg_type_scan_result_list_update, "");
+  
+    return 0;
 }
 
 void em_channel_t::process_msg(unsigned char *data, unsigned int len)

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -39,6 +39,10 @@
 #include <openssl/rand.h>
 #include <assert.h>
 #include <string>
+#include <set>
+#include <deque>
+#include <mutex>
+#include <ctime>
 #include <vector>
 #include <algorithm>
 #include "em_configuration.h"
@@ -58,6 +62,173 @@
 unsigned short em_configuration_t::msg_id = 0;
 // OUI value of Comcast
 static const unsigned char em_vendor_oui[EM_VENDOR_OUI_SIZE] = {0xd8, 0x9c, 0x8e};
+
+std::deque<time_t> g_failed_conn_report_timestamps;
+static std::mutex g_failed_conn_report_mutex;
+
+static bool allow_failed_conn_report(unsigned short max_reports_per_min)
+{
+    if (max_reports_per_min == 0) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(g_failed_conn_report_mutex);
+
+    time_t now = time(NULL);
+    while (!g_failed_conn_report_timestamps.empty() &&
+           (now - g_failed_conn_report_timestamps.front()) >= 60) {
+        g_failed_conn_report_timestamps.pop_front();
+    }
+
+    if (g_failed_conn_report_timestamps.size() >= max_reports_per_min) {
+        return false;
+    }
+
+    g_failed_conn_report_timestamps.push_back(now);
+    return true;
+}
+
+static bool update_sta_map_assoc_row(hash_map_t *sta_assoc_map, em_sta_info_t *row)
+{
+    mac_addr_str_t row_sta_str, row_bssid_str, row_radio_str;
+    em_long_string_t row_key;
+    dm_sta_t *existing_row;
+
+    dm_easy_mesh_t::macbytes_to_string(row->id, row_sta_str);
+    dm_easy_mesh_t::macbytes_to_string(row->bssid, row_bssid_str);
+    dm_easy_mesh_t::macbytes_to_string(row->radiomac, row_radio_str);
+    snprintf(row_key, sizeof(em_long_string_t), "%s@%s@%s", row_sta_str, row_bssid_str, row_radio_str);
+
+    existing_row = static_cast<dm_sta_t *>(hash_map_get(sta_assoc_map, row_key));
+    if (existing_row == NULL) {
+        hash_map_put(sta_assoc_map, strdup(row_key), new dm_sta_t(row));
+        em_printfout("sta_map add: %s", row_key);
+    } else {
+        memcpy(&existing_row->m_sta_info, row, sizeof(em_sta_info_t));
+        em_printfout("sta_map update: %s", row_key);
+    }
+
+    return true;
+}
+
+static unsigned short create_affiliated_sta_metrics_tlvs(unsigned char *buff,
+                                                         dm_easy_mesh_t *dm,
+                                                         const em_assoc_sta_mld_info_t *mld_info,
+                                                         em_target_sta_map_t target_map)
+{
+    em_tlv_t *tlv;
+    em_affiliated_sta_metrics_t *metrics;
+    const em_affiliated_sta_info_t *aff_sta;
+    em_sta_info_t *aff_sta_info;
+    dm_bss_t *aff_bss;
+    unsigned short sz;
+    unsigned short total_len = 0;
+    unsigned int j, r;
+    mac_address_t aff_sta_mac = {0};
+    bssid_t aff_bssid = {0};
+    mac_address_t aff_radio_mac = {0};
+
+    if ((dm == NULL) || (mld_info == NULL)) {
+        return 0;
+    }
+
+    for (j = 0; j < mld_info->num_affiliated_sta; j++) {
+        aff_sta = &mld_info->affiliated_sta[j];
+
+        tlv = reinterpret_cast<em_tlv_t *>(buff + total_len);
+        tlv->type = em_tlv_type_affiliated_sta_metrics;
+        metrics = reinterpret_cast<em_affiliated_sta_metrics_t *>(tlv->value);
+        memset(metrics, 0, sizeof(*metrics));
+        memcpy(metrics->sta_mac_addr, aff_sta->link_addr, sizeof(mac_address_t));
+        memcpy(aff_bssid, aff_sta->bssid, sizeof(bssid_t));
+
+        aff_bss = NULL;
+        for (r = 0; r < dm->get_num_radios(); r++) {
+            aff_bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, aff_bssid);
+            if (aff_bss != NULL) {
+                break;
+            }
+        }
+
+        aff_sta_info = NULL;
+        if (aff_bss != NULL) {
+            memcpy(aff_sta_mac, aff_sta->link_addr, sizeof(mac_address_t));
+            memcpy(aff_radio_mac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+
+            aff_sta_info = dm->get_sta_info(aff_sta_mac, aff_bssid, aff_radio_mac, target_map);
+        }
+
+        if (aff_sta_info != NULL) {
+            metrics->bytes_sent = htonl(aff_sta_info->bytes_tx);
+            metrics->bytes_recv = htonl(aff_sta_info->bytes_rx);
+            metrics->packets_sent = htonl(aff_sta_info->pkts_tx);
+            metrics->packets_recv = htonl(aff_sta_info->pkts_rx);
+            metrics->tx_packets_errors = htonl(aff_sta_info->errors_tx);
+        }
+
+        sz = static_cast<unsigned short>(sizeof(em_affiliated_sta_metrics_t));
+        tlv->len = htons(sz);
+        total_len += static_cast<unsigned short>(sizeof(em_tlv_t) + sz);
+    }
+
+    return total_len;
+}
+
+static bool handle_assoc_sta_mld_topology_update(dm_easy_mesh_t *dm)
+{
+    bool sta_db_update_needed;
+    unsigned int i, j, r;
+    em_assoc_sta_mld_info_t *assoc_info;
+    dm_bss_t *aff_bss;
+    em_sta_info_t sta_info;
+    mac_addr_str_t s_str, b_str_tmp, r_str_tmp;
+    em_long_string_t exist_key;
+    dm_sta_t *existing_sta;
+
+    sta_db_update_needed = false;
+    assoc_info = NULL;
+    aff_bss = NULL;
+
+    for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+        assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+        for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
+            aff_bss = NULL;
+            for (r = 0; r < dm->get_num_radios(); r++) {
+                aff_bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, assoc_info->affiliated_sta[j].bssid);
+                if (aff_bss != NULL) {
+                    break;
+                }
+            }
+
+            if (aff_bss == NULL) {
+                continue;
+            }
+
+            memset(&sta_info, 0, sizeof(em_sta_info_t));
+            memcpy(sta_info.id, assoc_info->mac_addr, sizeof(mac_address_t));
+            memcpy(sta_info.bssid, assoc_info->affiliated_sta[j].bssid, sizeof(mac_address_t));
+            memcpy(sta_info.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+            sta_info.associated = true;
+
+            dm_easy_mesh_t::macbytes_to_string(sta_info.id, s_str);
+            dm_easy_mesh_t::macbytes_to_string(sta_info.bssid, b_str_tmp);
+            dm_easy_mesh_t::macbytes_to_string(sta_info.radiomac, r_str_tmp);
+            snprintf(exist_key, sizeof(em_long_string_t), "%s@%s@%s", s_str, b_str_tmp, r_str_tmp);
+            existing_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_map, exist_key));
+            if (existing_sta != NULL) {
+                em_printfout("Existing sta row found for %s, preserving stats", exist_key);
+                memcpy(&sta_info, &existing_sta->m_sta_info, sizeof(em_sta_info_t));
+                sta_info.associated = true;
+            }
+
+            if (update_sta_map_assoc_row(dm->m_sta_assoc_map, &sta_info)) {
+                sta_db_update_needed = true;
+            }
+        }
+    }
+
+    return sta_db_update_needed;
+}
 
 /* Extract N bytes (ignore endianess) */
 static inline void _EnB(uint8_t **packet_ppointer, void *memory_pointer, uint32_t n)
@@ -107,10 +278,11 @@ unsigned short em_configuration_t::create_client_assoc_event_tlv(unsigned char *
 
     for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
         em_assoc_sta_mld_info_t& assoc_sta_mld_info = dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
-        if (memcmp(assoc_sta_mld_info.mac_addr, sta, sizeof(mac_address_t) == 0)) {
+        if (memcmp(assoc_sta_mld_info.mac_addr, sta, sizeof(mac_address_t)) == 0) {
             found_assoc_sta_mld = true;
             memcpy(tmp, assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
             memcpy(tmp + sizeof(mac_address_t), assoc_sta_mld_info.ap_mld_mac_addr, sizeof(mac_address_t));
+            break;        
         }
     }
 
@@ -123,6 +295,300 @@ unsigned short em_configuration_t::create_client_assoc_event_tlv(unsigned char *
     len = 2*sizeof(mac_address_t) + sizeof(unsigned char);
 
     return len;
+}
+
+
+int em_configuration_t::send_client_disassoc_stats_msg(const dm_sta_t *dassoc_sta)
+{
+    unsigned short  msg_type = em_msg_type_client_disassoc_stats;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int i, len = 0;
+    unsigned short sz, stats_sz, tlv_total_len;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm;
+    em_assoc_sta_mld_info_t *mld_info = NULL;
+    dm_sta_t dassoc_stats_sta;
+    em_sta_info_t *dassoc_stats_sta_info;
+    const em_sta_info_t *sta_info;
+    mac_address_t sta_id = {0}, radio_mac = {0};
+    bssid_t bssid = {0};
+
+    dm = get_data_model();
+    if (dassoc_sta == NULL) {
+        em_printfout("Client disassoc stats: input disassoc row is NULL");
+        return -1;
+    }
+
+    sta_info = &dassoc_sta->m_sta_info;
+    memcpy(sta_id, dassoc_sta->m_sta_info.id, sizeof(mac_address_t));
+    memcpy(bssid, dassoc_sta->m_sta_info.bssid, sizeof(bssid_t));
+    memcpy(radio_mac, dassoc_sta->m_sta_info.radiomac, sizeof(mac_address_t));
+
+    // Resolve stats from the global DM to get the correct values instead of using the input from command.
+    dassoc_stats_sta_info = dm->get_sta_info(sta_id, bssid, radio_mac, em_target_sta_map_disassoc);
+    if (dassoc_stats_sta_info != NULL) {
+        memcpy(&dassoc_stats_sta.m_sta_info, dassoc_stats_sta_info, sizeof(em_sta_info_t));
+        dassoc_sta = &dassoc_stats_sta;
+        sta_info = &dassoc_stats_sta.m_sta_info;
+    }
+
+    // Ethernet header: dst (controller AL MAC), src (agent AL MAC), EtherType
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int>(sizeof(mac_address_t));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int>(sizeof(mac_address_t));
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += static_cast<unsigned int>(sizeof(unsigned short));
+
+    // CMDU header
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    cmdu->last_frag_ind = 1;
+
+    tmp += sizeof(em_cmdu_t);
+    len += static_cast<unsigned int>(sizeof(em_cmdu_t));
+
+    // Resolve whether this STA belongs to an MLD client.
+    for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
+        em_assoc_sta_mld_info_t &assoc_sta_mld_info = dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+        if (memcmp(assoc_sta_mld_info.mac_addr, sta_info->id, sizeof(mac_address_t)) == 0) {
+            mld_info = &assoc_sta_mld_info;
+            break;
+        }
+    }
+
+    // STA MAC Address Type TLV (17.2.23)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_sta_mac_addr;
+    memcpy(tlv->value, sta_info->id, sizeof(mac_address_t));
+    tlv->len = htons(sizeof(mac_address_t));
+
+    tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sizeof(mac_address_t));
+
+    // Reason Code TLV (17.2.64)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_reason_code;
+    em_reason_code_t *rc = reinterpret_cast<em_reason_code_t *>(tlv->value);
+    rc->reason_code = htons(dassoc_sta->m_sta_info.reason_code);
+    sz = static_cast<unsigned short>(sizeof(em_reason_code_t));
+    tlv->len = htons(sz);
+
+    tmp += (sizeof(em_tlv_t) + sz);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sz);
+
+    // Associated STA Traffic Stats TLV (17.2.35)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_assoc_sta_traffic_sts;
+    stats_sz = static_cast<unsigned short>(static_cast<em_t *>(this)->create_assoc_sta_traffic_stats_tlv(tlv->value, dassoc_sta));
+    tlv->len = htons(stats_sz);
+    tlv_total_len = static_cast<unsigned short>(sizeof(em_tlv_t) + stats_sz);
+    tmp += tlv_total_len;
+    len += static_cast<unsigned int>(tlv_total_len);
+
+    // Zero or more Affiliated STA Metrics TLVs (17.2.100)
+    tlv_total_len = create_affiliated_sta_metrics_tlvs(tmp, dm, mld_info, em_target_sta_map_disassoc);
+    tmp += tlv_total_len;
+    len += static_cast<unsigned int>(tlv_total_len);
+
+    // End of message TLV
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += sizeof(em_tlv_t);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t));
+
+    if (em_msg_t(em_msg_type_client_disassoc_stats, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("Client disassoc stats msg validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        em_printfout("Client disassoc stats send failed, err=%d", errno);
+        return -1;
+    }
+
+    em_printfout("Client disassoc stats sent");
+
+    return static_cast<int>(len);
+}
+
+int em_configuration_t::send_failed_connection_msg(mac_address_t sta, bssid_t bssid,
+                                                   unsigned short status_code,
+                                                   unsigned short reason_code)
+{
+    unsigned short msg_type = em_msg_type_failed_conn;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int len = 0;
+    unsigned short sz;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (dm == NULL) {
+        em_printfout("%s:%d: Data model is NULL", __func__, __LINE__);
+        return -1;
+    }
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int>(sizeof(mac_address_t));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += static_cast<unsigned int>(sizeof(mac_address_t));
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += static_cast<unsigned int>(sizeof(unsigned short));
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    cmdu->last_frag_ind = 1;
+
+    tmp += sizeof(em_cmdu_t);
+    len += static_cast<unsigned int>(sizeof(em_cmdu_t));
+
+    // BSSID TLV (17.2.74)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_bssid;
+    tlv->len = htons(sizeof(mac_address_t));
+    memcpy(tlv->value, bssid, sizeof(mac_address_t));
+
+    tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sizeof(mac_address_t));
+
+    // STA MAC Address Type TLV (17.2.23)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_sta_mac_addr;
+    tlv->len = htons(sizeof(mac_address_t));
+    memcpy(tlv->value, sta, sizeof(mac_address_t));
+
+    tmp += (sizeof(em_tlv_t) + sizeof(mac_address_t));
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sizeof(mac_address_t));
+
+    // Status Code TLV (17.2.63)
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_status_code;
+    {
+        em_status_code_t *status = reinterpret_cast<em_status_code_t *>(tlv->value);
+        status->status_code = htons(status_code);
+    }
+    sz = static_cast<unsigned short>(sizeof(em_status_code_t));
+    tlv->len = htons(sz);
+
+    tmp += (sizeof(em_tlv_t) + sz);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t) + sz);
+
+    // Reason Code TLV (17.2.64) is included only when Status Code is zero.
+    if (status_code == 0) {
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_reason_code;
+        {
+            em_reason_code_t *reason = reinterpret_cast<em_reason_code_t *>(tlv->value);
+            reason->reason_code = htons(reason_code);
+        }
+        sz = static_cast<unsigned short>(sizeof(em_reason_code_t));
+        tlv->len = htons(sz);
+
+        tmp += (sizeof(em_tlv_t) + sz);
+        len += static_cast<unsigned int>(sizeof(em_tlv_t) + sz);
+    }
+
+    // End of message TLV
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += sizeof(em_tlv_t);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t));
+
+    if (em_msg_t(em_msg_type_failed_conn, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("%s:%d: Failed Connection msg validation failed", __func__, __LINE__);
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        em_printfout("%s:%d: Failed Connection msg send failed, error:%d", __func__, __LINE__, errno);
+        return -1;
+    }
+
+    em_printfout("%s:%d: Failed Connection msg send success", __func__, __LINE__);
+    return static_cast<int>(len);
+}
+
+void em_configuration_t::handle_failed_connection_event(const mac_address_t sta,
+                                                       const bssid_t bssid,
+                                                       unsigned short status_code,
+                                                       unsigned short reason_code,
+                                                       bool reason_code_present)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    unsigned short max_rate;
+    unsigned short final_reason_code;
+    bssid_t bssid_copy = {0};
+    mac_address_t sta_copy = {0};
+    std::string sta_str;
+    std::string bssid_str;
+
+    if (dm == NULL) {
+        em_printfout("FailedConn: data model is NULL, skipping");
+        return;
+    }
+
+    em_device_info_t *device_info = dm->get_device_info();
+    if (device_info == NULL) {
+        em_printfout("FailedConn: device_info is NULL, skipping");
+        return;
+    }
+
+    if (device_info->report_unsuccess_assocs == false) {
+        //em_printfout("FailedConn: report_unsuccess_assocs=false, skipping");
+        return;
+    }
+
+    max_rate = device_info->max_unsuccessful_assoc_report_rate;
+    if (max_rate == 0) {
+        max_rate = device_info->max_reporting_rate;
+    }
+
+    if (!allow_failed_conn_report(max_rate)) {
+        em_printfout("FailedConn: rate limit reached (max_rate=%u per min), skipping", max_rate);
+        return;
+    }
+
+    final_reason_code = 1;
+    if ((status_code == 0) && reason_code_present && (reason_code != 0)) {
+        final_reason_code = reason_code;
+    }
+
+    sta_str = util::mac_to_string(sta);
+    bssid_str = util::mac_to_string(bssid);
+    em_printfout("FailedConn: send sta=%s bssid=%s status=%u reason=%u has_reason=%d",
+                 sta_str.c_str(), bssid_str.c_str(), status_code,
+                 final_reason_code, static_cast<int>(reason_code_present));
+
+    memcpy(sta_copy, sta, sizeof(mac_address_t));
+    memcpy(bssid_copy, bssid, sizeof(bssid_t));
+
+    send_failed_connection_msg(sta_copy, bssid_copy, status_code, final_reason_code);
 }
 
 int em_configuration_t::send_topology_notification_by_client(mac_address_t sta, bssid_t bssid, bool assoc)
@@ -191,20 +657,19 @@ int em_configuration_t::send_topology_notification_by_client(mac_address_t sta, 
     tmp += (sizeof (em_tlv_t));
     len += static_cast<unsigned int> (sizeof (em_tlv_t));
 
-    printf("%s:%d Create topology notification msg successful, len:%d\n", __func__, __LINE__, len);
+    em_printfout("Create topology notification msg successful, len:%d", len);
 
     if (em_msg_t(em_msg_type_topo_notif, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("Topology notification msg validation failed\n");
-
+        em_printfout("Topology notification msg validation failed");
         return -1;
     }
 
     if (send_frame(buff, len)  < 0) {
-        printf("%s:%d: Topology notification send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Topology notification send failed for sta %s, error:%d", util::mac_to_string(sta).c_str(), errno);
         return -1;
     }
 
-    printf("%s:%d: Topology notification Send Successful\n", __func__, __LINE__);
+    em_printfout("Topology notification Send Successful for sta %s", util::mac_to_string(sta).c_str());
 
     return static_cast<int> (len);
 }
@@ -213,18 +678,33 @@ void em_configuration_t::handle_state_topology_notify()
 {
     dm_easy_mesh_t *dm;
     dm_sta_t *sta;
+    int notif_ret;
+    int disassoc_stats_ret;
+    std::string sta_str;
 
     dm = get_current_cmd()->get_data_model();
 
     sta = static_cast<dm_sta_t *>(hash_map_get_first(dm->m_sta_assoc_map));
     while (sta != NULL) {
+        em_printfout("Sending topology notification for associated sta %s", util::mac_to_string(sta->m_sta_info.id).c_str());
         send_topology_notification_by_client(sta->m_sta_info.id, sta->m_sta_info.bssid, true);
         sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_assoc_map, sta));
     }
 
     sta = static_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_dassoc_map));
     while (sta != NULL) {
-        send_topology_notification_by_client(sta->m_sta_info.id, sta->m_sta_info.bssid, false);
+            sta_str = util::mac_to_string(sta->m_sta_info.id);
+            notif_ret = send_topology_notification_by_client(sta->m_sta_info.id, sta->m_sta_info.bssid, false);
+            if (notif_ret >= 0) {
+                disassoc_stats_ret = send_client_disassoc_stats_msg(sta);
+                if (disassoc_stats_ret >= 0) {
+                    // dm->remove_assoc_sta_mld_info(sta->m_sta_info.id);
+                } else {
+                    em_printfout("topo notification: stats send failed for sta=%s", sta_str.c_str());
+                }
+            } else {
+                em_printfout("topo notification: disassoc notif failed for sta=%s", sta_str.c_str());
+            }
         sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_dassoc_map, sta));
     }
     set_state(em_state_agent_configured);
@@ -725,6 +1205,7 @@ int em_configuration_t::create_assoc_sta_mld_config_report_tlv(unsigned char *bu
         tlv->type = em_tlv_type_assoc_sta_mld_conf_rep;
 
         assoc_sta_mld = reinterpret_cast<em_assoc_sta_mld_t *>(tlv->value);
+        memset(assoc_sta_mld, 0, sizeof(em_assoc_sta_mld_t));
 
         em_assoc_sta_mld_info_t &assoc_sta_mld_info = dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
         memcpy(assoc_sta_mld->sta_mld_mac_addr, assoc_sta_mld_info.mac_addr, sizeof(mac_address_t));
@@ -739,8 +1220,9 @@ int em_configuration_t::create_assoc_sta_mld_config_report_tlv(unsigned char *bu
 
         for (j = 0; j < assoc_sta_mld->num_affiliated_sta; j++) {
             em_affiliated_sta_info_t &affiliated_sta_info = assoc_sta_mld_info.affiliated_sta[j];
+            memset(affiliated_sta_mld, 0, sizeof(em_affiliated_sta_mld_t));
             memcpy(affiliated_sta_mld->bssid, affiliated_sta_info.bssid, sizeof(mac_address_t));
-            memcpy(affiliated_sta_mld->affiliated_sta_mac_addr, affiliated_sta_info.mac_addr, sizeof(mac_address_t));
+            memcpy(affiliated_sta_mld->affiliated_sta_mac_addr, affiliated_sta_info.link_addr, sizeof(mac_address_t));
 
             affiliated_sta_mld = reinterpret_cast<em_affiliated_sta_mld_t *>(reinterpret_cast<unsigned char *>(affiliated_sta_mld) + sizeof(em_affiliated_sta_mld_t));
             affiliated_sta_len += static_cast<short unsigned int>(sizeof(em_affiliated_sta_mld_t));
@@ -775,6 +1257,8 @@ int em_configuration_t::create_vendor_operational_bss_tlv(unsigned char *buff)
 	printf("first tlv_len in em_configuration_t::create_custom_operational_bss_tlv = %d\n",tlv_len);
 	ap = reinterpret_cast<em_ap_vendor_op_bss_t *> (tlv->value);
 	ap->radios_num = dm->get_num_radios();
+    /* Include em_ap_vendor_op_bss_t header (radios_num) in TLV payload length. */
+    tlv_len = static_cast<unsigned short>(sizeof(em_ap_vendor_op_bss_t));
 	radio = ap->radios;
     for (radio_index = 0; radio_index < dm->get_num_radios(); radio_index++) {
         memcpy(radio->ruid, dm->get_radio_by_ref(radio_index).get_radio_interface_mac(), sizeof(mac_address_t));
@@ -851,6 +1335,7 @@ void em_configuration_t::handle_ap_vendor_operational_bss(unsigned char *value, 
 			dm_bss = dm->get_bss(radio->ruid, bss->bssid);
 			if (dm_bss == NULL) {
 				dm_bss = &dm->m_bss[dm->m_num_bss];
+				dm_bss->init();
 				dm->set_num_bss(dm->get_num_bss() + 1);
 			}
 			// fill up id first
@@ -1459,6 +1944,7 @@ int em_configuration_t::handle_ap_operational_bss(unsigned char *buff, unsigned 
 		
 			if (dm_bss == NULL) {
 				dm_bss = &dm->m_bss[dm->m_num_bss];
+				dm_bss->init();
 
 				// fill up id first
 				strncpy(dm_bss->m_bss_info.id.net_id, dm->m_device.m_device_info.id.net_id, sizeof(em_long_string_t));
@@ -1518,10 +2004,19 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
     em_client_assoc_event_t *assoc_evt_tlv;
     em_sta_info_t sta_info;
     em_bus_event_type_client_assoc_params_t    raw;
+    bool updated_any = false;
+    bool assoc_event;
+    unsigned int mld_i, aff_j, r;
+    em_assoc_sta_mld_info_t *assoc_info = NULL;
+    em_sta_info_t link_sta;
+    dm_bss_t *aff_bss = NULL;
+    mac_addr_str_t b_str, r_str;
+    em_long_string_t link_key;
+    dm_sta_t *assoc_row = NULL;
+    dm_sta_t *sta_row = NULL;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
 
 	dm = get_data_model();
-	em_printfout("Topology Notification received, length: %d", len);
 
 	if (em_msg_t(em_msg_type_topo_notif, m_peer_profile, buff, len).validate(errors) == 0) {
         printf("%s:%d: topology response msg validation failed\n", __func__, __LINE__);
@@ -1555,24 +2050,116 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
             dm_easy_mesh_t::macbytes_to_string(assoc_evt_tlv->bssid, bssid_str);
             dm_easy_mesh_t::macbytes_to_string(get_radio_interface_mac(), radio_mac_str);
             snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
+            assoc_event = assoc_evt_tlv->assoc_event;
 
-            //em_printfout("Client Device:%s %s to BSSID: %s\n", sta_mac_str,
-            //        (assoc_evt_tlv->assoc_event == 1)?"associated":"disassociated", bssid_str);
-            if ((assoc_evt_tlv->assoc_event == false)) {
-                //if disassoc, update db with thi sta_info info
-                memset(&sta_info, 0, sizeof(em_sta_info_t));
-                memcpy(sta_info.id, assoc_evt_tlv->cli_mac_address, sizeof(mac_address_t));
-                memcpy(sta_info.bssid, assoc_evt_tlv->bssid, sizeof(mac_address_t));
-                memcpy(sta_info.radiomac, get_radio_interface_mac(), sizeof(mac_address_t));
-                sta_info.associated = assoc_evt_tlv->assoc_event;
-
-                hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
-
-                dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
-                //em_printfout("Client updated to db: %s", key);
+            em_printfout("Client Device:%s %s to BSSID: %s\n", sta_mac_str,
+                   (assoc_evt_tlv->assoc_event == 1)?"associated":"disassociated", bssid_str);
+            if (assoc_event == false) {
+                em_printfout("topo notification disassoc: sta=%s bssid=%s key=%s",
+                        util::mac_to_string(assoc_evt_tlv->cli_mac_address).c_str(),
+                        util::mac_to_string(assoc_evt_tlv->bssid).c_str(), key);
             }
+            memset(&sta_info, 0, sizeof(em_sta_info_t));
+            memcpy(sta_info.id, assoc_evt_tlv->cli_mac_address, sizeof(mac_address_t));
+            memcpy(sta_info.bssid, assoc_evt_tlv->bssid, sizeof(mac_address_t));
+            memcpy(sta_info.radiomac, get_radio_interface_mac(), sizeof(mac_address_t));
+            sta_info.associated = assoc_event;
+
+            if (assoc_event == false) {
+                updated_any = false;
+
+                for (mld_i = 0; mld_i < dm->get_num_assoc_sta_mld(); mld_i++) {
+                    assoc_info = &dm->m_assoc_sta_mld[mld_i].m_assoc_sta_mld_info;
+                    if (memcmp(assoc_info->mac_addr, sta_info.id, sizeof(mac_address_t)) != 0) {
+                        continue;
+                    }
+                    for (aff_j = 0; aff_j < assoc_info->num_affiliated_sta; aff_j++) {
+                        bool link_radio_resolved = false;
+                        memset(&link_sta, 0, sizeof(em_sta_info_t));
+                        memcpy(link_sta.id, sta_info.id, sizeof(mac_address_t));
+                        memcpy(link_sta.bssid, assoc_info->affiliated_sta[aff_j].bssid, sizeof(mac_address_t));
+                        link_sta.associated = false;
+
+                        aff_bss = NULL;
+                        for (r = 0; r < dm->get_num_radios(); r++) {
+                            aff_bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, link_sta.bssid);
+                            if (aff_bss != NULL) {
+                                memcpy(link_sta.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+                                link_radio_resolved = true;
+                                break;
+                            }
+                        }
+
+                        if (link_radio_resolved == false) {
+                            em_printfout("TOPO_NOTIF_DISASSOC: skipping unresolved affiliated link sta=%s bssid=%s",
+                                    util::mac_to_string(link_sta.id).c_str(),
+                                    util::mac_to_string(link_sta.bssid).c_str());
+                            continue;
+                        }
+
+                        dm_easy_mesh_t::macbytes_to_string(link_sta.bssid, b_str);
+                        dm_easy_mesh_t::macbytes_to_string(link_sta.radiomac, r_str);
+                        snprintf(link_key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, b_str, r_str);
+
+                        assoc_row = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, link_key));
+                        if (assoc_row != NULL) {
+                            assoc_row->m_sta_info.associated = false;
+                            assoc_row->m_sta_info.frame_body_len = 0;
+                            memset(assoc_row->m_sta_info.frame_body, 0, sizeof(assoc_row->m_sta_info.frame_body));
+                        } else {
+                            hash_map_put(dm->m_sta_assoc_map, strdup(link_key), new dm_sta_t(&link_sta));
+                        }
+
+                        sta_row = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_map, link_key));
+                        if (sta_row != NULL) {
+                            sta_row->m_sta_info.associated = false;
+                            sta_row->m_sta_info.frame_body_len = 0;
+                            memset(sta_row->m_sta_info.frame_body, 0, sizeof(sta_row->m_sta_info.frame_body));
+                        }
+
+                        em_printfout("topo notification disassoc key=%s", link_key);
+                        updated_any = true;
+                    }
+                    break;
+                }
+
+                if (updated_any) {
+                    dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
+                } else {
+                    em_printfout("topo notification disassoc: no MLD info for sta=%s",
+                            util::mac_to_string(sta_info.id).c_str());
+                }
+            } else {
+                em_printfout("topo notification assoc defer: sta=%s bssid=%s",
+                        util::mac_to_string(sta_info.id).c_str(),
+                        util::mac_to_string(sta_info.bssid).c_str());
+                // Mark any stale entries for this STA on a different BSSID as disassociated
+                // so they don't appear alongside the new entry in the topology.
+                bool stale_cleared = false;
+                dm_sta_t *iter_sta = static_cast<dm_sta_t *>(hash_map_get_first(dm->m_sta_map));
+                while (iter_sta != NULL) {
+                    if ((memcmp(iter_sta->m_sta_info.id, sta_info.id, sizeof(mac_address_t)) == 0) &&
+                        (memcmp(iter_sta->m_sta_info.bssid, sta_info.bssid, sizeof(mac_address_t)) != 0) &&
+                        (iter_sta->m_sta_info.associated == true)) {
+                        iter_sta->m_sta_info.associated = false;
+                        stale_cleared = true;
+                    }
+                    iter_sta = static_cast<dm_sta_t *>(hash_map_get_next(dm->m_sta_map, iter_sta));
+                }
+                if (stale_cleared) {
+                    em_printfout("topo notification assoc: cleared stale entries for sta=%s", util::mac_to_string(sta_info.id).c_str());
+                    dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
+                }
+            }
+
             memcpy(raw.dev, dev_mac, sizeof(mac_address_t));
             memcpy(reinterpret_cast<unsigned char *> (&raw.assoc), reinterpret_cast<unsigned char *> (assoc_evt_tlv), sizeof(em_client_assoc_event_t));
+            if (assoc_event == false) {
+                em_printfout("topo notification disassoc: dispatch dev=%s sta=%s bssid=%s assoc=%d",
+                        util::mac_to_string(dev_mac).c_str(),
+                        util::mac_to_string(assoc_evt_tlv->cli_mac_address).c_str(),
+                        util::mac_to_string(assoc_evt_tlv->bssid).c_str(), assoc_evt_tlv->assoc_event);
+            }
             get_mgr()->io_process(em_bus_event_type_sta_assoc, reinterpret_cast<unsigned char *> (&raw), sizeof(em_bus_event_type_client_assoc_params_t));
             break;
         }
@@ -1593,6 +2180,8 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
     bool found_op_bss = false;
     bool found_profile = false;
     bool found_bss_config_rprt = false;
+    bool found_ap_mld = false;
+    unsigned int assoc_sta_mld_count = 0;
     em_profile_type_t profile = em_profile_type_reserved;
 	dm_easy_mesh_t *dm;
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
@@ -1710,8 +2299,6 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
         }
     }
 
-
-    bool found_ap_mld = false;
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type != em_tlv_type_ap_mld_config) {
             tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
@@ -1730,6 +2317,26 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
         handle_ap_mld_config_tlv(tlv->value, htons(tlv->len));
     }
     em_printfout("No of AP MLDs: %d", dm->m_num_ap_mld);
+
+    // Parse Associated STA MLD Configuration Report TLVs.
+    tlv = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    tmp_len = len - static_cast<unsigned int>(sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+    assoc_sta_mld_count = 0;
+    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+        if (tlv->type == em_tlv_type_assoc_sta_mld_conf_rep) {
+            em_printfout("Found Assoc STA MLD Configuration Report TLV #%u", assoc_sta_mld_count);
+            handle_assoc_sta_mld_conf_rep_tlv(tlv->value, htons(tlv->len));
+            assoc_sta_mld_count++;
+        }
+        tmp_len -= static_cast<unsigned int>(sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+    }
+    em_printfout("Total Assoc STA MLD TLVs parsed: %u, m_num_assoc_sta_mld=%u",
+        assoc_sta_mld_count, dm->m_num_assoc_sta_mld);
+
+    if (handle_assoc_sta_mld_topology_update(dm) == true) {
+        dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
+    }
 
     em_printfout("Src al mac: " MACSTRFMT, MAC2STR(src_al_mac));
 
@@ -1775,6 +2382,81 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
 int em_configuration_t::handle_ack_msg(unsigned char *buff, unsigned int len)
 {
     set_state(em_state_ctrl_ap_mld_req_ack_rcvd);
+    return 0;
+}
+
+
+int em_configuration_t::handle_assoc_sta_mld_conf_rep_tlv(unsigned char *buff, unsigned int len)
+{
+    em_assoc_sta_mld_t *assoc_sta_mld;
+    em_affiliated_sta_mld_t *affiliated_sta_mld;
+    em_assoc_sta_mld_info_t assoc_sta_mld_info;
+    dm_easy_mesh_t *dm;
+    unsigned int j;
+    unsigned int affiliated_payload_len;
+    unsigned int max_affiliated_in_tlv;
+    unsigned int reported_affiliated_count;
+
+    dm = get_data_model();
+
+    if (buff == NULL || len < sizeof(em_assoc_sta_mld_t)) {
+        em_printfout("Invalid assoc STA MLD TLV: buff=%p len=%u", buff, len);
+        return -1;
+    }
+
+    assoc_sta_mld = reinterpret_cast<em_assoc_sta_mld_t *>(buff);
+
+    memset(&assoc_sta_mld_info, 0, sizeof(em_assoc_sta_mld_info_t));
+
+    memcpy(assoc_sta_mld_info.mac_addr, assoc_sta_mld->sta_mld_mac_addr, sizeof(mac_address_t));
+    memcpy(assoc_sta_mld_info.ap_mld_mac_addr, assoc_sta_mld->ap_mld_mac_addr, sizeof(mac_address_t));
+    assoc_sta_mld_info.str   = assoc_sta_mld->str;
+    assoc_sta_mld_info.nstr  = assoc_sta_mld->nstr;
+    assoc_sta_mld_info.emlsr = assoc_sta_mld->emlsr;
+    assoc_sta_mld_info.emlmr = assoc_sta_mld->emlmr;
+
+    affiliated_payload_len = len - static_cast<unsigned int>(sizeof(em_assoc_sta_mld_t));
+    max_affiliated_in_tlv = affiliated_payload_len /
+        static_cast<unsigned int>(sizeof(em_affiliated_sta_mld_t));
+    reported_affiliated_count = assoc_sta_mld->num_affiliated_sta;
+
+    if (reported_affiliated_count > max_affiliated_in_tlv) {
+        em_printfout("Malformed assoc STA MLD TLV: num_affiliated_sta=%u exceeds payload capacity=%u (len=%u)",
+            reported_affiliated_count, max_affiliated_in_tlv, len);
+    }
+
+    assoc_sta_mld_info.num_affiliated_sta = static_cast<unsigned char>(
+        std::min(static_cast<unsigned int>(EM_MAX_AP_MLD),
+                 std::min(reported_affiliated_count, max_affiliated_in_tlv)));
+
+    affiliated_sta_mld = assoc_sta_mld->affiliated_sta_mld;
+    for (j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
+        memcpy(assoc_sta_mld_info.affiliated_sta[j].bssid,
+               affiliated_sta_mld->bssid, sizeof(mac_address_t));
+        memcpy(assoc_sta_mld_info.affiliated_sta[j].link_addr,
+               affiliated_sta_mld->affiliated_sta_mac_addr, sizeof(mac_address_t));
+        affiliated_sta_mld = reinterpret_cast<em_affiliated_sta_mld_t *>(
+            reinterpret_cast<unsigned char *>(affiliated_sta_mld) + sizeof(em_affiliated_sta_mld_t));
+    }
+
+    em_printfout("Parsed assoc STA MLD: sta_mld_mac=%s ap_mld_mac=%s str=%d nstr=%d emlsr=%d emlmr=%d num_affiliated_sta=%u",
+        util::mac_to_string(assoc_sta_mld_info.mac_addr).c_str(),
+        util::mac_to_string(assoc_sta_mld_info.ap_mld_mac_addr).c_str(),
+        assoc_sta_mld_info.str, assoc_sta_mld_info.nstr,
+        assoc_sta_mld_info.emlsr, assoc_sta_mld_info.emlmr,
+        assoc_sta_mld_info.num_affiliated_sta);
+
+    for (j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
+        em_printfout("affiliated_sta[%u]: bssid=%s mac_addr=%s", j,
+            util::mac_to_string(assoc_sta_mld_info.affiliated_sta[j].bssid).c_str(),
+            util::mac_to_string(assoc_sta_mld_info.affiliated_sta[j].link_addr).c_str());
+    }
+
+    // Replace existing STA-MLD row to avoid stale affiliated links.
+    dm->remove_assoc_sta_mld_info(assoc_sta_mld_info.mac_addr);
+    dm->update_assoc_sta_mld_info(&assoc_sta_mld_info);
+
+    em_printfout("Updated controller DM assoc STA MLD, m_num_assoc_sta_mld=%u", dm->m_num_assoc_sta_mld);
     return 0;
 }
 
@@ -1844,97 +2526,6 @@ int em_configuration_t::handle_ap_mld_config_tlv(unsigned char *buff, unsigned i
     return 0;
 }
 
-int em_configuration_t::handle_eht_operations_tlv(unsigned char *buff)
-{
-    short len = 0;
-    unsigned int i = 0, j = 0, k = 0, l = 0;
-    unsigned char *tmp = buff;
-
-    unsigned char num_radios;
-    unsigned char num_bss = 0;
-
-    em_eht_operations_t eht_ops;
-
-    dm_easy_mesh_t *dm;
-
-    dm = get_data_model();
-
-    // 32 octets are reserved for future use, so skip 32 octets
-    short reserved_octets = 32;
-    tmp += reserved_octets;
-    len += reserved_octets;
-
-    memcpy(&num_radios, tmp, sizeof(unsigned char));
-    
-    if (num_radios > EM_MAX_RADIO_PER_AGENT) {
-        em_printfout("Invalid num_radios=%d, max allowed=%d", num_radios, EM_MAX_RADIO_PER_AGENT);
-        return -1;
-    }
-    
-    eht_ops.radios_num = num_radios;
-    tmp += sizeof(unsigned char);
-    len += static_cast<short> (sizeof(unsigned char));
-
-    for (i = 0; i < num_radios; i++) {
-        memcpy(&eht_ops.radios[i].ruid, tmp, sizeof(mac_address_t));
-        tmp += sizeof(mac_address_t);
-        len += static_cast<short> (sizeof(mac_address_t));
-
-        memcpy(&num_bss, tmp, sizeof(unsigned char));
-        
-        if (num_bss > EM_MAX_BSS_PER_RADIO) {
-            em_printfout("Invalid num_bss=%d for radio %d, max allowed=%d", num_bss, i, EM_MAX_BSS_PER_RADIO);
-            return -1;
-        }
-        
-        eht_ops.radios[i].bss_num = num_bss;
-        tmp += sizeof(unsigned char);
-        len += static_cast<short> (sizeof(unsigned char));
-
-        for(j = 0; j < num_bss; j++) {
-            memcpy(&eht_ops.radios[i].bss[j], tmp, sizeof(em_eht_operations_bss_t));
-            tmp += sizeof(em_eht_operations_bss_t);
-            len += static_cast<short> (sizeof(em_eht_operations_bss_t));
-        }
-        // 25 octets are reserved for future use in radio, so skip 25 octets
-        short radio_reserved_octets = 25;
-        tmp += radio_reserved_octets;
-        len += radio_reserved_octets;
-    }
-
-    bool found_radio = false;
-    bool found_bss = false;
-    for (i = 0; i < eht_ops.radios_num; i++) {
-        for (j = 0; j < dm->get_num_radios(); j++) {
-            if (memcmp(eht_ops.radios[i].ruid, dm->m_radio[j].m_radio_info.id.dev_mac, sizeof(mac_address_t)) == 0) {
-                found_radio = true;
-                break;
-            }
-            if (found_radio == false) {
-                // do not update anything and retrun error
-                return -1;
-            }
-        }
-        found_radio = false;
-
-        for(k = 0; k < eht_ops.radios[i].bss_num; k++) {
-            for(l = 0; l < dm->get_num_bss(); l++) {
-                if (memcmp(eht_ops.radios[i].bss[k].bssid, dm->m_bss[l].m_bss_info.bssid.mac, sizeof(mac_address_t)) == 0) {
-                    found_bss = true;
-                    break;
-                }
-                if (found_bss == false) {
-                    // do not update anything and retrun error
-                    return -1;
-                }
-            }
-            found_bss = false;
-            memcpy(&dm->m_bss[l].get_bss_info()->eht_ops, &eht_ops.radios[i].bss[k], sizeof(em_eht_operations_bss_t));
-        }
-    }
-    return 0;
-}
-
 int em_configuration_t::handle_ap_mld_config_req(unsigned char *buff, unsigned int len)
 {
     em_tlv_t    *tlv;
@@ -1949,7 +2540,7 @@ int em_configuration_t::handle_ap_mld_config_req(unsigned char *buff, unsigned i
             handle_ap_mld_config_tlv(tlv->value, sizeof(em_ap_mld_config_t));
         }
         if (tlv->type == em_tlv_eht_operations) {
-            handle_eht_operations_tlv(tlv->value);
+            handle_eht_operations_tlv(tlv->value, htons(tlv->len));
             break;
         }
 
@@ -1968,45 +2559,6 @@ int em_configuration_t::handle_ap_mld_config_resp(unsigned char *buff, unsigned 
 {
     printf("%s:%d Received AP MLD configuration response\n",__func__, __LINE__);
     return 0;
-}
-
-unsigned short em_configuration_t::create_traffic_separation_policy(unsigned char *buff)
-{
-    unsigned short len = 0;
-    unsigned int i;
-    dm_easy_mesh_t *dm = get_data_model();
-    dm_network_ssid_t *net_ssid;
-    unsigned char *tmp = buff;
-
-    // get total ssid count
-    unsigned char ssids_num = dm->get_num_network_ssid();
-    *tmp = static_cast<unsigned char>(ssids_num);
-    tmp += sizeof(unsigned char);
-    len += sizeof(unsigned char);
-
-    for (i = 0; i < ssids_num; i++) {
-        net_ssid = dm->get_network_ssid(i);
-
-        std::vector<unsigned char> ssid_bytes(net_ssid->m_network_ssid_info.ssid, 
-                    net_ssid->m_network_ssid_info.ssid + strlen(net_ssid->m_network_ssid_info.ssid));
-        unsigned char ssid_len = static_cast<unsigned char>(ssid_bytes.size());
-
-        *tmp = ssid_len;
-        tmp += sizeof(unsigned char);
-        len += sizeof(unsigned char);
-
-        memcpy(tmp, ssid_bytes.data(), ssid_len);
-        tmp += ssid_len;
-        len += ssid_len;
-
-        unsigned short vlan_n = htons(net_ssid->m_network_ssid_info.vlan_id);
-        memcpy(tmp, &vlan_n, sizeof(vlan_n));
-        tmp += sizeof(unsigned short);
-        len += sizeof(unsigned short);
-	    em_printfout(" TRAFFIC SEPARATION SSID='%.*s' Len=%u, VLAN=%u ",ssid_len,ssid_bytes.data(), ssid_len, net_ssid->m_network_ssid_info.vlan_id);
-    }
-    em_printfout("Length: %d ", len);
-    return len;
 }
 
 unsigned short em_configuration_t::create_m2_msg(unsigned char *buff, em_haul_type_t haul_type)
@@ -2773,8 +3325,16 @@ int em_configuration_t::create_bss_config_req_msg(uint8_t *buff, uint8_t dest_al
     // tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_ap_wifi6_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
 
     //  One AP Radio Advanced Capabilities TLV for each of the supported radios of the Multi-AP Agent
-    tlv_size = create_ap_radio_advanced_cap_tlv(tlv_buff); // Data
-    tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_ap_radio_advanced_cap, tlv_buff, static_cast<unsigned int> (tlv_size));
+    std::vector<em_t *> em_radios;
+    get_mgr()->get_all_em_for_al_mac(get_al_interface_mac(), em_radios);
+    for (auto &em_radio : em_radios) {
+        memset(tlv_buff, 0, sizeof(tlv_buff));
+        tlv_size = em_radio->create_ap_radio_advanced_cap_tlv(tlv_buff);
+        if (tlv_size > 0) {
+            tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_ap_radio_advanced_cap, tlv_buff, static_cast<unsigned int>(tlv_size));
+        }
+    }
+    em_radios.clear();
 
     //  If the Agent supports EHT (Wi-Fi 7) operation, one Wi-Fi 7 Agent Capabilities TLV.
     // tlv_size = create_wifi7_tlv(tlv_buff); // Data
@@ -2863,7 +3423,7 @@ int em_configuration_t::create_bss_config_rsp_msg(uint8_t *buff, uint8_t dest_al
     tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_dflt_8021q_settings, tlv_buff, sizeof(em_8021q_settings_t));
 
     // Zero or One traffic separation policy tlv 17.2.50
-    tlv_size = create_traffic_separation_policy(tlv_buff); // Data
+    tlv_size = create_traffic_separation_policy_tlv(tlv_buff); // Data
     tmp = em_msg_t::add_tlv(tmp, &len, em_tlv_type_traffic_separation_policy, tlv_buff, static_cast<unsigned int> (tlv_size));
 
     // Zero or one Agent AP MLD Configuration TLV (see section 17.2.96)
@@ -3255,7 +3815,7 @@ int em_configuration_t::create_autoconfig_wsc_m2_msg(unsigned char *buff, unsign
 
     // first compute keys
     if (compute_keys(get_e_public(), static_cast<short unsigned int> (get_e_public_len()), get_r_private(), static_cast<short unsigned int> (get_r_private_len())) != 1) {
-        printf("%s:%d: Keys computation failed\n", __func__, __LINE__);
+        em_printfout("%s:%d: Keys computation failed\n", __func__, __LINE__);
         return 0;
     }
 
@@ -3319,24 +3879,6 @@ int em_configuration_t::create_autoconfig_wsc_m2_msg(unsigned char *buff, unsign
         em_printfout("Autoconfiguration skipped because no M2 is present. Return value: %d", sz);
         return 0;
     }
-
-    // default 8022.1q settings tlv 17.2.49
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_dflt_8021q_settings;
-    tlv->len = htons(sizeof(em_8021q_settings_t));
-    memset(tlv->value, 0, sizeof(tlv->len));
-
-    tmp += (sizeof(em_tlv_t) + sizeof(em_8021q_settings_t));
-    len += static_cast<int> (sizeof(em_tlv_t) + sizeof(em_8021q_settings_t));
-
-    // traffic separation policy tlv 17.2.50 
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_traffic_separation_policy;
-    sz = static_cast<short unsigned int> (create_traffic_separation_policy(tlv->value));
-    tlv->len = htons(sz);
-
-    tmp += (sizeof(em_tlv_t) + sz);
-    len += static_cast<int> (sizeof(em_tlv_t) + sz);
 
     // ap mld tlv 17.2.96
     tlv =reinterpret_cast<em_tlv_t *> (tmp);
@@ -3688,7 +4230,7 @@ int em_configuration_t::handle_wsc_m1(unsigned char *buff, unsigned int len)
     unsigned int tmp_len;
     unsigned short id;
     mac_addr_str_t mac_str;
-    em_device_info_t    dev_info;
+    em_device_info_t    dev_info = {};
     dm_easy_mesh_t *dm;
     em_freq_band_t  band;
     dm_radio_t *radio;
@@ -3818,8 +4360,9 @@ int em_configuration_t::handle_autoconfig_wsc_m2(unsigned char *buff, unsigned i
     dm_network_t network;
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *> (buff);
 
+    em_printfout("%s:%d: handle_autoconfig_wsc_m2 enter len:%d peer_profile:%d", __func__, __LINE__, len, m_peer_profile);
     if (em_msg_t(em_msg_type_autoconf_wsc, m_peer_profile, buff, len).validate(errors) == 0) {
-        printf("%s:%d: received wsc m2 msg failed validation\n", __func__, __LINE__);
+        em_printfout("%s:%d: received wsc m2 msg failed validation", __func__, __LINE__);
 
         return -1;
     }
@@ -4089,7 +4632,7 @@ int em_configuration_t::handle_bss_config_req_msg(uint8_t *buff, unsigned int le
                 break;
             case em_tlv_eht_operations:
                 em_printfout("Processing EHT Operations TLV");
-                handle_eht_operations_tlv(tlv->value);
+                handle_eht_operations_tlv(tlv->value, htons(tlv->len));
                 break;
             default:
                 em_printfout("Unknown TLV type %d in BSS Configuration Request message", tlv->type);
@@ -4459,7 +5002,7 @@ int em_configuration_t::handle_bss_config_rsp_msg(uint8_t *buff, unsigned int le
                 handle_bsta_mld_config_req(tlv->value, htons(tlv->len));
                 break;
             case em_tlv_eht_operations:
-                handle_eht_operations_tlv(tlv->value);
+                handle_eht_operations_tlv(tlv->value, htons(tlv->len));
                 break;
             default:
                 em_printfout("Unknown TLV type %d in BSS Configuration Response message", tlv->type);
@@ -4620,7 +5163,7 @@ int em_configuration_t::handle_bss_config_res_msg(uint8_t *buff, unsigned int le
                 // Not handled by UWM right now?
                 break;
             case em_tlv_eht_operations:
-                handle_eht_operations_tlv(tlv->value);
+                handle_eht_operations_tlv(tlv->value, htons(tlv->len));
                 break;
             default:
                 em_printfout("Unknown TLV type %d in BSS Configuration Result message", tlv->type);
@@ -5033,7 +5576,9 @@ int em_configuration_t::handle_autoconfig_wsc_m1(unsigned char *buff, unsigned i
     em_bus_event_type_m2_tx_params_t   raw;
 
     dm_easy_mesh_t::macbytes_to_string(get_peer_mac(), mac_str);
-    printf("%s:%d: Device AL MAC: %s\n", __func__, __LINE__, mac_str);
+    em_raw_hdr_t *m1_hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+    printf("%s:%d: Device AL MAC: %s, peer src: %02x:%02x:%02x:%02x:%02x:%02x\n", __func__, __LINE__, mac_str,
+        m1_hdr->src[0], m1_hdr->src[1], m1_hdr->src[2], m1_hdr->src[3], m1_hdr->src[4], m1_hdr->src[5]);
 
     if (em_msg_t(em_msg_type_autoconf_wsc, em_profile_type_3, buff, len).validate(errors) == 0) {
         printf("%s:%d: received autoconfig wsc m1 msg failed validation\n", __func__, __LINE__);
@@ -5061,18 +5606,19 @@ int em_configuration_t::handle_autoconfig_wsc_m1(unsigned char *buff, unsigned i
 
     int ret = create_autoconfig_wsc_m2_msg(msg, ntohs(cmdu->id));
     if (ret <= 0) {
+        printf("%s:%d: create_autoconfig_wsc_m2_msg failed, ret=%d\n", __func__, __LINE__, ret);
         return -1;
     }
     sz = static_cast<unsigned int> (ret);
 
     if (em_msg_t(em_msg_type_autoconf_wsc, em_profile_type_3, msg, sz).validate(errors) == 0) {
-        printf("Autoconfig wsc m2 msg failed validation in tnx end\n");
+        em_printfout("Autoconfig wsc m2 msg failed validation in tnx end\n");
 
         return -1;
     }
 
     if (send_frame(msg, sz)  < 0) {
-        printf("%s:%d: autoconfig wsc m2 send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("%s:%d: autoconfig wsc m2 send failed, error:%d\n", __func__, __LINE__, errno);
         return -1;
     }
 
@@ -5082,7 +5628,7 @@ int em_configuration_t::handle_autoconfig_wsc_m1(unsigned char *buff, unsigned i
     }
 
 	set_state(em_state_ctrl_wsc_m2_sent);
-	printf("%s:%d: autoconfig wsc m2 send, len:%d\n", __func__, __LINE__, sz);
+	em_printfout("%s:%d: autoconfig wsc m2 send, len:%d\n", __func__, __LINE__, sz);
     memcpy(raw.al, const_cast<unsigned char *> (get_peer_mac()), sizeof(mac_address_t));
     memcpy(raw.radio, get_radio_interface_mac(), sizeof(mac_address_t));
 
@@ -5131,16 +5677,21 @@ int em_configuration_t::handle_autoconfig_resp(unsigned char *buff, unsigned int
     }
 
     printf("Received resp and validated...creating M1 msg\n");
-    sz = static_cast<unsigned int> (create_autoconfig_wsc_m1_msg(msg, hdr->src));
+    int msg_len = create_autoconfig_wsc_m1_msg(msg, hdr->src);
+    if (msg_len < 0) {
+        em_printfout("Error: Failed to create autoconfig wsc m1 msg");
+        return -1;
+    }
+    sz = static_cast<unsigned int>(msg_len);
 
     if (em_msg_t(em_msg_type_autoconf_wsc, em_profile_type_3, msg, sz).validate(errors) == 0) {
-        printf("autoconfig wsc m1 validation failed\n");
+        em_printfout("Error: autoconfig wsc m1 validation failed");
 
         return -1;
     }
 
     if (send_frame(msg, sz)  < 0) {
-        printf("%s:%d: autoconfig wsc m1 send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: autoconfig wsc m1 send failed, error:%d", errno);
 
         return -1;
     }
@@ -5192,19 +5743,24 @@ int em_configuration_t::handle_autoconfig_search(unsigned char *buff, unsigned i
         return ec_mgr.handle_autoconf_chirp(reinterpret_cast<em_dpp_chirp_value_t*>(dpp_chirp_tlv->value), SWAP_LITTLE_ENDIAN(dpp_chirp_tlv->len), al_mac, ntohs(cmdu->id));
     }
     
-    sz = static_cast<unsigned int> (create_autoconfig_resp_msg(msg, band, al_mac, ntohs(cmdu->id)));
+    int msg_len = create_autoconfig_resp_msg(msg, band, al_mac, ntohs(cmdu->id));
+    if (msg_len < 0) {
+        em_printfout("Error: Failed to create autoconfig response msg");
+        return -1;
+    }
+    sz = static_cast<unsigned int>(msg_len);
     if (em_msg_t(em_msg_type_autoconf_resp, em_profile_type_3, msg, sz).validate(errors) == 0) {
-        printf("%s:%d: autoconfig rsp validation failed\n", __func__, __LINE__);
+        em_printfout("Error: autoconfig rsp validation failed");
 
         //return -1;
     }
 
     if (send_frame(msg, sz)  < 0) {
-        printf("%s:%d: autoconfig rsp send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: autoconfig rsp send failed, error:%d", errno);
 
         return -1;
     }
-    printf("%s:%d: autoconfig rsp send success\n", __func__, __LINE__);
+    em_printfout("autoconfig rsp send success");
 
     if (!get_is_dpp_onboarding()) {
         set_state(em_state_ctrl_wsc_m1_pending);
@@ -5241,11 +5797,12 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
 {
     unsigned char *tlvs;
     unsigned int tlvs_len;
+    std::vector<em_t *> em_radios;
 
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(data + sizeof(em_raw_hdr_t));
             
     tlvs = data + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t);
-    tlvs_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) - sizeof(em_cmdu_t));
+    tlvs_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
 
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(data);
     uint8_t *src_al_mac = hdr->src;
@@ -5256,7 +5813,7 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
                 handle_autoconfig_search(data, len);
 
             } else if (get_service_type() == em_service_type_agent) {
-                printf("%s:%d: received em_msg_type_autoconf_search message in agent ... dropping\n", __func__, __LINE__);
+                em_printfout("%s:%d: received em_msg_type_autoconf_search message in agent ... dropping\n", __func__, __LINE__);
             }
 
             break;
@@ -5270,14 +5827,21 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
             break;
 
         case em_msg_type_autoconf_wsc:
+            em_printfout("%s:%d: autoconf_wsc received: wsc_type=%d svc=%d state=%d\n", __func__, __LINE__,
+                get_wsc_msg_type(tlvs, tlvs_len), get_service_type(), get_state());
             if ((get_wsc_msg_type(tlvs, tlvs_len) == em_wsc_msg_type_m2) &&
                     (get_service_type() == em_service_type_agent) && (get_state() == em_state_agent_wsc_m2_pending)) {
-                        printf("%s:%d: received wsc_m2 len:%d\n", __func__, __LINE__, len);
+                        em_printfout("%s:%d: received wsc_m2 len:%d\n", __func__, __LINE__, len);
                         handle_autoconfig_wsc_m2(data, len);
             } else if ((get_wsc_msg_type(tlvs, tlvs_len) == em_wsc_msg_type_m1) &&
                     (get_service_type() == em_service_type_ctrl) && (get_state() == em_state_ctrl_wsc_m1_pending))  {
                         printf("%s:%d: received wsc_m1 len:%d\n", __func__, __LINE__, len);
                         handle_autoconfig_wsc_m1(data, len);
+            } else {
+                em_printfout("%s:%d: autoconf_wsc DROPPED: wsc_type=%d svc_ctrl=%d state_ok=%d\n", __func__, __LINE__,
+                    get_wsc_msg_type(tlvs, tlvs_len),
+                    (get_service_type() == em_service_type_ctrl),
+                    (get_state() == em_state_ctrl_wsc_m1_pending));
             }
 
             break;
@@ -5313,7 +5877,23 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
 			break;
 
         case em_msg_type_topo_resp:
-            if ((get_service_type() == em_service_type_ctrl) && (get_state() == em_state_ctrl_topo_sync_pending)){
+        {
+            // Accept topo_resp if this radio is in topo_sync_pending, OR if any
+            // AL radio is (sta_assoc dispatches only one radio so the response
+            // may land on a different radio than the one that sent the query).
+            bool any_al_topo_sync_pending = false;
+            {
+                std::vector<em_t *> al_check;
+                get_mgr()->get_all_em_for_al_mac(get_data_model()->get_agent_al_interface_mac(), al_check);
+                any_al_topo_sync_pending = std::any_of(al_check.begin(), al_check.end(), [](em_t *r) {
+                    return r->get_state() == em_state_ctrl_topo_sync_pending;
+                });
+            }
+            // bool sta_assoc_topo_sync = (get_current_cmd() != NULL &&
+            //     get_current_cmd()->m_type == em_cmd_type_sta_assoc);
+            if ((get_service_type() == em_service_type_ctrl) &&
+                (get_state() == em_state_ctrl_topo_sync_pending || any_al_topo_sync_pending)) {
+            // if ((get_service_type() == em_service_type_ctrl) && (get_state() == em_state_ctrl_topo_sync_pending)){
                 if (handle_topology_response(data, len) == 0) {
                     set_state(em_state_ctrl_topo_synchronized);
                     static_cast<em_t*>(this)->set_ssid_mismatch(false);
@@ -5340,11 +5920,23 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
                     printf("%s:%d em_msg_type_topo_resp handle failed \n", __func__, __LINE__);
                 }
             }
+        }
             break;
 
         case em_msg_type_topo_notif:
-            if ((get_service_type() == em_service_type_ctrl) && (get_state() >= em_state_ctrl_topo_synchronized)) {
-                handle_topology_notification(data, len);
+            em_radios.clear();
+            get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
+            for (auto *get_em : em_radios) {
+                if ((get_service_type() == em_service_type_ctrl) && (get_em->get_state() >= em_state_ctrl_topo_synchronized)) {
+                    get_em->handle_topology_notification(data, len);
+                    break;
+                }
+            }
+            break;
+
+        case em_msg_type_failed_conn:
+            if (get_service_type() == em_service_type_ctrl) {
+                em_printfout("Received failed connection message from agent src_al_mac:%s", util::mac_to_string(src_al_mac).c_str());
             }
             break;
         
@@ -5415,20 +6007,25 @@ void em_configuration_t::handle_state_config_none()
     unsigned char buff[MAX_EM_BUFF_SZ];
     unsigned int sz;
     char* errors[EM_MAX_TLV_MEMBERS] = {0};
-
-    sz = static_cast<unsigned int> (create_autoconfig_search_msg(buff));
+    int len = create_autoconfig_search_msg(buff);
+    if (len < 0) {
+        em_printfout("Error: Failed to create autoconfig_search msg");
+        return;
+    }
+    sz = static_cast<unsigned int>(len);
     if (em_msg_t(em_msg_type_autoconf_search, em_profile_type_3, buff, sz).validate(errors) == 0) {
-        printf("Autoconfig_search validation failed\n");
+        em_printfout("Error: Autoconfig_search validation failed");
 
         return;
     }
 
     if (send_frame(buff, sz, true)  < 0) {
-        printf("%s:%d: failed, err:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: failed, err:%d\n", errno);
         return;
     }
     em_printf("autoconfig_search send successful");
-    printf("%s:%d: autoconfig_search send successful\n", __func__, __LINE__);
+    em_printfout("autoconfig_search send successful");
+
     set_state(em_state_agent_autoconfig_rsp_pending);
 
     return;
@@ -5444,18 +6041,23 @@ void em_configuration_t::handle_state_autoconfig_renew()
 
 
     memcpy(ctrl_src, get_current_cmd()->get_data_model()->get_controller_interface_mac(), sizeof(mac_address_t));
-    sz = static_cast<unsigned int> (create_autoconfig_wsc_m1_msg(msg, ctrl_src));
+    int msg_len = create_autoconfig_wsc_m1_msg(msg, ctrl_src);
+    if (msg_len < 0) {
+        em_printfout("Error: Failed to create autoconfig wsc m1 msg");
+        return ;
+    }
+    sz = static_cast<unsigned int>(msg_len);
 
     if (em_msg_t(em_msg_type_autoconf_wsc, em_profile_type_3, msg, sz).validate(errors) == 0) {
-        printf("autoconfig wsc m1 validation failed\n");
+        em_printfout("Error: autoconfig wsc m1 validation failed");
         return ;
     }
 
     if (send_frame(msg, sz)  < 0) {
-        printf("%s:%d: autoconfig wsc m1 send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Error: autoconfig wsc m1 send failed, error:%d", errno);
         return ;
     }
-    printf("%s:%d: autoconfig wsc m1 send success\n", __func__, __LINE__);
+    em_printfout("autoconfig wsc m1 send success");
     set_state(em_state_agent_wsc_m2_pending);
 
     return ;
@@ -5561,6 +6163,9 @@ void em_configuration_t::process_ctrl_state()
         {
             std::vector<em_t *> em_radios;
             dm_easy_mesh_t *dm = get_data_model();
+            //this is needed as for cases like sta_assoc we send out topo query and client cap query which is per device and not per radio. So we need to allow single radio topo query for sta_assoc case
+            bool allow_single_radio_topo_query = (get_current_cmd() != NULL &&
+                get_current_cmd()->m_type == em_cmd_type_sta_assoc);
             get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
 
             // Evaluate SSID mismatch across this AL's radios only.
@@ -5570,26 +6175,68 @@ void em_configuration_t::process_ctrl_state()
 
             if (ssid_mismatch_present == false)
             {
-                for (auto &em : em_radios) {
-                    if (em->get_state() != em_state_ctrl_topo_sync_pending) {
-                        em_printfout("radio %s is in state:%d, not in topo sync pending state, ignoring",
-                            util::mac_to_string(em->get_radio_interface_mac()).c_str(), em->get_state());
-                        em_radios.clear();
-                        return;
+                if (!allow_single_radio_topo_query) {
+                    for (auto &em : em_radios) {
+                        if (em->get_state() != em_state_ctrl_topo_sync_pending) {
+                            em_printfout("radio %s is in state:%s, not in topo sync pending state, ignoring",
+                                util::mac_to_string(em->get_radio_interface_mac()).c_str(), em_t::state_2_str(em->get_state()));
+                            em_radios.clear();
+                            return;
+                        }
                     }
+                } else {
+                    em_printfout("sta_assoc single-radio topo query: skipping all-radios check for radio %s",
+                        util::mac_to_string(get_radio_interface_mac()).c_str());
                 }
+                // for (auto &em : em_radios) {
+                //     if (em->get_state() != em_state_ctrl_topo_sync_pending) {
+                //         em_printfout("radio %s is in state:%s, not in topo sync pending state, ignoring",
+                //             util::mac_to_string(em->get_radio_interface_mac()).c_str(), em_t::state_2_str(em->get_state()));
+                //         em_radios.clear();
+                //         return;
+                //     }
+                // }
+                // if (allow_single_radio_topo_query == false) {
+                //     for (auto &em : em_radios) {
+                //         if (em->get_state() != em_state_ctrl_topo_sync_pending) {
+                //             em_printfout("radio %s is in state:%s, not in topo sync pending state, ignoring",
+                //                 util::mac_to_string(em->get_radio_interface_mac()).c_str(), em_t::state_2_str(em->get_state()));
+                //             em_radios.clear();
+                //             return;
+                //         }
+                //     }
+                // }
                 // Reset the mismatch and topo_query_last sent values before sending topo query
                 dm->set_ssid_mismatch_check_time(0);
                 dm->set_last_topo_query_sent_time(0);
                 // If all radios are in topo sync pending state, send topo query on one of them, 
                 // ignore sending topo query on other radios
                 if (this == em_radios.front()){
+                // // sta_assoc: send exactly one topo query on the owning radio, then advance state
+                // // so the per-tick loop does not re-fire. The regular path requires all radios
+                // // to agree before sending, so it uses the front() guard instead.
+                // if (allow_single_radio_topo_query) {
+                //     if (m_topo_query_tx_cnt == 0) {
+                //         em_printfout("sta_assoc: Sending Topology query for agent al_mac:%s on radio: %s",
+                //             util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
+                //             util::mac_to_string(get_radio_interface_mac()).c_str());
+                //         em_t *al_em = get_mgr()->get_al_node();
+                //         al_em->set_state(em_state_ctrl_topo_sync_pending);
+                //         send_topology_query_msg();
+                //     }
+                //     // Advance state regardless so subsequent ticks do not re-enter this branch
+                //     set_state(em_state_ctrl_topo_synchronized);
+                // } else if (this == em_radios.front()) {
                     em_printfout("Sending the Topology query message to agent al_mac:%s on radio: %s",
                         util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
                         util::mac_to_string(get_radio_interface_mac()).c_str());
                     em_t *al_em = get_mgr()->get_al_node();
                     al_em->set_state(em_state_ctrl_topo_sync_pending);
                     send_topology_query_msg();
+                } else {
+                    em_printfout("topo_sync_pending: radio %s is not front radio %s, skipping topo query",
+                        util::mac_to_string(get_radio_interface_mac()).c_str(),
+                        util::mac_to_string(em_radios.front()->get_radio_interface_mac()).c_str());
                 }
                 em_radios.clear();
             }
@@ -5605,6 +6252,16 @@ void em_configuration_t::process_ctrl_state()
                 em_printfout("Topology has changed for device: %s", util::mac_to_string(dm->get_agent_al_interface_mac()).c_str());
                 dm->set_topo_state(false);
                 get_mgr()->publish_network_topology();
+            }
+            //Send beacon metrics query for the sta assoc case to get the beacon metrics from the STA
+            if (get_current_cmd() != NULL && get_current_cmd()->m_type == em_cmd_type_sta_assoc) {
+                em_cmd_params_t *evt_param = &get_current_cmd()->m_param;
+                mac_address_t sta_mac, bssid;
+                dm_easy_mesh_t::string_to_macbytes(evt_param->u.args.args[2], sta_mac);
+                dm_easy_mesh_t::string_to_macbytes(evt_param->u.args.args[1], bssid);
+                em_printfout("topo publish: sending beacon query for sta:%s bssid:%s",
+                    evt_param->u.args.args[2], evt_param->u.args.args[1]);
+                static_cast<em_t*>(this)->send_beacon_metrics_query(sta_mac, bssid);
             }
             set_state(em_state_ctrl_configured);
             break;

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -175,7 +175,11 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_agent_onewifi_bssconfig_ind);
             break;
         case em_cmd_type_sta_assoc:
-            if ((pcmd->get_orch_op() == dm_orch_type_topo_publish) && (m_sm.get_state() == em_state_ctrl_configured)) {
+            if ((pcmd->get_orch_op() == dm_orch_type_topo_sync) && (m_sm.get_state() == em_state_ctrl_configured)) {
+                m_sm.set_state(em_state_ctrl_topo_sync_pending);
+            } else if ((pcmd->get_orch_op() == dm_orch_type_sta_cap) && (m_sm.get_state() == em_state_ctrl_configured)) {
+                m_sm.set_state(em_state_ctrl_sta_cap_pending);
+            } else if (pcmd->get_orch_op() == dm_orch_type_topo_publish) {
                 m_sm.set_state(em_state_ctrl_topo_publish_pending);
             } else {
                 m_sm.set_state(em_state_ctrl_sta_cap_pending);
@@ -220,7 +224,7 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             break;
 
 		case em_cmd_type_set_policy:
-            set_state(em_state_ctrl_set_policy_pending);
+            m_sm.set_state(em_state_ctrl_set_policy_pending);
             break;
 
         case em_cmd_type_avail_spectrum_inquiry:
@@ -247,7 +251,15 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_agent_link_quality_report_pending);
             break;
 
-        default:
+        case em_cmd_type_unassoc_sta_query:
+            m_sm.set_state(em_state_ctrl_unassoc_sta_link_metrics_pending);
+            break;
+
+        case em_cmd_type_unassoc_sta_result:
+            m_sm.set_state(em_state_agent_unassoc_sta_metrics_report_pending);
+            break;
+        
+	default:
             break;
 
     }
@@ -287,6 +299,7 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_topo_resp:
         case em_msg_type_topo_query:
         case em_msg_type_topo_notif:
+        case em_msg_type_failed_conn:
         case em_msg_type_ap_mld_config_req:
         case em_msg_type_ap_mld_config_resp:
         case em_msg_type_bss_config_req:
@@ -301,6 +314,7 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_client_cap_query:
         case em_msg_type_client_cap_rprt:
             em_capability_t::process_msg(data, len);
+            em_metrics_t::process_msg(data, len);//lets trigger beacon qury after cap report
             break;
 
         case em_msg_type_channel_pref_query:
@@ -320,6 +334,8 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_beacon_metrics_rsp:
         case em_msg_type_ap_metrics_rsp:
         case em_msg_type_topo_vendor:
+	case em_msg_type_unassoc_sta_link_metrics_query: 
+        case em_msg_type_unassoc_sta_link_metrics_rsp:	    
             em_metrics_t::process_msg(data, len);
             break;
 
@@ -344,6 +360,8 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
                 em_configuration_t::process_msg(data, len);
             } else if (m_sm.get_state() == em_state_ctrl_sta_steer_pending) {
                 em_steering_t::process_msg(data, len);
+            } else if (m_sm.get_state() == em_state_ctrl_unassoc_sta_link_metrics_pending) {
+                em_metrics_t::process_msg(data, len);		    
             } else {
                 em_policy_cfg_t::process_msg(data, len);
                 em_channel_t::process_msg(data, len);
@@ -376,8 +394,26 @@ void em_t::proto_process(em_cmd_event_t *cevt)
             em_cmd_t *ap_cmd = static_cast<em_cmd_t*>(cevt->cmd_ptr);
             m_cmd = ap_cmd;
             em_metrics_t::process_agent_state(em_cmd_event_type_ap_metrics_report);
+            if (ap_cmd != NULL) {
+                ap_cmd->deinit();
+            }
             delete ap_cmd;
             m_cmd = saved_cmd;
+            break;
+        }
+        case em_cmd_event_type_failed_connection:
+        {
+            em_connection_status_evt_data_t *failed_conn_evt =
+                static_cast<em_connection_status_evt_data_t *>(cevt->cmd_ptr);
+
+            if (failed_conn_evt != NULL) {
+                handle_failed_connection_event(failed_conn_evt->sta_mac, failed_conn_evt->bssid,
+                                               failed_conn_evt->status_code,
+                                               failed_conn_evt->reason_code,
+                                               failed_conn_evt->reason_code_present);
+                free(failed_conn_evt);
+                cevt->cmd_ptr = NULL;
+            }
             break;
         }
         default:
@@ -457,6 +493,12 @@ void em_t::handle_agent_state()
             }
             break;
 
+        case em_cmd_type_unassoc_sta_result:
+            if (m_sm.get_state() == em_state_agent_unassoc_sta_metrics_report_pending) {
+                em_metrics_t::process_agent_state();
+            }
+            break;
+
         default:
             break;
     }
@@ -528,6 +570,10 @@ void em_t::handle_ctrl_state()
 
         case em_cmd_type_bsta_cap:
             em_capability_t::process_ctrl_state();
+            break;
+
+        case em_cmd_type_unassoc_sta_query:
+            em_metrics_t::process_ctrl_state();
             break;
 
         default:
@@ -1032,13 +1078,9 @@ short em_t::create_ap_cap_tlv(unsigned char *buff)
 
 int em_t::create_akm_suite_cap_tlv(uint8_t *buff)
 {
-    return 0;
-#if 0
     ASSERT_NOT_NULL(buff, -1, "%s:%d: Buffer is null\n", __func__, __LINE__);
     dm_easy_mesh_t *dm = get_data_model();
     ASSERT_NOT_NULL(dm, -1, "%s:%d: Data model is null\n", __func__, __LINE__);
-
-    em_akm_suite_info_t *akm_suite_info = reinterpret_cast<em_akm_suite_info_t *>(buff);
 
     std::set<std::string> fh_akms;
     std::set<std::string> bh_akms;
@@ -1058,67 +1100,92 @@ int em_t::create_akm_suite_cap_tlv(uint8_t *buff)
     std::vector<std::string> fh_akms_vec(fh_akms.begin(), fh_akms.end());
     std::vector<std::string> bh_akms_vec(bh_akms.begin(), bh_akms.end());
 
+    em_printfout("create_akm_suite_cap_tlv: radio=%s fh_akm_count=%zu bh_akm_count=%zu",
+        util::mac_to_string(get_radio_interface_mac()).c_str(),
+        fh_akms_vec.size(), bh_akms_vec.size());
+
     size_t tlv_size = sizeof(uint8_t) + sizeof(uint8_t); // Size of the `Num_BackAKM` and `Num_FrontAKM` fields
     tlv_size += (sizeof(em_fh_akm_suite_t) * fh_akms_vec.size()); // Size of fronthaul AKM suites
     tlv_size += (sizeof(em_bh_akm_suite_t) * bh_akms_vec.size()); // Size of backhaul AKM suites
 
     memset(buff, 0, tlv_size);
 
-    em_bh_akm_suite_info_t *bh_akm_suite_info = &akm_suite_info->bh_akm_suites;
-    em_fh_akm_suite_info_t *fh_akm_suite_info = &akm_suite_info->fh_akm_suites;
-    
-    bh_akm_suite_info->count = static_cast<uint8_t>(bh_akms_vec.size());
-    fh_akm_suite_info->count = static_cast<uint8_t>(fh_akms_vec.size());
+    uint8_t *tmp = buff;
+    uint8_t *bh_count_ptr = tmp++; // reserve space for backhaul count
+    uint8_t bh_count = 0;
 
-    em_bh_akm_suite_t *bh_akm_suite = bh_akm_suite_info->suites;
+    em_bh_akm_suite_t *bh_akm_suite = reinterpret_cast<em_bh_akm_suite_t *>(tmp);
     // Copy backhaul AKMs
     for (size_t i = 0; i < bh_akms_vec.size(); i++) {
         if (bh_akms_vec[i].empty()) continue;
+        em_printfout("create_akm_suite_cap_tlv: bh_akm[%zu]='%s'",
+                     i, bh_akms_vec[i].c_str());
         std::vector<uint8_t> bh_akm_bytes = util::akm_to_bytes(bh_akms_vec[i]);
         if (bh_akm_bytes.size() != 4) {
             em_printfout("Warning: Could not map backhaul AKM string '%s' to AKM suite bytes, skipping", bh_akms_vec[i].c_str());
             continue;
         }
         // OUI is first 3 bytes, suite type is last byte
-        memcpy(bh_akm_suite[i].oui, bh_akm_bytes.data(), 3);
-        bh_akm_suite[i].akm_suite_type = bh_akm_bytes[3];
+        memcpy(bh_akm_suite[bh_count].oui, bh_akm_bytes.data(), 3);
+        bh_akm_suite[bh_count].akm_suite_type = bh_akm_bytes[3];
+        em_printfout("create_akm_suite_cap_tlv: bh_akm[%u] oui=%02x:%02x:%02x suite_type=0x%02x",
+                     bh_count, bh_akm_suite[bh_count].oui[0], bh_akm_suite[bh_count].oui[1],
+                     bh_akm_suite[bh_count].oui[2], bh_akm_suite[bh_count].akm_suite_type);
+        bh_count++;
     }
+    *bh_count_ptr = bh_count;
 
-    em_fh_akm_suite_t *fh_akm_suite = fh_akm_suite_info->suites;
+    tmp += sizeof(em_bh_akm_suite_t) * bh_count;
+    uint8_t *fh_count_ptr = tmp++; // reserve space for fronthaul count
+    uint8_t fh_count = 0;
+
+    em_fh_akm_suite_t *fh_akm_suite = reinterpret_cast<em_fh_akm_suite_t *>(tmp);
 
     // Copy fronthaul AKMs
     for (size_t i = 0; i < fh_akms_vec.size(); i++) {
         if (fh_akms_vec[i].empty()) continue;
+        em_printfout("create_akm_suite_cap_tlv: fh_akm[%zu]='%s'",
+                     i, fh_akms_vec[i].c_str());
         std::vector<uint8_t> fh_akm_bytes = util::akm_to_bytes(fh_akms_vec[i]);
         if (fh_akm_bytes.size() != 4) {
             em_printfout("Warning: Could not map fronthaul AKM string '%s' to AKM suite bytes, skipping", fh_akms_vec[i].c_str());
             continue;
         }
         // OUI is first 3 bytes, suite type is last byte
-        memcpy(fh_akm_suite[i].oui, fh_akm_bytes.data(), 3);
-        fh_akm_suite[i].akm_suite_type = fh_akm_bytes[3];
+        memcpy(fh_akm_suite[fh_count].oui, fh_akm_bytes.data(), 3);
+        fh_akm_suite[fh_count].akm_suite_type = fh_akm_bytes[3];
+        em_printfout("create_akm_suite_cap_tlv: fh_akm[%u] oui=%02x:%02x:%02x suite_type=0x%02x",
+            fh_count, fh_akm_suite[fh_count].oui[0], fh_akm_suite[fh_count].oui[1],
+            fh_akm_suite[fh_count].oui[2], fh_akm_suite[fh_count].akm_suite_type);
+        fh_count++;
     }
+    *fh_count_ptr = fh_count;
 
+    tmp += sizeof(em_fh_akm_suite_t) * fh_count;
+    tlv_size = static_cast<size_t>(tmp - buff);
+
+    em_printfout("Created AKM Suite Cap TLV for Radio:%s, Num_FrontAKM:%d, Num_BackAKM:%d, tlv_size:%zu",
+        util::mac_to_string(get_radio_interface_mac()).c_str(),
+        static_cast<int>(fh_count), static_cast<int>(bh_count), tlv_size);
     return static_cast<int>(tlv_size);
-#endif
 }
 
 short em_t::create_ap_radio_advanced_cap_tlv(unsigned char *buff)
 {
     short len = 0;
     dm_easy_mesh_t *dm = get_data_model();
-    if (!dm) return -1;
+    if (!dm) return 0;
     em_ap_radio_advanced_cap_t *ap_adv_cap = reinterpret_cast<em_ap_radio_advanced_cap_t *>(buff);
     // One TLV per radio
-    for (unsigned int i = 0; i < dm->get_num_radios(); i++) {
-        dm_radio_t *radio = dm->get_radio(i);
-        if (!radio) continue;
-        memcpy(ap_adv_cap->ruid, radio->m_radio_info.intf.mac, sizeof(mac_address_t));
-        // TODO: remaining fields (bitfields) are Traffic Separation dependent.
-        // next radio
-        ap_adv_cap += 1;
-        len += static_cast<short>(sizeof(em_ap_radio_advanced_cap_t));
+    dm_radio_t *radio = dm->get_radio(get_radio_interface_mac());
+    if (!radio){
+        em_printfout("Radio not found for MAC %s", util::mac_to_string(get_radio_interface_mac()).c_str());
+        return 0;
     }
+    memset(ap_adv_cap, 0, sizeof(em_ap_radio_advanced_cap_t));
+    memcpy(ap_adv_cap->ruid, radio->m_radio_info.intf.mac, sizeof(mac_address_t));
+    // TODO: remaining fields (bitfields) are Traffic Separation dependent.
+    len += static_cast<short>(sizeof(em_ap_radio_advanced_cap_t));
 
     return len;
 }
@@ -1160,6 +1227,61 @@ short em_t::create_ht_tlv(unsigned char *buff)
 
     return len;
 }
+
+static uint16_t variant_to_airties_standards(wifi_ieee80211Variant_t current_variant)
+{
+    uint16_t std = 0;
+
+    if (current_variant & WIFI_80211_VARIANT_A)  std |= (1 << 15);
+    if (current_variant & WIFI_80211_VARIANT_B)  std |= (1 << 14);
+    if (current_variant & WIFI_80211_VARIANT_G)  std |= (1 << 13);
+    if (current_variant & WIFI_80211_VARIANT_N)  std |= (1 << 12);
+    if (current_variant & WIFI_80211_VARIANT_AC) std |= (1 << 11);
+    if (current_variant & WIFI_80211_VARIANT_AX) std |= (1 << 10);
+    if (current_variant & WIFI_80211_VARIANT_BE) std |= (1 << 9);
+    if (current_variant & WIFI_80211_VARIANT_BN) std |= (1 << 8);
+
+    return std;
+}
+
+short em_t::create_airties_radio_capability_tlv(unsigned char *buff)
+{
+    short len = 0;
+    dm_easy_mesh_t  *dm;
+    dm = get_data_model();
+    dm_radio_cap_t *radio_cap = dm->get_radio_cap(get_radio_interface_mac());
+
+    if (radio_cap == NULL) {
+        em_printfout("radio_cap NULL for MAC %s",
+                     util::mac_to_string(get_radio_interface_mac()).c_str());
+        return 0;
+    } else {
+        em_radio_cap_info_t* cap_info = radio_cap->get_radio_cap_info();
+        if (cap_info == NULL) {
+            em_printfout("No data Found");
+            return 0;
+        }
+        uint16_t supported_standards = htons(variant_to_airties_standards(cap_info->mode));
+        em_vendor_specific_v_t *vendor = reinterpret_cast<em_vendor_specific_v_t *>(buff);
+        if (vendor == NULL) {
+            em_printfout("No data Found");
+            return 0;
+        }
+        memcpy(reinterpret_cast<unsigned char *> (vendor->vendor_oui), airties_vendor_oui, EM_VENDOR_OUI_SIZE);
+        len += EM_VENDOR_OUI_SIZE;
+        uint16_t tlv_type = htons(static_cast<uint16_t>(em_tlv_type_radio_capability));
+        memcpy(reinterpret_cast<unsigned char *> (vendor->data), &tlv_type, sizeof(tlv_type));
+        len += static_cast<short>(sizeof(tlv_type));
+        em_radio_capability_vendor_t *tmp = reinterpret_cast<em_radio_capability_vendor_t *> (vendor->data + sizeof(tlv_type));
+        memcpy(tmp->interface_mac, get_radio_interface_mac(), sizeof(mac_address_t));
+        len += static_cast<short>(sizeof(mac_address_t));
+        memcpy(tmp->supported_standards, &supported_standards, sizeof(supported_standards));
+        len += static_cast<short>(sizeof(supported_standards));
+        len += 2; //reserved
+    }
+    return len;
+}
+
 
 short em_t::create_vht_tlv(unsigned char *buff)
 {
@@ -1377,8 +1499,8 @@ short em_t::create_wifi7_tlv(unsigned char *buff)
     offset += static_cast<short>(sizeof(unsigned char));
     em_printfout("  offset:%d", offset);
     for (unsigned int i = 0; i < dm->get_num_radios(); i++) {
-        em_wifi7_cap = &dm->get_radio_cap_info(static_cast<int>(i))->wifi7_cap;
-        em_printfout("Radio[%d]: %s", i, util::mac_to_string(dm->get_radio_cap_info(static_cast<int>(i))->ruid.mac).c_str());
+        em_wifi7_cap = &dm->get_radio_cap_info(i)->wifi7_cap;
+        em_printfout("Radio[%u]: %s", i, util::mac_to_string(dm->get_radio_cap_info(i)->ruid.mac).c_str());
 
         // MLO Support Capabilities
         mlo_mand = reinterpret_cast<em_wifi7_mlo_cap_support_tlv_t *>(buff + offset);
@@ -1475,93 +1597,153 @@ short em_t::create_wifi7_tlv(unsigned char *buff)
 short em_t::create_channelscan_tlv(unsigned char *buff)
 {
     short len = 0;
-    dm_easy_mesh_t  *dm;
-    dm = get_data_model();
-    dm_radio_cap_t *radio_cap = dm->get_radio_cap(0);// todo: it is dev specific, will be addressed in next phase
+    unsigned char *tmp = buff;
+    dm_easy_mesh_t *dm = get_data_model();
 
-    if (radio_cap == NULL) {
-        em_printfout("create_channelscan_tlv: radio_cap NULL for MAC %s",
-                     util::mac_to_string(get_radio_interface_mac()).c_str());
-        return 0;
+    // Num_Radio
+    unsigned char num_radios = static_cast<unsigned char>(dm->get_num_radios());
+    if (num_radios > EM_MAX_BANDS) num_radios = EM_MAX_BANDS;
+    *tmp = num_radios;
+    tmp += sizeof(unsigned char);
+    len += static_cast<short>(sizeof(unsigned char));
+
+    for (unsigned int i = 0; i < num_radios; i++) {
+        mac_address_t ruid;
+        memcpy(ruid, dm->get_radio_by_ref(i).m_radio_info.intf.mac, sizeof(mac_address_t));
+        dm_radio_cap_t *radio_cap = dm->get_radio_cap(ruid);
+        if (radio_cap == NULL) {
+            em_printfout("create_channelscan_tlv: radio_cap NULL for RUID %s",
+                util::mac_to_string(ruid).c_str());
+            return 0;
+        }
+       em_radio_cap_info_t *cap_info = radio_cap->get_radio_cap_info();
+        if (cap_info == NULL) {
+            em_printfout("create_channelscan_tlv: cap_info NULL for index %u", i);
+            return 0;
+        }
+
+        em_channel_scan_cap_radio_t *scan = reinterpret_cast<em_channel_scan_cap_radio_t *>(tmp);
+        // RUID
+        memcpy(scan->ruid, cap_info->ruid.mac, sizeof(mac_address_t));
+
+        // flags — struct bitfields map directly to spec layout
+        scan->boot_only    = cap_info->ch_scan.boot_only;
+        scan->scan_impact  = cap_info->ch_scan.scan_impact;
+        scan->reserved     = 0;
+
+        // Minimum Scan Interval — network byte order
+        scan->min_scan_interval = htonl(cap_info->ch_scan.min_scan_interval);
+
+        // fixed part of the struct (excludes variable-length op_classes array)
+        len += static_cast<short>(sizeof(em_channel_scan_cap_radio_t)
+                                  - sizeof(scan->op_classes));
+        tmp += sizeof(em_channel_scan_cap_radio_t) - sizeof(scan->op_classes);
+
+        // Per OpClass: OperatingClass(1) + Num_Chan(1) + ChannelList(Num_Chan)
+        // Populate scan-specific data already stored in ch_scan.
+        scan->op_classes_num = 0;
+        if (cap_info->ch_scan.op_classes_num > 0) {
+            scan->op_classes_num = cap_info->ch_scan.op_classes_num;
+            for (unsigned char j = 0; j < cap_info->ch_scan.op_classes_num; j++) {
+                const em_scan_cap_op_class_info_t *scan_entry = &cap_info->ch_scan.op_classes[j];
+
+                *tmp = scan_entry->op_class;  tmp++; len++;
+                *tmp = scan_entry->num;       tmp++; len++;
+
+                for (unsigned char k = 0; k < scan_entry->num; k++) {
+                    *tmp = scan_entry->channels.channel[k]; tmp++; len++;
+                }
+
+                em_printfout("Ch scan for radio:%s, op class=%d, channel cnt=%d", util::mac_to_string(cap_info->ruid.mac).c_str(), scan->op_classes_num, cap_info->ch_scan.op_classes[j].num);
+            }
+        }
     }
-    em_radio_cap_info_t* cap_info = radio_cap->get_radio_cap_info();
-    em_channel_scan_cap_radio_t *scan = reinterpret_cast<em_channel_scan_cap_radio_t *>(buff);
 
-    if ((scan == NULL) || (cap_info == NULL)) {
-        em_printfout("No data Found");
-        return 0;
-    }
-
-    memcpy(scan, &cap_info->ch_scan, sizeof(em_channel_scan_cap_radio_t));
-    len = sizeof(em_channel_scan_cap_radio_t);
+    em_printfout("create_channelscan_tlv: total len=%d, num_radios=%d", len, num_radios);
     return len;
 }
 
 short em_t::create_prof_2_tlv(unsigned char *buff)
 {
-    short len = 0;
-    dm_easy_mesh_t  *dm;
-    dm = get_data_model();
-    dm_radio_cap_t *radio_cap = dm->get_radio_cap(0);//todo: it is dev specific
-
-    if (radio_cap == NULL) {
-        em_printfout("create_prof_2_tlv: radio_cap NULL for MAC %s",
-                     util::mac_to_string(get_radio_interface_mac()).c_str());
-        return 0;
-    }
-    em_radio_cap_info_t* cap_info = radio_cap->get_radio_cap_info();
     em_profile_2_ap_cap_t *prof = reinterpret_cast<em_profile_2_ap_cap_t *>(buff);
 
-    if ((prof == NULL) || (cap_info == NULL)) {
-        em_printfout("No data Found");
-        return 0;
-    }
+    // Profile-2 AP Capability TLV (17.2.48) — fields are platform capability declarations.
+    // No HAL or runtime source exists for these; values are hardcoded per implementation:
+    //
+    // max_prior_rule:      0 — Service Prioritization rules not supported.
+    // reserved1/2:         0 — Reserved fields, always 0.
+    // traffic_separation:  0 — VLAN-based traffic separation not supported.
+    // dpp_onboarding:      1 — DPP/EasyConnect onboarding supported
+    //                          (EasyConnect module is compiled in; see src/em/prov/easyconnect/).
+    // prioritization:      0 — Service Prioritization not supported.
+    // byte_counter_units:  0 — Byte counters reported in bytes (0x00=bytes, 0x01=KB, 0x02=MB).
+    // max_vid_count:       0 — No VLAN IDs supported (traffic_separation=0).
+    prof->max_prior_rule     = 0;
+    prof->reserved1          = 0;
+    prof->reserved2          = 0;
+    prof->traffic_separation = 0;
+    prof->dpp_onboarding     = 1;
+    prof->prioritization     = 0;
+    prof->byte_counter_units = 0;
+    prof->max_vid_count      = 0;
 
-    memcpy(&prof, &cap_info->prof_2_ap_cap, sizeof(em_profile_2_ap_cap_t));
-    len = sizeof(em_profile_2_ap_cap_t);
-    return len;
+    return static_cast<short>(sizeof(em_profile_2_ap_cap_t));
 }
 
 short em_t::create_device_inventory_tlv(unsigned char *buff)
 {
     short len = 0;
     dm_easy_mesh_t* dm;
-    dm_radio_t* radio = get_data_model()->get_radio(static_cast<unsigned int>(0));//todo: it is dev specific
-    em_radio_info_t* radio_info = radio->get_radio_info();
     unsigned char *tmp = buff;
-
-    if ((radio_info == NULL)) {
-        em_printfout("No data Found");
-        return 0;
-    }
-
-    memcpy(tmp, &radio_info->inventory_info.serial_len, sizeof(unsigned char));
-    tmp += sizeof(unsigned char);
-    if (radio_info->inventory_info.serial_len) {
-        memcpy(tmp, radio_info->inventory_info.serial, radio_info->inventory_info.serial_len);
-        tmp += radio_info->inventory_info.serial_len;
-    }
-    len += static_cast<short>(sizeof(unsigned char) + radio_info->inventory_info.serial_len);
-
-    memcpy(tmp, &radio_info->inventory_info.ver_len, sizeof(unsigned char));
-    tmp += sizeof(unsigned char);
-    if (radio_info->inventory_info.ver_len) {
-        memcpy(tmp, radio_info->inventory_info.version, radio_info->inventory_info.ver_len);
-        tmp += radio_info->inventory_info.ver_len;
-    }
-    len += static_cast<short>(sizeof(unsigned char) + radio_info->inventory_info.ver_len);
-
-    memcpy(tmp, &radio_info->inventory_info.envi_len, sizeof(unsigned char));
-    tmp += sizeof(unsigned char);
-    if (radio_info->inventory_info.envi_len) {
-        memcpy(tmp, radio_info->inventory_info.environment, radio_info->inventory_info.envi_len);
-        tmp += radio_info->inventory_info.envi_len;
-    }
-    len += static_cast<short>(sizeof(unsigned char) + radio_info->inventory_info.envi_len);
+    unsigned char data_len;
+    size_t slen;
 
     dm = get_data_model();
+    auto* info = dm->get_device_info();
+
+    /* Per spec each inventory string is at most 64 octets */
+    static constexpr size_t EM_INVENTORY_STR_MAX = 64;
+
+    // 1. Serial Number
+    slen = (info) ? strlen(info->serial_number) : 0;
+    if (slen > sizeof(info->serial_number) - 1) slen = sizeof(info->serial_number) - 1;
+    if (slen > EM_INVENTORY_STR_MAX) slen = EM_INVENTORY_STR_MAX;
+    data_len = static_cast<unsigned char>(slen);
+    *tmp++ = data_len;
+    if (data_len > 0) {
+        memcpy(tmp, info->serial_number, data_len);
+        tmp += data_len;
+    }
+    len += (1 + data_len);
+
+    // 2. Software Version
+    slen = (info) ? strlen(info->software_ver) : 0;
+    if (slen > sizeof(info->software_ver) - 1) slen = sizeof(info->software_ver) - 1;
+    if (slen > EM_INVENTORY_STR_MAX) slen = EM_INVENTORY_STR_MAX;
+    data_len = static_cast<unsigned char>(slen);
+    *tmp++ = data_len;
+    if (data_len > 0) {
+        memcpy(tmp, info->software_ver, data_len);
+        tmp += data_len;
+    }
+    len += (1 + data_len);
+
+    // 3. Environment
+    slen = (info) ? strlen(info->environment) : 0;
+    if (slen > sizeof(info->environment) - 1) slen = sizeof(info->environment) - 1;
+    if (slen > EM_INVENTORY_STR_MAX) slen = EM_INVENTORY_STR_MAX;
+    data_len = static_cast<unsigned char>(slen);
+    *tmp++ = data_len;
+    if (data_len > 0) {
+        memcpy(tmp, info->environment, data_len);
+        tmp += data_len;
+    }
+    len += (1 + data_len);
+
+    em_printfout("data_len: %d, len: %d", data_len, len);
 
     unsigned char num_radios = static_cast<unsigned char> (dm->get_num_radios());
+    if (num_radios > EM_MAX_BANDS) num_radios = EM_MAX_BANDS;
     memcpy(tmp, &num_radios, sizeof(unsigned char));
     tmp += sizeof(unsigned char);
     len += static_cast<short>(sizeof(unsigned char));
@@ -1572,39 +1754,19 @@ short em_t::create_device_inventory_tlv(unsigned char *buff)
         tmp += sizeof(mac_address_t);
         len += static_cast<short>(sizeof(mac_address_t));
 
-        memcpy(tmp, &radio_info->inventory_info.radios[i].vendor_len, sizeof(unsigned char));
+        slen = (dm->get_radio_info(i)) ? strlen(dm->get_radio_info(i)->chip_vendor) : 0;
+        if (slen > sizeof(dm->get_radio_info(i)->chip_vendor) - 1) slen = sizeof(dm->get_radio_info(i)->chip_vendor) - 1;
+        if (slen > EM_INVENTORY_STR_MAX) slen = EM_INVENTORY_STR_MAX;
+        data_len = static_cast<unsigned char>(slen);
+        *tmp = data_len;
         tmp += sizeof(unsigned char);
-        if(radio_info->inventory_info.radios[i].vendor_len) {
-            memcpy(tmp, radio_info->inventory_info.radios[i].vendor, radio_info->inventory_info.radios[i].vendor_len);
-            tmp += radio_info->inventory_info.radios[i].vendor_len;
+        if (data_len > 0) {
+            memcpy(tmp, dm->get_radio_info(i)->chip_vendor, data_len);
+            tmp += data_len;
         }
-        len += static_cast<short>(sizeof(unsigned char) + radio_info->inventory_info.radios[i].vendor_len);
+
+        len += static_cast<short>(sizeof(unsigned char) + data_len);
     }
-    return len;
-}
-
-short em_t::create_radioad_tlv(unsigned char *buff)
-{
-    short len = 0;
-    dm_easy_mesh_t  *dm;
-    dm = get_data_model();
-    dm_radio_cap_t *radio_cap = dm->get_radio_cap(get_radio_interface_mac());
-
-    if (radio_cap == NULL) {
-        em_printfout("create_radioad_tlv: radio_cap NULL for MAC %s",
-                     util::mac_to_string(get_radio_interface_mac()).c_str());
-        return 0;
-    }
-    em_radio_cap_info_t* cap_info = radio_cap->get_radio_cap_info();
-    em_ap_radio_advanced_cap_t *ad = reinterpret_cast<em_ap_radio_advanced_cap_t *>(buff);
-
-    if ((ad == NULL) || (cap_info == NULL)) {
-        em_printfout("No data Found");
-        return 0;
-    }
-
-    memcpy(&ad, &cap_info->radio_ad_cap, sizeof(em_ap_radio_advanced_cap_t));
-    len = sizeof(em_ap_radio_advanced_cap_t);
     return len;
 }
 
@@ -1613,7 +1775,7 @@ short em_t::create_metric_col_int_tlv(unsigned char *buff)
     short len = 0;
     dm_easy_mesh_t  *dm;
     dm = get_data_model();
-    dm_radio_cap_t *radio_cap = dm->get_radio_cap(0);//todo: it is dev specific
+    dm_radio_cap_t *radio_cap = dm->get_radio_cap(0u);//todo: it is dev specific
 
     if (radio_cap == NULL) {
         em_printfout("create_metric_col_int_tlv: radio_cap NULL for MAC %s",
@@ -1628,38 +1790,114 @@ short em_t::create_metric_col_int_tlv(unsigned char *buff)
         return 0;
     }
 
-    memcpy(&clt, &cap_info->metric_interval, sizeof(em_metric_cltn_interval_t));
+    memcpy(clt, &cap_info->metric_interval, sizeof(em_metric_cltn_interval_t));
     len = sizeof(em_metric_cltn_interval_t);
     return len;
 }
 
 short em_t::create_cac_cap_tlv(unsigned char *buff)
 {
-    short len = 0;
-    dm_easy_mesh_t  *dm;
-    dm = get_data_model();
-    for(unsigned int index = 0; index < dm->get_num_radios(); index++){
-        dm_radio_t radio = dm->get_radio_by_ref(index);
-        dm_radio_cap_t *radio_cap = dm->get_radio_cap(radio.m_radio_info.intf.mac);
+    unsigned char *tmp = buff;
+    dm_easy_mesh_t *dm = get_data_model();
 
-        if (radio_cap == NULL) {
-            em_printfout("create_cac_cap_tlv: radio_cap NULL for MAC %s",
-                         util::mac_to_string(get_radio_interface_mac()).c_str());
-            return 0;
+    // Country Code - 2 octets
+    em_device_info_t *dev_info = dm->get_device_info();
+    if (dev_info != NULL && dev_info->country_code[0] != '\0') {
+        *tmp++ = static_cast<unsigned char>(dev_info->country_code[0]);
+        *tmp++ = static_cast<unsigned char>(dev_info->country_code[1]);
+    } else {
+        /* Fallback: read the kernel regulatory country via 'iw reg get' */
+        char sys_cc[3] = {0};//{'U', 'S', '\0'};
+        FILE *fp = popen("iw reg get 2>/dev/null | awk '/^country/ {print substr($2,1,2); exit}'", "r");
+        if (fp != NULL) {
+            char buf[8] = {};
+            if (fgets(buf, sizeof(buf), fp) != NULL && buf[0] >= 'A' && buf[0] <= 'Z') {
+                sys_cc[0] = buf[0];
+                sys_cc[1] = (buf[1] >= 'A' && buf[1] <= 'Z') ? buf[1] : 'S';
+            }
+            pclose(fp);
         }
-        em_radio_cap_info_t* cap_info = radio_cap->get_radio_cap_info();
-        em_cac_cap_t *cac = reinterpret_cast<em_cac_cap_t *>(buff);
-
-        if ((cac == NULL) || (cap_info == NULL)) {
-            em_printfout("No data Found");
-            return 0;
-        }
-
-        memcpy(&cac->radios[index], &cap_info->cac_cap, sizeof(em_cac_cap_radio_t));
-    	cac->radios_num = dm->get_num_radios();
+        *tmp++ = static_cast<unsigned char>(sys_cc[0]);
+        *tmp++ = static_cast<unsigned char>(sys_cc[1]);
     }
-    len = sizeof(em_cac_cap_t);
-    return len;
+
+    /* Num_Radio placeholder — filled after we know how many radios have CAC */
+    unsigned char *num_radio_ptr = tmp++;
+    unsigned char cac_radio_count = 0;
+
+    unsigned int max_radios = dm->get_num_radios();
+    if (max_radios > EM_MAX_BANDS) max_radios = EM_MAX_BANDS;
+
+    for (unsigned int index = 0; index < max_radios; index++) {
+        if (dm->get_radio_by_ref(index).m_radio_info.band != em_freq_band_5) {
+            continue;
+        }
+        dm_radio_cap_t *radio_cap = dm->get_radio_cap(index);
+        if (radio_cap == NULL) {
+            em_printfout("create_cac_cap_tlv: radio[%u] get_radio_cap returned NULL", index);
+            continue;
+        }
+        em_radio_cap_info_t *cap_info = radio_cap->get_radio_cap_info();
+        if (cap_info == NULL) {
+            em_printfout("create_cac_cap_tlv: radio[%u] get_radio_cap_info returned NULL", index);
+            continue;
+        }
+        em_cac_cap_radio_t *cac_radio = &cap_info->cac_cap;
+
+        /* Only include radios that can perform CAC */
+        if (cac_radio->cac_methods_num == 0) {
+            em_printfout("create_cac_cap_tlv: radio[%u] cac_methods_num=0, skipping", index);
+            continue;
+        }
+
+        /* RUID — 6 octets */
+        memcpy(tmp, cac_radio->ruid, sizeof(mac_address_t));
+        tmp += sizeof(mac_address_t);
+
+        /* Num_Types — 1 octet */
+        *tmp++ = cac_radio->cac_methods_num;
+
+        for (unsigned char m = 0; m < cac_radio->cac_methods_num; m++) {
+            em_cac_cap_method_t *method = &cac_radio->cac_methods[m];
+
+            /* Method — 1 octet */
+            *tmp++ = method->cac_method;
+
+            /* Duration — 3 octets big-endian */
+            unsigned int dur = method->cac_duration;
+            *tmp++ = static_cast<unsigned char>((dur >> 16) & 0xff);
+            *tmp++ = static_cast<unsigned char>((dur >>  8) & 0xff);
+            *tmp++ = static_cast<unsigned char>( dur        & 0xff);
+
+            /* Num_OpClass — 1 octet */
+            *tmp++ = method->op_classes_num;
+
+            for (unsigned char oc = 0; oc < method->op_classes_num; oc++) {
+                em_cac_op_class_t *op = &method->op_classes[oc];
+
+                /* OpClass — 1 octet */
+                *tmp++ = op->op_class;
+
+                /* Num_Chan — 1 octet */
+                *tmp++ = op->num;
+
+                /* Channel × Num_Chan */
+                for (unsigned char ch = 0; ch < op->num; ch++) {
+                    *tmp++ = op->channels[ch];
+                }
+            }
+        }
+        cac_radio_count++;
+    }
+
+    *num_radio_ptr = cac_radio_count;
+
+    em_printfout("create_cac_cap_tlv: num_radios=%u CC='%c%c'",
+        cac_radio_count,
+        (dev_info && dev_info->country_code[0]) ? dev_info->country_code[0] : '?',
+        (dev_info && dev_info->country_code[1]) ? dev_info->country_code[1] : '?');
+
+    return static_cast<short>(tmp - buff);
 }
 
 unsigned short em_t::create_eht_operations_tlv(unsigned char *buff)
@@ -1721,6 +1959,181 @@ unsigned short em_t::create_eht_operations_tlv(unsigned char *buff)
     }
 
     return len;
+}
+
+unsigned short em_t::create_traffic_separation_policy_tlv(unsigned char *buff)
+{
+    unsigned short len = 0;
+    unsigned int i;
+    dm_easy_mesh_t *dm = get_data_model();
+    dm_network_ssid_t *net_ssid;
+    unsigned char *tmp = buff;
+
+    // get total ssid count
+    unsigned char ssids_num = dm->get_num_network_ssid();
+    *tmp = static_cast<unsigned char>(ssids_num);
+    tmp += sizeof(unsigned char);
+    len += sizeof(unsigned char);
+
+    for (i = 0; i < ssids_num; i++) {
+        net_ssid = dm->get_network_ssid(i);
+
+        std::vector<unsigned char> ssid_bytes(net_ssid->m_network_ssid_info.ssid, 
+                    net_ssid->m_network_ssid_info.ssid + strlen(net_ssid->m_network_ssid_info.ssid));
+        unsigned char ssid_len = static_cast<unsigned char>(ssid_bytes.size());
+
+        *tmp = ssid_len;
+        tmp += sizeof(unsigned char);
+        len += sizeof(unsigned char);
+
+        memcpy(tmp, ssid_bytes.data(), ssid_len);
+        tmp += ssid_len;
+        len += ssid_len;
+
+        unsigned short vlan_n = htons(net_ssid->m_network_ssid_info.vlan_id);
+        memcpy(tmp, &vlan_n, sizeof(vlan_n));
+        tmp += sizeof(unsigned short);
+        len += sizeof(unsigned short);
+	    em_printfout(" TRAFFIC SEPARATION SSID='%.*s' Len=%u, VLAN=%u ",ssid_len,ssid_bytes.data(), ssid_len, net_ssid->m_network_ssid_info.vlan_id);
+    }
+    em_printfout("Length: %d ", len);
+    return len;
+}
+
+short em_t::create_def_8021q_settings_policy_tlv(unsigned char *buff)
+{
+    size_t len = 0;
+    dm_easy_mesh_t *dm;
+    unsigned int i;
+
+    if (get_current_cmd()->get_type() == em_cmd_type_set_policy) {
+        dm = get_current_cmd()->get_data_model();
+    } else {
+        dm = get_data_model();
+    }
+
+    for (i = 0; i < dm->get_num_policy(); i++) {
+        dm_policy_t *policy = &dm->m_policy[i];
+        if (policy->m_policy.id.type != em_policy_id_type_default_8021q_settings) {
+            continue;
+        }
+        em_8021q_settings_t *settings = reinterpret_cast<em_8021q_settings_t *>(buff);
+        settings->primary_vlan_id = htons(policy->m_policy.def_8021q_settings.primary_vid);
+        settings->default_pcp = policy->m_policy.def_8021q_settings.default_pcp & 0x07;
+        settings->reserved = 0;
+        em_printfout("Found Default 802.1Q Settings Policy in DM with primary_vid=%u, default_pcp=%u",
+            policy->m_policy.def_8021q_settings.primary_vid,
+            policy->m_policy.def_8021q_settings.default_pcp);
+        len += sizeof(em_8021q_settings_t);
+        break;
+    }
+
+    return static_cast<short>(len);
+}
+
+int em_t::handle_eht_operations_tlv(unsigned char *buff, unsigned short tlv_len)
+{
+    short len = 0;
+    unsigned int i = 0, j = 0, k = 0, l = 0;
+    unsigned char *tmp = buff;
+    unsigned char num_radios;
+    unsigned char num_bss = 0;
+    em_eht_operations_t eht_ops;
+    dm_easy_mesh_t *dm;
+
+    dm = get_data_model();
+
+    // 32 octets are reserved for future use, so skip 32 octets
+    short reserved_octets = 32;
+    if (tlv_len < reserved_octets + static_cast<short>(sizeof(unsigned char))) {
+        em_printfout("EHT operations TLV too short for reserved + num_radios (len=%u)", tlv_len);
+        return -1;
+    }
+    tmp += reserved_octets;
+    len += reserved_octets;
+
+    memcpy(&num_radios, tmp, sizeof(unsigned char));
+
+    if (num_radios > EM_MAX_RADIO_PER_AGENT) {
+        em_printfout("Invalid num_radios=%d, max allowed=%d", num_radios, EM_MAX_RADIO_PER_AGENT);
+        return -1;
+    }
+
+    eht_ops.radios_num = num_radios;
+    tmp += sizeof(unsigned char);
+    len += static_cast<short> (sizeof(unsigned char));
+
+    for (i = 0; i < num_radios; i++) {
+        if (len + static_cast<short>(sizeof(mac_address_t) + sizeof(unsigned char)) > tlv_len) {
+            em_printfout("EHT operations TLV truncated at radio %u (len=%u, need=%d)", i, tlv_len, len);
+            return -1;
+        }
+        memcpy(&eht_ops.radios[i].ruid, tmp, sizeof(mac_address_t));
+        tmp += sizeof(mac_address_t);
+        len += static_cast<short> (sizeof(mac_address_t));
+
+        memcpy(&num_bss, tmp, sizeof(unsigned char));
+
+        if (num_bss > EM_MAX_BSS_PER_RADIO) {
+            em_printfout("Invalid num_bss=%d for radio %u, max allowed=%d", num_bss, i, EM_MAX_BSS_PER_RADIO);
+            return -1;
+        }
+
+        eht_ops.radios[i].bss_num = num_bss;
+        tmp += sizeof(unsigned char);
+        len += static_cast<short> (sizeof(unsigned char));
+
+        short bss_bytes = static_cast<short>(num_bss * sizeof(em_eht_operations_bss_t));
+        short radio_reserved_octets = 25;
+        if (len + bss_bytes + radio_reserved_octets > tlv_len) {
+            em_printfout("EHT operations TLV truncated at radio %u BSS data (len=%u, need=%d)", i, tlv_len, len + bss_bytes + radio_reserved_octets);
+            return -1;
+        }
+
+        for(j = 0; j < num_bss; j++) {
+            memcpy(&eht_ops.radios[i].bss[j], tmp, sizeof(em_eht_operations_bss_t));
+            tmp += sizeof(em_eht_operations_bss_t);
+            len += static_cast<short> (sizeof(em_eht_operations_bss_t));
+        }
+        // 25 octets are reserved for future use in radio, so skip 25 octets
+        tmp += radio_reserved_octets;
+        len += radio_reserved_octets;
+    }
+
+    bool found_radio = false;
+    bool found_bss = false;
+    for (i = 0; i < eht_ops.radios_num; i++) {
+        for (j = 0; j < dm->get_num_radios(); j++) {
+            if (memcmp(eht_ops.radios[i].ruid, dm->m_radio[j].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                found_radio = true;
+                break;
+            }
+        }
+        if (found_radio == false) {
+            em_printfout("Radio with RUID %s not found in data model",
+                util::mac_to_string(eht_ops.radios[i].ruid).c_str());
+            return -1;
+        }
+        found_radio = false;
+
+        for(k = 0; k < eht_ops.radios[i].bss_num; k++) {
+            for(l = 0; l < dm->get_num_bss(); l++) {
+                if (memcmp(eht_ops.radios[i].bss[k].bssid, dm->m_bss[l].m_bss_info.bssid.mac, sizeof(mac_address_t)) == 0) {
+                    found_bss = true;
+                    break;
+                }
+            }
+            if (found_bss == false) {
+                em_printfout("BSS with BSSID %s not found in data model",
+                    util::mac_to_string(eht_ops.radios[i].bss[k].bssid).c_str());
+                return -1;
+            }
+            found_bss = false;
+            memcpy(&dm->m_bss[l].get_bss_info()->eht_ops, &eht_ops.radios[i].bss[k], sizeof(em_eht_operations_bss_t));
+        }
+    }
+
+    return 0;
 }
 
 cJSON *em_t::create_enrollee_bsta_list(uint8_t pa_al_mac[ETH_ALEN])
@@ -2245,25 +2658,25 @@ int em_t::handle_wifi7_agent_cap_tlv(unsigned char *buff)
 
     // Number of radios
     unsigned char *num_radios_ptr = reinterpret_cast<unsigned char *>(buff + offset);
-    int num_radios = static_cast<int>(*num_radios_ptr);
-    em_printfout("Number of radios in wifi7 agent cap: %d", num_radios);
+    unsigned int num_radios = static_cast<unsigned int>(*num_radios_ptr);
+    em_printfout("Number of radios in wifi7 agent cap: %u", num_radios);
     offset += static_cast<short>(sizeof(unsigned char));
 
     if (dm != NULL) {
-        int dm_num_radios = static_cast<int>(dm->get_num_radios());
+        unsigned int dm_num_radios = dm->get_num_radios();
         if (num_radios > EM_MAX_RADIO_PER_AGENT) {
-            em_printfout("Clamping num_radios from %d to EM_MAX_RADIO_PER_AGENT (%d)", num_radios, EM_MAX_RADIO_PER_AGENT);
+            em_printfout("Clamping num_radios from %u to EM_MAX_RADIO_PER_AGENT (%d)", num_radios, EM_MAX_RADIO_PER_AGENT);
             num_radios = EM_MAX_RADIO_PER_AGENT;
         }
         if (num_radios > dm_num_radios) {
-            em_printfout("Clamping num_radios from %d to dm->get_num_radios() (%d)", num_radios, dm_num_radios);
+            em_printfout("Clamping num_radios from %u to dm->get_num_radios() (%u)", num_radios, dm_num_radios);
             num_radios = dm_num_radios;
         }
     }
 
-    for (int idx = 0; idx < num_radios; idx++) {
+    for (unsigned int idx = 0; idx < num_radios; idx++) {
         em_wifi7_cap = &dm->get_radio_cap_info(idx)->wifi7_cap;
-        em_printfout("Updating wifi7 cap for radio[%d]:%s", idx, util::mac_to_string(dm->get_radio_cap_info(idx)->ruid.mac).c_str());
+        em_printfout("Updating wifi7 cap for radio[%u]:%s", idx, util::mac_to_string(dm->get_radio_cap_info(idx)->ruid.mac).c_str());
 
         // Extract MLO support info
         mlo_support = reinterpret_cast<em_wifi7_mlo_cap_support_tlv_t *>(buff + offset);
@@ -2462,6 +2875,7 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_ctrl_avail_spectrum_inquiry_pending)
         EM_STATE_2S(em_state_ctrl_bsta_cap_pending)
         EM_STATE_2S(em_state_ctrl_topo_publish_pending)
+	EM_STATE_2S(em_state_ctrl_unassoc_sta_link_metrics_pending)
         EM_STATE_2S(em_state_agent_unconfigured)
         EM_STATE_2S(em_state_agent_autoconfig_rsp_pending)
         EM_STATE_2S(em_state_agent_wsc_m2_pending)
@@ -2479,9 +2893,10 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_agent_client_cap_report)
         EM_STATE_2S(em_state_agent_channel_pref_query)
         EM_STATE_2S(em_state_agent_sta_link_metrics_pending)
-        EM_STATE_2S(em_state_max)
         EM_STATE_2S(em_state_agent_beacon_report_pending)
         EM_STATE_2S(em_state_agent_channel_select_configuration_pending)
+	EM_STATE_2S(em_state_agent_unassoc_sta_metrics_report_pending)
+        EM_STATE_2S(em_state_max)
         default: break;
     }
 

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -62,6 +62,8 @@ bool em_msg_t::get_client_mac_info(mac_address_t *mac)
             memcpy(mac, &cltinfo->client_mac_addr, sizeof(mac_address_t));
             return true;
         }
+        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
     }
     return false;
 }
@@ -120,6 +122,9 @@ bool em_msg_t::get_bss_id(mac_address_t *mac)
             memcpy(mac, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
             return true;
         } else if (tlv->type == em_tlv_type_ap_metrics) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
+        } else if (tlv->type == em_tlv_type_bssid) {
             memcpy(mac, tlv->value, sizeof(mac_address_t));
             return true;
         }
@@ -571,10 +576,10 @@ void em_msg_t::ap_cap_rprt()
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_wifi6_cap, (m_profile > em_profile_type_2) ? optional:bad, "17.2.72 of Wi-Fi Easy Mesh 5.0", 24);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_channel_scan_cap, (m_profile > em_profile_type_1) ? mandatory:bad, "17.2.38 of Wi-Fi Easy Mesh 5.0", 17);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_1905_layer_security_cap, (m_profile > em_profile_type_2) ? mandatory:bad, "17.2.67 of Wi-Fi Easy Mesh 5.0", 6);
-    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_cac_cap, (m_profile > em_profile_type_1) ? mandatory:bad, "17.2.46 of Wi-Fi Easy Mesh 5.0", 21);
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_cac_cap, optional, "17.2.46 of Wi-Fi Easy Mesh 5.0", 21);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_profile_2_ap_cap, (m_profile > em_profile_type_1) ? mandatory:bad, "17.2.48 of Wi-Fi Easy Mesh 5.0", 6); 
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_metric_cltn_interval, (m_profile > em_profile_type_1) ? mandatory:bad, "17.2.59 of Wi-Fi Easy Mesh 5.0", 7);
-    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_device_inventory, (m_profile > em_profile_type_2) ? mandatory:bad, "17.2.76 of Wi-Fi Easy Mesh 5.0", 270); 
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_device_inventory, optional, "17.2.76 of Wi-Fi Easy Mesh 5.0", 270); 
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_ap_radio_advanced_cap, optional, "17.2.52 of Wi-Fi Easy Mesh 5.0", 9);
 }
 
@@ -835,6 +840,7 @@ void em_msg_t::client_disassoc_stats()
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_sta_mac_addr, mandatory, "17.2.23 of Wi-Fi Easy Mesh 5.0", 9);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_reason_code, mandatory, "17.2.64 of Wi-Fi Easy Mesh 5.0", 5);
     m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_assoc_sta_traffic_sts, mandatory, "17.2.35 of Wi-Fi Easy Mesh 5.0", 37);
+    m_tlv_member[m_num_tlv++] = em_tlv_member_t(em_tlv_type_affiliated_sta_metrics, optional, "17.2.100 of Wi-Fi Easy Mesh 6.0", 26);
 }
 void em_msg_t::svc_prio_req()
 {

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <openssl/rand.h>
+#include <algorithm>
 #include "em_metrics.h"
 #include "em_msg.h"
 #include "dm_easy_mesh.h"
@@ -44,23 +45,37 @@
 #include "util.h"
 #include "em.h"
 #include "em_cmd_exec.h"
+#include "dm_easy_mesh_agent.h"
+#include "em_cmd_unassoc_sta_query.h"
 
 static     const unsigned char em_vendor_oui[EM_VENDOR_OUI_SIZE] = {0xd8, 0x9c, 0x8e};
 
-int em_metrics_t::handle_assoc_sta_link_metrics_tlv(unsigned char *buff)
+int em_metrics_t::handle_assoc_sta_link_metrics_tlv(unsigned char *buff,
+                                                    unsigned int tlv_len)
 {
-    em_assoc_sta_link_metrics_t	*sta_metrics;
+    em_assoc_sta_link_metrics_t *sta_metrics;
     em_assoc_link_metrics_t *metrics;
     dm_sta_t *sta;
     unsigned int i;
-    dm_easy_mesh_t  *dm;
+    dm_easy_mesh_t *dm;
+
+    if (buff == NULL || tlv_len == 0 || tlv_len < 7) {
+        return -1;
+    }
 
     dm = get_data_model();
 
-    sta_metrics = reinterpret_cast<em_assoc_sta_link_metrics_t *> (buff);
+    sta_metrics = reinterpret_cast<em_assoc_sta_link_metrics_t *>(buff);
+
+    unsigned int k = sta_metrics->num_bssids;
+    unsigned int expected_len = 7 + (k * sizeof(em_assoc_link_metrics_t));
+
+    if (tlv_len != expected_len) {
+        return -1;
+    }
 
     for (i = 0; i < sta_metrics->num_bssids; i++) {
-        metrics	= &sta_metrics->assoc_link_metrics[i];
+        metrics = &sta_metrics->assoc_link_metrics[i];
         sta = dm->find_sta(sta_metrics->sta_mac, metrics->bssid);
         if (sta == NULL) {
             continue;
@@ -69,12 +84,40 @@ int em_metrics_t::handle_assoc_sta_link_metrics_tlv(unsigned char *buff)
         sta->m_sta_info.est_dl_rate = metrics->est_mac_data_rate_dl;
         sta->m_sta_info.est_ul_rate = metrics->est_mac_data_rate_ul;
         sta->m_sta_info.rcpi = metrics->rcpi;
+
+        // RCPI-based beacon query trigger: if STA supports 802.11k beacon measurement
+        // and its RCPI is below the configured steering threshold, request a beacon report.
+        if (sta->m_sta_info.rcpi == 0 || !sta->m_sta_info.associated) {
+            continue;
+        }
+
+        if (sta->supports_beacon_measurement() == false) {
+            continue;
+        }
+        // Find the radio this BSS belongs to and check its RCPI threshold
+        dm_radio_t *radio = NULL;
+        for (unsigned int b = 0; b < dm->get_num_bss(); b++) {
+            if (memcmp(dm->m_bss[b].m_bss_info.bssid.mac, metrics->bssid, sizeof(mac_address_t)) == 0) {
+                radio = dm->get_radio(dm->m_bss[b].m_bss_info.id.ruid);
+                break;
+            }
+        }
+        if (radio != NULL) {
+            em_radio_info_t *radio_info = radio->get_radio_info();
+            unsigned int threshold = (radio_info != NULL) ? radio_info->rcpi_steering_threshold : 0;
+            if (threshold > 0 && sta->m_sta_info.rcpi < static_cast<unsigned char>(threshold)) {
+                em_printfout("STA %s RCPI=%u below threshold=%u, triggering beacon query",
+                    util::mac_to_string(sta->m_sta_info.id).c_str(),
+                    sta->m_sta_info.rcpi, threshold);
+                send_beacon_metrics_query(sta->m_sta_info.id, sta->m_sta_info.bssid);
+            }
+        }
     }
 
     return 0;
 }
 
-int em_metrics_t::handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff)
+int em_metrics_t::handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len)
 {
     em_assoc_sta_ext_link_metrics_t	*sta_metrics;
     em_assoc_ext_link_metrics_t *metrics;
@@ -82,9 +125,21 @@ int em_metrics_t::handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff)
     unsigned int i;
     dm_easy_mesh_t  *dm;
 
+    if (buff == NULL || tlv_len == 0 || tlv_len < 7) {
+            printf("Invalid input: null buffer or invalid tlv_len=%u\n", tlv_len);
+            return -1;
+    }
+
     dm = get_data_model();
 
     sta_metrics = reinterpret_cast<em_assoc_sta_ext_link_metrics_t *> (buff);
+
+    unsigned int k = sta_metrics->num_bssids;
+    unsigned int expected_len = offsetof(em_assoc_sta_ext_link_metrics_t, assoc_ext_link_metrics) + (k * sizeof(em_assoc_ext_link_metrics_t));
+
+    if (tlv_len != expected_len) {
+            return -1;
+    }
 
     for (i = 0; i < sta_metrics->num_bssids; i++) {
         metrics	= &sta_metrics->assoc_ext_link_metrics[i];
@@ -166,10 +221,11 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
 
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_assoc_sta_link_metric) {
-            handle_assoc_sta_link_metrics_tlv(tlv->value);
+            uint16_t tlv_len = ntohs(tlv->len);
+            handle_assoc_sta_link_metrics_tlv(tlv->value, tlv_len);
         }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     tlv = tlv_start;
@@ -194,11 +250,11 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
 
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_assoc_sta_ext_link_metric) {
-            handle_assoc_sta_ext_link_metrics_tlv(tlv->value);
+            handle_assoc_sta_ext_link_metrics_tlv(tlv->value, ntohs(tlv->len));
         }
 
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     tlv = tlv_start;
@@ -220,33 +276,259 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
 
 int em_metrics_t::handle_beacon_metrics_query(unsigned char *buff, unsigned int len)
 {
-    mac_address_t sta;
     em_tlv_t *tlv;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    size_t sz = 0;
 
     if (em_msg_t(em_msg_type_beacon_metrics_query, em_profile_type_2, buff, len).validate(errors) == 0) {
-        printf("%s:%d:Beacon Metrics query message validation failed\n",__func__,__LINE__);
+        em_printfout("Beacon Metrics query message validation failed");
         return -1;
     }
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
 
-    em_beacon_metrics_query_t *beacon_metrics = reinterpret_cast<em_beacon_metrics_query_t*> (tlv->value);
-    printf("\n\n    STA MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n",
-        beacon_metrics->sta_mac_addr[0], beacon_metrics->sta_mac_addr[1], beacon_metrics->sta_mac_addr[2],
-        beacon_metrics->sta_mac_addr[3], beacon_metrics->sta_mac_addr[4], beacon_metrics->sta_mac_addr[5]);
-    printf("   Operating Class: %u\n", beacon_metrics->op_class);
-    printf("   Channel Number: %u\n", beacon_metrics->channel_num);
-    printf("   BSSID: %02x:%02x:%02x:%02x:%02x:%02x\n",
-        beacon_metrics->bssid[0], beacon_metrics->bssid[1], beacon_metrics->bssid[2],
-        beacon_metrics->bssid[3], beacon_metrics->bssid[4], beacon_metrics->bssid[5]);
-    printf("   Reporting Detail: %u\n", beacon_metrics->rprt_detail);
-    printf("   SSID Length: %u\n", beacon_metrics->ssid_len);
-    printf("\n\n");
+    unsigned char *tmp = reinterpret_cast<unsigned char*> (&tlv->value);
 
+    const unsigned int tlv_payload_len = ntohs(tlv->len);
+    const unsigned int max_ssid_len = sizeof(em_beacon_metrics_query_t{}.ssid);
+    const unsigned int max_ap_channel_rprt = sizeof(em_beacon_metrics_query_t{}.ap_channel_rprt) /
+        sizeof(em_beacon_metrics_query_t{}.ap_channel_rprt[0]);
+    const unsigned int max_channels_in_list = sizeof(em_beacon_metrics_query_t{}.ap_channel_rprt[0].ap_channel_list) /
+        sizeof(em_beacon_metrics_query_t{}.ap_channel_rprt[0].ap_channel_list[0]);
+    const unsigned int max_element_ids = sizeof(em_beacon_metrics_query_t{}.element_list.element_list) /
+        sizeof(em_beacon_metrics_query_t{}.element_list.element_list[0]);
+    const unsigned int min_fixed_len = sizeof(mac_address_t) + sizeof(unsigned char) + sizeof(unsigned char) +
+        sizeof(mac_address_t) + sizeof(unsigned char) + sizeof(unsigned char);
 
-    memcpy(sta, tlv->value, sizeof(mac_address_t));
+    if (tlv_payload_len < min_fixed_len) {
+        em_printfout("Malformed Beacon Metrics Query TLV: payload too short (%u)", tlv_payload_len);
+        return -1;
+    }
 
+    em_beacon_metrics_query_t query_params = {};
+    memcpy(query_params.sta_mac_addr, tmp + sz, sizeof(mac_address_t));
+    sz += sizeof(mac_address_t);
+
+    query_params.op_class = *(tmp + sz);
+    sz += sizeof(unsigned char);
+    query_params.channel_num = *(tmp + sz);
+    sz += sizeof(unsigned char);
+    memcpy(query_params.bssid, tmp + sz, sizeof(mac_address_t));
+    sz += sizeof(mac_address_t);
+
+    query_params.rprt_detail = *(tmp + sz);
+    sz += sizeof(unsigned char);
+
+    {
+        unsigned int ssid_len = *(tmp + sz);
+        sz += sizeof(unsigned char);
+        if (sz + ssid_len > tlv_payload_len) {
+            em_printfout("Malformed Beacon Metrics Query TLV: ssid_len %u exceeds payload %u",
+                ssid_len, tlv_payload_len);
+            return -1;
+        }
+        query_params.ssid_len = (ssid_len > max_ssid_len) ? max_ssid_len : ssid_len;
+        if (query_params.ssid_len > 0) {
+            memcpy(query_params.ssid, tmp + sz, query_params.ssid_len);
+        }
+        sz += ssid_len;
+    }
+
+    if (sz + sizeof(unsigned char) > tlv_payload_len) {
+        em_printfout("Malformed Beacon Metrics Query TLV: missing AP Channel Report count");
+        return -1;
+    }
+
+    {
+        unsigned int num_ap_channel_rprt = *(tmp + sz);
+        sz += sizeof(unsigned char);
+        query_params.num_ap_channel_rprt = (num_ap_channel_rprt > max_ap_channel_rprt) ?
+            max_ap_channel_rprt : num_ap_channel_rprt;
+
+        for (unsigned int i = 0; i < num_ap_channel_rprt; i++) {
+            unsigned int ap_channel_rprt_len;
+            unsigned int num_channels;
+
+            if (sz + sizeof(unsigned char) > tlv_payload_len) {
+                em_printfout("Malformed Beacon Metrics Query TLV: missing AP Channel Report length");
+                return -1;
+            }
+
+            ap_channel_rprt_len = *(tmp + sz);
+            sz += sizeof(unsigned char);
+            if (ap_channel_rprt_len < 1) {
+                em_printfout("Malformed Beacon Metrics Query TLV: invalid AP Channel Report length %u",
+                    ap_channel_rprt_len);
+                return -1;
+            }
+            if (sz + ap_channel_rprt_len > tlv_payload_len) {
+                em_printfout("Malformed Beacon Metrics Query TLV: AP Channel Report overruns payload");
+                return -1;
+            }
+
+            num_channels = ap_channel_rprt_len - 1;
+            if (i < query_params.num_ap_channel_rprt) {
+                query_params.ap_channel_rprt[i].ap_channel_rprt_len =
+                    (ap_channel_rprt_len > (max_channels_in_list + 1)) ?
+                    (max_channels_in_list + 1) : ap_channel_rprt_len;
+                query_params.ap_channel_rprt[i].ap_channel_op_class = *(tmp + sz);
+            }
+            sz += sizeof(unsigned char);
+
+            for (unsigned int j = 0; j < num_channels; j++) {
+                if (i < query_params.num_ap_channel_rprt && j < max_channels_in_list) {
+                    query_params.ap_channel_rprt[i].ap_channel_list[j] = *(tmp + sz);
+                }
+                sz += sizeof(unsigned char);
+            }
+        }
+    }
+
+    if (sz < tlv_payload_len) {
+        unsigned int num_element_id = *(tmp + sz);
+        sz += sizeof(unsigned char);
+        if (sz + num_element_id > tlv_payload_len) {
+            em_printfout("Malformed Beacon Metrics Query TLV: element list overruns payload");
+            return -1;
+        }
+        query_params.element_list.num_element_id = (num_element_id > max_element_ids) ?
+            max_element_ids : num_element_id;
+        for (unsigned int i = 0; i < num_element_id; i++) {
+            if (i < query_params.element_list.num_element_id) {
+                query_params.element_list.element_list[i] = *(tmp + sz);
+            }
+            sz += sizeof(unsigned char);
+        }
+    }
+
+    em_printfout("    STA MAC Address: %s", util::mac_to_string(query_params.sta_mac_addr).c_str());
+    em_printfout("   Operating Class: %u", query_params.op_class);
+    em_printfout("   Channel Number: %u", query_params.channel_num);
+    em_printfout("   BSSID: %s", util::mac_to_string(query_params.bssid).c_str());
+    em_printfout("   Reporting Detail: %u", query_params.rprt_detail);
+    em_printfout("   SSID Length: %u", query_params.ssid_len);
+    em_printfout("   SSID: %.*s", query_params.ssid_len, query_params.ssid);
+    em_printfout("\n\n");
+
+    // Extract message ID for the ACK
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+    unsigned short msg_id = ntohs(cmdu->id);
+
+    // Check if the STA is associated with any BSS on this agent
+    dm_easy_mesh_t *dm = get_data_model();
+    dm_sta_t *sta = dm->get_first_sta(query_params.sta_mac_addr);
+    if (sta == NULL) {
+        em_printfout("STA %s not associated, sending error ACK (reason 0x02)",
+            util::mac_to_string(query_params.sta_mac_addr).c_str());
+        send_beacon_metrics_query_ack(query_params.sta_mac_addr, msg_id, 0x02);
+        return -1;
+    }
+
+    // STA is associated — send ACK before forwarding the request to OneWifi
+    send_beacon_metrics_query_ack(query_params.sta_mac_addr, msg_id, 0);
+
+    get_mgr()->io_process(em_bus_event_type_beacon_query, reinterpret_cast<unsigned char *>(&query_params), sizeof(em_beacon_metrics_query_t));
+
+    return 0;
+}
+
+int em_metrics_t::handle_unassoc_sta_link_metrics_tlv(unsigned char *buff, unsigned int tlv_len)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+
+    unsigned short pos = 0;
+    mac_addr_str_t mac_str;
+
+    if (tlv_len < 2) {
+        em_printfout("%s:%d Invalid TLV length=%u\n", __func__, __LINE__, tlv_len);
+        return -1;
+    }
+
+    unsigned char op_class = buff[pos++];
+    unsigned char num_sta  = buff[pos++];
+
+    for (unsigned int i = 0; i < num_sta; i++)
+    {
+        if (pos + sizeof(em_unassoc_sta_metric_t) > tlv_len) {
+            em_printfout("%s:%d Malformed Unassoc STA Link Metrics TLV: num_sta=%u parsed=%u tlv_len=%u\n", __func__, __LINE__, num_sta, i,tlv_len);
+            return -1;
+        }
+        em_unassoc_sta_metric_t *metric = reinterpret_cast<em_unassoc_sta_metric_t *>(buff + pos);
+
+        unsigned int idx = dm->m_num_unassoc_sta_metrics;
+
+        if (idx >= EM_MAX_UNASSOC_STA)
+        {
+            em_printfout("%s:%d Max STA limit reached",__func__, __LINE__);
+            break;
+        }
+
+        memcpy(dm->m_unassoc_sta_metrics[idx].sta_mac, metric->sta_mac,sizeof(mac_address_t));
+        dm->m_unassoc_sta_metrics[idx].channel = metric->channel;
+        dm->m_unassoc_sta_metrics[idx].op_class = op_class;
+        dm->m_unassoc_sta_metrics[idx].rcpi = metric->rcpi;
+        dm->m_unassoc_sta_metrics[idx].time_delta = ntohl(metric->time_delta);
+        dm_easy_mesh_t::macbytes_to_string(metric->sta_mac, mac_str);
+
+        dm->m_num_unassoc_sta_metrics++;
+
+        pos += sizeof(em_unassoc_sta_metric_t);
+    }
+    return 0;
+}
+
+int em_metrics_t::handle_unassoc_sta_link_metrics_rsp(unsigned char *buff, unsigned int len)
+{
+    em_tlv_t *tlv;
+    unsigned int tmp_len = 0;
+    unsigned int tlv_len = 0;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    if (m_unassoc_in_progress) {
+        return -1;
+    }
+
+    m_unassoc_in_progress = true;
+
+    if (em_msg_t(em_msg_type_unassoc_sta_link_metrics_rsp, get_profile_type(), buff, len).validate(errors) == 0) {
+        em_printfout("Unassoc STA Link Metrics Response validation failed");
+        m_unassoc_in_progress = false;
+        return -1;
+    }
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    memset(dm->m_unassoc_sta_metrics, 0, sizeof(dm->m_unassoc_sta_metrics));
+    dm->m_num_unassoc_sta_metrics = 0;
+
+    tlv = reinterpret_cast<em_tlv_t *>(buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    tmp_len = len - static_cast<unsigned int>(sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+
+    while (tmp_len >= sizeof(em_tlv_t)) {
+        if (tlv->type == em_tlv_type_eom) {
+            break;
+        }
+
+        tlv_len = static_cast<unsigned int>(ntohs(tlv->len));
+
+        if ((sizeof(em_tlv_t) + tlv_len) > tmp_len) {
+            em_printfout("Malformed TLV detected in Unassoc STA Link Metrics Response");
+            break;
+        }
+    
+        if (tlv->type == em_tlv_type_unassoc_sta_link_metric_rsp) {
+            if (handle_unassoc_sta_link_metrics_tlv(tlv->value, tlv_len) < 0) {
+                em_printfout("%s:%d Failed to parse Unassoc STA Link Metrics TLV\n", __func__, __LINE__);
+                m_unassoc_in_progress = false;
+                return -1;
+            }
+        }
+        tmp_len -= static_cast<unsigned int>(sizeof(em_tlv_t)) + tlv_len;
+        tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(tlv) + sizeof(em_tlv_t) + tlv_len);
+    }
+
+    m_unassoc_in_progress = false;
     return 0;
 }
 
@@ -263,7 +545,7 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
     dm = get_data_model();
 
     if (em_msg_t(em_msg_type_beacon_metrics_rsp, em_profile_type_2, buff, len).validate(errors) == 0) {
-        printf("%s:%d: Beacon Metrics Response message validation failed\n",__func__,__LINE__);
+        em_printfout("Beacon Metrics Response message validation failed on controller");
         return -1;
     }
 
@@ -279,6 +561,33 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
         tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
     }
 
+    if (response == NULL) {
+        em_printfout("Beacon Metrics Response: no beacon metrics response TLV found");
+        return -1;
+    }
+
+    // Discard null/stub reports where the first measurement report element
+    // contains a null BSSID (00:00:00:00:00:00).  This happens with MLO clients
+    // that return a zeroed report body instead of setting the Incapable bit
+    // in Measurement Report Mode (firmware non-compliance with 802.11-2020 9.4.2.22.2).
+    //
+    // Raw 802.11 Measurement Report IE layout (beacon type):
+    //   [0]=elem-id [1]=length [2]=token [3]=report-mode [4]=report-type
+    //   [5]=op-class [6]=channel [7..14]=start-time [15..16]=duration
+    //   [17]=frame-info [18]=RCPI [19]=RSNI [20..25]=BSSID
+    static constexpr unsigned int BSSID_OFFSET_IN_BEACON_RPT_IE = 20;
+    static constexpr unsigned int MIN_BEACON_RPT_IE_LEN = 26; // through BSSID
+    if (response->meas_rprt_count > 0 &&
+            report_len >= MIN_BEACON_RPT_IE_LEN) {
+        const unsigned char *first_ie = response->meas_reports;
+        mac_address_t null_bssid = {};
+        if (memcmp(first_ie + BSSID_OFFSET_IN_BEACON_RPT_IE, null_bssid, sizeof(mac_address_t)) == 0) {
+            em_printfout("Beacon Metrics Response: null BSSID in report, discarding stub measurement for sta:%s",
+                util::mac_to_string(response->sta_mac_addr).c_str());
+            return 0;
+        }
+    }
+
     sta = dm->get_first_sta(response->sta_mac_addr);
     while (sta != NULL) {
         if (memcmp(sta->m_sta_info.id, response->sta_mac_addr, sizeof(mac_address_t)) == 0) {
@@ -289,7 +598,7 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
 
     if(sta == NULL)
     {
-        printf("%s:%d: sta not found\n", __func__, __LINE__);
+        em_printfout("Beacon Metrics Response: sta not found in controller data model");
         return -1;
     }
 
@@ -297,15 +606,72 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
     sta->m_sta_info.beacon_report_len = report_len;
     memcpy(sta->m_sta_info.beacon_report_elem, response->meas_reports, static_cast<size_t> (report_len));
 
-    printf("%s:%d Beacon Metrics Response rcvd\n", __func__, __LINE__);
-    printf("%s:%d No of reports %d\n", __func__, __LINE__, sta->m_sta_info.num_beacon_meas_report);
-    printf("%s:%d Report len %d\n", __func__, __LINE__, sta->m_sta_info.beacon_report_len);
+    // Clear the timestamp so new queries can be sent immediately after a response
+    sta->m_sta_info.beacon_query_sent_time = 0;
+
+    em_printfout("Beacon Metrics Response rcvd for sta:%s reports:%u len:%u",
+        util::mac_to_string(sta->m_sta_info.id).c_str(),
+        sta->m_sta_info.num_beacon_meas_report, sta->m_sta_info.beacon_report_len);
+
+    // Send 1905 ACK back to the agent
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+    send_beacon_metrics_ack(ntohs(cmdu->id));
 
     //get_data_model()->set_db_cfg_param(db_cfg_type_sta_list_update, "");
 
-    //send_ack(sta);
-
     return 0;
+}
+
+int em_metrics_t::send_beacon_metrics_ack(unsigned short msg_id)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ] = {0};
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    // dst = agent, src = controller
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(em_msg_type_1905_ack);
+    cmdu->id   = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len  = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_2, buff, len).validate(errors) == 0) {
+        em_printfout("Beacon Metrics ACK validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        em_printfout("Beacon Metrics ACK send failed, error:%d", errno);
+        return -1;
+    }
+
+    em_printfout("Beacon Metrics ACK sent for msg_id=%u", msg_id);
+    return static_cast<int>(len);
 }
 
 int em_metrics_t::handle_ap_metrics_tlv(unsigned char *buff, bssid_t get_bssid)
@@ -320,7 +686,7 @@ int em_metrics_t::handle_ap_metrics_tlv(unsigned char *buff, bssid_t get_bssid)
         dm_easy_mesh_t::macbytes_to_string(ap_metrics->bssid, bss_str);
     } else {
         dm_easy_mesh_t::macbytes_to_string(ap_metrics->bssid, bss_str);
-        printf("%s:%d BSS not found: %s\n", __func__, __LINE__, bss_str);
+        em_printfout("Error: BSS not found: %s", bss_str);
     }
 
     return 0;
@@ -337,18 +703,18 @@ int em_metrics_t::handle_assoc_sta_traffic_stats(unsigned char *buff, bssid_t bs
 
     sta = dm->find_sta(sta_metrics->sta_mac, bssid);
     if (sta == NULL) {
-        em_printfout("sta not found: %s for bssid: %s", util::mac_to_string(sta_metrics->sta_mac).c_str(),
+        em_printfout("Error: sta not found: %s for bssid: %s", util::mac_to_string(sta_metrics->sta_mac).c_str(),
             util::mac_to_string(bssid).c_str());
         return -1;
     }
 
-    sta->m_sta_info.bytes_tx        = sta_metrics->tx_bytes;
-    sta->m_sta_info.bytes_rx        = sta_metrics->rx_bytes;
-    sta->m_sta_info.pkts_tx         = sta_metrics->tx_pkts;
-    sta->m_sta_info.pkts_rx         = sta_metrics->rx_pkts;
-    sta->m_sta_info.errors_tx       = sta_metrics->tx_pkt_errors;
-    sta->m_sta_info.errors_rx       = sta_metrics->rx_pkt_errors;
-    sta->m_sta_info.retrans_count   = sta_metrics->retx_cnt;
+    sta->m_sta_info.bytes_tx        = ntohl(sta_metrics->tx_bytes);
+    sta->m_sta_info.bytes_rx        = ntohl(sta_metrics->rx_bytes);
+    sta->m_sta_info.pkts_tx         = ntohl(sta_metrics->tx_pkts);
+    sta->m_sta_info.pkts_rx         = ntohl(sta_metrics->rx_pkts);
+    sta->m_sta_info.errors_tx       = ntohl(sta_metrics->tx_pkt_errors);
+    sta->m_sta_info.errors_rx       = ntohl(sta_metrics->rx_pkt_errors);
+    sta->m_sta_info.retrans_count   = ntohl(sta_metrics->retx_cnt);
 
     return 0;
 }
@@ -448,7 +814,7 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
     size_t tmp_len, base_len;
     dm_easy_mesh_t  *dm;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
-    bssid_t bssid;
+    bssid_t bssid = {};
 
     dm = get_data_model();
 
@@ -460,90 +826,50 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
     tlv_start =  reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     base_len = static_cast<size_t> (len) - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
 
+    // Single-pass loop: maintain running BSSID context so per-STA TLVs can be associated with the correct BSS
     tlv = tlv_start;
     tmp_len = base_len;
 
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_ap_metrics) {
-            handle_ap_metrics_tlv(tlv->value, bssid);
+        switch (tlv->type) {
+            case em_tlv_type_ap_metrics:
+                // Update current BSSID context; subsequent per-STA TLVs use this value.
+                handle_ap_metrics_tlv(tlv->value, bssid);
+                break;
+            case em_tlv_type_ap_ext_metric:
+                /* future implementation */
+                break;
+            case em_tlv_type_radio_metric:
+                /* future implementation */
+                break;
+            case em_tlv_type_assoc_sta_traffic_sts:
+                if (handle_assoc_sta_traffic_stats(tlv->value, bssid) != 0) {
+                    em_printfout("assoc_sta_traffic_stats failed, skipping TLV");
+                }
+                break;
+            case em_tlv_type_assoc_sta_link_metric:
+                if (handle_assoc_sta_link_metrics_tlv(tlv->value, ntohs(tlv->len)) != 0) {
+                    em_printfout("assoc_sta_link_metrics_tlv failed, skipping TLV");
+                }
+                break;
+            case em_tlv_type_assoc_sta_ext_link_metric:
+                if (handle_assoc_sta_ext_link_metrics_tlv(tlv->value, ntohs(tlv->len)) != 0) {
+                    em_printfout("assoc_sta_ext_link_metrics_tlv failed, skipping TLV");
+                }
+                break;
+            case em_tlv_type_assoc_wifi6_sta_rprt:
+                /* future implementation */
+                break;
+            case em_tlv_type_vendor_specific:
+                if (handle_assoc_sta_vendor_link_metrics_tlv(tlv->value, ntohs(tlv->len)) != 0) {
+                    em_printfout("assoc_sta_vendor_link_metrics_tlv failed, skipping TLV");
+                }
+                break;
+            default:
+                break;
         }
-        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    tlv = tlv_start;
-    tmp_len = base_len;
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_ap_ext_metric) {
-        }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    tlv = tlv_start;
-    tmp_len = base_len;
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_radio_metric) {
-        }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    tlv = tlv_start;
-    tmp_len = base_len;
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_assoc_sta_traffic_sts) {
-            //todo: bug fix to find sta
-            handle_assoc_sta_traffic_stats(tlv->value, bssid);
-        }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    tlv = tlv_start;
-    tmp_len = base_len;
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_assoc_sta_link_metric) {
-            handle_assoc_sta_link_metrics_tlv(tlv->value);
-        }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    tlv = tlv_start;
-    tmp_len = base_len;
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_assoc_sta_ext_link_metric) {
-            handle_assoc_sta_ext_link_metrics_tlv(tlv->value);
-        }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    tlv = tlv_start;
-    tmp_len = base_len;
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_assoc_wifi6_sta_rprt) {
-        }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
-    }
-
-    tlv = tlv_start;
-    tmp_len = base_len;
-
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
-        if (tlv->type == em_tlv_type_vendor_specific) {
-            handle_assoc_sta_vendor_link_metrics_tlv(tlv->value, ntohs(tlv->len));
-        }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     dm->set_db_cfg_param(db_cfg_type_sta_metrics_update, "");
@@ -742,7 +1068,7 @@ int em_metrics_t::send_associated_link_metrics_response(mac_address_t sta_mac, u
     //Error code  TLV 17.2.36
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_error_code;
-    sz = create_error_code_tlv(tlv->value, sta_mac, sta_found);
+    sz = create_error_code_tlv(tlv->value, sta_mac, sta_found, false);
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
@@ -803,6 +1129,20 @@ short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bss
 
     dm = get_data_model();
 
+    // Dedup: skip if a query was sent recently for this STA.
+    // Using a timestamp avoids a stuck boolean — the guard self-heals after the timeout.
+    static constexpr time_t BEACON_QUERY_TIMEOUT_SECS = 10;
+    dm_sta_t *sta_chk = dm->find_sta(sta_mac, bssid);
+    if (sta_chk != NULL && sta_chk->m_sta_info.beacon_query_sent_time != 0 &&
+            (time(NULL) - sta_chk->m_sta_info.beacon_query_sent_time) < BEACON_QUERY_TIMEOUT_SECS) {
+        em_printfout("Beacon Metrics Query already in flight for sta:%s (sent %lds ago), skipping",
+            util::mac_to_string(sta_mac).c_str(),
+            static_cast<long>(time(NULL) - sta_chk->m_sta_info.beacon_query_sent_time));
+        return 0;
+    }
+
+    dm = get_data_model();
+
     memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
     len += sizeof(mac_address_t);
@@ -830,6 +1170,10 @@ short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bss
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_bcon_metric_query;
     sz = create_beacon_metrics_query_tlv(tlv->value, sta_mac, bssid);
+    if (sz < 0) {
+        em_printfout("Failed to create beacon metrics query tlv for sta:%s and bssid:%s", util::mac_to_string(sta_mac).c_str(), util::mac_to_string(bssid).c_str());
+        return -1;
+    }
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += (sizeof (em_tlv_t) + static_cast<size_t> (sz));
@@ -844,16 +1188,23 @@ short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bss
     len += (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_beacon_metrics_query, em_profile_type_2, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        printf("Beacon Metrics Query msg validation failed\n");
+        em_printfout("Beacon Metrics Query msg validation failed");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: Beacon Metrics Query send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Beacon Metrics Query send failed, error:%d", errno);
         return -1;
     }
 
-    printf("%s:%d: Beacon Metrics Query send success\n", __func__, __LINE__);
+    em_printfout("Beacon Metrics Query send success for sta:%s", util::mac_to_string(sta_mac).c_str());
+
+    // Record send time — used by the dedup guard to suppress duplicate triggers
+    dm_sta_t *sta_sent = dm->find_sta(sta_mac, bssid);
+    if (sta_sent != NULL) {
+        sta_sent->m_sta_info.beacon_query_sent_time = time(NULL);
+    }
+
     return static_cast<short> (len);
 }
 
@@ -869,11 +1220,15 @@ int em_metrics_t::send_beacon_metrics_response()
     short sz = 0;
     unsigned short type = htons(ETH_P_1905);
     dm_easy_mesh_t *dm = get_data_model();
-    mac_addr_str_t mac_str;
     bool sta_found = false;
     dm_sta_t *sta;
 
     sta = reinterpret_cast<dm_sta_t *> (hash_map_get_first(get_current_cmd()->get_data_model()->m_sta_map));
+    if (sta == NULL) {
+        em_printfout("No STA in beacon report data model, cannot send response");
+        set_state(em_state_agent_configured);
+        return -1;
+    }
 
     memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
@@ -910,7 +1265,7 @@ int em_metrics_t::send_beacon_metrics_response()
     //Error code  TLV 17.2.36
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_error_code;
-    sz = create_error_code_tlv(tlv->value, sta->m_sta_info.id, sta_found);
+    sz = create_error_code_tlv(tlv->value, sta->m_sta_info.id, sta_found, false);
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
@@ -925,16 +1280,20 @@ int em_metrics_t::send_beacon_metrics_response()
     len += (sizeof(em_tlv_t));
 
     if (em_msg_t(em_msg_type_beacon_metrics_rsp, em_profile_type_2, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        printf("%s:%d: Beacon Metrics Response validation failed for %s\n", __func__, __LINE__, mac_str);
+        em_printfout("Beacon Metrics Response validation failed");
+        set_state(em_state_agent_configured);
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: Beacon Metrics Response send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Beacon Metrics Response send failed, error:%d", errno);
+        set_state(em_state_agent_configured);
         return -1;
     }
 
-    printf("%s:%d: Beacon Metrics Response send success\n", __func__, __LINE__);
+    em_printfout("Beacon Metrics Response send success for sta:%s reports:%u",
+        util::mac_to_string(sta->m_sta_info.id).c_str(), sta->m_sta_info.num_beacon_meas_report);
+    set_state(em_state_agent_configured);
 
     return static_cast<int> (len);
 }
@@ -1065,13 +1424,15 @@ int em_metrics_t::send_ap_metrics_response()
         len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
 
         //AP Extended Metrics TLV (17.2.61)
-        tlv = reinterpret_cast<em_tlv_t *> (tmp);
-        tlv->type = em_tlv_type_ap_ext_metric;
-        sz = create_ap_ext_metrics_tlv(tlv->value, dm->m_bss[bss_index]);
-        tlv->len =  htons(static_cast<unsigned short> (sz));
+        if (get_profile_type() > em_profile_type_1) {
+            tlv = reinterpret_cast<em_tlv_t *> (tmp);
+            tlv->type = em_tlv_type_ap_ext_metric;
+            sz = create_ap_ext_metrics_tlv(tlv->value, dm->m_bss[bss_index]);
+            tlv->len =  htons(static_cast<unsigned short> (sz));
 
-        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+            tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+            len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        }
 
         //now search if this sta is associated to this
         sta = reinterpret_cast<dm_sta_t *> (hash_map_get_first(dm->m_sta_map));
@@ -1099,23 +1460,27 @@ int em_metrics_t::send_ap_metrics_response()
             len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
 
             //Associated STA Extended Link Metrics TLV (17.2.62)
-            tlv = reinterpret_cast<em_tlv_t *> (tmp);
-            tlv->type = em_tlv_type_assoc_sta_ext_link_metric;
-            sz = create_assoc_ext_sta_link_metrics_tlv(tlv->value, sta->m_sta_info.id, sta);
-            tlv->len =  htons(static_cast<unsigned short> (sz));
+            if (get_profile_type() > em_profile_type_1) {
+                tlv = reinterpret_cast<em_tlv_t *> (tmp);
+                tlv->type = em_tlv_type_assoc_sta_ext_link_metric;
+                sz = create_assoc_ext_sta_link_metrics_tlv(tlv->value, sta->m_sta_info.id, sta);
+                tlv->len =  htons(static_cast<unsigned short> (sz));
 
-            tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-            len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+                tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+                len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+            }
 
             //Associated Wi-Fi 6 STA Status Report TLV (17.2.73)
             //Profile-3 msg, hence failing even though optional
-            tlv = reinterpret_cast<em_tlv_t *> (tmp);
-            tlv->type = em_tlv_type_assoc_wifi6_sta_rprt;
-            sz = create_assoc_wifi6_sta_sta_report_tlv(tlv->value, sta);
-            tlv->len =  htons(static_cast<unsigned short> (sz));
+            if (get_profile_type() > em_profile_type_2) {
+                tlv = reinterpret_cast<em_tlv_t *> (tmp);
+                tlv->type = em_tlv_type_assoc_wifi6_sta_rprt;
+                sz = create_assoc_wifi6_sta_sta_report_tlv(tlv->value, sta);
+                tlv->len =  htons(static_cast<unsigned short> (sz));
 
-            tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-            len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+                tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+                len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+            }
 
             //assoc vendor link metrics
             tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -1132,17 +1497,19 @@ int em_metrics_t::send_ap_metrics_response()
 
     for (int i = 0; i < get_current_cmd()->get_param()->u.ap_metrics_params.num_radios; i++) {
         //Radio Metrics TLV (17.2.60)
-        tlv = reinterpret_cast<em_tlv_t *> (tmp);
-        tlv->type = em_tlv_type_radio_metric;
-        sz = create_radio_metrics_tlv(tlv->value, i);
-        if (sz == 0) {
-            em_printfout("create_radio_metrics_tlv size equals to zero\n");
-            continue;
-        }
-        tlv->len =  htons(static_cast<unsigned short> (sz));
+        if (get_profile_type() > em_profile_type_1) {
+            tlv = reinterpret_cast<em_tlv_t *> (tmp);
+            tlv->type = em_tlv_type_radio_metric;
+            sz = create_radio_metrics_tlv(tlv->value, i);
+            if (sz == 0) {
+                em_printfout("create_radio_metrics_tlv size equals to zero\n");
+                continue;
+            }
+            tlv->len =  htons(static_cast<unsigned short> (sz));
 
-        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+            tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+            len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        }
     }
 
     // End of message
@@ -1153,7 +1520,7 @@ int em_metrics_t::send_ap_metrics_response()
     tmp += (sizeof(em_tlv_t));
     len += (sizeof(em_tlv_t));
 
-    if (em_msg_t(em_msg_type_ap_metrics_rsp, em_profile_type_2, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
+    if (em_msg_t(em_msg_type_ap_metrics_rsp, get_profile_type(), buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
         em_printfout("AP Metrics Response validation failed for agent:%s, still sending",
             util::mac_to_string(dm->get_agent_al_interface_mac()).c_str());
         //return -1;
@@ -1306,10 +1673,11 @@ short em_metrics_t::create_beacon_metrics_query_tlv(unsigned char *buff, mac_add
 {
     size_t len = 0;
     dm_easy_mesh_t *dm;
-    ssid_t ssid;
+    ssid_t ssid = {0};
     dm_sta_t *sta;
     unsigned int j;
-    unsigned char ap_channel_list[] = {1, 6, 11};
+    bool ssid_found = false;
+    unsigned int radio_op_class = 128; // default fallback: 5GHz VHT80
     
 	dm = get_data_model();
 
@@ -1321,75 +1689,131 @@ short em_metrics_t::create_beacon_metrics_query_tlv(unsigned char *buff, mac_add
         sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
     }
 
+    if (sta == NULL) {
+        em_printfout("STA not found for mac:%s", util::mac_to_string(sta_mac).c_str());
+        return -1;
+    }
+
+    em_printfout("BSS lookup: sta_mac:%s sta->bssid:%s bssid_param:%s num_bss:%u",
+        util::mac_to_string(sta_mac).c_str(),
+        util::mac_to_string(sta->m_sta_info.bssid).c_str(),
+        util::mac_to_string(bssid).c_str(),
+        dm->get_num_bss());
+
+    // Try bssid parameter first (from em_sta->bssid), then fall back to sta->m_sta_info.bssid
     for (j = 0; j < dm->get_num_bss(); j++) {
-        if (memcmp(&dm->m_bss[j].m_bss_info.bssid, sta->m_sta_info.bssid, sizeof(bssid_t)) != 0) {
+        em_printfout("  BSS[%u] bssid:%s ssid:%s", j,
+            util::mac_to_string(dm->m_bss[j].m_bss_info.bssid.mac).c_str(),
+            dm->m_bss[j].m_bss_info.ssid);
+        if (memcmp(dm->m_bss[j].m_bss_info.bssid.mac, bssid, sizeof(bssid_t)) == 0) {
             snprintf(ssid, sizeof(ssid_t), "%s", dm->m_bss[j].m_bss_info.ssid);
+            ssid_found = true;
+            em_printfout("BSS found via bssid param: ssid:%s", ssid);
             break;
         }
     }
 
-
-    em_beacon_metrics_query_t *beacon_metrics = reinterpret_cast<em_beacon_metrics_query_t*> (buff);
-
-    if (sta == NULL) {
-
-    }
-    else {
-
-        memcpy(beacon_metrics->sta_mac_addr, sta_mac, sizeof(mac_addr_t));
-        len += sizeof(beacon_metrics->sta_mac_addr);
-
-        beacon_metrics->op_class = 10;
-        len += sizeof(beacon_metrics->op_class);
-
-        beacon_metrics->channel_num = 6;
-        len += sizeof(beacon_metrics->channel_num);
-
-        memcpy(beacon_metrics->bssid, bssid, sizeof(bssid_t));
-        len += sizeof(beacon_metrics->bssid);
-
-        beacon_metrics-> rprt_detail = 1;
-        len += sizeof(beacon_metrics-> rprt_detail);
-
-        beacon_metrics->ssid_len = sizeof(ssid);
-        len += sizeof(beacon_metrics->ssid_len);
-
-        memcpy(beacon_metrics->ssid, ssid, sizeof(ssid));
-        len += sizeof(ssid);
-
-        beacon_metrics->num_ap_channel_rprt = 2;
-        len += sizeof(beacon_metrics->num_ap_channel_rprt);
-
-        em_beacon_ap_channel_rprt_t *ap_chann_rprt;// = buff + len;
-
-        for (int i = 0; i < beacon_metrics->num_ap_channel_rprt; i++) {
-            ap_chann_rprt = reinterpret_cast<em_beacon_ap_channel_rprt_t *> (buff + len);
-            ap_chann_rprt->ap_channel_rprt_len = 4;
-            len += sizeof(ap_chann_rprt->ap_channel_rprt_len);
-
-            ap_chann_rprt->ap_channel_op_class = 10;
-            len += sizeof(ap_chann_rprt->ap_channel_op_class);
-
-            for(int j = 0; j < ap_chann_rprt->ap_channel_rprt_len - 1; j++) {
-                ap_chann_rprt->ap_channel_list[j] = ap_channel_list[j];
-                len += sizeof(unsigned char);
+    if (!ssid_found) {
+        // Fallback: try sta->m_sta_info.bssid
+        for (j = 0; j < dm->get_num_bss(); j++) {
+            if (memcmp(dm->m_bss[j].m_bss_info.bssid.mac, sta->m_sta_info.bssid, sizeof(bssid_t)) == 0) {
+                snprintf(ssid, sizeof(ssid_t), "%s", dm->m_bss[j].m_bss_info.ssid);
+                ssid_found = true;
+                em_printfout("BSS found via sta->bssid fallback: ssid:%s", ssid);
+                break;
             }
         }
     }
 
+    if (!ssid_found) {
+        em_printfout("BSS not found for bssid_param:%s sta->bssid:%s, cannot populate SSID",
+            util::mac_to_string(bssid).c_str(),
+            util::mac_to_string(sta->m_sta_info.bssid).c_str());
+        return -1;
+    }
+
+    // Derive op_class and channel from the operating channel report data
+    // (em_op_class_type_current entries populated by handle_op_channel_report)
+    unsigned int ap_channel = 0;
+    {
+        em_op_class_info_t *oci = nullptr;
+        for (unsigned int oc_idx = 0; oc_idx < dm->m_num_opclass; oc_idx++) {
+            em_op_class_info_t *candidate = &dm->m_op_class[oc_idx].m_op_class_info;
+            if ((memcmp(candidate->id.ruid, dm->m_bss[j].m_bss_info.id.ruid, sizeof(mac_address_t)) == 0) &&
+                    (candidate->id.type == em_op_class_type_current)) {
+                oci = candidate;
+                break;
+            }
+        }
+        if (oci != nullptr) {
+            radio_op_class = oci->op_class;
+            ap_channel = oci->channel;
+            em_printfout("Derived radio op_class %u channel %u from operating channel report for ruid:%s",
+                radio_op_class, ap_channel, util::mac_to_string(dm->m_bss[j].m_bss_info.id.ruid).c_str());
+        } else {
+            em_printfout("Could not get current op_class from operating channel report for ruid, using default %u",
+                radio_op_class);
+        }
+    }
+
+    em_beacon_metrics_query_t *beacon_metrics = reinterpret_cast<em_beacon_metrics_query_t*> (buff);
+
+    memcpy(beacon_metrics->sta_mac_addr, sta_mac, sizeof(mac_addr_t));
+    len += sizeof(beacon_metrics->sta_mac_addr);
+
+    beacon_metrics->op_class = radio_op_class;//static_cast<unsigned char>(scan_op_class);
+    len += sizeof(beacon_metrics->op_class);
+
+    // Use the AP's actual operating channel from the operating channel report.
+    if (ap_channel == 0) {
+        em_printfout("Operating channel report had channel 0, falling back to channel 255 (wildcard)");
+        ap_channel = 255;
+    } else {
+        em_printfout("Using AP operating channel %u from operating channel report for beacon request", ap_channel);
+    }
+    beacon_metrics->channel_num = 255;//ap_channel//todo: test and see with only correct op class, static_cast<unsigned char>(ap_channel);
+    len += sizeof(beacon_metrics->channel_num);
+
+    // Keep real BSSID so agent can resolve ap_index; OW will override to wildcard after lookup
+    memcpy(beacon_metrics->bssid, bssid, sizeof(bssid_t));
+    len += sizeof(beacon_metrics->bssid);
+
+    beacon_metrics->rprt_detail = 1;
+    len += sizeof(beacon_metrics->rprt_detail);
+
+    beacon_metrics->ssid_len = strlen(ssid);
+    len += sizeof(beacon_metrics->ssid_len);
+
+    memcpy(beacon_metrics->ssid, ssid, beacon_metrics->ssid_len);
+    len += beacon_metrics->ssid_len;
+
+    // Single AP Channel Report with only the current operating channel
+    uint8_t num_rprts = 1;
+    *(buff + len) = num_rprts;
+    len += sizeof(uint8_t);
+
+    // AP Channel Report: length = 2 (1 byte op_class + 1 byte channel)
+    uint8_t rprt_len = 2;
+    *(buff + len) = rprt_len;
+    len += sizeof(uint8_t);
+
+    *(buff + len) = static_cast<uint8_t>(radio_op_class);
+    len += sizeof(uint8_t);
+
+    *(buff + len) = static_cast<uint8_t>(ap_channel);
+    len += sizeof(uint8_t);
+
+    em_printfout("AP Channel Report: op_class=%u channel=%u", radio_op_class, ap_channel);
+
     // Print the filled data
-    printf("STA MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n",
-           beacon_metrics->sta_mac_addr[0], beacon_metrics->sta_mac_addr[1], beacon_metrics->sta_mac_addr[2],
-           beacon_metrics->sta_mac_addr[3], beacon_metrics->sta_mac_addr[4], beacon_metrics->sta_mac_addr[5]);
-    printf("Operating Class: %u\n", beacon_metrics->op_class);
-    printf("Channel Number: %u\n", beacon_metrics->channel_num);
-    mac_addr_str_t mac_str;
-    dm_easy_mesh_t::macbytes_to_string(beacon_metrics->bssid, mac_str);
-    printf("BSSID: %s\n", mac_str);
-    printf("Reporting Detail: %u\n", beacon_metrics->rprt_detail);
-    printf("SSID Length: %u\n", beacon_metrics->ssid_len);
-    printf("SSID: %s\n", beacon_metrics->ssid);
-    printf("Number of AP Channel Reports: %u\n", beacon_metrics->num_ap_channel_rprt);
+    em_printfout("STA MAC Address: %s", util::mac_to_string(beacon_metrics->sta_mac_addr).c_str());
+    em_printfout("Operating Class: %u", beacon_metrics->op_class);
+    em_printfout("Channel Number: %u", beacon_metrics->channel_num);
+    em_printfout("BSSID: %s", util::mac_to_string(beacon_metrics->bssid).c_str());
+    em_printfout("Reporting Detail: %u", beacon_metrics->rprt_detail);
+    em_printfout("SSID Length: %u", beacon_metrics->ssid_len);
+    em_printfout("SSID: %.*s", beacon_metrics->ssid_len, beacon_metrics->ssid);
+    em_printfout("Number of AP Channel Reports: %u", num_rprts);
 
     return static_cast<short> (len);
 }
@@ -1657,7 +2081,7 @@ short em_metrics_t::create_link_stats_alarm_tlv(unsigned char *buff)
     return static_cast<short> (len);
 }
 
-short em_metrics_t::create_error_code_tlv(unsigned char *buff, mac_address_t sta, bool sta_found)
+short em_metrics_t::create_error_code_tlv(unsigned char *buff, mac_address_t sta, bool sta_found, bool is_associated)
 {
     short len = 0;
     unsigned char *tmp = buff;
@@ -1668,6 +2092,13 @@ short em_metrics_t::create_error_code_tlv(unsigned char *buff, mac_address_t sta
         reason = 0x02;
     } */
 
+    (void)sta_found;
+    if (is_associated) {
+        reason = 0x01;   // STA is associated (Unassoc Query error)
+    } else {
+        reason = 0x00;   // default / no error / legacy behavior
+    }
+
     memcpy(tmp, &reason, sizeof(unsigned char));
     tmp += sizeof(unsigned char);
     len += static_cast<short> (sizeof(unsigned char));
@@ -1677,6 +2108,615 @@ short em_metrics_t::create_error_code_tlv(unsigned char *buff, mac_address_t sta
     len += static_cast<short> (sizeof(mac_address_t));
 
     return len;
+}
+
+int em_metrics_t::handle_1905_ack(unsigned char *buff, unsigned int len)
+{
+    std::vector<em_t *> em_radios;
+    em_t *matched_em = nullptr;
+    mac_address_t src_mac;
+
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+
+    unsigned short response_msg_id = ntohs(cmdu->id);
+
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(buff);
+
+    memcpy(src_mac, hdr->src, sizeof(mac_address_t));
+
+    get_mgr()->get_all_em_for_al_mac(src_mac, em_radios);
+
+    for (auto &em : em_radios)
+    {
+        if ((em->get_state() == em_state_ctrl_unassoc_sta_link_metrics_pending) &&
+            (response_msg_id == em->get_unassoc_sta_query_msg_id()))
+        {
+            matched_em = em;
+	    em->clear_unassoc_sta_query_msg_id();
+            break;
+        }
+    }
+
+    if (matched_em != nullptr) {
+        matched_em->set_state(em_state_ctrl_configured);
+    }
+
+    em_radios.clear();
+    em_printfout("Unassociated STA Link Metrics Query Ack handled successfully");
+    return 0;
+}
+
+int em_metrics_t::send_1905_ack_unassoc_sta_query(mac_address_t *sta_list, 
+		                        int sta_count, unsigned short msg_id)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    unsigned int len = 0;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    // --------------------------------------
+    // Ethernet Header and CMDU
+    // --------------------------------------
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len +=  static_cast<short> (sizeof(mac_address_t));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len +=  static_cast<short> (sizeof(mac_address_t));
+
+    memcpy(tmp, &type, sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += static_cast<unsigned int>(sizeof(unsigned short));;
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+
+    cmdu->type = htons(em_msg_type_1905_ack);
+    cmdu->id = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    tmp += sizeof(em_cmdu_t);
+    len += static_cast<unsigned int>(sizeof(em_cmdu_t));
+
+    // Error Code TLVs (if any)
+    for (int i = 0; i < sta_count; i++) {
+
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_error_code;
+
+        short sz =  create_error_code_tlv(tlv->value, sta_list[i], true, true);
+
+	tlv->len = htons(static_cast<short unsigned int> (sz));
+
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_3, buff, len).validate(errors) == 0) {
+        printf("%s:%d: ACK validation failed\n", __func__, __LINE__);
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        printf("%s:%d: ACK send failed, error:%d\n", __func__, __LINE__, errno);
+        return -1;
+    }
+    printf("%s:%d: ACK sent (Unassoc STA Query)\n", __func__, __LINE__);
+
+    return static_cast<int> (len);
+}
+
+int em_metrics_t::handle_unassoc_sta_link_metrics_query(unsigned char *buff, unsigned int len)
+{
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    if (em_msg_t(em_msg_type_unassoc_sta_link_metrics_query, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("%s:%d validation failed", __func__,__LINE__);
+        return -1;
+    }
+
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+
+    uint16_t msg_id = ntohs(cmdu->id);
+
+    dm_easy_mesh_t *dm = get_data_model();
+    dm->set_msg_id(msg_id);
+
+    mac_address_t error_sta_list[EM_MAX_STA_PER_AGENT];
+    int error_sta_count = 0;
+
+    unsigned char work_buff[MAX_EM_BUFF_SZ] = {0};
+    unsigned char *work_ptr = work_buff;
+
+    auto remaining_work_buf = [&](unsigned char *ptr) -> size_t {
+	    return MAX_EM_BUFF_SZ - static_cast<size_t>(ptr - work_buff);
+        };
+
+    unsigned char *tlv_ptr = buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t);
+
+    unsigned char *cmdu_end = buff + len;
+
+    while (tlv_ptr + sizeof(em_tlv_t) <= cmdu_end) {
+
+        em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tlv_ptr);
+
+        if (tlv->type == em_tlv_type_eom) {
+            break;
+        }
+
+        uint16_t tlv_len = ntohs(tlv->len);
+
+        if ((tlv_ptr + sizeof(em_tlv_t) + tlv_len) > cmdu_end) {
+            em_printfout("%s:%d TLV overflow", __func__,__LINE__);
+            return -1;
+        }
+
+        if (tlv->type == em_tlv_type_unassoc_sta_link_metric_query) {
+
+            unsigned char *query_ptr = tlv->value;
+            unsigned char *query_end = query_ptr + tlv_len;
+
+            while (query_ptr + 2 <= query_end) {
+
+                uint8_t op_class = *query_ptr++;
+                uint8_t num_channels = *query_ptr++;
+
+                if (num_channels > EM_MAX_CHANNELS_PER_OPCLASS) {
+                    em_printfout("%s:%d Invalid num_channels=%u (max=%u)", __func__, __LINE__, num_channels, EM_MAX_CHANNELS_PER_OPCLASS);
+                    return -1;
+                }
+
+                if (remaining_work_buf(work_ptr) < 2) {
+                    em_printfout("%s:%d work buffer exhausted", __func__, __LINE__);
+                    return -1;
+                }
+
+                unsigned char *opclass_start = work_ptr;
+
+                *work_ptr++ = op_class;
+
+                uint8_t *num_channels_field = work_ptr++;
+                uint8_t valid_channel_count = 0;
+
+                for (uint8_t channel_idx = 0; channel_idx < num_channels; channel_idx++) {
+
+                    if (query_ptr + 2 > query_end) {
+                        break;
+                    }
+
+                    uint8_t channel = *query_ptr++;
+                    uint8_t num_sta = *query_ptr++;
+
+		    if (num_sta > EM_MAX_STA_PER_CHANNEL) {
+                        em_printfout("%s:%d Invalid num_sta=%u (max=%u)",__func__, __LINE__, num_sta, EM_MAX_STA_PER_CHANNEL);
+                        return -1;
+                    }
+
+                    constexpr size_t CHANNEL_BUF_SIZE = 2 + (EM_MAX_STA_PER_CHANNEL * sizeof(mac_address_t));
+
+                    unsigned char channel_buf[CHANNEL_BUF_SIZE];
+                    unsigned char *channel_ptr = channel_buf;
+
+                    *channel_ptr++ = channel;
+
+                    uint8_t *num_sta_field = channel_ptr++;
+                    uint8_t valid_sta_count = 0;
+
+                    for (uint8_t sta_idx = 0; sta_idx < num_sta; sta_idx++) {
+
+                        if (query_ptr + sizeof(mac_address_t) > query_end) {
+                            break;
+                        }
+
+                        mac_address_t sta;
+                        memcpy(sta, query_ptr, sizeof(mac_address_t));
+
+                        query_ptr += sizeof(mac_address_t);
+
+			// Check if the STA is associated with any BSS on this agent
+                        dm_sta_t *assoc_sta = dm->get_first_sta(sta);
+		        bool sta_is_associated = (assoc_sta != NULL);
+                        
+		        if (sta_is_associated) {
+                            bool already_added = false;
+
+                            for (int err_idx = 0; err_idx < error_sta_count; err_idx++) {
+                                if (memcmp(error_sta_list[err_idx], sta, sizeof(mac_address_t)) == 0) {
+                                    already_added = true;
+                                    break;
+                                }
+                            }
+
+                            if (!already_added && error_sta_count < EM_MAX_STA_PER_AGENT) {
+                                memcpy(error_sta_list[error_sta_count], sta, sizeof(mac_address_t));
+                                error_sta_count++;
+                            }
+                        } else {
+                            size_t required = sizeof(mac_address_t);
+
+                            if (static_cast<size_t>(channel_ptr - channel_buf) + required > CHANNEL_BUF_SIZE) {
+
+                                em_printfout("%s:%d channel buffer overflow",__func__, __LINE__);
+                                return -1;
+                            }
+
+                            memcpy(channel_ptr, sta, sizeof(mac_address_t));
+                            channel_ptr += sizeof(mac_address_t);
+                            valid_sta_count++;
+                        }
+                    }
+
+                    if (valid_sta_count > 0) {
+                        *num_sta_field = valid_sta_count;
+
+                        uint16_t channel_len = static_cast<uint16_t>(2 + (valid_sta_count * sizeof(mac_address_t)));
+
+                        if (remaining_work_buf(work_ptr) < channel_len) {
+                            em_printfout("%s:%d work buffer overflow", __func__,  __LINE__);
+                            return -1;
+                        }
+
+                        memcpy(work_ptr, channel_buf, channel_len);
+                        work_ptr += channel_len;
+                        valid_channel_count++;
+                    }
+                }
+
+                if (valid_channel_count == 0) {
+                    /* rollback empty opclass */
+                    work_ptr = opclass_start;
+                } else {
+                    *num_channels_field = valid_channel_count;
+                }
+            }
+        }
+        tlv_ptr += sizeof(em_tlv_t) + tlv_len;
+    }
+    send_1905_ack_unassoc_sta_query(error_sta_list, error_sta_count, msg_id);
+
+    if (work_ptr > work_buff) {
+        uint16_t work_len = static_cast<uint16_t>(work_ptr - work_buff);
+        get_mgr()->io_process(em_bus_event_type_unassoc_sta_link_metrics_query, work_buff, work_len);
+        em_printfout("%s:%d Sent Unassoc STA Query to Agent len=%u", __func__, __LINE__, work_len);
+    }
+    return 0;
+}
+
+unsigned short em_metrics_t::create_unassoc_sta_link_metrics_query_tlv(unsigned char *buff, em_unassoc_query_opclass_t *op)
+{
+    unsigned char *ptr = buff;
+    unsigned short len = 0;
+
+    if (op == NULL) {
+        em_printfout("op is NULL");
+        return 0;
+    }
+
+    *ptr++ = op->op_class;
+    len++;
+
+    *ptr++ = op->num_channels;
+    len++;
+
+    for (int j = 0; j < op->num_channels; j++) {
+        auto &ch = op->channel_list[j];
+
+	*ptr++ = ch.channel;
+        len++;
+
+        *ptr++ = ch.num_sta;
+        len++;
+        for (int k = 0; k < ch.num_sta; k++) {
+            //Adding STA
+            memcpy(ptr, ch.sta_list[k], sizeof(mac_address_t));
+            ptr += sizeof(mac_address_t);
+            len += static_cast<short>(sizeof(mac_address_t));	    
+        }
+    }
+    return len;
+}
+
+int em_metrics_t::send_unassoc_sta_link_metrics_query_msg()
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+    unsigned int len = 0;
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+
+    dm_easy_mesh_t *dm = get_data_model();
+
+    if (dm == NULL) {
+        return -1;
+    }
+
+    em_cmd_unassoc_sta_query_t *cmd = static_cast<em_cmd_unassoc_sta_query_t *>(get_current_cmd());
+    if (cmd == NULL) {
+        return -1;
+    }
+
+    em_unassoc_query_list_t *query = cmd->get_query();
+
+    if (query == NULL) {
+        return -1;
+    }
+
+    memset(buff, 0, sizeof(buff));
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(),  sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    unsigned short type = htons(ETH_P_1905);
+    memcpy(tmp, &type, sizeof(type));
+    tmp += sizeof(type);
+    len += sizeof(type);
+
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(cmdu, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(em_msg_type_unassoc_sta_link_metrics_query);
+
+    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    cmdu->last_frag_ind = 1;
+    cmdu->relay_ind = 0;
+
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    // TLVs
+    for (int i = 0; i < query->num_opclass; i++) {
+        auto &op = query->opclass_list[i];
+        unsigned int required_payload = 2;   // op_class + num_channels
+
+        for (int j = 0; j < op.num_channels; j++) {
+            required_payload += 2;     // channel + num_sta
+            required_payload += static_cast<unsigned int>(op.channel_list[j].num_sta) * sizeof(mac_address_t);
+        }
+
+        unsigned int remaining = MAX_EM_BUFF_SZ - static_cast<unsigned int>(tmp - buff);
+
+        if (remaining < (sizeof(em_tlv_t) + required_payload)) {
+            em_printfout("%s:%d insufficient buffer space (remaining=%u required=%u)", __func__, __LINE__, remaining, sizeof(em_tlv_t) + required_payload);
+            return -1;
+        }
+
+        em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_unassoc_sta_link_metric_query;
+       
+        unsigned int sz = static_cast<unsigned int>(create_unassoc_sta_link_metrics_query_tlv(tlv->value, &op));
+       tlv->len = htons(static_cast<uint16_t>(sz));
+
+       tmp += sizeof(em_tlv_t) + static_cast<size_t>(sz);
+   
+       len += static_cast<unsigned int>(sizeof(em_tlv_t) + static_cast<size_t>(sz));
+    }
+   
+    unsigned int remaining = MAX_EM_BUFF_SZ - static_cast<unsigned int>(tmp - buff);
+
+    if (remaining < sizeof(em_tlv_t)) {
+        em_printfout("%s:%d insufficient buffer space for EOM TLV", __func__, __LINE__);
+        return -1;
+    } 
+
+    em_tlv_t *eom = reinterpret_cast<em_tlv_t *>(tmp);
+    eom->type = em_tlv_type_eom;
+    eom->len = 0;
+
+    tmp += sizeof(em_tlv_t);
+    len += static_cast<unsigned int>(sizeof(em_tlv_t));;
+
+    if (em_msg_t(em_msg_type_unassoc_sta_link_metrics_query, em_profile_type_3, buff, len).validate(errors) == 0) {
+        em_printfout("Unassociated STA Link Metrics Query validation failed");
+        return -1;
+    }
+
+   if (send_frame(buff, len) < 0) {
+        em_printfout("%s:%d: Unassoc Query send failed errno=%d",__func__, __LINE__, errno);
+        return -1;
+    }
+
+    em_printfout("%s:%d: Unassoc Query sent to Agent successfully", __func__, __LINE__);
+
+    em_t *em = static_cast<em_t *>(this);
+    em->m_unassoc_sta_query_msg_id = ntohs(cmdu->id);
+    em_printfout("%s:%d Stored query msg_id=%u", 
+             __func__, __LINE__, em->m_unassoc_sta_query_msg_id);
+
+    m_unassoc_sta_query_msg_id  =  ntohs(cmdu->id);
+    
+    return static_cast<int>(len);
+}
+
+//Unassociated STA Link Metrics Response Part
+/*
+ * create_unassoc_sta_link_metrics_tlv()
+ *
+ * Purpose:
+ * --------
+ * Creates ONE TLV for ONE operating class.
+ *
+ * Output:
+ * -------
+ * TLV contains:
+ * - op_class
+ * - num_sta
+ * - all STA metrics for that op_class
+ */
+
+unsigned short em_metrics_t::create_unassoc_sta_link_metrics_resp_tlv(unsigned char *buff, unsigned char op_class, em_unassoc_sta_metrics_rsp_t *rsp)
+{
+    em_unassoc_sta_link_metrics_rsp_t *tlv = reinterpret_cast<em_unassoc_sta_link_metrics_rsp_t *>(buff);
+
+    unsigned short len = 0;
+    unsigned char count = 0;
+
+    tlv->op_class = op_class;
+
+
+    /*
+     * Advance length for op_class field
+     */
+    len += 1;
+
+    /*
+     * Reserve space for num_sta field.
+     *
+     * We do not yet know how many STA entries
+     * belong to this op_class.
+     *
+     * We'll fill tlv->num_sta later.
+     */
+    len += 1;
+
+    /*
+     * TLV buffer layout:
+     *
+     * --------------------------------------------------
+     * | op_class | num_sta | STA metric entries ... |
+     * --------------------------------------------------
+     *
+     * Each STA metric entry contains:
+     *   - STA MAC
+     *   - channel
+     *   - time_delta
+     *   - rcpi
+     */
+    for (unsigned int i = 0; i < rsp->num_entries; i++) {
+        /*
+         * Skip entries belonging to
+         * different operating classes.
+         */
+        if (rsp->entry[i].op_class != op_class) {
+            continue;
+        }
+        
+        em_unassoc_sta_metric_t *sta_metric = reinterpret_cast<em_unassoc_sta_metric_t *>(buff + len);
+
+        memcpy(sta_metric->sta_mac, rsp->entry[i].sta_mac, sizeof(mac_address_t));
+        sta_metric->channel = rsp->entry[i].channel;
+        sta_metric->time_delta = htonl(rsp->entry[i].time_delta);
+        sta_metric->rcpi = rsp->entry[i].rcpi;
+        len += sizeof(em_unassoc_sta_metric_t);
+        count++;
+    }
+
+    tlv->num_sta = count;
+
+    return len;
+}
+
+/*
+ * send_unassoc_sta_link_metrics_response()
+ *
+ * Builds and sends ONE response message
+ * containing ONE Unassoc STA Link Metrics TLV
+ * for ONE operating class.
+ */
+void em_metrics_t::send_unassoc_sta_link_metrics_resp_msg()	
+{
+    unsigned char buff[MAX_EM_BUFF_SZ];
+    unsigned char *tmp = buff;
+
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+
+    size_t len = 0;
+
+    bool sent_opclass[256] = {false};
+    unsigned short type = htons(ETH_P_1905);
+    unsigned short msg_type = em_msg_type_unassoc_sta_link_metrics_rsp;
+
+    dm_easy_mesh_t *dm = get_data_model();
+    unsigned short msg_id = dm->get_msg_id();
+    em_unassoc_sta_metrics_rsp_t *rsp = &dm->m_unassoc_sta_metrics_rsp;
+
+    memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, &type, sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(cmdu, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(msg_type);
+    cmdu->id = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    tmp += sizeof(em_cmdu_t);
+    len +=  static_cast<unsigned int>(sizeof(em_cmdu_t)); 
+
+    for (unsigned int i = 0; i < rsp->num_entries; i++) {
+
+        unsigned char op_class = rsp->entry[i].op_class;
+
+        if (sent_opclass[op_class]) {
+            continue;
+        }
+
+        em_tlv_t *tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        memset(tlv, 0, sizeof(em_tlv_t));
+
+        tlv->type = em_tlv_type_unassoc_sta_link_metric_rsp;
+
+        unsigned short sz = create_unassoc_sta_link_metrics_resp_tlv(tlv->value, op_class, rsp);
+
+        unsigned int required = sizeof(em_tlv_t) + sz;
+
+        if ((len + required) > MAX_EM_BUFF_SZ) {
+            em_printfout("%s:%d insufficient buffer space for Unassoc STA Metrics TLV (len=%u required=%u max=%u)",__func__, __LINE__,
+                                       static_cast<unsigned int>(len), required, MAX_EM_BUFF_SZ);
+            return;
+        }
+
+        tlv->len = htons(sz);
+
+        tmp += required;
+        len += required;
+        sent_opclass[op_class] = true;
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (send_frame(buff, static_cast<unsigned int>(len)) < 0) {
+        em_printfout("%s:%d: UnAssociated STA Link Metrics Response send failed, error:%d\n", __func__, __LINE__, errno);
+	return;
+    }
+    /*
+     * Clear the processed entries after successfully sending the response.
+     * This prevents the same Unassociated STA metrics data from being
+     * retransmitted if the command is executed again or the state handler 
+     * is invoked multiple times for the same response object.
+     */
+    em_printfout("%s:%d Clearing num_entries after successful response send\n",__func__, __LINE__);
+    rsp->num_entries = 0;
+    set_state(em_state_agent_configured);
 }
 
 void em_metrics_t::process_msg(unsigned char *data, unsigned int len)
@@ -1706,6 +2746,77 @@ void em_metrics_t::process_msg(unsigned char *data, unsigned int len)
         case em_msg_type_topo_vendor:
             handle_vendor_msg(data, len);
             break;
+        case em_msg_type_unassoc_sta_link_metrics_query:
+            handle_unassoc_sta_link_metrics_query(data, len);
+            break;
+        case em_msg_type_unassoc_sta_link_metrics_rsp:
+            handle_unassoc_sta_link_metrics_rsp(data, len);
+            break;
+        case em_msg_type_1905_ack:
+            handle_1905_ack(data, len);
+            break;
+
+        case em_msg_type_client_cap_rprt:
+        {
+            // Extract the specific STA from the Client Info TLV so we only
+            // send one beacon query for the STA that just joined.
+            em_tlv_t *cap_tlv = reinterpret_cast<em_tlv_t *>(data + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+            unsigned int cap_len = len - static_cast<unsigned int>(sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
+            mac_address_t join_sta_mac = {0};
+            bssid_t       join_bssid   = {0};
+            bool found_sta = false;
+            while (cap_len >= sizeof(em_tlv_t)) {
+                unsigned int tlv_len = static_cast<unsigned int>(ntohs(cap_tlv->len));
+                unsigned int tlv_total_len = static_cast<unsigned int>(sizeof(em_tlv_t)) + tlv_len;
+
+                if (tlv_total_len > cap_len) {
+                    em_printfout("cap report: malformed TLV walk, tlv_len=%u cap_len=%u", tlv_len, cap_len);
+                    break;
+                }
+
+                if (cap_tlv->type == em_tlv_type_eom) {
+                    break;
+                }
+
+                if (cap_tlv->type == em_tlv_type_client_info) {
+                    if (tlv_len >= (sizeof(bssid_t) + sizeof(mac_address_t))) {
+                        // em_client_info_t layout: bssid[6] then client_mac[6]
+                        memcpy(join_bssid, cap_tlv->value, sizeof(bssid_t));
+                        memcpy(join_sta_mac, cap_tlv->value + sizeof(bssid_t), sizeof(mac_address_t));
+                        found_sta = true;
+                    } else {
+                        em_printfout("cap report: malformed Client Info TLV len=%u", tlv_len);
+                    }
+                    break;
+                }
+                cap_len -= tlv_total_len;
+                cap_tlv = reinterpret_cast<em_tlv_t *>(reinterpret_cast<unsigned char *>(cap_tlv) + tlv_total_len);
+            }
+            if (found_sta) {
+                em_printfout("cap report: beacon query will be triggered after topo publish for sta:%s bssid:%s",
+                    util::mac_to_string(join_sta_mac).c_str(),
+                    util::mac_to_string(join_bssid).c_str());
+            } else {
+                em_printfout("cap report: could not find Client Info TLV");
+            }
+
+            // Previous implementation: send beacon query for all associated STAs.
+            // Kept for reference.
+            // em_sta_info_t *em_sta = get_data_model()->get_first_sta_info(em_target_sta_map_assoc);
+            // while (em_sta != NULL) {
+            //     if (!sta_supports_beacon_measurement(em_sta->rm_cap)) {
+            //         em_printfout("cap report: STA %s has no 802.11k beacon meas capability, skipping query",
+            //             util::mac_to_string(em_sta->id).c_str());
+            //     } else {
+            //         em_printfout("cap report: sending beacon query for sta:%s bssid:%s",
+            //             util::mac_to_string(em_sta->id).c_str(),
+            //             util::mac_to_string(em_sta->bssid).c_str());
+            //         send_beacon_metrics_query(em_sta->id, em_sta->bssid);
+            //     }
+            //     em_sta = get_data_model()->get_next_sta_info(em_sta, em_target_sta_map_assoc);
+            // }
+            break;
+        }
 
         default:
             break;
@@ -1718,6 +2829,10 @@ void em_metrics_t::process_ctrl_state()
         case em_state_ctrl_sta_link_metrics_pending:
             send_all_associated_sta_link_metrics_msg();
             break;
+        case em_state_ctrl_unassoc_sta_link_metrics_pending:
+            send_unassoc_sta_link_metrics_query_msg();
+            break;
+	    
         default:
             printf("%s:%d: unhandled case %s\n", __func__, __LINE__, em_t::state_2_str(get_state()));
             break;
@@ -1739,6 +2854,10 @@ void em_metrics_t::process_agent_state()
             send_link_quality_report();
             break;
 
+        case em_state_agent_unassoc_sta_metrics_report_pending:
+            send_unassoc_sta_link_metrics_resp_msg();
+            break;
+
         default:
             break;
     }
@@ -1754,6 +2873,72 @@ void em_metrics_t::process_agent_state(em_cmd_event_type_t type)
         default:
             break;
     }
+}
+
+int em_metrics_t::send_beacon_metrics_query_ack(mac_address_t sta_mac, unsigned short msg_id, unsigned char reason)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ] = {0};
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    // dst = controller, src = agent
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(em_msg_type_1905_ack);
+    cmdu->id   = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    if (reason != 0) {
+        // 17.2.36 Error Code TLV
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_error_code;
+        unsigned char *ec = tlv->value;
+        *ec = reason;
+        ec += sizeof(unsigned char);
+        memcpy(ec, sta_mac, sizeof(mac_address_t));
+        ec += sizeof(mac_address_t);
+        tlv->len = htons(static_cast<unsigned short>(sizeof(unsigned char) + sizeof(mac_address_t)));
+        tmp += sizeof(em_tlv_t) + sizeof(unsigned char) + sizeof(mac_address_t);
+        len += sizeof(em_tlv_t) + sizeof(unsigned char) + sizeof(mac_address_t);
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len  = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_2, buff, len).validate(errors) == 0) {
+        em_printfout("Beacon Metrics Query ACK validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        em_printfout("Beacon Metrics Query ACK send failed, error:%d", errno);
+        return -1;
+    }
+
+    em_printfout("Beacon Metrics Query ACK sent for msg_id=%u reason=%u", msg_id, reason);
+    return static_cast<int>(len);
 }
 
 em_metrics_t::em_metrics_t()

--- a/src/em/policy_cfg/em_policy_cfg.cpp
+++ b/src/em/policy_cfg/em_policy_cfg.cpp
@@ -53,7 +53,6 @@ short em_policy_cfg_t::create_metrics_rep_policy_tlv(unsigned char *buff)
 	unsigned int i = 0;
 	em_metric_rprt_policy_t	*metric;
 	em_metric_rprt_policy_radio_t *radio_metric;
-	mac_address_t broadcast_mac = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
 	if (get_current_cmd()->get_type() == em_cmd_type_em_config) {
         dm = get_data_model();
@@ -61,6 +60,9 @@ short em_policy_cfg_t::create_metrics_rep_policy_tlv(unsigned char *buff)
         dm = get_current_cmd()->get_data_model();
 	}
 
+    em_printfout("Creating metrics report policy TLV, num policies=%u, num radios=%u",
+        dm->get_num_policy(),
+        dm->get_num_radios());
     /*Validate policy count */
     unsigned int num_policies = dm->get_num_policy();
     if ((num_policies == 0) || (num_policies > EM_MAX_POLICIES)) {
@@ -79,73 +81,59 @@ short em_policy_cfg_t::create_metrics_rep_policy_tlv(unsigned char *buff)
         policy = &dm->m_policy[i];
         if (policy->m_policy.id.type == em_policy_id_type_ap_metrics_rep) {
             found_match = true;
+            //use radio from previous
             break;
         }
     }
 
 	if (found_match == false) {
-		return 0;
-	}	
+        em_printfout("No matching policy found for metrics report policy TLV in cmd_dm, trying DM");
+        policy = nullptr;
+        for (i = 0; i < get_data_model()->get_num_policy(); i++) {
+            if (get_data_model()->m_policy[i].m_policy.id.type == em_policy_id_type_ap_metrics_rep) {
+                policy = &get_data_model()->m_policy[i];
+                break;
+            }
+        }
+        if (policy == nullptr) {
+            em_printfout("No ap_metrics_rep policy found in DM either, skipping TLV");
+            return 0;
+        }
+	}
 
-	found_match = false;
 	metric->interval = static_cast<unsigned char> (policy->m_policy.interval);
 
     unsigned int radio_cnt = 0;
 
-	for (i = 0; i < dm->get_num_policy(); i++) {
+    for (i = 0; i < dm->get_num_policy(); i++) {
 		policy = &dm->m_policy[i];
 		if (policy->m_policy.id.type == em_policy_id_type_radio_metrics_rep) {
-			if ((memcmp(policy->m_policy.id.radio_mac, broadcast_mac, sizeof(mac_address_t)) == 0)) {
-				found_match = true;
-                //if broadcast, fill all radios
-                em_printfout("  Fill broadcast mac: %s", util::mac_to_string(get_data_model()->get_radio_info(radio_cnt)->id.ruid).c_str());
-                radio_cnt = get_data_model()->get_num_radios();
-            	break;	
-			} else {
-                radio_metric = &metric->radios[radio_cnt];
-                memcpy(radio_metric->ruid, policy->m_policy.id.radio_mac, sizeof(mac_address_t));
-                em_printfout("Radio %d MAC: %s for type %d", radio_cnt, util::mac_to_string(policy->m_policy.id.radio_mac).c_str(), policy->m_policy.id.type);
-
-                radio_metric->rcpi_thres = static_cast<unsigned char> (policy->m_policy.rcpi_threshold);
-                radio_metric->rcpi_hysteresis = static_cast<unsigned char> (policy->m_policy.rcpi_hysteresis);
-                radio_metric->util_thres = static_cast<unsigned char> (policy->m_policy.util_threshold);
-                radio_metric->sta_policy = 0;
-                if (policy->m_policy.sta_traffic_stats == true) {
-                    radio_metric->sta_policy |= (1 << 7);
+            for(unsigned int r = 0; r < get_data_model()->get_num_radios(); r++) {
+                if ((memcmp(policy->m_policy.id.radio_mac, get_data_model()->get_radio_info(r)->id.ruid, sizeof(mac_address_t)) == 0)) {
+                    radio_metric = &metric->radios[radio_cnt];
+                    em_printfout(" Radio %d MAC: %s", radio_cnt, util::mac_to_string(policy->m_policy.id.radio_mac).c_str());
+                    memcpy(radio_metric->ruid, policy->m_policy.id.radio_mac, sizeof(mac_address_t));
+                    radio_metric->rcpi_thres = static_cast<unsigned char> (policy->m_policy.rcpi_threshold);
+                    radio_metric->rcpi_hysteresis = static_cast<unsigned char> (policy->m_policy.rcpi_hysteresis);
+                    radio_metric->util_thres = static_cast<unsigned char> (policy->m_policy.util_threshold);
+                    radio_metric->sta_policy = 0;
+                    if (policy->m_policy.sta_traffic_stats == true) {
+                        radio_metric->sta_policy |= (1 << 7);
+                    }
+                    if (policy->m_policy.sta_link_metric == true) {
+                        radio_metric->sta_policy |= (1 << 6);
+                    }
+                    if (policy->m_policy.sta_status == true) {
+                        radio_metric->sta_policy |= (1 << 5);
+                    }
+                    radio_cnt++;
                 }
-                if (policy->m_policy.sta_link_metric == true) {
-                    radio_metric->sta_policy |= (1 << 6);
-                }
-                if (policy->m_policy.sta_status == true) {
-                    radio_metric->sta_policy |= (1 << 5);
-                }
-                radio_cnt++;
             }
-		}
-	}
-	em_printfout(" NUM of radios: %d", radio_cnt);
+    	}
+    }
+	em_printfout("Num of radios: %d", radio_cnt);
+
     metric->radios_num = radio_cnt;
-
-    if (found_match == true) {
-        for(i = 0; i < get_data_model()->get_num_radios(); i++) {
-            radio_metric = &metric->radios[i];
-            em_printfout(" Radio %d MAC: %s", i, util::mac_to_string(get_data_model()->get_radio_info(i)->id.ruid).c_str());
-            memcpy(radio_metric->ruid, get_data_model()->get_radio_info(i)->id.ruid, sizeof(mac_address_t));
-            radio_metric->rcpi_thres = static_cast<unsigned char> (policy->m_policy.rcpi_threshold);
-            radio_metric->rcpi_hysteresis = static_cast<unsigned char> (policy->m_policy.rcpi_hysteresis);
-            radio_metric->util_thres = static_cast<unsigned char> (policy->m_policy.util_threshold);
-            radio_metric->sta_policy = 0;
-            if (policy->m_policy.sta_traffic_stats == true) {
-                radio_metric->sta_policy |= (1 << 7);
-            }
-            if (policy->m_policy.sta_link_metric == true) {
-                radio_metric->sta_policy |= (1 << 6);
-            }
-            if (policy->m_policy.sta_status == true) {
-                radio_metric->sta_policy |= (1 << 5);
-            }
-        }
-	}
 
 	tmp += 2*sizeof(unsigned char) + metric->radios_num * sizeof(em_metric_rprt_policy_radio_t);
 	len += static_cast<short> (2*sizeof(unsigned char) + metric->radios_num * sizeof(em_metric_rprt_policy_radio_t));
@@ -166,7 +154,13 @@ short em_policy_cfg_t::create_steering_policy_tlv(unsigned char *buff)
 	mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 	mac_address_t broadcast_mac = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-	dm = get_data_model();
+	if (get_current_cmd()->get_type() == em_cmd_type_em_config) {
+		dm = get_data_model();
+	} else if (get_current_cmd()->get_type() == em_cmd_type_set_policy) {
+		dm = get_current_cmd()->get_data_model();
+	} else {
+		dm = get_data_model();
+	}
 	
 	for (i = 0; i < dm->get_num_policy(); i++) {
 		policy = &dm->m_policy[i];
@@ -189,7 +183,6 @@ short em_policy_cfg_t::create_steering_policy_tlv(unsigned char *buff)
 				memcpy(sta_policy->sta_mac[sta_policy->num_sta], policy->m_policy.sta_mac[i], sizeof(mac_address_t));
 				sta_policy->num_sta++;
 			}
-
 		}
 	}
 
@@ -221,91 +214,81 @@ short em_policy_cfg_t::create_steering_policy_tlv(unsigned char *buff)
 		}
 	}
 
+    unsigned int num_radios = 0;
+
+    	for (i = 0; i < dm->get_num_policy(); i++) {
+            policy = &dm->m_policy[i];
+            if (policy->m_policy.id.type == em_policy_id_type_steering_param) {
+                for (unsigned int r = 0; r < get_data_model()->get_num_radios(); r++) {
+                    if (memcmp(policy->m_policy.id.radio_mac, get_data_model()->get_radio_info(r)->id.ruid, sizeof(mac_address_t)) == 0) {
+                        num_radios++;
+                        break;
+                    }
+                }
+            }
+        }
+
 	tmp += sizeof(unsigned char) + sta_policy->num_sta*sizeof(mac_address_t);
 	len += sizeof(unsigned char) + sta_policy->num_sta*sizeof(mac_address_t);
+
+    //radio
+    *tmp = static_cast<unsigned char>(num_radios);
+    tmp += sizeof(unsigned char);
+    len += sizeof(unsigned char);
+    em_printfout("Steering policy: found radio policy with type %d, num_radios=%u",
+        policy->m_policy.id.type,
+        num_radios);
 
 	for (i = 0; i < dm->get_num_policy(); i++) {
 		policy = &dm->m_policy[i];
 		if (policy->m_policy.id.type == em_policy_id_type_steering_param) {
-			if ((memcmp(policy->m_policy.id.radio_mac, broadcast_mac, sizeof(mac_address_t)) == 0) ||
-					(memcmp(policy->m_policy.id.radio_mac, get_radio_interface_mac(), sizeof(mac_address_t)) == 0)) {
-				found_match = true;
-            	break;	
-			}
+            for (unsigned int r = 0; r < get_data_model()->get_num_radios(); r++) {
+                if (memcmp(policy->m_policy.id.radio_mac, get_data_model()->get_radio_info(r)->id.ruid, sizeof(mac_address_t)) == 0) {
+                    radio_policy = reinterpret_cast<em_steering_policy_radio_t *>(tmp);
+                    memcpy(radio_policy->ruid,
+                        get_data_model()->get_radio_info(r)->id.ruid,
+                        sizeof(mac_address_t));
+                    radio_policy->steering_policy = static_cast<unsigned char>(policy->m_policy.policy);
+                    radio_policy->channel_util_thresh = static_cast<unsigned char>(policy->m_policy.util_threshold);
+                    radio_policy->rssi_steering_thresh = static_cast<unsigned char>(policy->m_policy.rcpi_threshold);
+                    tmp += sizeof(em_steering_policy_radio_t);
+                    len += sizeof(em_steering_policy_radio_t);
+                    break;
+                }
+            }
 		}
-	}
-
-	//radio
-	if (found_match == false) {
-		*tmp = 0;
-		tmp += sizeof(unsigned char);
-		len += sizeof(unsigned char);
-	} else {
-		*tmp = 1;
-		tmp += sizeof(unsigned char);
-		len += sizeof(unsigned char);
-
-		radio_policy = reinterpret_cast<em_steering_policy_radio_t *> (tmp);
-		memcpy(radio_policy->ruid, get_radio_interface_mac(), sizeof(mac_address_t));
-		radio_policy->steering_policy = static_cast<unsigned char> (policy->m_policy.policy);
-		radio_policy->channel_util_thresh = static_cast<unsigned char> (policy->m_policy.util_threshold);
-		radio_policy->rssi_steering_thresh = static_cast<unsigned char> (policy->m_policy.rcpi_threshold);
-
-		tmp += sizeof(em_steering_policy_radio_t);
-		len += sizeof(em_steering_policy_radio_t);
 	}
 
 	return static_cast<short> (len);
 }
 
-short em_policy_cfg_t::create_def_8021q_settings_policy_tlv(unsigned char *buff)
-{
-    size_t len = 0;
-
-    return static_cast<short> (len);
-}
-
-short em_policy_cfg_t::create_traffic_sep_policy_tlv(unsigned char *buff)
-{
-    size_t len = 0;
-    dm_easy_mesh_t *dm = get_data_model();
-    dm_network_ssid_t *net_ssid;
-    unsigned char *tmp = buff;
-    unsigned int i = 0;
-
-    // get total ssid count
-    unsigned char ssids_num = dm->get_num_network_ssid();
-    *tmp = static_cast<unsigned char>(ssids_num);
-    tmp += sizeof(unsigned char);
-    len += sizeof(unsigned char);
-
-    for (i = 0; i < ssids_num; i++) {
-        net_ssid = dm->get_network_ssid(i);
-
-        std::vector<unsigned char> ssid_bytes(net_ssid->m_network_ssid_info.ssid,
-                  net_ssid->m_network_ssid_info.ssid + strlen(net_ssid->m_network_ssid_info.ssid));
-        unsigned char ssid_len = static_cast<unsigned char>(ssid_bytes.size());
-
-        *tmp = ssid_len;
-        tmp += sizeof(unsigned char);
-        len += sizeof(unsigned char);
-
-        memcpy(tmp, ssid_bytes.data(), ssid_len);
-        tmp += ssid_len;
-        len += ssid_len;
-
-        unsigned short vlan_n = htons(net_ssid->m_network_ssid_info.vlan_id);
-        memcpy(tmp, &vlan_n, sizeof(vlan_n));
-        tmp += sizeof(unsigned short);
-        len += sizeof(unsigned short);
-    }
-
-    return static_cast<short> (len);
-}
-
 short em_policy_cfg_t::create_chan_scan_report_policy_tlv(unsigned char *buff)
 {
     size_t len = 0;
+    dm_easy_mesh_t *dm;
+    unsigned int i;
+
+    if (get_current_cmd()->get_type() == em_cmd_type_set_policy) {
+        dm = get_current_cmd()->get_data_model();
+    } else {
+        dm = get_data_model();
+    }
+
+    for (i = 0; i < dm->get_num_policy(); i++) {
+        dm_policy_t *policy = &dm->m_policy[i];
+        if (policy->m_policy.id.type != em_policy_id_type_channel_scan) {
+            continue;
+        }
+        em_channel_scan_rprt_policy_t *scan_policy =
+            reinterpret_cast<em_channel_scan_rprt_policy_t *>(buff);
+        scan_policy->rprt_ind_ch_scan =
+            policy->m_policy.independent_scan_report ? 1 : 0;
+        scan_policy->reserved = 0;
+        em_printfout("Found Channel Scan Reporting Policy in DM with rprt_ind_ch_scan=%d",
+            scan_policy->rprt_ind_ch_scan);
+        len += sizeof(em_channel_scan_rprt_policy_t);
+        break;
+    }
 
     return static_cast<short> (len);
 }
@@ -313,21 +296,91 @@ short em_policy_cfg_t::create_chan_scan_report_policy_tlv(unsigned char *buff)
 short em_policy_cfg_t::create_unsucc_assoc_policy_tlv(unsigned char *buff)
 {
     size_t len = 0;
+    dm_easy_mesh_t *dm;
+    unsigned int i;
+
+    if (get_current_cmd()->get_type() == em_cmd_type_set_policy) {
+        dm = get_current_cmd()->get_data_model();
+    } else {
+        dm = get_data_model();
+    }
+
+    for (i = 0; i < dm->get_num_policy(); i++) {
+        dm_policy_t *policy = &dm->m_policy[i];
+        if (policy->m_policy.id.type != em_policy_id_type_unsuccess_assoc) {
+            continue;
+        }
+        em_printfout("Found Unsuccessful Association Policy in DM with report_unassoc_sta=%d, max_reporting_rate=%u",
+            policy->m_policy.report_unassoc_sta, policy->m_policy.max_reporting_rate);
+        em_unsuccessful_assoc_policy_t *assoc = reinterpret_cast<em_unsuccessful_assoc_policy_t *>(buff);
+        assoc->rprt_flag = policy->m_policy.report_unassoc_sta ? 1 : 0;
+        assoc->reserved = 0;
+        assoc->max_rprt_rate = htonl(policy->m_policy.max_reporting_rate);
+        len += sizeof(em_unsuccessful_assoc_policy_t);
+        break;
+    }
 
     return static_cast<short> (len);
 }
 
-short em_policy_cfg_t::create_backhaul_bss_conf_policy_tlv(unsigned char *buff)
+// Encodes a single Backhaul BSS Configuration TLV value for the given entry.
+// The caller emits one TLV per entry (spec 17.2.66: "zero or more" TLVs).
+short em_policy_cfg_t::create_backhaul_bss_conf_policy_tlv(unsigned char *buff, const em_backhaul_bss_config_policy_t *entry)
 {
-    size_t len = 0;
-
-    return static_cast<short> (len);
+    static const mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    // Skip TLV if BSSID is all zeros — no meaningful config to send.
+    if (memcmp(entry->bssid, null_mac, sizeof(mac_address_t)) == 0) {
+        return 0;
+    }
+    em_bh_bss_config_t *bss_cfg = reinterpret_cast<em_bh_bss_config_t *>(buff);
+    memcpy(bss_cfg->bssid, entry->bssid, sizeof(mac_address_t));
+    bss_cfg->p1_bsta_disallowed = entry->b_profile_1_sta_disallowed ? 1 : 0;
+    bss_cfg->p2_bsta_disallowed = entry->b_profile_2_sta_disallowed ? 1 : 0;
+    bss_cfg->reserved = 0;
+    return static_cast<short>(sizeof(em_bh_bss_config_t));
 }
-short em_policy_cfg_t::create_qos_mgt_policy_tlv(unsigned char *buff)
+
+short em_policy_cfg_t::create_qos_mgt_policy_tlv(unsigned char *buff, dm_policy_t *policy, unsigned int qi)
 {
     size_t len = 0;
+    unsigned int j;
+    unsigned char *tmp = buff;
 
-    return static_cast<short> (len);
+    unsigned char mscs_num = static_cast<unsigned char>(
+        (policy->m_policy.qos_mgt[qi].num_mscs < EM_MAX_MSC_PER_TRAFFIC_SEPAR)
+            ? policy->m_policy.qos_mgt[qi].num_mscs : EM_MAX_MSC_PER_TRAFFIC_SEPAR);
+    unsigned char scs_num = static_cast<unsigned char>(
+        (policy->m_policy.qos_mgt[qi].num_scs < EM_MAX_SCS_PER_TRAFFIC_SEPAR)
+            ? policy->m_policy.qos_mgt[qi].num_scs : EM_MAX_SCS_PER_TRAFFIC_SEPAR);
+
+    // Skip TLV if both lists are empty — no meaningful config to send.
+    if (mscs_num == 0 && scs_num == 0) {
+        return 0;
+    }
+    em_printfout("Found QoS Management Policy in DM with qi=%u num_mscs=%u, num_scs=%u", qi, mscs_num, scs_num);
+
+    // Wire format is variable-length: [mscs_num][mscs MACs...][scs_num][scs MACs...][20 reserved]
+    *tmp++ = mscs_num;
+    len += sizeof(unsigned char);
+    for (j = 0; j < mscs_num; j++) {
+        memcpy(tmp, policy->m_policy.qos_mgt[qi].msc_mac[j], sizeof(mac_address_t));
+        tmp += sizeof(mac_address_t);
+        len += sizeof(mac_address_t);
+    }
+
+    *tmp++ = scs_num;
+    len += sizeof(unsigned char);
+    for (j = 0; j < scs_num; j++) {
+        memcpy(tmp, policy->m_policy.qos_mgt[qi].sc_mac[j], sizeof(mac_address_t));
+        tmp += sizeof(mac_address_t);
+        len += sizeof(mac_address_t);
+    }
+
+    // 20 reserved bytes at the end (spec section 17.2.92).
+    memset(tmp, 0, 20);
+    len += 20;
+
+    return static_cast<short>(len);
 }
 
 short em_policy_cfg_t::create_vendor_policy_cfg_tlv(unsigned char *buff)
@@ -420,7 +473,7 @@ short em_policy_cfg_t::create_vendor_policy_cfg_tlv(unsigned char *buff)
 
 int em_policy_cfg_t::send_policy_cfg_request_msg()
 {
-    unsigned char buff[MAX_EM_BUFF_SZ] = {0};
+    unsigned char buff[MAX_EM_BUFF_SZ * 4] = {0};
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
     unsigned short  msg_type = em_msg_type_map_policy_config_req;
     size_t len = 0;
@@ -432,6 +485,12 @@ int em_policy_cfg_t::send_policy_cfg_request_msg()
     dm_easy_mesh_t *dm;
 
     dm = get_data_model();
+
+    // For UI-triggered set_policy: only include TLVs for policy types that are
+    // present in the command dm (i.e., the policies that actually changed).
+    // For onboarding (em_config / autoconfig renew): always include all TLVs.
+    bool is_set_policy = (get_current_cmd()->get_type() == em_cmd_type_set_policy);
+    dm_easy_mesh_t *cmd_dm = is_set_policy ? get_current_cmd()->get_data_model() : nullptr;
 
     memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
@@ -457,85 +516,125 @@ int em_policy_cfg_t::send_policy_cfg_request_msg()
     len += sizeof(em_cmdu_t);
 
     // Zero or one Steering Policy TLV (see section 17.2.11).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_steering_policy;
-	sz = create_steering_policy_tlv(tlv->value);
-	tlv->len = htons(static_cast<short unsigned int> (sz));
+    if (!is_set_policy || cmd_dm->has_policy_type(em_policy_id_type_steering_local)
+            || cmd_dm->has_policy_type(em_policy_id_type_steering_btm)
+            || cmd_dm->has_policy_type(em_policy_id_type_steering_param)) {
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_steering_policy;
+        sz = create_steering_policy_tlv(tlv->value);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
 
-	tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));    
-
-	// Zero or one Metric Reporting Policy TLV (see section 17.2.12).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_metric_reporting_policy;
-    sz = create_metrics_rep_policy_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    // Zero or one Metric Reporting Policy TLV (see section 17.2.12).
+    if (!is_set_policy || cmd_dm->has_policy_type(em_policy_id_type_ap_metrics_rep)
+            || cmd_dm->has_policy_type(em_policy_id_type_radio_metrics_rep)) {
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_metric_reporting_policy;
+        sz = create_metrics_rep_policy_tlv(tlv->value);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
 
     // Zero or one Default 802.1Q Settings TLV (see section 17.2.49).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_dflt_8021q_settings;
-    sz = create_def_8021q_settings_policy_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    if (!is_set_policy || cmd_dm->has_policy_type(em_policy_id_type_default_8021q_settings)) {
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_dflt_8021q_settings;
+        sz = create_def_8021q_settings_policy_tlv(tlv->value);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
 
     // Zero or one Traffic Separation Policy TLV (see section 17.2.50).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_traffic_separation_policy;
-    sz = create_traffic_sep_policy_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    // Built from SSID/VLAN data; included only during onboarding.
+    if (!is_set_policy) {
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_traffic_separation_policy;
+        sz = static_cast<short>(create_traffic_separation_policy_tlv(tlv->value));
+        tlv->len = htons(static_cast<unsigned short>(static_cast<unsigned int>(sz)));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
 
     // Zero or one Channel Scan Reporting Policy TLV (see section 17.2.37).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_channel_scan_rprt_policy;
-    sz = create_chan_scan_report_policy_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    if (!is_set_policy || cmd_dm->has_policy_type(em_policy_id_type_channel_scan)) {
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_channel_scan_rprt_policy;
+        sz = create_chan_scan_report_policy_tlv(tlv->value);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
 
     // Zero or one Unsuccessful Association Policy TLV (see section 17.2.58).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_unsucc_assoc_policy;
-    sz = create_unsucc_assoc_policy_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
+    if (!is_set_policy || cmd_dm->has_policy_type(em_policy_id_type_unsuccess_assoc)) {
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_unsucc_assoc_policy;
+        sz = create_unsucc_assoc_policy_tlv(tlv->value);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
 
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    // Zero or more Backhaul BSS Configuration TLVs (spec 17.2.66): one TLV per BSSID entry.
+    dm_easy_mesh_t *bh_dm = is_set_policy ? cmd_dm : dm;
+    for (unsigned int pi = 0; pi < bh_dm->get_num_policy(); pi++) {
+        dm_policy_t *bh_pol = &bh_dm->m_policy[pi];
+        if (bh_pol->m_policy.id.type != em_policy_id_type_backhaul_bss_config) {
+            continue;
+        }
+        for (unsigned int bi = 0; bi < bh_pol->m_policy.num_backhaul_bss_config; bi++) {
+            const em_backhaul_bss_config_policy_t *entry = &bh_pol->m_policy.backhaul_bss_config[bi];
+            static const mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+            if (memcmp(entry->bssid, null_mac, sizeof(mac_address_t)) == 0) {
+                continue;
+            }
+            tlv = reinterpret_cast<em_tlv_t *>(tmp);
+            tlv->type = em_tlv_type_backhaul_bss_conf;
+            sz = create_backhaul_bss_conf_policy_tlv(tlv->value, entry);
+            tlv->len = htons(static_cast<short unsigned int>(sz));
+            em_printfout("Sending Backhaul BSS Config TLV: BSSID=%s p1=%d p2=%d",
+                util::mac_to_string(entry->bssid).c_str(),
+                entry->b_profile_1_sta_disallowed,
+                entry->b_profile_2_sta_disallowed);
+            tmp += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+            len += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+        }
+    }
 
-    // Zero or more Backhaul BSS Configuration TLV (see section 17.2.66).
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_backhaul_bss_conf;
-    sz = create_backhaul_bss_conf_policy_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
+    // Zero or more QoS Management Policy TLVs (spec 17.2.92): one TLV per entry.
+    dm_easy_mesh_t *qos_dm = is_set_policy ? cmd_dm : dm;
+    for (unsigned int pi = 0; pi < qos_dm->get_num_policy(); pi++) {
+        dm_policy_t *qos_pol = &qos_dm->m_policy[pi];
+        if (qos_pol->m_policy.id.type != em_policy_id_type_qos_mgt) {
+            continue;
+        }
+        for (unsigned int qi = 0; qi < qos_pol->m_policy.num_qos_mgt; qi++) {
+            tlv = reinterpret_cast<em_tlv_t *>(tmp);
+            tlv->type = em_tlv_type_qos_mgmt_policy;
+            sz = create_qos_mgt_policy_tlv(tlv->value, qos_pol, qi);
+            if (sz > 0) {
+                tlv->len = htons(static_cast<short unsigned int>(sz));
+                tmp += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+                len += (sizeof(em_tlv_t) + static_cast<size_t>(sz));
+            }
+        }
+    }
 
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-
-    // Zero or more QoS Management Policy TLVs (see section 17.2.92)
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_qos_mgmt_policy;
-    sz = create_qos_mgt_policy_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-
-    //em_tlv_type_vendor_policy_cfg_sta_marker
-    tlv = reinterpret_cast<em_tlv_t *> (tmp);
-    tlv->type = em_tlv_type_vendor_specific;
-    sz = create_vendor_policy_cfg_tlv(tlv->value);
-    tlv->len = htons(static_cast<short unsigned int> (sz));
-
-    tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
-    len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    // Vendor-specific TLV (alarm threshold / client filters / managed STA marker).
+    if (!is_set_policy || cmd_dm->has_policy_type(em_policy_id_type_alarm_threshold)
+            || cmd_dm->has_policy_type(em_policy_id_type_client_filters)
+            || cmd_dm->has_policy_type(em_policy_id_type_ap_metrics_rep)) {
+        tlv = reinterpret_cast<em_tlv_t *> (tmp);
+        tlv->type = em_tlv_type_vendor_specific;
+        sz = create_vendor_policy_cfg_tlv(tlv->value);
+        tlv->len = htons(static_cast<short unsigned int> (sz));
+        tmp += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+        len += (sizeof(em_tlv_t) + static_cast<size_t> (sz));
+    }
 
     // End of message
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
@@ -554,7 +653,7 @@ int em_policy_cfg_t::send_policy_cfg_request_msg()
         return -1;
     }
 
-	printf("%s:%d: Policy Cfg Request Msg Send Success\n", __func__, __LINE__);
+	em_printfout("Policy Cfg Request Msg Send Success");
 
     m_policy_req_msg_id = ntohs(cmdu->id);
 
@@ -572,7 +671,12 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
     unsigned char *cursor = NULL;
     em_vendor_data_t *data = NULL;
 
-    memset(&policy, 0, sizeof(policy));
+    // Start from last applied policy so that absent TLVs retain their
+    // existing values instead of being zeroed out.
+    static em_policy_cfg_params_t last_policy = {};
+    policy = last_policy;
+    policy.num_bh_bss_cfg = 0;
+    policy.num_qos_mgmt = 0;
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (buff + sizeof(em_raw_hdr_t));
 
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
@@ -581,17 +685,18 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
 
     while ((tlv->type != em_tlv_type_eom) && (tlv_len > 0)) {
         if (tlv->type == em_tlv_type_steering_policy) {
+            data_len = 0; // reset per-TLV offset
             em_steering_policy_sta_t *steer_pol_sta = reinterpret_cast<em_steering_policy_sta_t *> (tlv->value);
             policy.steering_policy.local_steer_policy.num_sta = steer_pol_sta->num_sta;
             for(i = 0; i < steer_pol_sta->num_sta; i++) {
-                memcpy(policy.steering_policy.local_steer_policy.sta_mac[i], steer_pol_sta->sta_mac, sizeof(mac_address_t));
+                memcpy(policy.steering_policy.local_steer_policy.sta_mac[i], steer_pol_sta->sta_mac[i], sizeof(mac_address_t));
             }
             data_len += sizeof(steer_pol_sta->num_sta) + (sizeof(mac_addr_t) * steer_pol_sta->num_sta);
 
             em_steering_policy_sta_t *btm_steer_pol = reinterpret_cast<em_steering_policy_sta_t *> (tlv->value + data_len);
             policy.steering_policy.btm_steer_policy.num_sta = btm_steer_pol->num_sta;
             for(i = 0; i < btm_steer_pol->num_sta; i++) {
-                memcpy(policy.steering_policy.btm_steer_policy.sta_mac[i], btm_steer_pol->sta_mac, sizeof(mac_address_t));
+                memcpy(policy.steering_policy.btm_steer_policy.sta_mac[i], btm_steer_pol->sta_mac[i], sizeof(mac_address_t));
             }
             data_len += sizeof(btm_steer_pol->num_sta) + (sizeof(mac_addr_t) * btm_steer_pol->num_sta);
 
@@ -600,23 +705,33 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
 
             em_steering_policy_radio_t *radio_steer_pol = reinterpret_cast<em_steering_policy_radio_t *> (tlv->value + data_len);
             for(i = 0; i < policy.steering_policy.radio_num; i++) {
-                memcpy(&policy.steering_policy.radio_steer_policy[i], radio_steer_pol, sizeof(em_steering_policy_radio_t));
-                radio_steer_pol = reinterpret_cast<em_steering_policy_radio_t *> (tlv->value + data_len);
+                memcpy(&policy.steering_policy.radio_steer_policy[i], &radio_steer_pol[i], sizeof(em_steering_policy_radio_t));
             }
             data_len += policy.steering_policy.radio_num * sizeof(em_steering_policy_radio_t);
         } else if (tlv->type == em_tlv_type_metric_reporting_policy) {
             em_metric_rprt_policy_t *metrics = reinterpret_cast<em_metric_rprt_policy_t *> (tlv->value);
             policy.metrics_policy.interval = metrics->interval;
-            policy.metrics_policy.radios_num = metrics->radios_num;
             data_len += (2 * sizeof(unsigned char));
 
-            for(i = 0; i < metrics->radios_num; i++) {
-                em_metric_rprt_policy_radio_t *radio = &metrics->radios[i];
-                memcpy(&policy.metrics_policy.radios[i], radio, sizeof(em_metric_rprt_policy_radio_t));
-                em_printfout("Recvd policy for radio %s", util::mac_to_string(policy.metrics_policy.radios[i].ruid).c_str());
+            // Only overwrite radios if the TLV actually carries radio entries;
+            // otherwise keep the previously cached per-radio policies (from last_policy).
+            if (metrics->radios_num > 0) {
+                policy.metrics_policy.radios_num = metrics->radios_num;
+                for(i = 0; i < metrics->radios_num; i++) {
+                    em_metric_rprt_policy_radio_t *radio = &metrics->radios[i];
+                    memcpy(&policy.metrics_policy.radios[i], radio, sizeof(em_metric_rprt_policy_radio_t));
+                    em_printfout("Recvd policy for radio %s", util::mac_to_string(policy.metrics_policy.radios[i].ruid).c_str());
+                }
             }
             data_len += (metrics->radios_num * sizeof(em_metric_rprt_policy_radio_t));
         } else if (tlv->type == em_tlv_type_dflt_8021q_settings) {
+            if (ntohs(tlv->len) >= sizeof(em_8021q_settings_t)) {
+                em_8021q_settings_t *settings = reinterpret_cast<em_8021q_settings_t *>(tlv->value);
+                policy.def_8021q_settings.primary_vlan_id = ntohs(settings->primary_vlan_id);
+                policy.def_8021q_settings.default_pcp = settings->default_pcp;
+                em_printfout("Recvd Default 802.1Q Settings: primary_vlan_id=%u, default_pcp=%u",
+                    policy.def_8021q_settings.primary_vlan_id, policy.def_8021q_settings.default_pcp);
+            }
         } else if (tlv->type == em_tlv_type_traffic_separation_policy) {
             unsigned char *tmp = static_cast<unsigned char *>(tlv->value);
             policy.traffic_separation_policy.ssids_num = *tmp;
@@ -646,13 +761,81 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
                 }
 	        }
         } else if (tlv->type == em_tlv_type_channel_scan_rprt_policy) {
+            if (ntohs(tlv->len) == sizeof(em_channel_scan_rprt_policy_t)) {
+                em_channel_scan_rprt_policy_t *scan_policy =
+                    reinterpret_cast<em_channel_scan_rprt_policy_t *>(tlv->value);
+                policy.channel_scan_policy.rprt_ind_ch_scan = scan_policy->rprt_ind_ch_scan;
+                em_printfout("Recvd Channel Scan Reporting Policy: rprt_ind_ch_scan=%d",
+                    policy.channel_scan_policy.rprt_ind_ch_scan);
+            }
         } else if (tlv->type == em_tlv_type_unsucc_assoc_policy) {
+            if (ntohs(tlv->len) == sizeof(em_unsuccessful_assoc_policy_t)) {
+                em_unsuccessful_assoc_policy_t *assoc =
+                    reinterpret_cast<em_unsuccessful_assoc_policy_t *>(tlv->value);
+                policy.unsuccessful_assoc_policy.rprt_flag = assoc->rprt_flag;
+                policy.unsuccessful_assoc_policy.max_rprt_rate = ntohl(assoc->max_rprt_rate);
+
+                em_device_info_t *device_info = get_data_model()->get_device_info();
+                if (device_info != NULL) {
+                   device_info->report_unsuccess_assocs =
+                        (policy.unsuccessful_assoc_policy.rprt_flag != 0);
+                    device_info->max_unsuccessful_assoc_report_rate =
+                        static_cast<unsigned short>(policy.unsuccessful_assoc_policy.max_rprt_rate);
+                    em_printfout("Updated device info with unsuccessful assoc policy: report_unsuccess_assocs=%d, max_unsuccessful_assoc_report_rate=%d",
+                        device_info->report_unsuccess_assocs, device_info->max_unsuccessful_assoc_report_rate);
+                }
+
+                em_printfout("Recvd Unsuccessful Assoc Policy: rprt_flag=%d, max_rprt_rate=%d",
+                    policy.unsuccessful_assoc_policy.rprt_flag,
+                    policy.unsuccessful_assoc_policy.max_rprt_rate);
+            }
         } else if (tlv->type == em_tlv_type_backhaul_bss_conf) {
-        } else if (tlv->type == em_tlv_type_qos_mgmt_policy){
+            if (policy.num_bh_bss_cfg < EM_MAX_BSS_PER_RADIO) {
+                unsigned int bh_cnt = policy.num_bh_bss_cfg;
+                // Spec 17.2.66: one TLV carries exactly one Backhaul BSS Config entry.
+                em_bh_bss_config_t *bss_cfg = reinterpret_cast<em_bh_bss_config_t *>(tlv->value);
+                em_printfout("Recvd Backhaul BSS Config TLV[%u]: bssid=%s, p1_disallowed=%d, p2_disallowed=%d",
+                    bh_cnt, util::mac_to_string(bss_cfg->bssid).c_str(),
+                    bss_cfg->p1_bsta_disallowed, bss_cfg->p2_bsta_disallowed);
+                memcpy(policy.bh_bss_cfg_policy[bh_cnt].bssid, bss_cfg->bssid, sizeof(mac_address_t));
+                policy.bh_bss_cfg_policy[bh_cnt].p1_bsta_disallowed = bss_cfg->p1_bsta_disallowed;
+                policy.bh_bss_cfg_policy[bh_cnt].p2_bsta_disallowed = bss_cfg->p2_bsta_disallowed;
+                policy.num_bh_bss_cfg++;
+            }
+        } else if (tlv->type == em_tlv_type_qos_mgmt_policy) {
+            if (policy.num_qos_mgmt < EM_MAX_QOS_MGMT_POLICY) {
+                unsigned int q_cnt = policy.num_qos_mgmt;
+                unsigned char *qos_data = tlv->value;
+                size_t qos_offset = 0;
+
+                unsigned char mscs_num = qos_data[qos_offset++];
+                mscs_num = (mscs_num < EM_MAX_STA_PER_AGENT) ? mscs_num : EM_MAX_STA_PER_AGENT;
+                policy.qos_mgmt_policy[q_cnt].mscs_disallowed_num = mscs_num;
+                for (unsigned int idx = 0; idx < mscs_num; idx++) {
+                    memcpy(policy.qos_mgmt_policy[q_cnt].mac_addr_mscs_disallowed[idx].sta_mac_addr,
+                        qos_data + qos_offset, sizeof(mac_address_t));
+                    qos_offset += sizeof(mac_address_t);
+                }
+
+                unsigned char scs_num = qos_data[qos_offset++];
+                scs_num = (scs_num < EM_MAX_STA_PER_AGENT) ? scs_num : EM_MAX_STA_PER_AGENT;
+                policy.qos_mgmt_policy[q_cnt].scs_disallowed_num = scs_num;
+                for (unsigned int idx = 0; idx < scs_num; idx++) {
+                    memcpy(policy.qos_mgmt_policy[q_cnt].mac_addr_scs_disallowed[idx].sta_mac_addr,
+                        qos_data + qos_offset, sizeof(mac_address_t));
+                    qos_offset += sizeof(mac_address_t);
+                }
+
+                policy.num_qos_mgmt++;
+                em_printfout("Recvd QoS Mgmt Policy[%u]: mscs_num=%d, scs_num=%d",
+                    q_cnt,
+                    policy.qos_mgmt_policy[q_cnt].mscs_disallowed_num,
+                    policy.qos_mgmt_policy[q_cnt].scs_disallowed_num);
+            }
         } else if (tlv->type == em_tlv_type_vendor_specific) {
             em_vendor_specific_t *vendor_tlv = reinterpret_cast<em_vendor_specific_t *> (tlv->value);
-            em_printfout("Recvd vendor tlv, num: %d and tlv->len:%d", vendor_tlv->num, htons(tlv->len));
-            if ((vendor_tlv->num <= 0) || (htons(tlv->len) == 0)) {
+            em_printfout("Recvd vendor tlv, num: %d and tlv->len:%d", vendor_tlv->num, ntohs(tlv->len));
+            if ((vendor_tlv->num <= 0) || (ntohs(tlv->len) == 0)) {
                 break;
             }
 
@@ -691,9 +874,12 @@ int em_policy_cfg_t::handle_policy_cfg_req(unsigned char *buff, unsigned int len
             }
         }
 
-        tlv_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tlv_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
+
+    // Save as baseline for next partial update.
+    last_policy = policy;
 
     get_mgr()->io_process(em_bus_event_type_set_policy, reinterpret_cast<unsigned char *> (&policy), sizeof(policy));
     send_1905_ack_message(ntohs(cmdu->id));
@@ -765,6 +951,7 @@ int em_policy_cfg_t::send_1905_ack_message(unsigned short msg_id)
 
 int em_policy_cfg_t::handle_1905_ack(unsigned char *buff, unsigned int len)
 {
+    em_printfout("  ############ Handling 1905 ACK for Policy Cfg, msg len=%d", len);
     std::vector<em_t *> em_radios;
     bool match_found = false;
 
@@ -790,7 +977,7 @@ int em_policy_cfg_t::handle_1905_ack(unsigned char *buff, unsigned int len)
 		    em->set_state(em_state_ctrl_configured);
 	    }
     } else {
-	    em_printfout("No radio waiting for policy config ack for given msg_id\n");
+	    em_printfout("No radio waiting for policy config ack for given msg_id");
     }
     em_radios.clear();
     return 0;
@@ -825,14 +1012,14 @@ void em_policy_cfg_t::process_ctrl_state()
 		case em_state_ctrl_set_policy_pending:
             {
                 em_printfout("Processing set policy pending state for radio %s", util::mac_to_string(get_radio_interface_mac()).c_str());
-                std::vector<em_t *> em_radios;
+                 std::vector<em_t *> em_radios;
                 dm_easy_mesh_t *dm = get_data_model();
                 mac_address_t current_ruid;
                 memcpy(current_ruid, get_radio_interface_mac(), sizeof(mac_address_t));
 
                 get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
-                for (auto &em : em_radios)
-                {
+
+                for (auto &em : em_radios) {
                     // Check for null em pointer in vector
                     if (em == NULL) {
                         em_printfout("Warning: Null em pointer in vector, skipping");
@@ -841,10 +1028,11 @@ void em_policy_cfg_t::process_ctrl_state()
                     // Check if radio is in set policy pending, if not log and return without sending policy config request 
                     // check state of em is configured, to handle the case where radio exchange autoconfiguration messages multiple times
                     // resulting the queue of multiple em_cmd_type_em_config.
-                    if (em->get_state() != em_state_ctrl_set_policy_pending && em->get_state() != em_state_ctrl_configured)
-                    {
+                    em_printfout("Checking radio[%s]'s state:%s for sending policy config request", util::mac_to_string(em->get_radio_interface_mac()).c_str(),  em_t::state_2_str(em->get_state()));
+                    if (get_current_cmd()->get_type() != em_cmd_type_set_policy &&
+                        em->get_state() != em_state_ctrl_set_policy_pending && em->get_state() != em_state_ctrl_configured) {
                         em_printfout("radio %s is in state:%s, not in em_state_ctrl_set_policy_pending or not in em_state_ctrl_configured",
-                                     util::mac_to_string(em->get_radio_interface_mac()).c_str(),  em_t::state_2_str(em->get_state()));
+                            util::mac_to_string(em->get_radio_interface_mac()).c_str(),  em_t::state_2_str(em->get_state()));
                         em_radios.clear();
                         return;
                     }
@@ -862,7 +1050,6 @@ void em_policy_cfg_t::process_ctrl_state()
                          int send_result = send_policy_cfg_request_msg();
                          if (send_result < 0) {
                              em_printfout("Error: Failed to send policy config request message");
-                             return;
                          } else {
                              em_printfout("Policy config request sent successfully, bytes: %d", send_result);
                          }
@@ -871,6 +1058,9 @@ void em_policy_cfg_t::process_ctrl_state()
                     em_printfout("Policy config request message already sent by radio %s, not sending again from radio %s",
                               util::mac_to_string(em_radios.front()->get_radio_interface_mac()).c_str(),
                               util::mac_to_string(get_radio_interface_mac()).c_str());
+
+                } else {
+                    em_printfout("Policy config request already sent (msg_id: 0x%04x), waiting for ACK", m_policy_req_msg_id);
                 }
                 em_radios.clear();
             }

--- a/src/orch/em_orch.cpp
+++ b/src/orch/em_orch.cpp
@@ -45,10 +45,18 @@ unsigned int em_orch_t::submit_commands(em_cmd_t *pcmd[], unsigned int num)
     unsigned int submitted = 0;
     bool submit = true;
 
-    for (i = 0; i < num; i++) {
+    if (pcmd == NULL) {
+        return 0;
+    }
+
+    for (i = 0; i < num && i < EM_MAX_CMD; i++) {
+        // Skip unset slots (analyze_* may return fewer commands than num)
+        if (pcmd[i] == NULL) {
+            continue;
+        }
         if ((submit = pre_process_orch_op(pcmd[i])) == false) {
             // complete the command
-            destroy_command(pcmd[i]);	
+            destroy_command(pcmd[i]);
             submit = true;
             continue;
         } else {

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -139,6 +139,12 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
+        case em_cmd_type_unassoc_sta_result:
+            if (em->get_state() == em_state_agent_configured) {
+                return true;
+            }
+            break;
+
         default:
             if ((em->get_state() == em_state_agent_unconfigured) ||
                     (em->get_state() == em_state_agent_configured) ||
@@ -190,6 +196,11 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
     } else if (pcmd->m_type == em_cmd_type_get_link_quality_report) {
         if ((em->get_state() >= em_state_agent_topo_synchronized) ||
             ((em->get_state() == em_state_agent_link_quality_report_pending))) {
+            return true;
+        }
+    } else if (pcmd->m_type == em_cmd_type_unassoc_sta_result) {
+        if ((em->get_state() == em_state_agent_configured) ||
+            ((em->get_state() ==em_state_agent_unassoc_sta_metrics_report_pending))) {
             return true;
         }
     }
@@ -279,6 +290,13 @@ bool em_orch_agent_t::pre_process_orch_op(em_cmd_t *pcmd)
                     hash_map_put(dm->m_sta_map, strdup(key), new dm_sta_t(*sta));
                 }
 
+                // check why is this here
+                // dm_sta_t *stale_dassoc = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_dassoc_map, key));
+                // if (stale_dassoc != NULL) {
+                //     em_printfout("Assoc row key=%s found in live disassoc map; removing stale disassoc entry", key);
+                //     delete stale_dassoc;
+                // }
+
                 sta = static_cast<dm_sta_t *> (hash_map_get_next(pcmd->get_data_model()->m_sta_assoc_map, sta));
             }
 
@@ -289,14 +307,30 @@ bool em_orch_agent_t::pre_process_orch_op(em_cmd_t *pcmd)
                 dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
                 snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bss_mac_str, radio_mac_str);
 
-                em_sta_info_t *em_sta = dm->get_sta_info(sta->get_sta_info()->id, sta->get_sta_info()->bssid, sta->get_sta_info()->radiomac, em_target_sta_map_consolidated);
-                sta = static_cast<dm_sta_t *>(hash_map_get_next(pcmd->get_data_model()->m_sta_dassoc_map, sta));
+                em_sta_info_t *em_sta = dm->get_sta_info(sta->m_sta_info.id, sta->m_sta_info.bssid, sta->m_sta_info.radiomac, em_target_sta_map_consolidated);
                 if (em_sta != NULL) {
-                    printf("Consolidated Map removed with key: %s\n", key);
+                    sta = static_cast<dm_sta_t *>(hash_map_get_next(pcmd->get_data_model()->m_sta_dassoc_map, sta));
+
+                    em_printfout("Consolidated Map removed with key: %s, updating em_target_sta_map_disassoc entry", key);
                     dm_sta_t *tmp = sta;
                     tmp = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_map, key));
+
+                    // Copy all stats from the consolidated row into the dassoc row.
+                    // memcpy(&sta->m_sta_info, em_sta, sizeof(em_sta_info_t));
+                    // sta->m_sta_info.associated = false;
+                    // em_sta_info_t *em_sta_dassoc = dm->get_sta_info(sta->m_sta_info.id, sta->m_sta_info.bssid, sta->m_sta_info.radiomac, em_target_sta_map_disassoc);
+                    // if (em_sta_dassoc != NULL) {
+                    //     em_printfout("Consolidated Map removed with key: %s, updating em_target_sta_map_disassoc entry", key);
+                    //     // memcpy(em_sta_dassoc, &sta->m_sta_info, sizeof(em_sta_info_t));
+                    //     memcpy(em_sta_dassoc, em_sta, sizeof(em_sta_info_t));
+                    // } else {
+                    //     em_printfout("Consolidated Map removed with key: %s, added em_target_sta_map_disassoc entry", key);
+                    //     dm->put_sta_info(&sta->m_sta_info, em_target_sta_map_disassoc); 
+                    // }
+                    // dm_sta_t *tmp = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_map, key));
                     delete tmp;
                 }
+                sta = static_cast<dm_sta_t *>(hash_map_get_next(pcmd->get_data_model()->m_sta_dassoc_map, sta));
             }
             break;
         case dm_orch_type_sta_insert:
@@ -476,7 +510,7 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
                 sta = em->find_sta(mac1, mac2);
                 if (sta != NULL) {
                     queue_push(pcmd->m_em_candidates, em);
-                    printf("%s:%d Beacon report build candidate pushed\n", __func__, __LINE__);
+                    em_printfout("Beacon report build candidate pushed");
                     count++;
                 }
                 break;
@@ -488,7 +522,17 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
                 }
                 break;
 
-			default:
+            case em_cmd_type_unassoc_sta_result:
+                // Unassociated STA metrics response is processed only once.
+                // Select the first non-AL EM instance as the candidate and
+                // avoid queuing additional EMs for the same response.		
+                if (!(em->is_al_interface_em()) && (count == 0)) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+                break;
+
+            default:
                 break;
         }
         em = static_cast<em_t *> (hash_map_get_next(m_mgr->m_em_map, em));	

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -217,6 +217,8 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             } else if (em->get_state() == em_state_ctrl_sta_cap_confirmed) {
                 em->set_state(em_state_ctrl_configured);
                 return true;
+            } else if (em->get_state() == em_state_ctrl_topo_synchronized) {
+                return true;
             } else if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             }
@@ -253,6 +255,17 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
 
 		case em_cmd_type_set_policy:
             if (em->get_state() == em_state_ctrl_configured) {
+                // Commit policies from the command DM to the live data model and DB
+                dm_easy_mesh_t *cmd_dm = pcmd->get_data_model();
+                dm_easy_mesh_t *live_dm = em->get_data_model();
+                if (cmd_dm != NULL && live_dm != NULL) {
+                    for (unsigned int p = 0; p < cmd_dm->get_num_policy(); p++) {
+                        live_dm->set_policy(cmd_dm->m_policy[p]);
+                    }
+                    // Trigger DB write
+                    cmd_dm->set_db_cfg_param(db_cfg_type_policy_list_update, "");
+                    m_mgr->update_tables(cmd_dm);
+                }
                 return true;
             }
 			break;
@@ -268,6 +281,12 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             return true;
 
         case em_cmd_type_bsta_cap:
+            if (em->get_state() == em_state_ctrl_configured) {
+                return true;
+            }
+            break;
+
+	case em_cmd_type_unassoc_sta_query:
             if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             }
@@ -331,7 +350,8 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_scan_channel:
         case em_cmd_type_set_policy:
         case em_cmd_type_bsta_cap:
-            if (em->get_state() == em_state_ctrl_configured) {
+	    case em_cmd_type_unassoc_sta_query:
+            if (em->get_state() >= em_state_ctrl_topo_synchronized) {
                 return true;
             }
             break;
@@ -376,6 +396,12 @@ void em_orch_ctrl_t::pre_process_cancel(em_cmd_t *pcmd, em_t *em)
             // Reset the count of active channel selection requests
             // Currently this counter is not used, reset for future use of this counter
             em->set_channel_sel_req_tx_count(0);
+            break;
+
+        case em_cmd_type_set_policy:
+            em_printfout("Cancel received for Set Policy command, transitioning to configured state radio: %s",
+                util::mac_to_string(em->get_radio_interface_mac()).c_str());
+            em->set_state(em_state_ctrl_configured);
             break;
 
         default:
@@ -489,6 +515,33 @@ bool em_orch_ctrl_t::pre_process_orch_op(em_cmd_t *pcmd)
             m_mgr->update_network_topology();
             break;
 
+        case dm_orch_type_policy_cfg:
+        {
+            // Update dev_dm flat array so the next SET comparison sees the updated
+            // baseline and doesn't re-detect the same change as new.
+            dm_easy_mesh_t *dev_dm = m_mgr->get_data_model(GLOBAL_NET_ID, dm->m_device.m_device_info.intf.mac);
+            if (dev_dm != nullptr) {
+                for (unsigned int p = 0; p < dm->get_num_policy(); p++) {
+                    dm_policy_t &pol = dm->get_policy_by_ref(p);
+                    bool found = false;
+                    for (unsigned int j = 0; j < dev_dm->get_num_policy(); j++) {
+                        if (dev_dm->m_policy[j].m_policy.id.type == pol.m_policy.id.type &&
+                            memcmp(dev_dm->m_policy[j].m_policy.id.radio_mac,
+                                   pol.m_policy.id.radio_mac, sizeof(mac_address_t)) == 0) {
+                            dev_dm->m_policy[j] = pol;
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found && dev_dm->get_num_policy() < EM_MAX_POLICIES) {
+                        dev_dm->m_policy[dev_dm->get_num_policy()] = pol;
+                        dev_dm->set_num_policy(dev_dm->get_num_policy() + 1);
+                    }
+                }
+            }
+            break;
+        }
+
         case dm_orch_type_topo_publish:
         case dm_orch_type_bsta_cap_query:
 			break;
@@ -504,12 +557,11 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
 {
     em_t *em;
     dm_easy_mesh_t *dm;
-    mac_address_t	bss_mac, rad_mac;
+    mac_address_t   rad_mac, dev_mac;
     unsigned int count = 0, i;
-    mac_addr_str_t mac_str;
     em_disassoc_params_t *disassoc_param;
     dm_sta_t *sta;
-	mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    mac_address_t null_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
     if (pcmd->m_type == em_cmd_type_em_config) {
         em = static_cast<em_t *>(hash_map_get(m_mgr->m_em_map, pcmd->m_param.u.args.args[0]));
@@ -520,16 +572,29 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
         return count;
     }
 
-	pthread_mutex_lock(&m_mgr->m_mutex);
+    if (pcmd->m_type == em_cmd_type_set_policy) {
+        dm = pcmd->get_data_model();
+        std::vector<em_t *> em_radios;
+        m_mgr->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
+        if (!em_radios.empty()) {
+            em_printfout("Set Policy: %s pushed to queue", util::mac_to_string(em_radios.front()->get_radio_interface_mac()).c_str());
+            queue_push(pcmd->m_em_candidates, em_radios.front());
+            count++;
+        }
+        return count;
+    }
+
+    pthread_mutex_lock(&m_mgr->m_mutex);
     em = static_cast<em_t *>(hash_map_get_first(m_mgr->m_em_map));
     while (em != NULL) {
         switch (pcmd->m_type) {
             case em_cmd_type_set_ssid:
-		if (em->is_al_interface_em() == false) {
-			dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
-			printf("%s:%d Set SSID : %s push to queue \n", __func__, __LINE__,mac_str);
-			queue_push(pcmd->m_em_candidates, em);
-			count++;
+                if (em->is_al_interface_em() == false) {
+                    //mac_addr_str_t mac_str;
+                    //dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+                    //em_printfout("Set SSID: %s push to queue", mac_str);
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
                 }
                 break;
 
@@ -548,61 +613,77 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                 break;
 
             case em_cmd_type_cfg_renew:
-		dm = pcmd->get_data_model();
-		dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[0], dm->m_radio[0].m_radio_info.intf.mac);
-		// check if the radio is null mac
-		if ((memcmp(null_mac, dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) &&  (em->is_al_interface_em() == false)) {
-			printf("%s:%d push to queue since null mac \n", __func__, __LINE__);	
-			queue_push(pcmd->m_em_candidates, em);
-                	count++;
-		} else if ((memcmp(em->get_radio_interface_mac(), dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) && (em->is_al_interface_em() == false)) {
-			dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
-			printf("%s:%d Auto config renew %s push to queue since mac matches\n", __func__, __LINE__,mac_str);
-			queue_push(pcmd->m_em_candidates, em);
-			count++;
+                dm = pcmd->get_data_model();
+                dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[0], dm->m_radio[0].m_radio_info.intf.mac);
+                // check if the radio is null mac
+                if ((memcmp(null_mac, dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) &&
+                    (em->is_al_interface_em() == false)) {
+                    //em_printfout("Push to queue since null mac");	
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                } else if ((memcmp(em->get_radio_interface_mac(), dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) &&
+                    (em->is_al_interface_em() == false)) {
+                    //mac_addr_str_t mac_str;
+                    //dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+                    //em_printfout("Auto config renew %s push to queue since mac matches", mac_str);
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
                 }
                 break;
 
             case em_cmd_type_sta_assoc:
                 dm = em->get_data_model();
-                dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[1], bss_mac);
-                //printf("%s:%d:BSS for this STA %s is %s\n", __func__, __LINE__, pcmd->m_param.u.args.args[2], pcmd->m_param.u.args.args[1]);
-                for (i = 0; i < dm->m_num_bss; i++) {
-                    if ((memcmp(dm->m_bss[i].m_bss_info.bssid.mac, bss_mac, sizeof(mac_address_t)) == 0) &&
-                        (em->is_al_interface_em() == false)) {
-                        queue_push(pcmd->m_em_candidates, em);
-                        count++;
-                        //printf("%s:%d:Found em this STA, candidate count: %d\n", __func__, __LINE__, count);
-                        break;
-                    }
+                dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[0], dev_mac);
+                if ((em->is_al_interface_em() == false) &&
+                    (memcmp(dm->get_agent_al_interface_mac(), dev_mac, sizeof(mac_address_t)) == 0) &&
+                    (count == 0)) {
+                    em_printfout("sta_assoc: using radio %s for dev %s orch_op: %s",
+                        util::mac_to_string(em->get_radio_interface_mac()).c_str(),
+                        pcmd->m_param.u.args.args[0],
+                        em_cmd_t::get_orch_op_str(pcmd->get_orch_op()));
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
                 }
                 break;
 
             case em_cmd_type_sta_link_metrics:
                 if ((em->is_al_interface_em() == false) && (em->get_state() == em_state_ctrl_configured)  && 
-                        (em->has_at_least_one_associated_sta() == true)) {
+                    (em->has_at_least_one_associated_sta() == true)) {
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
                 }
                 break;
-            
             case em_cmd_type_set_channel:
-				if (em->is_al_interface_em() == false) {
-					for(i = 0; i < pcmd->m_param.u.args.num_args; i++) {
-						if(atoi(pcmd->m_param.u.args.args[i]) == em->get_band()) {
-							dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
-							printf("%s:%d Set Channel : %s push to queue \n", __func__, __LINE__,mac_str);
-							queue_push(pcmd->m_em_candidates, em);
-							count++;
-							break;
-						}
-					}
+                if ((em->is_al_interface_em() == false) && (!pcmd->m_param.u.args.num_args)) {
+                    dm = pcmd->get_data_model();
+                    if (memcmp(em->get_radio_interface_mac(), dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                        queue_push(pcmd->m_em_candidates, em);
+                        count++;
+                    }
+                } else if (em->is_al_interface_em() == false) {
+                    for (i = 0; i < pcmd->m_param.u.args.num_args; i++) {
+                        if (atoi(pcmd->m_param.u.args.args[i]) == em->get_band()) {
+                            //mac_addr_str_t mac_str;
+                            //dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+                            //em_printfout("Set Channel: %s push to queue", mac_str);
+                            queue_push(pcmd->m_em_candidates, em);
+                            count++;
+                            break;
+                        }
+                    }
                 }
                 break;
+
             case em_cmd_type_scan_channel:
+                dm = pcmd->get_data_model();
                 if (em->is_al_interface_em() == false) {
-                    queue_push(pcmd->m_em_candidates, em);
-                    count++;
+                    if (memcmp(em->get_radio_interface_mac(), dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                        //mac_addr_str_t mac_str;
+                        //dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+                        //em_printfout("Channel Scan: %s pushed to queue", mac_str);
+                        queue_push(pcmd->m_em_candidates, em);
+                        count++;
+                    }
                 }
                 break;
 
@@ -624,30 +705,23 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                 }
                 break;
 
-			case em_cmd_type_set_policy:
-                dm = pcmd->get_data_model();
-                //need a radio from a device to send, no need to push all ems
-                if (memcmp(em->get_radio_interface_mac(), dm->m_radio[0].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
-                    dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
-                    em_printfout("em: %s pushed for command: em_cmd_type_set_policy\n", mac_str);
-                    queue_push(pcmd->m_em_candidates, em);
-                    count++;
-                    break;
-                }
+            case em_cmd_type_set_policy:
+                // handled before the loop
                 break;
 
-			case em_cmd_type_set_radio:
-				dm = pcmd->get_data_model();
-				for (i = 0; i < dm->get_num_radios(); i++) {
-					if (memcmp(em->get_radio_interface_mac(), dm->m_radio[i].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
-						dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
-						//printf("%s:%d: em: %s pushed for command: em_cmd_type_set_policy\n", __func__, __LINE__, mac_str);
+            case em_cmd_type_set_radio:
+                dm = pcmd->get_data_model();
+                for (i = 0; i < dm->get_num_radios(); i++) {
+                    if (memcmp(em->get_radio_interface_mac(), dm->m_radio[i].m_radio_info.intf.mac, sizeof(mac_address_t)) == 0) {
+                        //mac_addr_str_t mac_str;
+                        //dm_easy_mesh_t::macbytes_to_string(em->get_radio_interface_mac(), mac_str);
+                        //em_printfout("Set Radio: %s pushed to queue", mac_str);
                         queue_push(pcmd->m_em_candidates, em);
                         count++;
-						break;
-					}
-				}
-				break;
+                        break;
+                    }
+                }
+                break;
 
             case em_cmd_type_mld_reconfig:
                 if (em->is_al_interface_em()) {
@@ -667,21 +741,27 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                 dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[0], rad_mac);
                 //search this radio em of for this agent al device to filter the em
                 dm = em->get_data_model();
-                if ((memcmp(em->get_radio_interface_mac(), rad_mac, sizeof(mac_address_t)) == 0))
-                {
+                if ((memcmp(em->get_radio_interface_mac(), rad_mac, sizeof(mac_address_t)) == 0)) {
                     queue_push(pcmd->m_em_candidates, em);
                     count++;
-                    em_printfout("BSTA CAP count: %d; push to queue for em radio: %s\n", count, util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                    em_printfout("BSTA CAP count: %d; push to queue for em radio: %s", count, util::mac_to_string(em->get_radio_interface_mac()).c_str());
                     break;
                 }
                 break;
-
-            default:
-                break;
-        }			
+            case em_cmd_type_unassoc_sta_query:
+		if (count == 0 && memcmp(em->get_data_model()->get_agent_al_interface_mac(),
+					pcmd->m_param.u.unassoc_sta_query_params.al_mac, sizeof(mac_address_t)) == 0) {
+		    queue_push(pcmd->m_em_candidates, em);
+		    count++;
+		}		
+		break;
+	    default:
+		break;
+	}
         em = static_cast<em_t *>(hash_map_get_next(m_mgr->m_em_map, em));
     }
-	pthread_mutex_unlock(&m_mgr->m_mutex);
+
+    pthread_mutex_unlock(&m_mgr->m_mutex);
 
     return count;
 }

--- a/src/rdkb-cli/Makefile.am
+++ b/src/rdkb-cli/Makefile.am
@@ -72,6 +72,7 @@ libemcli_la_SOURCES = \
  $(top_srcdir)/src/cmd/em_cmd_btm_report.cpp \
  $(top_srcdir)/src/cmd/em_cmd_get_mld_config.cpp \
  $(top_srcdir)/src/cmd/em_cmd_mld_reconfig.cpp \
+ $(top_srcdir)/src/cmd/em_cmd_unassoc_sta_query.cpp \
  $(top_srcdir)/src/dm/dm_device.cpp \
  $(top_srcdir)/src/dm/dm_ieee_1905_security.cpp \
  $(top_srcdir)/src/dm/dm_easy_mesh.cpp  \

--- a/src/rdkb-cli/em_cmd_cli.cpp
+++ b/src/rdkb-cli/em_cmd_cli.cpp
@@ -69,6 +69,7 @@ em_cmd_params_t spec_params[] = {
     {.u = {.args = {2, {"", "", "", "", ""}, "MLDConfig"}}},
     {.u = {.args = {2, {"", "", "", "", ""}, "MLDReconfig"}}},
     {.u = {.args = {2, {"", "", "", "", ""}, "WifiReset"}}},
+    {.u = {.args = {2, {"", "", "", "", ""}, "UnassocSTAQuery.json"}}},
 	{.u = {.args = {0, {"", "", "", "", ""}, "max"}}},
 };
 
@@ -103,7 +104,8 @@ em_cmd_t em_cmd_cli_t::m_client_cmd_spec[] = {
     em_cmd_t(em_cmd_type_get_mld_config, spec_params[26]),
     em_cmd_t(em_cmd_type_mld_reconfig, spec_params[27]),
     em_cmd_t(em_cmd_type_get_reset, spec_params[28]),
-    em_cmd_t(em_cmd_type_max, spec_params[29]),
+    em_cmd_t(em_cmd_type_unassoc_sta_query, spec_params[29]),
+    em_cmd_t(em_cmd_type_max, spec_params[30]),
 };
 
 int em_cmd_cli_t::get_edited_node(em_network_node_t *node, const char *header, char *buff)
@@ -454,6 +456,20 @@ int em_cmd_cli_t::execute(char *result)
             snprintf(info->name, sizeof(info->name), "%s", param->u.args.fixed_args);
             break;
 
+       case em_cmd_type_unassoc_sta_query:
+
+           bevt->type = em_bus_event_type_unassoc_sta_query;
+           info = &bevt->u.subdoc;
+
+           strncpy(info->name, param->u.args.fixed_args, sizeof(info->name) - 1);
+           info->name[sizeof(info->name) - 1] = '\0';
+
+           if ((bevt->data_len = get_edited_node(m_cmd.m_param.net_node, "UnassocSTAQuery", info->buff)) < 0) {
+               em_printfout("%s:%d: failed to get UnassocSTAQuery node\n", __func__, __LINE__);
+               return -1;
+           }
+           break;
+	   
         default:
             break;
     }

--- a/src/rdkb-cli/main.go
+++ b/src/rdkb-cli/main.go
@@ -490,6 +490,22 @@ type Default802_1Q_Settings struct {
 	DefaultPCP      int     `json:"defaultPCP"`
 }
 
+type UnsuccessfulAssociation struct {
+	ReportUnsuccessAssoc bool `json:"reportUnsuccessAssoc"`
+	MaxReportingRate  int  `json:"maxReportingRate"`
+}
+
+type BackhaulBSSConfig struct {
+    BSSID                  string `json:"bssid"`
+    Profile1bSTADisallowed bool   `json:"profile1bSTADisallowed"`
+    Profile2bSTADisallowed bool   `json:"profile2bSTADisallowed"`
+}
+
+type QoSManagementPolicy struct {
+    MSCSDisallowedSTAList []string `json:"mscsDisallowedSTAList"`
+    SCSDisallowedSTAList  []string `json:"scsDisallowedSTAList"`
+}
+
 type RadioSpecificMetrics struct {
 	ID                      string   `json:"id"`
 	STARCPIThreshold        int      `json:"starCPIThreshold"`
@@ -513,8 +529,11 @@ type wifiPolicyConfig struct {
 	APMetricReportingPolicy        APMetricReporting       `json:"apMetricReportingPolicy,omitempty"`
 	LocalSteeringDisallowed        []string                `json:"localSteeringDisallowed"`
 	BTMSteeringDisallowed          []string                `json:"btmSteeringDisallowed"`
-	ReportIndependentChannelScans  int                    `json:"reportIndependentChannelScans"`
+	ReportIndependentChannelScans  int                     `json:"reportIndependentChannelScans"`
 	Default802_1Q_SettingsPolicy   Default802_1Q_Settings  `json:"default802_1Q_SettingsPolicy"`
+	UnsuccessfulAssocPolicy        UnsuccessfulAssociation   `json:"unsuccessfulAssocPolicy"`
+	BackhaulBSSConfigPolicy        []BackhaulBSSConfig       `json:"backhaulBssConfigPolicy,omitempty"`
+	QoSManagementPolicy            QoSManagementPolicy       `json:"qosManagementPolicy,omitempty"`
 	RadioSpecificMetricsPolicy     []RadioSpecificMetrics    `json:"radioSpecificMetricsPolicy,omitempty"`
 	RadioSteeringParametersPolicy  []RadioSteeringParameters `json:"radioSteeringParametersPolicy,omitempty"`
 }
@@ -614,6 +633,22 @@ type Obstacle struct {
 	Points      []Point2D `json:"points"`
 	Attenuation float64   `json:"attenuation_db"` // Signal loss in dB
 	Material    string    `json:"material,omitempty"`
+}
+
+// Holds parameters for Unassociated STA Link Metrics Query
+type unassocStaChannel struct {
+        Channel     int      `json:"channel"`
+        StaMacList  []string `json:"sta_macs"`
+}
+
+type unassocStaOpClass struct {
+        OpClass int                  `json:"opclass"`
+        Channels []unassocStaChannel `json:"channels"`
+}
+
+type unassocStaQueryRequest struct {
+        AlMac string                  `json:"AlMac"`
+        QueryList []unassocStaOpClass `json:"UnassocStaQueryList"`
 }
 
 //ckp cov end
@@ -2870,6 +2905,9 @@ func main() {
 	//system setting Wifi Reset
 	api.HandleFunc("/wifireset", WifiResetHandler).Methods("GET", "POST")
 
+	// Unassoc STA 
+	api.HandleFunc("/unassoc_sta_query", unassocStaQueryHandler).Methods("POST")
+
 	// Enable CORS
 	router.Use(corsMiddleware)
 
@@ -3481,6 +3519,104 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
     }
 }
 
+
+/*
+ * func: unassocStaQueryHandler()
+ *
+ * Description:
+ * Handles POST /unassoc_sta_query requests.
+ * Parses payload and triggers Unassociated STA Link Metrics Query.
+ */
+func unassocStaQueryHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method != http.MethodPost {
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+        return
+    }
+
+    defer r.Body.Close()
+    
+    const maxRequestSize = 64 * 1024 // 64 KB
+    r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
+
+    var req unassocStaQueryRequest
+    log.Printf("[DEBUG][HTTP] Received unassoc STA query request")
+
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "Invalid request payload", http.StatusBadRequest)
+        return
+    }
+
+    if req.AlMac == "" {
+        http.Error(w, "AlMac required", http.StatusBadRequest)
+        return
+    }
+
+    if len(req.QueryList) == 0 {
+        http.Error(w, "UnassocStaQueryList required", http.StatusBadRequest)
+        return
+    }
+
+    for _, op := range req.QueryList {
+
+        if len(op.Channels) == 0 {
+            http.Error(w, "Each opclass must contain channels", http.StatusBadRequest)
+            return
+        }
+
+        for _, ch := range op.Channels {
+
+            if len(ch.StaMacList) == 0 {
+                http.Error(w, "Each channel must contain STA list", http.StatusBadRequest)
+                return
+            }
+        }
+    }
+
+    for i, op := range req.QueryList {
+        log.Printf("[DEBUG][HTTP] OpClass[%d]=%d Channels=%d", i, op.OpClass, len(op.Channels))
+
+        for j, ch := range op.Channels {
+            log.Printf("[DEBUG][HTTP]   Channel[%d]=%d STA Count=%d", j, ch.Channel, len(ch.StaMacList))
+        }
+    }
+
+    jsonBytes, err := json.Marshal(req)
+    if err != nil {
+        log.Printf("[ERROR][HTTP] Failed to marshal request: %v", err)
+        http.Error(w, "Failed to process request", http.StatusInternalServerError)
+        return
+    }
+
+    cJsonStr := C.CString(string(jsonBytes))
+    defer C.free(unsafe.Pointer(cJsonStr))
+
+    node := C.get_network_tree(cJsonStr)
+    if node == nil {
+        http.Error(w, "Failed to create network tree", http.StatusInternalServerError)
+        return
+    }
+    defer C.free_network_tree(node)
+
+    cmd := C.CString("unassoc_sta_query OneWifiMesh")
+    defer C.free(unsafe.Pointer(cmd))
+    result := C.exec(cmd, C.strlen(cmd), node)
+
+    if result == nil {
+        http.Error(w, "Command execution failed", http.StatusInternalServerError)
+        return
+    }
+    defer C.free_network_tree(result)
+
+    //log.Printf("[CLI] Unassoc STA Query sent: %+v", req)
+
+    w.Header().Set("Content-Type", "application/json")
+
+    if err := json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "message": "Unassoc STA Query sent",}); err != nil {
+        log.Printf("[ERROR][HTTP] Failed to encode response: %v", err)
+    }    
+}
+
+
 //------------------------------------------------------------
 //                    Helper Functions
 //--------------------------------------------------------------
@@ -3781,6 +3917,7 @@ func loadTopologyFromDeviceTree(w  http.ResponseWriter) {
     // Helper to create STA list with circular layout
     createSTAList := func(deviceX, deviceY float32, radioList []Radio) []map[string]interface{} {
         var staList []map[string]interface{}
+        uniqueSTASet := make(map[string]struct{})
 
         for _, radio := range radioList {
             for _, bss := range radio.BSSList {
@@ -3791,6 +3928,13 @@ func loadTopologyFromDeviceTree(w  http.ResponseWriter) {
                     if bss.HaulType == "Backhaul" && bss.SSID == sta.SSID {
                        continue
                     }
+                    staIdentity := sta.MACAddress + "_" + sta.MLDAddr
+                    // Ignore duplicate STA entries which associated on another MLD Links
+                    if _, exists := uniqueSTASet[staIdentity]; exists {
+                        continue
+                    }
+                    uniqueSTASet[staIdentity] = struct{}{}
+
                     staList = append(staList, map[string]interface{}{
                         "staMAC":     sta.MACAddress,
                         "clientType": sta.ClientType,
@@ -3935,10 +4079,25 @@ func loadTopologyFromStaticJSON(w http.ResponseWriter) {
     // Helper to create STA list with circular layout
     createSTAList := func(deviceX, deviceY float32, radioList []Radio) []map[string]interface{} {
         var staList []map[string]interface{}
+        uniqueSTASet := make(map[string]struct{})
 
         for _, radio := range radioList {
             for _, bss := range radio.BSSList {
                 for _, sta := range bss.STAList {
+                    if !sta.Associated {
+                        continue
+                    }
+                    if bss.HaulType == "Backhaul" {
+                        continue
+                    }
+
+                    staIdentity := sta.MACAddress + "_" + sta.MLDAddr
+                    // Ignore duplicate STA entries which associated on another MLD Links
+                    if _, exists := uniqueSTASet[staIdentity]; exists {
+                        continue
+                    }
+                    uniqueSTASet[staIdentity] = struct{}{}
+
                     staList = append(staList, map[string]interface{}{
                         "staMAC":     sta.MACAddress,
                         "clientType": sta.ClientType,
@@ -4310,7 +4469,7 @@ func getPolicyConfiguration(deviceListTree *C.em_network_node_t) []wifiPolicyCon
             cDisallowed := C.CString("Disallowed STA")
             defer C.free(unsafe.Pointer(cDisallowed))
             disallowedNode := C.get_network_tree_by_key(localSteeringNode, cDisallowed)
-            localDisallowedMACs = parseDisallowedSTAMACs(disallowedNode)
+            localDisallowedMACs = parseMACList(disallowedNode)
         }
 
         // BTM Steering Disallowed Policy
@@ -4322,7 +4481,7 @@ func getPolicyConfiguration(deviceListTree *C.em_network_node_t) []wifiPolicyCon
             cDisallowed := C.CString("Disallowed STA")
             defer C.free(unsafe.Pointer(cDisallowed))
             disallowedNode := C.get_network_tree_by_key(btmSteeringNode, cDisallowed)
-            btmDisallowedMACs = parseDisallowedSTAMACs(disallowedNode)
+            btmDisallowedMACs = parseMACList(disallowedNode)
         }
 
         // Channel Scan Reporting Policy
@@ -4343,6 +4502,65 @@ func getPolicyConfiguration(deviceListTree *C.em_network_node_t) []wifiPolicyCon
         dot1qSetting := Default802_1Q_Settings{
             PrimaryVLANID: getKeyIntValue(dot1qSettingNode, "Primary VLAN ID"),
             DefaultPCP:    getKeyIntValue(dot1qSettingNode, "Default PCP"),
+        }
+
+        // Unsuccessful Association Policy
+        cUnsuccAssoc := C.CString("Unsuccessful Association Policy")
+        defer C.free(unsafe.Pointer(cUnsuccAssoc))
+        unSuccesfullAssociation := UnsuccessfulAssociation{}
+        unsuccAssocNode := C.get_network_tree_by_key(policyNode, cUnsuccAssoc)
+        if(unsuccAssocNode != nil) {
+            unSuccesfullAssociation.ReportUnsuccessAssoc = getTreeValue(unsuccAssocNode, "Report Unsuccessful Associations") == "true"
+            unSuccesfullAssociation.MaxReportingRate = getKeyIntValue(unsuccAssocNode, "Maximum Reporting Rate")
+		}
+
+        // Backhaul BSS Config Policy
+        backhaulBssConfigList := []BackhaulBSSConfig{}
+        cBackhaulBssConfig := C.CString("Backhaul BSS Configuration Policy")
+        backhaulBssConfigNode := C.get_network_tree_by_key(policyNode, cBackhaulBssConfig)
+        C.free(unsafe.Pointer(cBackhaulBssConfig))
+        if backhaulBssConfigNode != nil {
+            for j := 0; j < int(backhaulBssConfigNode.num_children); j++ {
+                child := backhaulBssConfigNode.child[j]
+                if child == nil {
+                    continue
+                }
+                bssid := strings.ToUpper(getTreeValue(child, "BSSID"))
+                if bssid == "" || bssid == "00:00:00:00:00:00" {
+                    continue
+                }
+
+                entry := BackhaulBSSConfig{
+                    BSSID: bssid,
+                    Profile1bSTADisallowed: getTreeValue(child, "Profile-1 bSTA Disallowed") == "true",
+                    Profile2bSTADisallowed: getTreeValue(child, "Profile-2 bSTA Disallowed") == "true",
+                }
+                backhaulBssConfigList = append(backhaulBssConfigList, entry)
+            }
+        }
+
+        // QoS Management Policy
+        cQoS := C.CString("QoS Management Policy")
+        defer C.free(unsafe.Pointer(cQoS))
+        qosPolicy := QoSManagementPolicy{
+			MSCSDisallowedSTAList: []string{},
+			SCSDisallowedSTAList:  []string{},
+		}
+        qosNode := C.get_network_tree_by_key(policyNode, cQoS)
+        if qosNode != nil {
+			cMSCS := C.CString("MSCS Disallowed STA List")
+			defer C.free(unsafe.Pointer(cMSCS))
+			mscsNode := C.get_network_tree_by_key(qosNode, cMSCS)
+			if mscsNode != nil {
+				qosPolicy.MSCSDisallowedSTAList = parseMACList(mscsNode)
+			}
+
+            cSCS := C.CString("SCS Disallowed STA List")
+			defer C.free(unsafe.Pointer(cSCS))
+			scsNode := C.get_network_tree_by_key(qosNode, cSCS)
+			if scsNode != nil {
+				qosPolicy.SCSDisallowedSTAList = parseMACList(scsNode)
+			}
         }
 
         // Radio Specific Metrics Policy
@@ -4391,6 +4609,9 @@ func getPolicyConfiguration(deviceListTree *C.em_network_node_t) []wifiPolicyCon
             BTMSteeringDisallowed: btmDisallowedMACs,
             ReportIndependentChannelScans: getKeyIntValue(channelScanReportingNode, "Report Independent Channel Scans"),
             Default802_1Q_SettingsPolicy: dot1qSetting,
+            UnsuccessfulAssocPolicy: unSuccesfullAssociation,
+            BackhaulBSSConfigPolicy: backhaulBssConfigList,
+            QoSManagementPolicy: qosPolicy,
             RadioSpecificMetricsPolicy: radioMetricsArr,
             RadioSteeringParametersPolicy: radioSteeringArr,
         }
@@ -4437,15 +4658,14 @@ func updatePolicySettings(deviceListTree *C.em_network_node_t, policyConfig wifi
         defer C.free(unsafe.Pointer(cLocalSteering))
         localSteeringNode := C.get_network_tree_by_key(policyNode, cLocalSteering)
         if localSteeringNode != nil {
-            updateDisallowedSTAStruct(localSteeringNode, "Disallowed STA", policyConfig.LocalSteeringDisallowed)
+            updateNodeArray(localSteeringNode, "Disallowed STA", normalizeMACArrayString(policyConfig.LocalSteeringDisallowed))
         }
-
         // BTM Steering Disallowed Policy
         cBTMSteering := C.CString("BTM Steering Disallowed Policy")
         defer C.free(unsafe.Pointer(cBTMSteering))
         btmSteeringNode := C.get_network_tree_by_key(policyNode, cBTMSteering)
         if btmSteeringNode != nil {
-            updateDisallowedSTAStruct(btmSteeringNode, "Disallowed STA", policyConfig.BTMSteeringDisallowed)
+            updateNodeArray(btmSteeringNode, "Disallowed STA", normalizeMACArrayString(policyConfig.BTMSteeringDisallowed))
         }
 
         // Channel Scan Reporting Policy
@@ -4463,6 +4683,64 @@ func updatePolicySettings(deviceListTree *C.em_network_node_t, policyConfig wifi
         if (dot1qSettingNode != nil) {
             updateNodeInt(dot1qSettingNode, "Primary VLAN ID", policyConfig.Default802_1Q_SettingsPolicy.PrimaryVLANID)
             updateNodeInt(dot1qSettingNode, "Default PCP", policyConfig.Default802_1Q_SettingsPolicy.DefaultPCP)
+        }
+
+        // "Unsuccessful Association Policy
+        cUnsuccAssoc := C.CString("Unsuccessful Association Policy")
+        defer C.free(unsafe.Pointer(cUnsuccAssoc))
+        unsuccAssocNode := C.get_network_tree_by_key(policyNode, cUnsuccAssoc)
+        if unsuccAssocNode != nil {
+            updateNodeBool(unsuccAssocNode, "Report Unsuccessful Associations", policyConfig.UnsuccessfulAssocPolicy.ReportUnsuccessAssoc)
+            updateNodeInt(unsuccAssocNode, "Maximum Reporting Rate", policyConfig.UnsuccessfulAssocPolicy.MaxReportingRate)
+        }
+
+        // Backhaul BSS Configuration Policy
+        cBackhaul := C.CString("Backhaul BSS Configuration Policy")
+        backhaulNode := C.get_network_tree_by_key(policyNode, cBackhaul)
+        C.free(unsafe.Pointer(cBackhaul))
+        if backhaulNode != nil {
+            for _, entry := range policyConfig.BackhaulBSSConfigPolicy {
+                if entry.BSSID == "" || entry.BSSID == "00:00:00:00:00:00" {
+                    continue
+                }
+                reqBSSID := strings.ToUpper(entry.BSSID)
+                for j := 0; j < int(backhaulNode.num_children); j++ {
+                    child := backhaulNode.child[j]
+                    if child == nil {
+                        continue
+                    }
+                    treeBSSID := strings.ToUpper(getTreeValue(child, "BSSID"))
+                    if treeBSSID == reqBSSID {
+                        updateNodeBool(child,"Profile-1 bSTA Disallowed",entry.Profile1bSTADisallowed)
+                        updateNodeBool(child,"Profile-2 bSTA Disallowed",entry.Profile2bSTADisallowed)
+                        break
+                    }
+                }
+            }
+        }
+
+        // QoS Management Policy
+        cQoS := C.CString("QoS Management Policy")
+        defer C.free(unsafe.Pointer(cQoS))
+        qosNode := C.get_network_tree_by_key(policyNode, cQoS)
+        if qosNode != nil {
+            // MSCS Disallowed STA List
+            cMSCS := C.CString("MSCS Disallowed STA List")
+            defer C.free(unsafe.Pointer(cMSCS))
+            mscsNode := C.get_network_tree_by_key(qosNode, cMSCS)
+            if mscsNode != nil {
+                mscsArray := normalizeMACArrayString(policyConfig.QoSManagementPolicy.MSCSDisallowedSTAList)
+                updateNodeArray(mscsNode, "MSCS Disallowed STA List", mscsArray)
+            }
+
+            // SCS Disallowed STA List
+            cSCS := C.CString("SCS Disallowed STA List")
+            defer C.free(unsafe.Pointer(cSCS))
+            scsNode := C.get_network_tree_by_key(qosNode, cSCS)
+            if scsNode != nil {
+                scsArray := normalizeMACArrayString(policyConfig.QoSManagementPolicy.SCSDisallowedSTAList)
+                updateNodeArray(scsNode, "SCS Disallowed STA List", scsArray)
+            }
         }
 
         // Radio Specific Metrics Policy
@@ -4620,29 +4898,64 @@ func reconcileChildrenToCount(parent *C.em_network_node_t, newChildCount int) in
     return current
 }
 
-/* func: parseDisallowedSTAMACs()
+/* func: parseMACList()
  * Description:
- * Parse the Disallowed STA MAC from policy list
- * returns: array of disallowed stat mac.
+ * Parse the array of MAC from policy list
+ * returns: array of mac address.
  */
-func parseDisallowedSTAMACs(disallowedNode *C.em_network_node_t) []string {
+func parseMACList(node *C.em_network_node_t) []string {
     macs := []string{}
-    if disallowedNode == nil {
+    if node == nil {
         return macs
     }
 
-    count := int(disallowedNode.num_children)
+    count := int(node.num_children)
     for i := 0; i < count; i++ {
-        elem := disallowedNode.child[i]
+        elem := node.child[i]
         if elem == nil {
             continue
         }
-        mac := getTreeValue(elem, "MAC")
+
+        mac := C.GoString(&elem.value_str[0])
+
         if mac != "" && mac != "00:00:00:00:00:00" {
             macs = append(macs, mac)
         }
     }
+
     return macs
+}
+
+/* func: normalizeMACArrayString()
+ * Description:
+ * Processes a list of MAC addresses by cleaning and standardizing them.
+ * returns: A string containing normalized, unique MAC addresses in bracketed comma-separated format.
+ */
+func normalizeMACArrayString(macs []string) string {
+    // Deduplicate + normalize to uppercase
+    seen := make(map[string]struct{}, len(macs))
+
+    for _, mac := range macs {
+        m := strings.ToUpper(strings.TrimSpace(mac))
+
+        // Skip invalid/default values
+        if m == "" || m == "00:00:00:00:00:00" {
+            continue
+        }
+
+        seen[m] = struct{}{}
+    }
+
+    // Convert map keys to slice
+    normalized := make([]string, 0, len(seen))
+    for k := range seen {
+        normalized = append(normalized, k)
+    }
+
+    // sort alphabetically
+    sort.Strings(normalized)
+
+    return "[" + strings.Join(normalized, ", ") + "]"
 }
 
 /* func: applyWifiPolicyConfig()

--- a/src/rdkb-cli/static/index.html
+++ b/src/rdkb-cli/static/index.html
@@ -886,25 +886,27 @@
                 </form>
             </div>
         </section>
-        <!-- Local Steering Disallowed Policy -->
-        <section class="card policy-card" aria-labelledby="local-steering-title">
-            <div class="card-header header-with-actions">
-                <h2 id="local-steering-title" class="card-title">Local Steering Disallowed Policy</h2>
+        <!-- Steering Policy -->
+        <section class="card policy-card" aria-labelledby="steering-policy-title">
+            <div class="card-header">
+                <h2 id="steering-policy-title">Steering Policy</h2>
                 <div class="header-actions">
                     <div class="apply-scope" role="group" aria-label="Apply scope">
                         <label class="scope-option">
-                            <input type="radio" name="applyScope-local" value="selected" checked />
+                            <input type="radio" name="applyScope-steering" value="selected" checked />
                             <span>Selected device</span>
                         </label>
                         <label class="scope-option">
-                            <input type="radio" name="applyScope-local" value="all" />
+                            <input type="radio" name="applyScope-steering" value="all" />
                             <span>All Devices</span>
                         </label>
-                        <button type="button" class="btn btn-primary btn-sm apply-section" data-section="local-disallowed"> Save </button>
+                        <button type="button" class="btn btn-primary btn-sm apply-section" data-section="steering-policy">Save</button>
                     </div>
                 </div>
             </div>
+            <!-- Local Steering Disallowed -->
             <div class="card-body">
+                <h3 class="subsection-title">Local Steering Disallowed</h3>
                 <div class="table-scroll">
                     <table class="data-table" id="local-disallowed-table" aria-label="Local Steering Disallowed MACs">
                         <thead>
@@ -935,27 +937,8 @@
                         </tbody>
                     </table>
                 </div>
-            </div>
-        </section>
-        <!-- BTM Steering Disallowed Policy -->
-        <section class="card policy-card" aria-labelledby="btm-steering-title">
-            <div class="card-header header-with-actions">
-                <h2 id="btm-steering-title" class="card-title">BTM Steering Disallowed Policy</h2>
-                <div class="header-actions">
-                    <div class="apply-scope" role="group" aria-label="Apply scope">
-                        <label class="scope-option">
-                            <input type="radio" name="applyScope-btm" value="selected" checked />
-                            <span>Selected device</span>
-                        </label>
-                        <label class="scope-option">
-                            <input type="radio" name="applyScope-btm" value="all" />
-                            <span>All Devices</span>
-                        </label>
-                        <button type="button" class="btn btn-primary btn-sm apply-section" data-section="btm-disallowed"> Save </button>
-                    </div>
-                </div>
-            </div>
-            <div class="card-body">
+                <!-- BTM Steering Disallowed -->
+                <h3 class="subsection-title">BTM Steering Disallowed</h3>
                 <div class="table-scroll">
                     <table class="data-table" id="btm-disallowed-table" aria-label="BTM Steering Disallowed MACs">
                         <thead>
@@ -983,6 +966,34 @@
                         <tbody id="btmMacBody">
                         </tbody>
                     </table>
+                </div>
+                <!-- Radio Steering Parameters -->
+                <h3 class="subsection-title">Radio Steering Parameters</h3>
+                <div class="policy-table-wrapper">
+                    <table class="policy-table" aria-label="Radio steering policies">
+                        <colgroup>
+                            <col style="width: 220px;">  <!-- ID -->
+                            <col style="width: 140px;">  <!-- Steering Policy -->
+                            <col style="width: 180px;">  <!-- Utilization Threshold -->
+                            <col style="width: 180px;">  <!-- RCPI Threshold -->
+                            <col style="width: 110px;">  <!-- Actions -->
+                        </colgroup>
+                        <thead>
+                            <tr>
+                                <th scope="col">ID</th>
+                                <th scope="col">Steering Policy</th>
+                                <th scope="col">Utilization Threshold</th>
+                                <th scope="col">RCPI Threshold</th>
+                                <th scope="col" class="actions-col">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody id="policy-rows">
+                            <!-- Rows injected by JS -->
+                        </tbody>
+                    </table>
+                </div>
+                <div class="toolbar">
+                    <button type="button" id="add-row-btn" class="btn btn-secondary btn-sm">+ Add Station Entry</button>
                 </div>
             </div>
         </section>
@@ -1051,6 +1062,155 @@
                 </form>
             </div>
         </section>
+        <!-- Report Unsuccessful Associations Policy -->
+        <section class="card policy-card" aria-labelledby="unsuccess-assoc-title">
+            <div class="card-header">
+                <h2 id="unsuccess-assoc-title">Report Unsuccessful Associations Policy</h2>
+                <div class="header-actions">
+                    <div class="apply-scope" role="group" aria-label="Apply scope">
+                        <label class="scope-option">
+                            <input type="radio" name="applyScope-assoc" value="selected" checked />
+                            <span>Selected device</span>
+                        </label>
+                        <label class="scope-option">
+                            <input type="radio" name="applyScope-assoc" value="all" />
+                            <span>All Devices</span>
+                        </label>
+                        <button type="button" class="btn btn-primary btn-sm apply-section" data-section="unsuccessful-assoc"> Save </button>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <form id="unsuccess-assoc-form">
+                    <div class="form-grid">
+                        <div class="form-field">
+                            <label for="report-unassoc-sta" class="form-label">Report Unsuccessful Associations</label>
+                            <select id="report-unassoc-sta"
+                                name="report_unassoc_sta"
+                                class="form-select form-select--enhanced">
+                                <option value="1">Enabled</option>
+                                <option value="0">Disabled</option>
+                            </select>
+                        </div>
+                        <div class="form-field">
+                            <label for="max-reporting-rate" class="form-label">Max Reporting Rate</label>
+                            <input type="number"
+                                id="max-reporting-rate"
+                                name="max_reporting_rate"
+                                class="form-input"
+                                min="0"
+                                max="4294967295"
+                                step="1"
+                                required
+                                placeholder="Enter rate (e.g. 100)" />
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </section>
+        <!-- Backhaul BSS Config Policy -->
+        <section class="card policy-card" aria-labelledby="backhaul-bss-title">
+            <div class="card-header">
+                <h2 id="backhaul-bss-title">Backhaul BSS Config Policy</h2>
+                <div class="header-actions">
+                    <div class="apply-scope" role="group">
+                        <label class="scope-option">
+                            <input type="radio" name="applyScope-backhaul" value="selected" checked />
+                            <span>Selected device</span>
+                        </label>
+                        <label class="scope-option">
+                            <input type="radio" name="applyScope-backhaul" value="all" />
+                            <span>All Devices</span>
+                        </label>
+                        <button type="button" class="btn btn-primary btn-sm apply-section" data-section="backhaul-bss">Save</button>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="policy-table-wrapper">
+                    <table class="policy-table" aria-label="Backhaul BSS Config">
+                        <colgroup>
+                            <col style="width: 260px;"> <!-- BSSID -->
+                            <col style="width: 220px;"> <!-- Profile-1 -->
+                            <col style="width: 220px;"> <!-- Profile-2 -->
+                        </colgroup>
+                        <thead>
+                            <tr>
+                                <th>BSSID</th>
+                                <th>Profile-1 bSTA Disallowed</th>
+                                <th>Profile-2 bSTA Disallowed</th>
+                            </tr>
+                        </thead>
+                        <tbody id="backhaul-bss-rows">
+                            <!-- populated by JS -->
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+        <!-- QoS Management Policy -->
+        <section class="card policy-card" aria-labelledby="qos-mgt-title">
+            <div class="card-header">
+                <h2 id="qos-mgt-title">QoS Management Policy</h2>
+                <div class="header-actions">
+                    <div class="apply-scope" role="group" aria-label="Apply scope">
+                        <label class="scope-option">
+                            <input type="radio" name="applyScope-qos" value="selected" checked />
+                            <span>Selected device</span>
+                        </label>
+                        <label class="scope-option">
+                            <input type="radio" name="applyScope-qos" value="all" />
+                            <span>All Devices</span>
+                        </label>
+                        <button type="button" class="btn btn-primary btn-sm apply-section" data-section="qos-mgt">Save</button>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <!-- MSCS Disallowed STA List -->
+                 <h3 class="subsection-title">MSCS Disallowed STA List</h3>
+                 <div class="table-scroll">
+                    <table class="data-table" id="mscs-table">
+                        <thead>
+                            <tr>
+                                <th><input type="checkbox" id="select-all-mscs" /></th>
+                                <th>
+                                    <div class="th-with-actions">
+                                        <span>MAC Address</span>
+                                        <div class="th-actions">
+                                            <button type="button" class="icon-btn" id="add-mscs">+</button>
+                                            <button type="button" class="icon-btn" id="remove-mscs">-</button>
+                                        </div>
+                                    </div>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody id="mscs-body"></tbody>
+                    </table>
+                </div>
+                <!-- SCS Disallowed STA List -->
+                <h3 class="subsection-title">SCS Disallowed STA List</h3>
+                <div class="table-scroll">
+                    <table class="data-table" id="scs-table">
+                        <thead>
+                            <tr>
+                                <th><input type="checkbox" id="select-all-scs" /></th>
+                                <th>
+                                    <div class="th-with-actions">
+                                        <span>MAC Address</span>
+                                        <div class="th-actions">
+                                            <button type="button" class="icon-btn" id="add-scs">+</button>
+                                            <button type="button" class="icon-btn" id="remove-scs">-</button>
+                                        </div>
+                                    </div>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody id="scs-body"></tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
         <!-- Radio Specific Metrics Policy -->
         <section class="card policy-card" aria-labelledby="radio-metrics-title">
             <div class="card-header">
@@ -1101,53 +1261,6 @@
                 </div>
                 <div class="toolbar">
                     <button type="button" id="add-radio-metrics-row" class="btn btn-secondary btn-sm">+ Add Station Entry</button>
-                </div>
-            </div>
-        </section>
-        <!-- Radio Steering Parameters -->
-        <section class="card policy-card" aria-labelledby="radio-steering-title">
-            <div class="card-header">
-                <h2 id="radio-steering-title">Radio Steering Parameters</h2>
-                <div class="header-actions">
-                    <div class="apply-scope" role="group" aria-label="Apply scope">
-                        <label class="scope-option">
-                            <input type="radio" name="applyScope-steer" value="selected" checked />
-                            <span>Selected device</span>
-                        </label>
-                        <label class="scope-option">
-                            <input type="radio" name="applyScope-steer" value="all" />
-                            <span>All Devices</span>
-                        </label>
-                        <button type="button" class="btn btn-primary btn-sm apply-section" data-section="radio-steering">Save</button>
-                    </div>
-                </div>
-            </div>
-            <div class="card-body">
-                <div class="policy-table-wrapper">
-                    <table class="policy-table" aria-label="Radio steering policies">
-                        <colgroup>
-                            <col style="width: 220px;">  <!-- ID -->
-                            <col style="width: 140px;">  <!-- Steering Policy -->
-                            <col style="width: 180px;">  <!-- Utilization Threshold -->
-                            <col style="width: 180px;">  <!-- RCPI Threshold -->
-                            <col style="width: 110px;">  <!-- Actions -->
-                        </colgroup>
-                        <thead>
-                            <tr>
-                                <th scope="col">ID</th>
-                                <th scope="col">Steering Policy</th>
-                                <th scope="col">Utilization Threshold</th>
-                                <th scope="col">RCPI Threshold</th>
-                                <th scope="col" class="actions-col">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody id="policy-rows">
-                            <!-- Rows injected by JS -->
-                        </tbody>
-                    </table>
-                </div>
-                <div class="toolbar">
-                    <button type="button" id="add-row-btn" class="btn btn-secondary btn-sm">+ Add Station Entry</button>
                 </div>
             </div>
         </section>

--- a/src/rdkb-cli/static/script.js
+++ b/src/rdkb-cli/static/script.js
@@ -281,15 +281,17 @@ class EasyMeshController {
       const sectionKey = btn.getAttribute("data-section");
       if (!sectionKey) return;
 
-      // Resolve the radio name (scope group) for this section
-      const scopeName = sectionMap(sectionKey);
-      const scope = document.querySelector(`input[name="${scopeName}"]:checked`)?.value || "selected";
+      const section = btn.closest(".policy-card");
+      if (!section) return;
+
+      const scope = section.querySelector('input[type="radio"]:checked')?.value || "selected";
 
       // Collect the section's values from the form/table
       this.savePolicySettings(sectionKey, scope);
 
     });
 
+    document.querySelector("#report-unassoc-sta")?.addEventListener("change", toggleMaxRateField);
     const applyPolicyBtn = document.getElementById('apply-policy-settings');
     if (applyPolicyBtn) {
       applyPolicyBtn.addEventListener('click', () => this.handlePolicySettingApply());
@@ -357,6 +359,67 @@ class EasyMeshController {
       remBtn?.addEventListener("click", () => {
         const removed = this.removeSelectedRows(tbody, selectAll);
         if (removed > 0) this.showNotification?.(`${removed} MAC${removed > 1 ? "s" : ""} removed`, "success");
+      });
+    })();
+
+    // QoS Management Policy: + / - buttons
+    (() => {
+      // MSCS Disallowed STA List
+      const mscsBody = document.querySelector("#mscs-body");
+      const mscsAdd  = document.getElementById("add-mscs");
+      const mscsRem  = document.getElementById("remove-mscs");
+      const mscsAll  = document.getElementById("select-all-mscs");
+
+      if (mscsAll && mscsBody) {
+        mscsAll.addEventListener("change", () => {
+          mscsBody.querySelectorAll('input.row-select')
+          .forEach(cb => cb.checked = mscsAll.checked);
+          this.updateSelectAllState(mscsBody, mscsAll);
+        });
+
+        mscsBody.addEventListener("change", (e) => {
+          if (e.target && e.target.matches('input.row-select')) {
+            this.updateSelectAllState(mscsBody, mscsAll);
+          }
+        });
+      }
+      mscsAdd?.addEventListener("click", () =>this.addDisallowedMacRow(mscsBody, mscsAll));
+      mscsRem?.addEventListener("click", () => {
+        const removed = this.removeSelectedRows(mscsBody, mscsAll);
+        if (removed > 0) {
+          this.showNotification?.(`${removed} MAC${removed > 1 ? "s" : ""} removed`,"success");
+        }
+      });
+
+      // SCS Disallowed STA List
+      const scsBody = document.querySelector("#scs-body");
+      const scsAdd  = document.getElementById("add-scs");
+      const scsRem  = document.getElementById("remove-scs");
+      const scsAll  = document.getElementById("select-all-scs");
+
+      if (scsAll && scsBody) {
+        scsAll.addEventListener("change", () => {
+          scsBody.querySelectorAll('input.row-select')
+          .forEach(cb => cb.checked = scsAll.checked);
+          this.updateSelectAllState(scsBody, scsAll);
+        });
+
+        scsBody.addEventListener("change", (e) => {
+          if (e.target && e.target.matches('input.row-select')) {
+            this.updateSelectAllState(scsBody, scsAll);
+          }
+        });
+      }
+
+      scsAdd?.addEventListener("click", () =>
+        this.addDisallowedMacRow(scsBody, scsAll)
+      );
+
+      scsRem?.addEventListener("click", () => {
+        const removed = this.removeSelectedRows(scsBody, scsAll);
+        if (removed > 0) {
+          this.showNotification?.(`${removed} MAC${removed > 1 ? "s" : ""} removed`,"success");
+        }
       });
     })();
 
@@ -520,22 +583,78 @@ savePolicySettings(sectionKey, scope = "selected") {
       this.showNotification('AP metrics policy saved successfully', 'success');
       break;
     }
-    case "local-disallowed": {
-      const list = getMacList("#localMacBody") || [];
+    case "steering-policy": {
+
+      // Fetch all steering policies
+      const localList = getMacList("#localMacBody") || [];
+      const btmList = getMacList("#btmMacBody") || [];
+      const radioRows = RSP.getAll();
+
+      if (!Array.isArray(radioRows) || radioRows.length === 0) {
+        this.showNotification('At least one Radio Steering row with a valid ID (Station MAC) is required.', 'error');
+        return;
+      }
+
+      const norm = v => PolicyUtil.normalizeId(v);
+
+      // Build lookup map from UI updates
+      const updateMap = new Map();
+      radioRows.forEach(r => {
+        const key = norm(r.id);
+        if (key) updateMap.set(key, { ...r, id: key });
+      });
+      const selectedIdx = this.updatedPolicySettings.findIndex(
+        p => p.id === selectedDeviceId
+      );
+
       indicesToUpdate.forEach(i => {
         const d = this.updatedPolicySettings[i];
-        d.localSteeringDisallowed = Array.isArray(list) ? [...list] : [];
+        d.localSteeringDisallowed = [...localList];
+        d.btmSteeringDisallowed = [...btmList];
+
+        const existing = d.radioSteeringParametersPolicy || [];
+
+        const existingMap = new Map();
+        existing.forEach(r => {
+          const key = norm(r.id);
+          if (key) existingMap.set(key, r);
+        });
+
+        const uiKeys = new Set(updateMap.keys());
+
+        if (uiKeys.size === 1 && uiKeys.has(PolicyUtil.MAC_ALL)) {
+          d.radioSteeringParametersPolicy = [updateMap.get(PolicyUtil.MAC_ALL)];
+          return;
+        }
+
+        let updated;
+
+        if (i === selectedIdx) {
+          updated = existing
+            .filter(r => uiKeys.has(norm(r.id)))
+            .map(r => {
+              const key = norm(r.id);
+              const match = updateMap.get(key);
+              return match ? { ...r, ...match } : r;
+            });
+        } else {
+          updated = existing.map(r => {
+            const key = norm(r.id);
+            const match = updateMap.get(key);
+            return match ? { ...r, ...match } : r;
+          });
+        }
+
+        if (i === selectedIdx) {
+          updateMap.forEach((uiRow, key) => {
+            if (!existingMap.has(key)) {
+              updated.push(uiRow);
+            }
+          });
+        }
+        d.radioSteeringParametersPolicy = updated;
       });
-      this.showNotification('Local Steering Disallowed Policy saved successfully', 'success');
-      break;
-    }
-    case "btm-disallowed": {
-      const list = getMacList("#btmMacBody") || [];
-      indicesToUpdate.forEach(i => {
-        const d = this.updatedPolicySettings[i];
-        d.btmSteeringDisallowed = Array.isArray(list) ? [...list] : [];
-      });
-      this.showNotification('BTM Steering Disallowed Policy saved successfully', 'success');
+      this.showNotification('Steering Policy saved successfully', 'success')
       break;
     }
     case "channel-scan": {
@@ -565,31 +684,132 @@ savePolicySettings(sectionKey, scope = "selected") {
       this.showNotification('Default 802.1Q Settings Policy saved successfully', 'success');
       break;
     }
+    case "unsuccessful-assoc": {
+      const reportVal = document.querySelector("#report-unassoc-sta")?.value ?? "0";
+      const rateVal   = document.querySelector("#max-reporting-rate")?.value ?? "0";
+
+      // Convert values
+      const reportBool = reportVal === "1";
+      const rateNum = rateVal === "" ? 0 : Number(rateVal);
+      const rateNumValid = Number.isNaN(rateNum) ? 0 : rateNum;
+
+      indicesToUpdate.forEach(i => {
+        const d = this.updatedPolicySettings[i];
+        d.unsuccessfulAssocPolicy ||= {};
+        d.unsuccessfulAssocPolicy.reportUnsuccessAssoc = reportBool;
+        d.unsuccessfulAssocPolicy.maxReportingRate = reportBool ? rateNumValid : 0;
+      });
+      this.showNotification('Unsuccessful Association Policy saved successfully', 'success');
+      break;
+    }
+    case "backhaul-bss": {
+      const rows = document.querySelectorAll("#backhaul-bss-rows tr");
+      if (!rows || rows.length === 0) {
+        this.showNotification('No Backhaul BSS entries found', 'error');
+        return;
+      }
+      const uiRows = Array.from(rows).map(row => ({
+        bssid: row.querySelector("input[name='bssid']")?.value || "",
+        profile1bSTADisallowed:row.querySelector("select[name='profile1']")?.value === "1",
+        profile2bSTADisallowed:row.querySelector("select[name='profile2']")?.value === "1"
+      })).filter(r => r.bssid);
+
+      // Build lookup map
+      const updateMap = new Map();
+      uiRows.forEach(r => {
+        updateMap.set(r.bssid, r);
+      });
+
+      indicesToUpdate.forEach(i => {
+        const d = this.updatedPolicySettings[i];
+        const existing = d.backhaulBssConfigPolicy || [];
+
+        // Update only matching BSSIDs
+        const updated = existing.map(entry => {
+          const match = updateMap.get(entry.bssid);
+          return match ? { ...entry, ...match } : entry;
+        });
+        d.backhaulBssConfigPolicy = updated;
+      });
+      this.showNotification('Backhaul BSS Config Policy saved successfully', 'success');
+      break;
+    }
+
+    case "qos-mgt": {
+      const mscsList = getMacList("#mscs-body") || [];
+      const scsList  = getMacList("#scs-body") || [];
+
+      indicesToUpdate.forEach(i => {
+        const d = this.updatedPolicySettings[i];
+        d.qosManagementPolicy ||= {};
+        d.qosManagementPolicy.mscsDisallowedSTAList = [...mscsList];
+        d.qosManagementPolicy.scsDisallowedSTAList  = [...scsList];
+      });
+      this.showNotification('QoS Management Policy saved successfully', 'success');
+      break;
+    }
     case "radio-metrics": {
       const rows = RMP.getAll();
       if (!Array.isArray(rows) || rows.length === 0) {
-        this.showNotification('At least one Radio specific Matrics row with a valid ID (Station MAC") is required.', 'error');
+        this.showNotification('At least one Radio specific Metrics row with a valid ID (Station MAC") is required.', 'error');
         return;
       }
+
+      const norm = v => PolicyUtil.normalizeId(v)
+
+      // Build lookup map using ID
+      const updateMap = new Map();
+      rows.forEach(r => {
+        const key = norm(r.id);
+        if (key) updateMap.set(key, { ...r, id: key });
+      });
+
+      const selectedIdx = this.updatedPolicySettings.findIndex(
+        p => p.id === selectedDeviceId
+      );
+
+
       indicesToUpdate.forEach(i => {
         const d = this.updatedPolicySettings[i];
-        d.radioSpecificMetricsPolicy = rows;
+        const existing = d.radioSpecificMetricsPolicy || [];
+
+        // Build existing map
+        const existingMap = new Map();
+        existing.forEach(r => {
+          const key = norm(r.id);
+          if (key) existingMap.set(key, r);
+        });
+        const uiKeys = new Set(updateMap.keys());
+        if (uiKeys.size === 1 && uiKeys.has(PolicyUtil.MAC_ALL)) {
+          d.radioSpecificMetricsPolicy = [updateMap.get(PolicyUtil.MAC_ALL)];
+          return;
+        }
+        let updated;
+        if (i === selectedIdx) {
+          updated = existing
+          .filter(r => uiKeys.has(norm(r.id)))   // remove deleted rows
+          .map(r => {
+            const key = norm(r.id);
+            const match = updateMap.get(key);
+            return match ? { ...r, ...match } : r;
+          });
+        } else {
+          updated = existing.map(r => {
+            const key = norm(r.id);
+            const match = updateMap.get(key);
+            return match ? { ...r, ...match } : r;
+          });
+        }
+        if (i === selectedIdx) {
+          updateMap.forEach((uiRow, key) => {
+            if (!existingMap.has(key)) {
+              updated.push(uiRow);
+            }
+          });
+        }
+        d.radioSpecificMetricsPolicy = updated;
       });
       this.showNotification('Radio Specific Metrics Policy saved successfully', 'success');
-      break;
-    }
-    case "radio-steering": {
-      const rows = RSP.getAll();
-
-      if (!Array.isArray(rows) || rows.length === 0) {
-        this.showNotification('At least one Radio Steering row with a valid ID (Station MAC") is required.', 'error');
-        return;
-      }
-      indicesToUpdate.forEach(i => {
-        const d = this.updatedPolicySettings[i];
-        d.radioSteeringParametersPolicy = rows;
-      });
-      this.showNotification('Radio Steering Parameters saved successfully', 'success');
       break;
     }
 
@@ -2087,6 +2307,10 @@ async handleWebSocketMessage(data) {
     const height = container.node().clientHeight;
     const self = this;
 
+    // Create cache for node position and zoom which persist across refresh calls
+    this.nodePositionCache = this.nodePositionCache || new Map();
+    this.zoomTransformCache = this.zoomTransformCache || d3.zoomIdentity;
+
     // Return if container is not ready
     if (width === 0 || height === 0) {
       setTimeout(() => this.updateTopologyVisualization(), 100);
@@ -2096,6 +2320,13 @@ async handleWebSocketMessage(data) {
     // Return if container is empty
     if (!this.topology?.nodes?.length) return;
 
+    const currentNodeIds = new Set(this.topology.nodes.map(n => String(n.id)));
+    for (const key of this.nodePositionCache.keys()) {
+      if (!currentNodeIds.has(key)) {
+        this.nodePositionCache.delete(key);
+      }
+    }
+
     // Clear previous content
     container.selectAll('*').remove();
 
@@ -2103,11 +2334,16 @@ async handleWebSocketMessage(data) {
     const svg = container.append('svg')
     .attr('width', width)
     .attr('height', height)
-    .call(d3.zoom().on('zoom', (event) => {
-      svgGroup.attr('transform', event.transform);
-    }));
 
     const svgGroup = svg.append('g');
+    const zoom = d3.zoom().on('zoom', (event) => {
+      svgGroup.attr('transform', event.transform);
+      // Save zoom state
+      this.zoomTransformCache = event.transform;
+    });
+
+    svg.call(zoom);
+    svg.call(zoom.transform, this.zoomTransformCache);
 
     // Normalize node and edge IDs to strings
     this.topology.nodes.forEach(n => n.id = String(n.id));
@@ -2136,14 +2372,10 @@ async handleWebSocketMessage(data) {
     const haulColors = {
       Fronthaul: '#c3cbf8ff',
       Backhaul: '#e68b8bff',
-      Iot: '#d3ced3ff'
+      Iot: '#d3ced3ff',
+      Hotspot: '#9fe0c3ff',
+      Configurator: '#f4d28cff'
     };
-
-    const circleOffsets = [
-      { x: -65, y: 50 },
-      { x: 65, y: 50 },
-      { x: 0, y: -65 }
-    ];
 
     const bandColors = {
       '-1': '#0bd476ff',
@@ -2170,8 +2402,18 @@ async handleWebSocketMessage(data) {
     const offsetY = (height - graphHeight) / 2 - minY;
 
     this.topology.nodes.forEach(node => {
-      node.fx = node.x + offsetX;
-      node.fy = node.y + offsetY;
+      const saved = this.nodePositionCache.get(node.id);
+      if (saved) {
+        node.x = saved.x;
+        node.y = saved.y;
+      } else {
+        node.x = node.x + offsetX;
+        node.y = node.y + offsetY;
+      }
+
+      // Keep nodes fixed after positioning
+      node.fx = node.x;
+      node.fy = node.y;
     });
 
     // Create simulation
@@ -2197,16 +2439,26 @@ async handleWebSocketMessage(data) {
     // Draw overlapping haulType circles and icon
     node.each(function(d) {
       const g = d3.select(this);
-      const haulTypes = d.haulTypes?.map(ht => ht.name) || [];
+      const haulTypes = d.haulTypes || [];
+      const count = haulTypes.length;
 
-      haulTypes.forEach((type, i) => {
-        const offset = circleOffsets[i] || { x: 0, y: 0 };
-        const verticalShift = offset.x < 0 ? -8 : offset.x > 0 ? 8 : 0;
+      const circleRadius = 80;
+      const layoutRadius = circleRadius * 0.9;
+
+      haulTypes.forEach((haul, i) => {
+        // Skip invalid entries safely
+        if (!haul || typeof haul !== 'object') return;
+
+        const angle = (2 * Math.PI / count) * i;
+        const offset = {
+          x: layoutRadius * Math.cos(angle),
+          y: layoutRadius * Math.sin(angle)
+        };
 
         // SSID heading inside the each circle
-        const haul = d.haulTypes?.[i];
+        const type = haul.name || 'Unknown';
         const ssid = haul?.ssid || 'SSID N/A';
-        const vlanId = haul?.VlanId || 'N/A';
+        const vlanId = haul?.VlanId ?? 'N/A';
         const mldMap = new Map();
 
         // Extract BSS-band details
@@ -2243,7 +2495,7 @@ async handleWebSocketMessage(data) {
 
         // Draw haultype overlapping circle
         g.append('circle')
-          .attr('r', 80)
+          .attr('r', circleRadius)
           .attr('cx', offset.x)
           .attr('cy', offset.y)
           .attr('fill', haulColors[type] || '#ccc')
@@ -2268,7 +2520,7 @@ async handleWebSocketMessage(data) {
 
         g.append('text')
           .attr('x', offset.x)
-          .attr('y', offset.y + verticalShift)
+          .attr('y', offset.y)
           .attr('text-anchor', 'middle')
           .attr('dominant-baseline', 'middle')
           .attr('font-size', '12px')
@@ -2280,7 +2532,7 @@ async handleWebSocketMessage(data) {
       // STA Placement
       if (Array.isArray(d.STAList) && d.STAList.length > 0) {
         const staList = d.STAList;
-        const baseRadius = 80;
+        const baseRadius = circleRadius + 10;
         const angleStep = (2 * Math.PI) / staList.length;
         const nodeRadius = 20;
         const maxSize = 30;
@@ -2469,8 +2721,6 @@ async handleWebSocketMessage(data) {
 
     function dragstarted(event, d) {
       if (!event.active) simulation.alphaTarget(0.3).restart();
-      d.fx = d.x;
-      d.fy = d.y;
     }
 
     function dragged(event, d) {
@@ -2480,12 +2730,14 @@ async handleWebSocketMessage(data) {
 
     function dragended(event, d) {
       if (!event.active) simulation.alphaTarget(0);
+      self.nodePositionCache.set(d.id, {
+        x: d.fx,
+        y: d.fy
+      });
 
-      // Only release if not originally fixed
-      if (!(d.fixed?.x === true && d.fixed?.y === true)) {
-        d.fx = null;
-        d.fy = null;
-      }
+      // Lock at new position
+      d.x = d.fx;
+      d.y = d.fy;
     }
   }
 
@@ -3484,6 +3736,7 @@ async handleWebSocketMessage(data) {
         const firstId = sel.value;
         const policy = this.policyByDeviceId[firstId];
         populatePolicyUI(policy);
+        toggleMaxRateField();
       }
 
     } catch (err) {
@@ -3566,6 +3819,76 @@ async handleWebSocketMessage(data) {
   }
 }
 
+  /**
+   * Render Backhaul BSS policy
+   */
+function renderBackhaulBSS(rows) {
+  const tbody = document.querySelector("#backhaul-bss-rows");
+  if (!tbody) return;
+
+  tbody.innerHTML = "";
+
+  rows.forEach(row => {
+    const tr = document.createElement("tr");
+
+    // BSSID
+    const tdBssid = document.createElement("td");
+    const inputBssid = document.createElement("input");
+    inputBssid.type = "text";
+    inputBssid.name = "bssid";
+    inputBssid.value = row.bssid || "";
+    inputBssid.readOnly = true;
+    tdBssid.appendChild(inputBssid);
+
+    // Profile-1 bSTA Disallowed
+    const tdProfile1 = document.createElement("td");
+    const select1 = document.createElement("select");
+    select1.name = "profile1";
+
+    const opt1Disallowed = document.createElement("option");
+    opt1Disallowed.value = "1";
+    opt1Disallowed.textContent = "Disallowed";
+
+    const opt1Allowed = document.createElement("option");
+    opt1Allowed.value = "0";
+    opt1Allowed.textContent = "Allowed";
+    select1.appendChild(opt1Disallowed);
+    select1.appendChild(opt1Allowed);
+
+    // Set selected value
+    select1.value = row.profile1bSTADisallowed ? "1" : "0";
+    tdProfile1.appendChild(select1);
+
+    // Profile-2 bSTA Disallowed
+    const tdProfile2 = document.createElement("td");
+    const select2 = document.createElement("select");
+    select2.name = "profile2";
+
+    const opt2Disallowed = document.createElement("option");
+    opt2Disallowed.value = "1";
+    opt2Disallowed.textContent = "Disallowed";
+
+    const opt2Allowed = document.createElement("option");
+    opt2Allowed.value = "0";
+    opt2Allowed.textContent = "Allowed";
+    select2.appendChild(opt2Disallowed);
+    select2.appendChild(opt2Allowed);
+
+    // Set selected value
+    select2.value = row.profile2bSTADisallowed ? "1" : "0";
+    tdProfile2.appendChild(select2);
+
+    // Append all cells to row
+    tr.appendChild(tdBssid);
+    tr.appendChild(tdProfile1);
+    tr.appendChild(tdProfile2);
+
+    // Append row to tbody
+    tbody.appendChild(tr);
+  });
+
+}
+
 /**
   * show all the available device list for wifi policy config
   */
@@ -3598,7 +3921,7 @@ function populateDeviceSelectorFromPolicy(data) {
 }
 
 /**
- * Load wifi policy config for seected device
+ * Load wifi policy config for selected device
  */
 function populatePolicyUI(policy) {
   if (!policy) return;
@@ -3620,6 +3943,21 @@ function populatePolicyUI(policy) {
   setInputValue("#primary-vlan-id", dot1q.primaryVLANID);
   setInputValue("#default-pcp", dot1q.defaultPCP);
 
+  // Unsuccessful Association Policy
+  const ua = policy.unsuccessfulAssocPolicy || {};
+  setInputValue("#report-unassoc-sta", ua.reportUnsuccessAssoc?1:0);
+  setInputValue("#max-reporting-rate", ua.maxReportingRate);
+  toggleMaxRateField();
+
+  // Backhaul BSS Config Policy
+  const backhaul = policy.backhaulBssConfigPolicy || [];
+  renderBackhaulBSS(backhaul);
+
+  // QoS Management Policy (NEW)
+  const qos = policy.qosManagementPolicy || {};
+  fillMacTable("#mscs-body", qos.mscsDisallowedSTAList);
+  fillMacTable("#scs-body",  qos.scsDisallowedSTAList);
+
   // Radio Specific Metrics (table)
   const rmpEntries = getRadioMetricsEntries(policy);
   RMP.render(rmpEntries);
@@ -3629,6 +3967,25 @@ function populatePolicyUI(policy) {
   const rspEntries = getRadioSteeringEntries(policy);
   RSP.render(rspEntries);
   RSP.bind();
+}
+
+/**
+ * toggle Max Rate Field based on report unassoc status
+ */
+function toggleMaxRateField() {
+  const reportSelect = document.querySelector("#report-unassoc-sta");
+  const rateInput = document.querySelector("#max-reporting-rate");
+
+  if (!reportSelect || !rateInput) return;
+
+  const isDisabled = reportSelect.value === "0";
+
+  rateInput.disabled = isDisabled;
+
+  if (isDisabled) {
+    rateInput.value = "0";
+  }
+
 }
 
 // RMP entries (array or single legacy object)
@@ -3871,8 +4228,6 @@ function createPolicyTable({
     if (!tbody) return;
     const tr = createRow(prefill || {}, { editableId: true });
     tbody.appendChild(tr);
-    //const idInput = tr.querySelector('input[name="id"]');
-    //if (idInput) { idInput.focus(); idInput.select?.(); }
     // Show one-time scope chooser for this new row
     attachNewEntryScopeChooser(tr);
     updateAddButtonState();
@@ -3881,8 +4236,8 @@ function createPolicyTable({
   function getAll() {
     const rows = qsa(`${tbodySel} tr`);
     return rows.map(tr => {
-      let id = tr.querySelector('input[name="id"]')?.value?.trim().toLowerCase() || "";
-      if (id === "all stations") id = PolicyUtil.MAC_ALL;
+      let raw = tr.querySelector('input[name="id"]')?.value || "";
+      let id = normalizeId(raw)
 
       const out = { id };
       for (const col of columns) {
@@ -3895,7 +4250,7 @@ function createPolicyTable({
         }
       }
       return out;
-    });
+    }).filter(r => r.id);
   }
 
   function bind() {
@@ -4051,20 +4406,6 @@ function fillMacTable(tbodySel, macArray) {
     tr.appendChild(tdMac);
     tbody.appendChild(tr);
   });
-}
-
-function sectionMap(sectionKey) {
-  // Maps data-section to the radio group's name attribute
-  switch (sectionKey) {
-    case "ap-metrics":        return "applyScope-ap";
-    case "local-disallowed":  return "applyScope-local";
-    case "btm-disallowed":    return "applyScope-btm";
-    case "channel-scan":      return "applyScope-scan";
-    case "dot1q-defaults":    return "applyScope-dot1q";
-    case "radio-metrics":     return "applyScope-radio";
-    case "radio-steering":    return "applyScope-steer";
-    default:                  return "";
-  }
 }
 
 function getMacList(tbodySelector) {

--- a/src/rdkb-cli/static/style.css
+++ b/src/rdkb-cli/static/style.css
@@ -2219,9 +2219,10 @@ body {
 
 .table-scroll {
   overflow: auto;
-  max-height: 360px;
+  max-height: 180px;
   border: 1px solid #e4e7ec;
   border-radius: 8px;
+  margin-bottom: 16px;
   background: #ffffff;
 }
 
@@ -2514,6 +2515,13 @@ body {
 
 .toolbar { display: flex; gap: 8px; margin-top: 12px; }
 
+#backhaul-bss-rows input[name="bssid"][readonly] {
+  background-color: #f5f5f5;
+  color: #666;
+  cursor: not-allowed;
+  border-color: #ddd;
+}
+.policy-table select {  background-color: #ffffff;  color: #344054;}
 #policy-rows input[name="id"][readonly],
 #radio-metrics-rows input[name="id"][readonly] {
   background-color: #f5f5f5;

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -710,6 +710,9 @@ int main(int argc, char **argv) {
     "ec_manager_t.handle_recv_ec_action_frame_invalid_frame:"
     "ec_manager_t.handle_recv_ec_action_frame_invalid_MAC:"
     "ec_manager_t.handle_recv_gas_pub_action_frame_null_MAC:"
-    "ec_manager_t.process_direct_encap_dpp_msg_enrollee_null_src_mac";
+    "ec_manager_t.process_direct_encap_dpp_msg_enrollee_null_src_mac:"
+    "em_ctrl_t_Test.input_listen_default:"
+    "em_ctrl_t_Test.delete_nodes_valid:"
+    "em_ctrl_t_Test.delete_node_existing_ieee80211n_24";
     return RUN_ALL_TESTS();
 }

--- a/tests/test_l1_al_service_registration_response.cpp
+++ b/tests/test_l1_al_service_registration_response.cpp
@@ -43,17 +43,22 @@
  * | 02 | Call deserializeRegistrationResponse with valid data | validData | None | Should Pass |
  */
 TEST(AlServiceRegistrationResponseTest, DeserializeWithValidData) {
-    std::vector<unsigned char> validData = {
-        0xAA, 0xBB, 0xCC, 0xDD,
-        0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E,
-        0x01
-    };
-    std::cout << "Entering DeserializeWithValidData test" << std::endl;
+
+    constexpr size_t totalSize =
+        sizeof(uint32_t) +
+        sizeof(MacAddress) +
+        sizeof(uint8_t);
+
+    std::vector<unsigned char> validData(totalSize, 0x00);
+
+    // Optional: put a SUCCESS result in last byte
+    validData[totalSize - 1] = 0x01;
+
     AlServiceRegistrationResponse instance;
+
     EXPECT_NO_THROW({
         instance.deserializeRegistrationResponse(validData);
     });
-    std::cout << "Exiting DeserializeWithValidData test" << std::endl;
 }
 
 /**
@@ -105,11 +110,12 @@ TEST(AlServiceRegistrationResponseTest, DeserializeWithNullData) {
  */
 TEST(AlServiceRegistrationResponseTest, RetrieveAlMacAddressLocalWithValidInput) {
     std::cout << "Entering RetrieveAlMacAddressLocalWithValidInput test" << std::endl;
-	AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), RegistrationResult::SUCCESS);
+    AlServiceRegistrationResponse instance(parseMacAddress("00:1A:2B:3C:4D:5E"), RegistrationResult::SUCCESS);
     MacAddress result = instance.getAlMacAddressLocal();
-	std::cout << "The result is " << result << std::endl;
+    std::cout << "The result is " << result << std::endl;
     std::cout << "Exiting RetrieveAlMacAddressLocalWithValidInput test" << std::endl;
 }
+
 
 /**
  * @brief Test the retrieval of AL MAC address with empty input

--- a/tests/test_l1_dm_assoc_sta_mld.cpp
+++ b/tests/test_l1_dm_assoc_sta_mld.cpp
@@ -918,8 +918,8 @@ TEST(dm_assoc_sta_mld_t_Test, AssigningDefaultObject) {
  * | Variation / Step | Description | Test Data |Expected Result |Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01| Create an object of dm_assoc_sta_mld_t and assign maximum values to its members | obj1.m_assoc_sta_mld_info.str = true, obj1.m_assoc_sta_mld_info.num_affiliated_sta = 255 | Values should be assigned correctly | Should be successful |
- * | 02| Assign obj1 to another object obj2 using the assignment operator | obj2 = obj1 | obj2 should have the same values as obj1 | Should Pass |
- * | 03| Verify the values of obj2 | obj2.m_assoc_sta_mld_info.str, obj2.m_assoc_sta_mld_info.num_affiliated_sta | obj2.m_assoc_sta_mld_info.str == obj1.m_assoc_sta_mld_info.str, obj2.m_assoc_sta_mld_info.num_affiliated_sta == obj1.m_assoc_sta_mld_info.num_affiliated_sta | Should Pass |
+ * | 02| Assign obj1 to another object obj2 using the assignment operator | obj2 = obj1 | obj2.str should equal obj1.str; obj2.num_affiliated_sta should be clamped to EM_MAX_AP_MLD (not copied verbatim from obj1) | Should Pass |
+ * | 03| Verify the values of obj2 | obj2.m_assoc_sta_mld_info.str, obj2.m_assoc_sta_mld_info.num_affiliated_sta | obj2.m_assoc_sta_mld_info.str == obj1.m_assoc_sta_mld_info.str, obj2.m_assoc_sta_mld_info.num_affiliated_sta == EM_MAX_AP_MLD | Should Pass |
  */
 TEST(dm_assoc_sta_mld_t_Test, AssigningMaxValues) {
     std::cout << "Entering AssigningMaxValues" << std::endl;
@@ -931,7 +931,7 @@ TEST(dm_assoc_sta_mld_t_Test, AssigningMaxValues) {
     obj1.m_assoc_sta_mld_info.num_affiliated_sta = 255;
     obj2 = obj1;
     ASSERT_EQ(obj2.m_assoc_sta_mld_info.str, obj1.m_assoc_sta_mld_info.str);
-    ASSERT_EQ(obj2.m_assoc_sta_mld_info.num_affiliated_sta, obj1.m_assoc_sta_mld_info.num_affiliated_sta);
+    ASSERT_EQ(obj2.m_assoc_sta_mld_info.num_affiliated_sta, static_cast<unsigned char>(EM_MAX_AP_MLD));
     std::cout << "Exiting AssigningMaxValues" << std::endl;
 }
 
@@ -1008,9 +1008,9 @@ TEST(dm_assoc_sta_mld_t_Test, ValidAPMLDInformation) {
     ap_mld_info.emlmr = true;
     ap_mld_info.num_affiliated_sta = 2;
     memcpy(ap_mld_info.affiliated_sta[0].bssid, bssid1, 6);
-    memcpy(ap_mld_info.affiliated_sta[0].mac_addr, sta_mac1, 6);
+    memcpy(ap_mld_info.affiliated_sta[0].link_addr, sta_mac1, 6);
     memcpy(ap_mld_info.affiliated_sta[1].bssid, bssid2, 6);
-    memcpy(ap_mld_info.affiliated_sta[1].mac_addr, sta_mac2, 6);
+    memcpy(ap_mld_info.affiliated_sta[1].link_addr, sta_mac2, 6);
     // Create instance with initialized data
     dm_assoc_sta_mld_t assoc_sta_mld(&ap_mld_info);
     std::cout << "Exiting ValidAPMLDInformation test";

--- a/tests/test_l1_dm_device.cpp
+++ b/tests/test_l1_dm_device.cpp
@@ -355,7 +355,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceWithEmptyInterfaceName) {
 /**
  * @brief Test to verify the retrieval of AL Interface MAC Address with a valid MAC address
  *
- * This test checks if the `get_al_interface_mac` function correctly retrieves the MAC address
+ * This test checks if the `get_backhaul_al_interface_mac` function correctly retrieves the MAC address
  * that has been set in the `m_device_info.backhaul_alid.mac` field of the `dm_device_t` object.
  *
  * **Test Group ID:** Basic: 01@n
@@ -370,7 +370,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceWithEmptyInterfaceName) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the expected MAC address in the `m_device_info.backhaul_alid.mac` field | expected_mac = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E} | MAC address should be set successfully | Should be successful |
- * | 02 | Retrieve the MAC address using `get_al_interface_mac` function | None | MAC address should not be null | Should Pass |
+ * | 02 | Retrieve the MAC address using `get_backhaul_al_interface_mac` function | None | MAC address should not be null | Should Pass |
  * | 03 | Verify each byte of the retrieved MAC address against the expected MAC address | expected_mac = {0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E} | Each byte should match the expected MAC address | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithValidMACAddress) {
@@ -393,7 +393,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithValidMACAddress) {
 /**
  * @brief Test to verify the retrieval of AL Interface MAC Address when it is set to all zeros.
  *
- * This test checks if the `get_al_interface_mac` function correctly retrieves the MAC address when it is set to all zeros. 
+ * This test checks if the `get_backhaul_al_interface_mac` function correctly retrieves the MAC address when it is set to all zeros. 
  * It ensures that the function does not return a null pointer and that the retrieved MAC address matches the expected all-zero MAC address.
  *
  * **Test Group ID:** Basic: 01@n
@@ -408,7 +408,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithValidMACAddress) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the device's backhaul ALID MAC address to all zeros | expected_mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00} | None | Should be successful |
- * | 02 | Retrieve the AL Interface MAC address using `get_al_interface_mac` | None | mac should not be null | Should Pass |
+ * | 02 | Retrieve the AL Interface MAC address using `get_backhaul_al_interface_mac` | None | mac should not be null | Should Pass |
  * | 03 | Verify that the retrieved MAC address matches the expected all-zero MAC address | mac = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00} | Each byte of mac should match expected_mac | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllZeroMACAddress) {
@@ -431,7 +431,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllZeroMACAddress) {
 /**
  * @brief Test to verify the retrieval of AL Interface MAC Address when all bytes are set to FF
  *
- * This test checks if the `get_al_interface_mac` function correctly retrieves the MAC address when all bytes are set to 0xFF. 
+ * This test checks if the `get_backhaul_al_interface_mac` function correctly retrieves the MAC address when all bytes are set to 0xFF. 
  * It ensures that the function returns the expected MAC address and that the returned pointer is not null.
  *
  * **Test Group ID:** Basic: 01@n
@@ -446,7 +446,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllZeroMACAddress) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the MAC address in the device to all 0xFF | expected_mac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF} | None | Should be successful |
- * | 02 | Retrieve the AL Interface MAC address using `get_al_interface_mac` | None | mac != nullptr | Should Pass |
+ * | 02 | Retrieve the AL Interface MAC address using `get_backhaul_al_interface_mac` | None | mac != nullptr | Should Pass |
  * | 03 | Verify each byte of the retrieved MAC address matches the expected value | expected_mac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF} | Each byte of mac should be equal to expected_mac | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
@@ -469,7 +469,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
 /**
  * @brief Test to verify retrieval of AL interface name with a valid AL interface name.
  *
- * This test checks if the function `get_al_interface_name` correctly retrieves the AL interface name when a valid name is set in the device's backhaul ALID.
+ * This test checks if the function `get_backhaul_al_interface_name` correctly retrieves the AL interface name when a valid name is set in the device's backhaul ALID.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 014@n
@@ -483,7 +483,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the AL interface name in the device's backhaul ALID | expected_name = "eth0" | None | Should be successful |
- * | 02 | Retrieve the AL interface name using `get_al_interface_name` | None | result = "eth0" | Should Pass |
+ * | 02 | Retrieve the AL interface name using `get_backhaul_al_interface_name` | None | result = "eth0" | Should Pass |
  * | 03 | Verify the retrieved AL interface name matches the expected name | result = "eth0", expected_name = "eth0" | Assertion should pass | Should Pass |
  */
  TEST(dm_device_t_Test, RetrieveALInterfaceNameWithValidALInterfaceName) {
@@ -504,7 +504,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
 /**
  * @brief Test to verify the retrieval of AL Interface Name when it is empty.
  *
- * This test checks the behavior of the get_al_interface_name() method when the AL Interface Name is set to an empty string. 
+ * This test checks the behavior of the get_backhaul_al_interface_name() method when the AL Interface Name is set to an empty string. 
  * It ensures that the method correctly returns an empty string in this scenario.
  *
  * **Test Group ID:** Basic: 01@n
@@ -519,7 +519,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceMACAddressWithAllFFMACAddress) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the AL Interface Name to an empty string | expected_name = "" | None | Should be successful |
- * | 02 | Retrieve the AL Interface Name using get_al_interface_name() | None | result = "" | Should Pass |
+ * | 02 | Retrieve the AL Interface Name using get_backhaul_al_interface_name() | None | result = "" | Should Pass |
  * | 03 | Verify the retrieved AL Interface Name is an empty string | result = "", expected_name = "" | result == expected_name | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceNameWithEmptyALInterfaceName) {
@@ -540,7 +540,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceNameWithEmptyALInterfaceName) {
 /**
  * @brief Test to retrieve AL interface name with special characters in AL interface name
  *
- * This test verifies that the function `get_al_interface_name` correctly retrieves the AL interface name when it contains special characters. This is important to ensure that the function can handle and return names with special characters accurately.
+ * This test verifies that the function `get_backhaul_al_interface_name` correctly retrieves the AL interface name when it contains special characters. This is important to ensure that the function can handle and return names with special characters accurately.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 016@n
@@ -554,7 +554,7 @@ TEST(dm_device_t_Test, RetrieveALInterfaceNameWithEmptyALInterfaceName) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set the AL interface name with special characters | expected_name = "eth0@# 123" | None | Should be successful |
- * | 02 | Retrieve the AL interface name using `get_al_interface_name` | None | result = "eth0@# 123" | Should Pass |
+ * | 02 | Retrieve the AL interface name using `get_backhaul_al_interface_name` | None | result = "eth0@# 123" | Should Pass |
  * | 03 | Verify the retrieved AL interface name matches the expected name | result = "eth0@# 123", expected_name = "eth0@# 123" | Assertion check: result == expected_name | Should Pass |
  */
 TEST(dm_device_t_Test, RetrieveALInterfaceNameWithSpecialCharactersInALInterfaceName) {

--- a/tests/test_l1_dm_easy_mesh.cpp
+++ b/tests/test_l1_dm_easy_mesh.cpp
@@ -2716,8 +2716,8 @@ TEST(dm_easy_mesh_t, decode_client_cap_config_null_radio_mac) {
  * **Test Procedure:**
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
- * | 01 | Invoke decode_config with JSON template for "SetAnticipatedChannelPreference" | input: subdoc->buff = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": {\"Network\": {\"ID\": \"TestNetwork\", \"AnticipatedChannelPreference\": [{ \"Class\": 1, \"ChannelList\": [1,6,11] }]}} } }", key = "SetAnticipatedChannelPreference", num pointer = valid address | API return value is 0 and ASSERT_NE(subdoc, nullptr) passes | Should Pass |
- * | 02 | Invoke decode_config with JSON template for "ChannelScanRequest" | input: subdoc->buff = "{ \"wfa-dataelements:ChannelScanRequest\": {\"Network\": {\"ID\": \"TestNetwork\", \"ChannelScanParameters\": [{ \"Class\": 1, \"ChannelList\": [1,6,11] }]}} } }", key = "ChannelScanRequest", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
+ * | 01 | Invoke decode_config with JSON template for "SetAnticipatedChannelPreference" | input: subdoc->buff = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": {\"Network\": {\"ID\": \"TestNetwork\", \"AnticipatedChannelPreference\": [{ \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }], \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\" }]}} } }", key = "SetAnticipatedChannelPreference", num pointer = valid address | API return value is 0 and ASSERT_NE(subdoc, nullptr) passes | Should Pass |
+ * | 02 | Invoke decode_config with JSON template for "ChannelScanRequest" | input: subdoc->buff = "{ \"wfa-dataelements:ChannelScanRequest\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"RadioList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"ChannelScanParameters\": [{ \"Class\": 1, \"ChannelList\": [1,6,11] }] }] }]}} } }", key = "ChannelScanRequest", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
  * | 03 | Invoke decode_config with JSON template for "SetPolicy" | input: subdoc->buff = "{ \"wfa-dataelements:SetPolicy\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"Policy\": { \"AP Metrics Reporting Policy\": {} }}]}} } }", key = "SetPolicy", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
  * | 04 | Invoke decode_config with JSON template for "RadioEnable" | input: subdoc->buff = "{ \"wfa-dataelements:RadioEnable\": {\"Network\": {\"ID\": \"TestNetwork\", \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\", \"RadioList\": [{ \"ID\": \"Radio1\", \"Enable\": true }]}]}} } }", key = "RadioEnable", num pointer = valid address | API return value is 0 and EXPECT_EQ(ret, 0) passes | Should Pass |
  */
@@ -2741,6 +2741,9 @@ TEST(dm_easy_mesh_t, decode_config_supported_routing)
     "    \"ID\": \"TestNetwork\","
     "    \"AnticipatedChannelPreference\": ["
     "      { \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }"
+    "    ],"
+    "    \"DeviceList\": ["
+    "      { \"ID\": \"AA:BB:CC:DD:EE:FF\" }"
     "    ]"
     "  }"
     "} }",
@@ -2749,8 +2752,16 @@ TEST(dm_easy_mesh_t, decode_config_supported_routing)
     "{ \"wfa-dataelements:ChannelScanRequest\": {"
     "  \"Network\": {"
     "    \"ID\": \"TestNetwork\","
-    "    \"ChannelScanParameters\": ["
-    "      { \"Class\": 1, \"ChannelList\": [1,6,11], \"ChannelPrefList\": [0,0,0] }"
+    "    \"DeviceList\": ["
+    "      { \"ID\": \"AA:BB:CC:DD:EE:FF\","
+    "        \"RadioList\": ["
+    "          { \"ID\": \"AA:BB:CC:DD:EE:FF\","
+    "            \"ChannelScanParameters\": ["
+    "              { \"Class\": 1, \"ChannelList\": [1,6,11] }"
+    "            ]"
+    "          }"
+    "        ]"
+    "      }"
     "    ]"
     "  }"
     "} }",
@@ -3372,7 +3383,7 @@ TEST(dm_easy_mesh_t, decode_config_reset_null_key_pointer)
  * @brief Verify that decode_config_set_channel correctly decodes anticipated channel configuration with valid input.
  *
  * This test validates that the decode_config_set_channel API correctly processes a valid JSON configuration containing anticipated channel preferences.
- * It ensures that the function returns a status of 0 and that the output parameter (num) is set to 0 when provided with a valid anticipated channel configuration.
+ * It ensures that the function returns a status of 0 and that the output parameter (num) is set to 1 when provided with a valid anticipated channel configuration.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 075@n
@@ -3386,9 +3397,9 @@ TEST(dm_easy_mesh_t, decode_config_reset_null_key_pointer)
  * | Variation / Step | Description                                                                                             | Test Data                                                                                                                                                                              | Expected Result                                      | Notes          |
  * | :--------------: | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------------- |
  * | 01               | Initialize dm_easy_mesh_t object and subdoc structure; print entering message                           | None                                                                                                                                                                                   | Objects initialized and entering message printed   | Should be successful  |
- * | 02               | Setup JSON string in subdoc->buff for anticipated channel configuration                                  | json = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": { \"Network\": { \"ID\": \"TestNet\", \"AnticipatedChannelPreference\": [{ \"Class\": 81, \"ChannelList\": [1, 6, 11] }] } } }" | subdoc->buff correctly assigned the JSON configuration | Should be successful  |
- * | 03               | Invoke decode_config_set_channel API with valid input parameters                                        | subdoc (with valid JSON), key = "wfa-dataelements:SetAnticipatedChannelPreference", offset = 0, num pointer                                                     | API returns 0 and updates num to 0                   | Should Pass    |
- * | 04               | Assert that the return value and output parameter (num) are as expected                                   | ret = 0, num = 0                                                                                                                                                                       | EXPECT_EQ(ret, 0) and EXPECT_EQ(num, 0)               | Should Pass    |
+ * | 02               | Setup JSON string in subdoc->buff for anticipated channel configuration                                  | json = "{ \"wfa-dataelements:SetAnticipatedChannelPreference\": { \"Network\": { \"ID\": \"TestNet\", \"AnticipatedChannelPreference\": [{ \"Class\": 81, \"ChannelList\": [1, 6, 11], \"ChannelPrefList\": [0, 0, 0] }], \"DeviceList\": [{ \"ID\": \"AA:BB:CC:DD:EE:FF\" }] } } }" | subdoc->buff correctly assigned the JSON configuration | Should be successful  |
+ * | 03               | Invoke decode_config_set_channel API with valid input parameters                                        | subdoc (with valid JSON), key = "wfa-dataelements:SetAnticipatedChannelPreference", offset = 0, num pointer                                                     | API returns 0 and updates num to 1                   | Should Pass    |
+ * | 04               | Assert that the return value and output parameter (num) are as expected                                   | ret = 0, num = 1                                                                                                                                                                       | EXPECT_EQ(ret, 0) and EXPECT_EQ(num, 1)               | Should Pass    |
  */
 TEST(dm_easy_mesh_t, decode_config_set_channel_valid_anticipated)
 {
@@ -3407,6 +3418,11 @@ TEST(dm_easy_mesh_t, decode_config_set_channel_valid_anticipated)
         "         \"ChannelList\": [1, 6, 11],"
         "         \"ChannelPrefList\": [0, 0, 0]"
         "       }"
+        "     ],"
+        "     \"DeviceList\": ["
+        "       {"
+        "         \"ID\": \"AA:BB:CC:DD:EE:FF\""
+        "       }"
         "     ]"
         "   }"
         " }"
@@ -3421,8 +3437,121 @@ TEST(dm_easy_mesh_t, decode_config_set_channel_valid_anticipated)
         &num
     );
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(num, 0);
+    EXPECT_EQ(num, 1);
     std::cout << "Exiting decode_config_set_channel_valid_anticipated\n";
+}
+
+TEST(dm_easy_mesh_t, decode_config_set_channel_valid_selection_request)
+{
+    std::cout << "Entering decode_config_set_channel_valid_selection_request\n";
+    dm_easy_mesh_t obj;
+    char subdoc_buf[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ]{};
+    em_subdoc_info_t *subdoc = reinterpret_cast<em_subdoc_info_t*>(subdoc_buf);
+    const char json[] =
+        "{"
+        "  \"wfa-dataelements:ChannelSelectionRequest\": {"
+        "    \"Network\": {"
+        "      \"ID\": \"TestNet\","
+        "      \"DeviceList\": [{"
+        "        \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "        \"RadioList\": [{"
+        "          \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "          \"ChannelSelectionRequest\": [{"
+        "            \"Class\": 81,"
+        "            \"ChannelList\": [1, 6, 11],"
+        "            \"ChannelPrefList\": [0, 0, 0]"
+        "          }]"
+        "        }]"
+        "      }]"
+        "    }"
+        "  }"
+        "}";
+    snprintf(subdoc->buff, EM_IO_BUFF_SZ, "%s", json);
+    unsigned int num = 0;
+    std::cout << "Invoking decode_config_set_channel with valid ChannelSelectionRequest\n";
+    int ret = obj.decode_config_set_channel(
+        subdoc,
+        "wfa-dataelements:ChannelSelectionRequest",
+        0,
+        &num
+    );
+    EXPECT_EQ(ret, 0);
+    EXPECT_EQ(num, 1);
+    std::cout << "Exiting decode_config_set_channel_valid_selection_request\n";
+}
+
+TEST(dm_easy_mesh_t, decode_config_set_channel_missing_class_in_selection_request)
+{
+    std::cout << "Entering decode_config_set_channel_missing_class_in_selection_request\n";
+    dm_easy_mesh_t obj;
+    char subdoc_buf[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ]{};
+    em_subdoc_info_t *subdoc = reinterpret_cast<em_subdoc_info_t*>(subdoc_buf);
+    const char json[] =
+        "{"
+        "  \"wfa-dataelements:ChannelSelectionRequest\": {"
+        "    \"Network\": {"
+        "      \"ID\": \"TestNet\","
+        "      \"DeviceList\": [{"
+        "        \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "        \"RadioList\": [{"
+        "          \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "          \"ChannelSelectionRequest\": [{"
+        "            \"ChannelList\": [1, 6, 11],"
+        "            \"ChannelPrefList\": [0, 0, 0]"
+        "          }]"
+        "        }]"
+        "      }]"
+        "    }"
+        "  }"
+        "}";
+    snprintf(subdoc->buff, EM_IO_BUFF_SZ, "%s", json);
+    unsigned int num = 0;
+    std::cout << "Invoking decode_config_set_channel with missing Class\n";
+    int ret = obj.decode_config_set_channel(
+        subdoc,
+        "wfa-dataelements:ChannelSelectionRequest",
+        0,
+        &num
+    );
+    EXPECT_EQ(ret, EM_PARSE_ERR_GEN);
+    std::cout << "Exiting decode_config_set_channel_missing_class_in_selection_request\n";
+}
+
+TEST(dm_easy_mesh_t, decode_config_set_channel_missing_channel_pref_list_in_selection_request)
+{
+    std::cout << "Entering decode_config_set_channel_missing_channel_pref_list_in_selection_request\n";
+    dm_easy_mesh_t obj;
+    char subdoc_buf[sizeof(em_subdoc_info_t) + EM_IO_BUFF_SZ]{};
+    em_subdoc_info_t *subdoc = reinterpret_cast<em_subdoc_info_t*>(subdoc_buf);
+    const char json[] =
+        "{"
+        "  \"wfa-dataelements:ChannelSelectionRequest\": {"
+        "    \"Network\": {"
+        "      \"ID\": \"TestNet\","
+        "      \"DeviceList\": [{"
+        "        \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "        \"RadioList\": [{"
+        "          \"ID\": \"AA:BB:CC:DD:EE:FF\","
+        "          \"ChannelSelectionRequest\": [{"
+        "            \"Class\": 81,"
+        "            \"ChannelList\": [1, 6, 11]"
+        "          }]"
+        "        }]"
+        "      }]"
+        "    }"
+        "  }"
+        "}";
+    snprintf(subdoc->buff, EM_IO_BUFF_SZ, "%s", json);
+    unsigned int num = 0;
+    std::cout << "Invoking decode_config_set_channel with missing ChannelPrefList\n";
+    int ret = obj.decode_config_set_channel(
+        subdoc,
+        "wfa-dataelements:ChannelSelectionRequest",
+        0,
+        &num
+    );
+    EXPECT_EQ(ret, EM_PARSE_ERR_GEN);
+    std::cout << "Exiting decode_config_set_channel_missing_channel_pref_list_in_selection_request\n";
 }
 
 /**

--- a/tests/test_l1_dm_easy_mesh_list.cpp
+++ b/tests/test_l1_dm_easy_mesh_list.cpp
@@ -106,7 +106,7 @@ protected:
 
 
     void SetUp() override {
-	__lsan_disable();
+	    __lsan_disable();
         list.init(static_cast<em_mgr_t*>(&mgr));
         
         // Add data models for Network1
@@ -135,12 +135,7 @@ protected:
     void TearDown() override {
         if (skip_teardown) {
             return;
-        }
-        list.delete_data_model("Network1", mac1);
-	    list.delete_data_model("Network1", mac2);
-	    list.delete_data_model("Network2", mac3);
-	    list.delete_data_model("Network2", mac4);
-
+		}
         if (dm1->m_wifi_data != NULL) {
             free(dm1->m_wifi_data);
             dm1->m_wifi_data = nullptr;
@@ -157,7 +152,15 @@ protected:
             free(dm4->m_wifi_data);
             dm4->m_wifi_data = nullptr;
         }
-	__lsan_enable();
+		list.delete_data_model("Network1", mac1);
+	    list.delete_data_model("Network1", mac2);
+	    list.delete_data_model("Network2", mac3);
+	    list.delete_data_model("Network2", mac4);
+		dm1 = nullptr;
+        dm2 = nullptr;
+        dm3 = nullptr;
+        dm4 = nullptr;
+	    __lsan_enable();
     }
 };
 
@@ -1079,7 +1082,7 @@ TEST_F(dm_easy_mesh_list_tTEST, get_first_device_returns_valid_pointer)
  * | 03               | Assert that the returned firstElement is not null                          | firstElement, expected value: non-null                                                             | Assertion passes when firstElement != nullptr                           | Should Pass     |
  * | 04               | Validate that the network id of firstElement is "Network2"                  | firstElement->m_device.m_device_info.id.net_id = "Network2"                                          | The network id string is equal to "Network2"                           | Should Pass     |
  * | 05               | Validate that the profile type of firstElement is em_profile_type_3         | firstElement->m_device.m_device_info.profile, expected: em_profile_type_3                             | Profile type matches em_profile_type_3                                 | Should Pass     |
- * | 06               | Validate that the number of policies for firstElement is 7                  | firstElement->m_num_policy, expected: 7                                                              | Policy count equals 7                                                   | Should Pass     |
+ * | 06               | Validate that the number of policies for firstElement is 8                  | firstElement->m_num_policy, expected: 8                                                              | Policy count equals 8                                                   | Should Pass     |
  * | 07               | Log the exit message "Exiting get_first_dm_valid test"                    | No input arguments                                                                                 | "Exiting get_first_dm_valid test" printed to stdout                     | Should be successful |
  */
 TEST_F(dm_easy_mesh_list_tTEST, get_first_dm_valid)
@@ -1089,7 +1092,7 @@ TEST_F(dm_easy_mesh_list_tTEST, get_first_dm_valid)
     ASSERT_NE(firstElement, nullptr);
 	EXPECT_STREQ(firstElement->m_device.m_device_info.id.net_id, "Network2");
 	EXPECT_EQ(firstElement->m_device.m_device_info.profile, em_profile_type_3);
-	EXPECT_EQ(firstElement->m_num_policy, 7);
+	EXPECT_EQ(firstElement->m_num_policy, 8);
     std::cout << "Exiting get_first_dm_valid test" << std::endl;
 }
 

--- a/tests/test_l1_dm_radio_cap.cpp
+++ b/tests/test_l1_dm_radio_cap.cpp
@@ -483,14 +483,14 @@ TEST(dm_radio_cap_t_Test, NullRadioCapPointer) {
 * **Test Procedure:**@n
 * | Variation / Step | Description | Test Data | Expected Result | Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
-* | 01 | Create invalid radio capability structure | radio_cap.ch_scan.intf.media = 9999, radio_cap.ch_scan.band = 9999 | None | Should be successful |
+* | 01 | Create invalid radio capability structure | radio_cap.ruid.media = 9999, radio_cap.num_op_classes = UINT_MAX | None | Should be successful |
 * | 02 | Initialize dm_radio_cap_t object with invalid structure | dm_radio_cap_t radio_cap_obj(&radio_cap) | None | Should be successful |
 */
 TEST(dm_radio_cap_t_Test, InvalidRadioCapStructure) {
     std::cout << "Entering InvalidRadioCapStructure test";
     em_radio_cap_info_t radio_cap{};
-    radio_cap.ch_scan.scan_impact = static_cast<unsigned char>(3);
-    radio_cap.ch_scan.op_classes_num = static_cast<unsigned char>(255);
+    radio_cap.ruid.media = static_cast<em_media_type_t>(9999);
+    radio_cap.num_op_classes = UINT_MAX;
     dm_radio_cap_t radio_cap_obj(&radio_cap);
     std::cout << "Exiting InvalidRadioCapStructure test";
 }
@@ -877,16 +877,18 @@ TEST(dm_radio_cap_t_Test, AssigningMixedValues) {
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01 | Create two dm_radio_cap_t objects | obj1, obj2 | Objects created successfully | Should be successful |
 * | 02 | Assign an invalid enum value to obj2's media type | 0x9999 (not defined in em_media_type_t) | Value assigned without compile-time error | Invalid value handled |
-* | 03 | Assign obj2 to obj1 | obj1 = obj2 | Assignment successful | Should be successful |
-* | 04 | Compare the media type values of obj1 and obj2 | obj2.m_radio_cap_info.ruid.media != obj1.m_radio_cap_info.ruid.media | Should not be the same | Should Pass |
+* | 03 | Verify obj2 has a different media type than the default-initialised obj1 | obj2.m_radio_cap_info.ruid.media != obj1.m_radio_cap_info.ruid.media | EXPECT_NE passes; objects are not equal before assignment | Should Pass |
+* | 04 | Assign obj2 to obj1 | obj1 = obj2 | Assignment successful | Should be successful |
+* | 05 | Verify obj1 has the same media type as obj2 after assignment | obj1.m_radio_cap_info.ruid.media == obj2.m_radio_cap_info.ruid.media | EXPECT_EQ passes; assignment correctly copied the invalid value | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, AssigningInvalidValue) {
     std::cout << "Entering AssigningInvalidValue test";
     dm_radio_cap_t obj1{};
-    dm_radio_cap_t obj2{}; 
-    obj2.m_radio_cap_info.ruid.media = em_media_type_max;
-    obj1 = obj2;
+    dm_radio_cap_t obj2{};
+    obj2.m_radio_cap_info.ruid.media = static_cast<em_media_type_t>(0x9999);
     EXPECT_NE(obj2.m_radio_cap_info.ruid.media, obj1.m_radio_cap_info.ruid.media);
+    obj1 = obj2;
+    EXPECT_EQ(obj1.m_radio_cap_info.ruid.media, obj2.m_radio_cap_info.ruid.media);
     std::cout << "Exiting AssigningInvalidValue test";
 }
 
@@ -910,7 +912,8 @@ TEST(dm_radio_cap_t_Test, AssigningInvalidValue) {
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01 | Create first dm_radio_cap_t object | obj1 = dm_radio_cap_t() | None | Should be successful |
 * | 02 | Create second dm_radio_cap_t object | obj2 = dm_radio_cap_t() | None | Should be successful |
-* | 03 | Compare the two objects using equality operator | obj1 == obj2 | EXPECT_TRUE(obj1 == obj2) | Should Pass |
+* | 03 | Set wifi7_cap.mlo_cap_support.ruid[0] and ch_scan.min_scan_interval to the same values in both objects | obj1.m_radio_cap_info.wifi7_cap.mlo_cap_support.ruid[0] = 2, obj1.m_radio_cap_info.ch_scan.min_scan_interval = 80, same for obj2 | None | Should be successful |
+* | 04 | Verify that both objects have the same field values | EXPECT_EQ on ruid[0] and min_scan_interval | EXPECT_EQ passes | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareIdenticalObjects) {
     std::cout << "Entering CompareIdenticalObjects" << std::endl;
@@ -944,8 +947,8 @@ TEST(dm_radio_cap_t_Test, CompareIdenticalObjects) {
 * | Variation / Step | Description | Test Data |Expected Result |Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01| Initialize obj1 and obj2 | obj1 = dm_radio_cap_t(), obj2 = dm_radio_cap_t() | Objects initialized | Should be successful |
-* | 02| Set number_of_bss for obj2 | obj2.m_radio_cap_info.ch_scan.number_of_bss = 5 | obj2.m_radio_cap_info.ch_scan.number_of_bss = 5 | Should be successful |
-* | 03| Compare obj1 and obj2 using equality operator | obj1 == obj2 | EXPECT_FALSE(obj1 == obj2) | Should Pass |
+* | 02| Set op_classes_num for obj1 to 2 and obj2 to 5 | obj1.m_radio_cap_info.ch_scan.op_classes_num = 2, obj2.m_radio_cap_info.ch_scan.op_classes_num = 5 | Values set | Should be successful |
+* | 03| Compare obj1 and obj2 using EXPECT_NE | obj1.ch_scan.op_classes_num != obj2.ch_scan.op_classes_num | EXPECT_NE passes | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentNumberOfBSS) {
     std::cout << "Entering CompareDifferentNumberOfBSS" << std::endl;
@@ -1008,7 +1011,7 @@ TEST(dm_radio_cap_t_Test, CompareDifferentMediaType) {
 * | Variation / Step | Description | Test Data | Expected Result | Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01 | Initialize obj1 and obj2 | obj1, obj2 | Objects initialized | Should be successful |
-* | 02 | Set obj2.m_radio_cap_info.ch_scan.enabled to true | obj2.m_radio_cap_info.ch_scan.enabled = true | Value set | Should be successful |
+* | 02 | Set obj1.m_radio_cap_info.ch_scan.boot_only to 0 and obj2 to 1 | obj1.m_radio_cap_info.ch_scan.boot_only = 0, obj2.m_radio_cap_info.ch_scan.boot_only = 1 | Values set | Should be successful |
 * | 03 | Compare obj1 and obj2 using equality operator | obj1, obj2 | EXPECT_FALSE(obj1 == obj2) | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentEnabledValue) {
@@ -1040,7 +1043,7 @@ TEST(dm_radio_cap_t_Test, CompareDifferentEnabledValue) {
 * | Variation / Step | Description | Test Data | Expected Result | Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01 | Initialize two `dm_radio_cap_t` objects | obj1, obj2 | Objects initialized | Should be successful |
-* | 02 | Set `chip_vendor` of `obj2` to "VendorX" | obj2.m_radio_cap_info.ch_scan.chip_vendor = "VendorX" | `chip_vendor` set to "VendorX" | Should be successful |
+* | 02 | Set `ch_scan.ruid` of `obj1` to "vndA" and `obj2` to "vndX" | obj1.m_radio_cap_info.ch_scan.ruid = "vndA\0\0", obj2.m_radio_cap_info.ch_scan.ruid = "vndX\0\0" | `ruid` set with different values | Should be successful |
 * | 03 | Compare `obj1` and `obj2` using equality operator | obj1, obj2 | EXPECT_FALSE(obj1 == obj2) | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentChipVendor) {
@@ -1072,7 +1075,7 @@ TEST(dm_radio_cap_t_Test, CompareDifferentChipVendor) {
 * | Variation / Step | Description | Test Data |Expected Result |Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01| Create two dm_radio_cap_t objects | obj1, obj2 | Objects created successfully | Should be successful |
-* | 02| Set srg_bss_color_bitmap[0] of obj2 to 1 | obj2.m_radio_cap_info.ch_scan.srg_bss_color_bitmap[0] = 1 | Value set successfully | Should be successful |
+* | 02| Set ch_scan.ruid[0] of obj2 to 1 and obj1 to 0 | obj1.m_radio_cap_info.ch_scan.ruid[0] = 0, obj2.m_radio_cap_info.ch_scan.ruid[0] = 1 | Value set successfully | Should be successful |
 * | 03| Compare obj1 and obj2 using equality operator | obj1 == obj2 | EXPECT_FALSE(obj1 == obj2) | Should Pass |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentBSSColorBitmap) {
@@ -1199,7 +1202,7 @@ TEST(dm_radio_cap_t_Test, CompareDifferentEHTOpsReserved) {
 * | Variation / Step | Description | Test Data |Expected Result |Notes |
 * | :----: | --------- | ---------- |-------------- | ----- |
 * | 01| Create two dm_radio_cap_t objects | obj1, obj2 | Objects created successfully | Should be successful |
-* | 02| Set EHT capability for obj2 | obj2.m_radio_cap_info.eht_cap = "EHT Capability" | EHT capability set successfully | Should be successful |
+* | 02| Set eht_ops.radios_num of obj1 to 1 and obj2 to 2 | obj1.m_radio_cap_info.eht_ops.radios_num = 1, obj2.m_radio_cap_info.eht_ops.radios_num = 2 | EHT ops radios_num set with different values | Should be successful |
 * | 03| Compare obj1 and obj2 using equality operator | obj1 == obj2 | EXPECT_FALSE(obj1 == obj2) | Should Fail |
 */
 TEST(dm_radio_cap_t_Test, CompareDifferentEHTCap) {

--- a/tests/test_l1_em_cmd.cpp
+++ b/tests/test_l1_em_cmd.cpp
@@ -185,7 +185,7 @@ TEST(em_cmd_t, bus_2_cmd_type_ValidConversion)
         { em_bus_event_type_client_cap_query,   em_cmd_type_client_cap_query },
         { em_bus_event_type_listener_stop,      em_cmd_type_none },
         { em_bus_event_type_dm_commit,          em_cmd_type_none },
-        { em_bus_event_type_m2_tx,              em_cmd_type_none },
+        { em_bus_event_type_m2_tx,              em_cmd_type_em_config },
         { em_bus_event_type_topo_sync,          em_cmd_type_em_config },
         { em_bus_event_type_onewifi_mesh_sta_cb,em_cmd_type_none },
         { em_bus_event_type_onewifi_radio_cb,   em_cmd_type_none },
@@ -1470,7 +1470,7 @@ TEST(em_cmd_t, ConstructionWithOutOfRangeCmdType)
     dm_easy_mesh_t dm;
     dm.init();
     em_cmd_t cmd(static_cast<em_cmd_type_t>(-1), param, dm);
-    EXPECT_EQ(cmd.m_type, static_cast<em_cmd_type_t>(-1));
+    EXPECT_EQ(cmd.m_type, em_cmd_type_max);
     cmd.deinit();
     dm.deinit();
     std::cout << "Exiting ConstructionWithOutOfRangeCmdType test" << std::endl;
@@ -3062,9 +3062,9 @@ TEST(em_cmd_t, get_svc_valid_none) {
     std::cout << "Exiting get_svc_valid_none test" << std::endl;
 }
 /**
- * @brief Validate that the get_svc function returns the invalid service type when m_svc is explicitly set to an out-of-range value.
+ * @brief Validate that the get_svc function returns em_service_type_none when m_svc is explicitly set to an out-of-range value.
  *
- * This test verifies that when the m_svc member of the em_cmd_t object is assigned an invalid value (-1), the get_svc() method correctly returns this invalid value. This helps ensure that the API does not modify or incorrectly process invalid input values.
+ * This test verifies that when the m_svc member of the em_cmd_t object is assigned an invalid value (cast from -1), the get_svc() method returns em_service_type_none. This helps ensure that the API handles out-of-range input gracefully and consistently.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 067@n
@@ -3075,9 +3075,9 @@ TEST(em_cmd_t, get_svc_valid_none) {
  * **User Interaction:** None@n
  *
  * **Test Procedure:**@n
- * | Variation / Step | Description                                                         | Test Data                               | Expected Result                                            | Notes      |
- * | :--------------: | ------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------- | ---------- |
- * | 01               | Instantiate em_cmd_t, set m_svc to -1, and invoke get_svc() method.   | m_svc = -1, output svc = -1               | get_svc() returns -1 and the EXPECT_EQ assertion passes.   | Should Pass|
+ * | Variation / Step | Description                                                                                          | Test Data                                                       | Expected Result                                                                | Notes      |
+ * | :--------------: | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------ | ---------- |
+ * | 01               | Instantiate em_cmd_t, set m_svc to static_cast<em_service_type_t>(-1), and invoke get_svc() method. | m_svc = static_cast<em_service_type_t>(-1)                      | get_svc() returns em_service_type_none and the EXPECT_EQ assertion passes.     | Should Pass|
  */
 TEST(em_cmd_t, get_svc_invalid_value_check) {
     std::cout << "Entering get_svc_invalid_value_check test" << std::endl;
@@ -3086,7 +3086,7 @@ TEST(em_cmd_t, get_svc_invalid_value_check) {
     std::cout << "Invoking get_svc()" << std::endl;
     em_service_type_t svc = cmd.get_svc();
     std::cout << "get_svc() returned value: " << static_cast<unsigned int>(svc) << std::endl;
-    EXPECT_EQ(svc, -1);
+    EXPECT_EQ(svc, em_service_type_none);
     std::cout << "Exiting get_svc_invalid_value_check test" << std::endl;
 }
 /**

--- a/tests/test_l1_em_cmd_em_config.cpp
+++ b/tests/test_l1_em_cmd_em_config.cpp
@@ -65,7 +65,7 @@ TEST(em_cmd_em_config_t, em_cmd_em_config_t_full_valid) {
     EXPECT_EQ(configCmd.m_param.u.args.num_args, 2);
     EXPECT_STREQ(configCmd.m_param.u.args.args[0], arg0);
     EXPECT_STREQ(configCmd.m_param.u.args.args[1], arg1);
-    EXPECT_EQ(configCmd.m_num_orch_desc, 10);
+    EXPECT_EQ(configCmd.m_num_orch_desc, 9);
     EXPECT_EQ(configCmd.m_orch_desc[0].op, dm_orch_type_bss_delete);
     EXPECT_FALSE(configCmd.m_orch_desc[0].submit);
     EXPECT_EQ(configCmd.m_svc, em_service_type_ctrl);
@@ -89,7 +89,7 @@ TEST(em_cmd_em_config_t, em_cmd_em_config_t_full_valid) {
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Initialize empty em_cmd_params_t and dm_easy_mesh_t objects, then create an instance of em_cmd_em_config_t using these parameters. | params = {}, dm = {} | Instance is created with m_type set to em_cmd_type_em_config, m_name set to "em_config", fixed_args as an empty string, and num_args as 0. | Should Pass |
- * | 02 | Validate that the orchestration fields are correctly initialized. | m_num_orch_desc = 8, orch_desc[0].op = dm_orch_type_bss_delete, orch_desc[0].submit = false, m_svc = em_service_type_ctrl | All field values match the expected configuration. | Should Pass |
+ * | 02 | Validate that the orchestration fields are correctly initialized. | m_num_orch_desc = 9, orch_desc[0].op = dm_orch_type_bss_delete, orch_desc[0].submit = false, m_svc = em_service_type_ctrl | All field values match the expected configuration. | Should Pass |
  * | 03 | Invoke configCmd.deinit() to release resources. | No input | deinit completes without errors. | Should be successful |
  */
 TEST(em_cmd_em_config_t, em_cmd_em_config_t_empty) {
@@ -101,7 +101,7 @@ TEST(em_cmd_em_config_t, em_cmd_em_config_t_empty) {
     EXPECT_STREQ(configCmd.m_name, "em_config");
     EXPECT_STREQ(configCmd.m_param.u.args.fixed_args, "");
     EXPECT_EQ(configCmd.m_param.u.args.num_args, 0);
-    EXPECT_EQ(configCmd.m_num_orch_desc, 10);
+    EXPECT_EQ(configCmd.m_num_orch_desc, 9);
     EXPECT_EQ(configCmd.m_orch_desc[0].op, dm_orch_type_bss_delete);
     EXPECT_FALSE(configCmd.m_orch_desc[0].submit);
     EXPECT_EQ(configCmd.m_svc, em_service_type_ctrl);
@@ -163,7 +163,7 @@ TEST(em_cmd_em_config_t, em_cmd_em_config_t_max_boundary) {
     EXPECT_EQ(configCmd.m_param.u.args.num_args, 2);
     EXPECT_STREQ(configCmd.m_param.u.args.args[0], maxArg);
     EXPECT_STREQ(configCmd.m_param.u.args.args[1], maxArg);
-    EXPECT_EQ(configCmd.m_num_orch_desc, 10);
+    EXPECT_EQ(configCmd.m_num_orch_desc, 9);
     EXPECT_EQ(configCmd.m_orch_desc[0].op, dm_orch_type_bss_delete);
     EXPECT_FALSE(configCmd.m_orch_desc[0].submit);
     EXPECT_EQ(configCmd.m_svc, em_service_type_ctrl);

--- a/tests/test_l1_em_cmd_set_channel.cpp
+++ b/tests/test_l1_em_cmd_set_channel.cpp
@@ -38,7 +38,7 @@
  * **Test Procedure:**
  * | Variation / Step | Description                                                                | Test Data                                                                                                                                                                                                                          | Expected Result                                                                                                                                                                     | Notes      |
  * | :--------------: | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
- * | 01               | Initialize parameters and environment, then invoke em_cmd_set_channel_t API with fixed_args set to "6" | input: param.u.args.fixed_args = "6", dm_easy_mesh_t instance; output: cmd.m_type, cmd.m_name, cmd.m_param.u.args.fixed_args, cmd.m_param.u.args.num_args, cmd.m_svc, cmd.m_num_orch_desc, cmd.m_orch_desc[0].op, cmd.m_orch_desc[0].submit | Command object has m_type equal to em_cmd_type_set_channel, m_name equal to "set_channel", fixed_args equal to "6", num_args equal to 0, m_svc equal to em_service_type_ctrl, m_num_orch_desc equal to 2, orch_desc[0].op equal to dm_orch_type_channel_sel, orch_desc[0].submit equal to true | Should Pass |
+ * | 01               | Initialize parameters and environment, then invoke em_cmd_set_channel_t API with fixed_args set to "6" | input: param.u.args.fixed_args = "6", dm_easy_mesh_t instance; output: cmd.m_type, cmd.m_name, cmd.m_param.u.args.fixed_args, cmd.m_param.u.args.num_args, cmd.m_svc, cmd.m_num_orch_desc, cmd.m_orch_desc[0].op, cmd.m_orch_desc[0].submit | Command object has m_type equal to em_cmd_type_set_channel, m_name equal to "set_channel", fixed_args equal to "6", num_args equal to 0, m_svc equal to em_service_type_ctrl, m_num_orch_desc equal to 1, orch_desc[0].op equal to dm_orch_type_channel_sel, orch_desc[0].submit equal to true | Should Pass |
  */
 TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_6) {
     std::cout << "Entering em_cmd_set_channel_t_valid_channel_6 test" << std::endl;
@@ -53,7 +53,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_6) {
     EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "6");
     EXPECT_EQ(cmd.m_param.u.args.num_args, 0);
     EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
-    EXPECT_EQ(cmd.m_num_orch_desc, 2);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_channel_sel);
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     cmd.deinit();
@@ -75,7 +75,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_6) {
  * **Test Procedure:**
  * | Variation / Step | Description                                                                                          | Test Data                                                                                        | Expected Result                                                                                                                                         | Notes      |
  * | :--------------: | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
- * | 01               | Initialize the command parameters with fixed_args set to "11", invoke em_cmd_set_channel_t, and verify property values | param.u.args.fixed_args = "11", dm_easy_mesh_t dm = default, output: m_type, m_name, fixed_args, m_svc, m_num_orch_desc, m_orch_desc[0].op, m_orch_desc[0].submit | m_type equals em_cmd_type_set_channel, m_name equals "set_channel", fixed_args equals "11", m_svc equals em_service_type_ctrl, m_num_orch_desc equals 2, m_orch_desc[0].op equals dm_orch_type_channel_sel, m_orch_desc[0].submit is true | Should Pass |
+ * | 01               | Initialize the command parameters with fixed_args set to "11", invoke em_cmd_set_channel_t, and verify property values | param.u.args.fixed_args = "11", dm_easy_mesh_t dm = default, output: m_type, m_name, fixed_args, m_svc, m_num_orch_desc, m_orch_desc[0].op, m_orch_desc[0].submit | m_type equals em_cmd_type_set_channel, m_name equals "set_channel", fixed_args equals "11", m_svc equals em_service_type_ctrl, m_num_orch_desc equals 1, m_orch_desc[0].op equals dm_orch_type_channel_sel, m_orch_desc[0].submit is true | Should Pass |
  */
 TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_11) {
     std::cout << "Entering em_cmd_set_channel_t_valid_channel_11 test" << std::endl;
@@ -89,7 +89,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_11) {
     EXPECT_STREQ(cmd.m_name, "set_channel");
     EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "11");
     EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
-    EXPECT_EQ(cmd.m_num_orch_desc, 2);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_channel_sel);
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     cmd.deinit();
@@ -116,7 +116,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_valid_channel_11) {
  * | Variation / Step | Description | Test Data | Expected Result |Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Initialize input parameters with empty channel string and default dm object | param.u.args.fixed_args[0] = '\0', param.u.args.fixed_args[last] = '\0', dm = default constructed dm_easy_mesh_t | Parameters initialized without errors; no output produced | Should be successful |
- * | 02 | Call em_cmd_set_channel_t constructor with the prepared parameters | input: param (with empty fixed_args), dm object | cmd.m_type equals em_cmd_type_set_channel, cmd.m_name equals "set_channel", cmd.m_param.u.args.fixed_args equals empty string, cmd.m_svc equals em_service_type_ctrl, cmd.m_num_orch_desc equals 2, cmd.m_orch_desc[0].op equals dm_orch_type_channel_sel, cmd.m_orch_desc[0].submit equals true | Should Pass |
+ * | 02 | Call em_cmd_set_channel_t constructor with the prepared parameters | input: param (with empty fixed_args), dm object | cmd.m_type equals em_cmd_type_set_channel, cmd.m_name equals "set_channel", cmd.m_param.u.args.fixed_args equals empty string, cmd.m_svc equals em_service_type_ctrl, cmd.m_num_orch_desc equals 1, cmd.m_orch_desc[0].op equals dm_orch_type_channel_sel, cmd.m_orch_desc[0].submit equals true | Should Pass |
  * | 03 | Deinitialize the command object | API call: cmd.deinit() | Resources associated with cmd are freed successfully | Should be successful |
  */
 TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_empty_channel_input) {
@@ -131,7 +131,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_empty_channel_input) {
     EXPECT_STREQ(cmd.m_name, "set_channel");
     EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "");
     EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
-    EXPECT_EQ(cmd.m_num_orch_desc, 2);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_channel_sel);
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     cmd.deinit();
@@ -153,7 +153,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_empty_channel_input) {
  * **Test Procedure:**
  * | Variation / Step | Description                                                                                                          | Test Data                                                                                                                                                 | Expected Result                                                                                                                                                    | Notes      |
  * | :--------------: | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
- * | 01               | Invoke em_cmd_set_channel_t with fixed_args set to a non-numeric string "abc".                                       | input: fixed_args = "abc", dm_easy_mesh_t = default, output: m_type = em_cmd_type_set_channel, m_name = "set_channel", m_param.u.args.fixed_args = "abc", m_svc = em_service_type_ctrl, m_num_orch_desc = 2, m_orch_desc[0].op = dm_orch_type_channel_sel, m_orch_desc[0].submit = true | The command object should be initialized correctly; all EXPECT assertions in the test should pass confirming the expected behavior when a non-numeric channel is provided. | Should Pass |
+ * | 01               | Invoke em_cmd_set_channel_t with fixed_args set to a non-numeric string "abc".                                       | input: fixed_args = "abc", dm_easy_mesh_t = default, output: m_type = em_cmd_type_set_channel, m_name = "set_channel", m_param.u.args.fixed_args = "abc", m_svc = em_service_type_ctrl, m_num_orch_desc = 1, m_orch_desc[0].op = dm_orch_type_channel_sel, m_orch_desc[0].submit = true | The command object should be initialized correctly; all EXPECT assertions in the test should pass confirming the expected behavior when a non-numeric channel is provided. | Should Pass |
  */
 TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_non_numeric_channel_input) {
     std::cout << "Entering em_cmd_set_channel_t_non_numeric_channel_input test" << std::endl;
@@ -167,7 +167,7 @@ TEST(em_cmd_set_channel_t, em_cmd_set_channel_t_non_numeric_channel_input) {
     EXPECT_STREQ(cmd.m_name, "set_channel");
     EXPECT_STREQ(cmd.m_param.u.args.fixed_args, "abc");
     EXPECT_EQ(cmd.m_svc, em_service_type_ctrl);
-    EXPECT_EQ(cmd.m_num_orch_desc, 2);
+    EXPECT_EQ(cmd.m_num_orch_desc, 1);
     EXPECT_EQ(cmd.m_orch_desc[0].op, dm_orch_type_channel_sel);
     EXPECT_TRUE(cmd.m_orch_desc[0].submit);
     cmd.deinit();

--- a/tests/test_l1_em_cmd_sta_assoc.cpp
+++ b/tests/test_l1_em_cmd_sta_assoc.cpp
@@ -39,7 +39,7 @@
  * | Variation / Step | Description | Test Data | Expected Result | Notes |
  * | :----: | --------- | ---------- |-------------- | ----- |
  * | 01 | Set up valid parameters for the API call | validParam.u.args.num_args = 1, validParam.u.args.args[0] = "ValidArg", validParam.u.args.fixed_args = "FixedValid", dm instance of dm_easy_mesh_t | Parameters are set correctly and ready for use | Should be successful |
- * | 02 | Construct the em_cmd_sta_assoc_t object using valid parameters | Input: validParam and dm | Object's members m_param reflect the provided valid parameters; m_type equals em_cmd_type_sta_assoc; m_name equals "sta_assoc"; m_svc equals em_service_type_ctrl; m_orch_op_idx equals 0; m_num_orch_desc equals 1; m_orch_desc[0].op equals dm_orch_type_sta_cap; m_orch_desc[0].submit equals true; m_data_model.m_cmd_ctx.type equals dm_orch_type_sta_cap | Should Pass |
+ * | 02 | Construct the em_cmd_sta_assoc_t object using valid parameters | Input: validParam and dm | Object's members m_param reflect the provided valid parameters; m_type equals em_cmd_type_sta_assoc; m_name equals "sta_assoc"; m_svc equals em_service_type_ctrl; m_orch_op_idx equals 0; m_num_orch_desc equals 3; m_orch_desc[0].op equals dm_orch_type_topo_sync; m_orch_desc[1].op equals dm_orch_type_sta_cap; m_orch_desc[2].op equals dm_orch_type_topo_publish; all submit equals true; m_data_model.m_cmd_ctx.type equals dm_orch_type_topo_sync | Should Pass |
  * | 03 | Validate object properties using assertions | Comparisons: em_cmd_sta_assoc_t object's members against expected values | EXPECT_EQ and EXPECT_STREQ assertions confirm correct initialization | Should Pass |
  * | 04 | Invoke deinit to cleanup the object | API call: assoc.deinit() | Successful deinitialization without errors | Should Pass |
  */
@@ -59,12 +59,14 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_parameters) {
     EXPECT_STREQ(assoc.m_name, "sta_assoc");
     EXPECT_EQ(assoc.m_svc, em_service_type_ctrl);
     EXPECT_EQ(assoc.m_orch_op_idx, 0);
-    EXPECT_EQ(assoc.m_num_orch_desc, 2);
-    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_num_orch_desc, 3);
+    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_topo_sync);
     EXPECT_TRUE(assoc.m_orch_desc[0].submit);
-    EXPECT_EQ(assoc.m_orch_desc[1].op, dm_orch_type_topo_publish);
+    EXPECT_EQ(assoc.m_orch_desc[1].op, dm_orch_type_sta_cap);
     EXPECT_TRUE(assoc.m_orch_desc[1].submit);
-    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_orch_desc[2].op, dm_orch_type_topo_publish);
+    EXPECT_TRUE(assoc.m_orch_desc[2].submit);
+    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_topo_sync);
     assoc.deinit();
     std::cout << "Exiting em_cmd_sta_assoc_t_valid_parameters test" << std::endl;
 }
@@ -87,7 +89,7 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_parameters) {
  * | 01 | Initialize em_cmd_params_t with minimal parameters | num_args = 0, fixed_args = "" | Structure initialized with zero arguments and empty fixed_args | Should be successful |
  * | 02 | Instantiate dm_easy_mesh_t object | None | dm object created successfully | Should be successful |
  * | 03 | Invoke em_cmd_sta_assoc_t constructor with minimal parameters | param (num_args = 0, fixed_args = ""), dm instance | em_cmd_sta_assoc_t object constructed with default values | Should Pass |
- * | 04 | Validate initialized fields of em_cmd_sta_assoc_t object | assoc.m_param.u.args.num_args = 0, assoc.m_param.u.args.fixed_args = "", assoc.m_type = em_cmd_type_sta_assoc, assoc.m_name = "sta_assoc", assoc.m_svc = em_service_type_ctrl, assoc.m_orch_op_idx = 0, assoc.m_num_orch_desc = 1, assoc.m_orch_desc[0].op = dm_orch_type_sta_cap, assoc.m_orch_desc[0].submit = true, assoc.m_data_model.m_cmd_ctx.type = dm_orch_type_sta_cap | Each field matches expected value as per the API design | Should Pass |
+ * | 04 | Validate initialized fields of em_cmd_sta_assoc_t object | assoc.m_param.u.args.num_args = 0, assoc.m_param.u.args.fixed_args = "", assoc.m_type = em_cmd_type_sta_assoc, assoc.m_name = "sta_assoc", assoc.m_svc = em_service_type_ctrl, assoc.m_orch_op_idx = 0, assoc.m_num_orch_desc = 3, assoc.m_orch_desc[0].op = dm_orch_type_topo_sync, assoc.m_orch_desc[1].op = dm_orch_type_sta_cap, assoc.m_orch_desc[2].op = dm_orch_type_topo_publish, all submit = true, assoc.m_data_model.m_cmd_ctx.type = dm_orch_type_topo_sync | Each field matches expected value as per the API design | Should Pass |
  * | 05 | Cleanup by invoking deinit() method on the em_cmd_sta_assoc_t object | None | Object deinitialized successfully | Should be successful |
  */
 TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_minimal_parameters) {
@@ -105,10 +107,14 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_minimal_parameters) {
     EXPECT_STREQ(assoc.m_name, "sta_assoc");
     EXPECT_EQ(assoc.m_svc, em_service_type_ctrl);
     EXPECT_EQ(assoc.m_orch_op_idx, 0);
-    EXPECT_EQ(assoc.m_num_orch_desc, 2);
-    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_num_orch_desc, 3);
+    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_topo_sync);
     EXPECT_TRUE(assoc.m_orch_desc[0].submit);
-    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_orch_desc[1].op, dm_orch_type_sta_cap);
+    EXPECT_TRUE(assoc.m_orch_desc[1].submit);
+    EXPECT_EQ(assoc.m_orch_desc[2].op, dm_orch_type_topo_publish);
+    EXPECT_TRUE(assoc.m_orch_desc[2].submit);
+    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_topo_sync);
     assoc.deinit();
     std::cout << "Exiting em_cmd_sta_assoc_t_valid_minimal_parameters test" << std::endl;
 }
@@ -132,7 +138,7 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_valid_minimal_parameters) {
  * | 02 | Initialize the first argument in args array with maximum characters. | args[0] = 127 'Y' characters, null-terminated | The args[0] string in param is correctly set and null-terminated. | Should be successful |
  * | 03 | Set num_args value and prepare the parameter structure before constructor invocation. | num_args = 5 | The num_args field in param is set to 5. | Should be successful |
  * | 04 | Call the em_cmd_sta_assoc_t constructor with the parameter structure and dm instance. | Input: param structure and dm instance | A new assoc instance is created with its members initialized according to the input parameters, including m_param.u.args, m_type, m_name, m_svc, m_orch_op_idx, m_num_orch_desc, m_orch_desc, and m_data_model fields. | Should Pass |
- * | 05 | Verify the initialization by asserting each member's value and then deinitialize the instance. | Expected values: num_args = 5, fixed_args, args[0] match, m_type = em_cmd_type_sta_assoc, m_name = "sta_assoc", m_svc = em_service_type_ctrl, m_orch_op_idx = 0, m_num_orch_desc = 1, m_orch_desc[0].op = dm_orch_type_sta_cap, m_orch_desc[0].submit true, m_data_model.m_cmd_ctx.type = dm_orch_type_sta_cap. | All assertions pass confirming the proper initialization. | Should Pass |
+ * | 05 | Verify the initialization by asserting each member's value and then deinitialize the instance. | Expected values: num_args = 5, fixed_args, args[0] match, m_type = em_cmd_type_sta_assoc, m_name = "sta_assoc", m_svc = em_service_type_ctrl, m_orch_op_idx = 0, m_num_orch_desc = 3, m_orch_desc[0].op = dm_orch_type_topo_sync, m_orch_desc[1].op = dm_orch_type_sta_cap, m_orch_desc[2].op = dm_orch_type_topo_publish, all submit true, m_data_model.m_cmd_ctx.type = dm_orch_type_topo_sync. | All assertions pass confirming the proper initialization. | Should Pass |
  */
 TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_ctor_max_fixed_args) {
     std::cout << "Entering em_cmd_sta_assoc_t_ctor_max_fixed_args test" << std::endl;
@@ -157,10 +163,14 @@ TEST(em_cmd_sta_assoc_t, em_cmd_sta_assoc_t_ctor_max_fixed_args) {
     EXPECT_STREQ(assoc.m_name, "sta_assoc");
     EXPECT_EQ(assoc.m_svc, em_service_type_ctrl);
     EXPECT_EQ(assoc.m_orch_op_idx, 0);
-    EXPECT_EQ(assoc.m_num_orch_desc, 2);
-    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_num_orch_desc, 3);
+    EXPECT_EQ(assoc.m_orch_desc[0].op, dm_orch_type_topo_sync);
     EXPECT_TRUE(assoc.m_orch_desc[0].submit);
-    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_sta_cap);
+    EXPECT_EQ(assoc.m_orch_desc[1].op, dm_orch_type_sta_cap);
+    EXPECT_TRUE(assoc.m_orch_desc[1].submit);
+    EXPECT_EQ(assoc.m_orch_desc[2].op, dm_orch_type_topo_publish);
+    EXPECT_TRUE(assoc.m_orch_desc[2].submit);
+    EXPECT_EQ(assoc.m_data_model.m_cmd_ctx.type, dm_orch_type_topo_sync);
     assoc.deinit();
     std::cout << "Exiting em_cmd_sta_assoc_t_ctor_max_fixed_args test" << std::endl;
 }

--- a/tests/test_l1_em_msg.cpp
+++ b/tests/test_l1_em_msg.cpp
@@ -3590,7 +3590,10 @@ TEST(em_msg_t, get_next_tlv_buff_len_zero) {
 /**
  * @brief Test the retrieval of valid client MAC information from a TLV buffer.
  *
- * This test verifies that the API successfully parses a TLV buffer containing valid client information including the MAC address, correctly extracting and returning the MAC address. The test ensures the API works as expected and confirms the integrity of the TLV parsing.
+ * This test verifies that the get_client_mac_info API successfully parses a TLV buffer containing a valid
+ * em_client_info_t structure (comprising both a BSSID and a client MAC address), and correctly extracts
+ * the client MAC address into the output buffer. The test ensures the API returns true and that the
+ * extracted MAC address matches the expected value.
  *
  * **Test Group ID:** Basic: 01
  * **Test Case ID:** 101
@@ -3601,18 +3604,23 @@ TEST(em_msg_t, get_next_tlv_buff_len_zero) {
  * **User Interaction:** None
  *
  * **Test Procedure:**
- * | Variation / Step | Description                                                                                  | Test Data                                                                                                     | Expected Result                                                                                            | Notes            |
- * | :--------------: | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- |
- * |      01        | Initialize the TLV buffer and write valid client info including MAC using write_tlv            | buffer size = TLV_HEADER_SIZE + 6, mac_val = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB}                             | Buffer contains valid TLV with correct client information                                                  | Should be successful |
- * |      02        | Create an instance of em_msg_t using the prepared TLV buffer                                   | buffer, buffer length = TLV_HEADER_SIZE + 6                                                                   | em_msg_t object is successfully created                                                                    | Should be successful |
- * |      03        | Call get_client_mac_info to extract the MAC address and compare it with the expected MAC value | output pointer to mac (6 bytes), expected mac_val = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB}                         | Function returns true and the extracted MAC address matches the expected value as per EXPECT_TRUE and EXPECT_EQ | Should Pass       |
+ * | Variation / Step | Description                                                                                        | Test Data                                                                                                                                                                           | Expected Result                                                                                            | Notes                |
+ * | :--------------: | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------- |
+ * |      01        | Populate an em_client_info_t structure with a known BSSID and client MAC address                     | bssid = {0x00,0x11,0x22,0x33,0x44,0x55}, mac_val = {0x01,0x23,0x45,0x67,0x89,0xAB}                                                                                                  | em_client_info_t fields are set to the expected values                                                     | Should be successful |
+ * |      02        | Write the em_client_info_t structure as a client info TLV into the buffer using write_tlv            | buffer size = TLV_HEADER_SIZE + sizeof(em_client_info_t), TLV type = em_tlv_type_client_info, value = reinterpret_cast of em_client_info_t, length = sizeof(em_client_info_t)       | Buffer contains a valid em_tlv_type_client_info TLV with the correct payload                               | Should be successful |
+ * |      03        | Create an instance of em_msg_t using the prepared TLV buffer                                         | buffer, buffer length = sizeof(buffer)                                                                                                                                              | em_msg_t object is successfully created                                                                    | Should be successful |
+ * |      04        | Call get_client_mac_info to extract the client MAC address and compare with the expected value       | output pointer to mac (6 bytes, initialized to zeros), expected mac_val = {0x01,0x23,0x45,0x67,0x89,0xAB}                                                                           | function returns true, the extracted MAC address matches mac_val as verified by EXPECT_TRUE and EXPECT_EQ  | Should Pass          |
  */
 TEST(em_msg_t, get_client_mac_info_valid_client_info_tlv)
 {
     std::cout << "Entering get_client_mac_info_valid_client_info_tlv test" << std::endl;
-    unsigned char buffer[TLV_HEADER_SIZE + 6];
+    unsigned char buffer[TLV_HEADER_SIZE + sizeof(em_client_info_t)];
+    unsigned char bssid[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
     unsigned char mac_val[6] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB};
-    write_tlv(buffer, em_tlv_type_client_info, mac_val, sizeof(mac_val));
+    em_client_info_t client_info;
+    memcpy(client_info.bssid, bssid, sizeof(bssid));
+    memcpy(client_info.client_mac_addr, mac_val, sizeof(mac_val));
+    write_tlv(buffer, em_tlv_type_client_info, reinterpret_cast<unsigned char*>(&client_info), sizeof(client_info));
     em_msg_t msg(buffer, sizeof(buffer));
     unsigned char mac[6] = {0};
     bool ret = msg.get_client_mac_info(reinterpret_cast<mac_address_t*>(mac));

--- a/tests/test_l1_em_orch.cpp
+++ b/tests/test_l1_em_orch.cpp
@@ -842,7 +842,7 @@ TEST_F(EmOrchTest, ZeroCommands) {
  * **Test Procedure:**
  * | Variation / Step | Description                                            | Test Data                           | Expected Result                              | Notes      |
  * | :--------------: | ------------------------------------------------------ | ----------------------------------- | -------------------------------------------- | ---------- |
- * |       01         | Invoke submit_commands with a nullptr command pointer  | commands = nullptr, num = 3           | Returns 0 and EXPECT_NE(result, 0) assertion   | Should Pass|
+ * |       01         | Invoke submit_commands with a nullptr command pointer  | commands = nullptr, num = 3           | Returns 0 and EXPECT_EQ(result, 0) assertion   | Should Pass|
  */
 TEST_F(EmOrchTest, NullCommandsPointer) {
     std::cout << "Entering NullCommandsPointer test" << std::endl;
@@ -850,7 +850,7 @@ TEST_F(EmOrchTest, NullCommandsPointer) {
     std::cout << "Invoking submit_commands with a nullptr for the command array and num = 3" << std::endl;
     unsigned int result = orch->submit_commands(nullptr, 3);
     std::cout << "submit_commands returned: " << result << std::endl;
-    EXPECT_NE(result, 0);
+    EXPECT_EQ(result, 0);
 
     std::cout << "Exiting NullCommandsPointer test" << std::endl;
 }

--- a/tests/test_l1_em_orch_agent.cpp
+++ b/tests/test_l1_em_orch_agent.cpp
@@ -787,7 +787,7 @@ TEST_F(em_orch_agent_t_TEST, ZeroCommands) {
 /**
  * @brief Verify that submit_commands handles a nullptr command array correctly.
  *
- * This test verifies that when a nullptr is passed as the command array along with a valid count (num = 3), the submit_commands API returns a non-zero value. This behavior indicates that the function correctly handles invalid input.
+ * This test verifies that when a nullptr is passed as the command array along with a valid count (num = 3), the submit_commands API returns 0 (no commands submitted). This behavior indicates that the function handles the null command array gracefully without crashing.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 023@n
@@ -800,14 +800,14 @@ TEST_F(em_orch_agent_t_TEST, ZeroCommands) {
  * **Test Procedure:**
  * | Variation / Step | Description                                                        | Test Data                                 | Expected Result                                   | Notes       |
  * | :--------------: | ------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------------------- | ----------- |
- * | 01               | Invoke submit_commands with a nullptr for the command array and num=3 | command = nullptr, num = 3                | Return value is non-zero and EXPECT_NE(result, 0) passes | Should Pass |
+ * | 01               | Invoke submit_commands with a nullptr for the command array and num=3 | command = nullptr, num = 3                | No commands submitted; returns 0 and EXPECT_EQ(result, 0) passes | Should Pass |
  */
 TEST_F(em_orch_agent_t_TEST, NullCommandsPointer) {
     std::cout << "Entering NullCommandsPointer test" << std::endl;
     std::cout << "Invoking submit_commands with a nullptr for the command array and num = 3" << std::endl;
     unsigned int result = orch->submit_commands(nullptr, 3);
     std::cout << "submit_commands returned: " << result << std::endl;
-    EXPECT_NE(result, 0);
+    EXPECT_EQ(result, 0);
     std::cout << "Exiting NullCommandsPointer test" << std::endl;
 }
 /**

--- a/tests/test_l1_em_orch_ctrl.cpp
+++ b/tests/test_l1_em_orch_ctrl.cpp
@@ -786,7 +786,7 @@ TEST_F(em_orch_ctrl_t_TEST, ZeroCommands) {
 /**
  * @brief Verify that submit_commands handles a nullptr command array correctly.
  *
- * This test verifies that when a nullptr is passed as the command array along with a valid count (num = 3), the submit_commands API returns a non-zero value. This behavior indicates that the function correctly handles invalid input.
+ * This test verifies that when a nullptr is passed as the command array along with a valid count (num = 3), the submit_commands API returns 0 (no commands submitted). This behavior indicates that the function handles the null command array gracefully without crashing.
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 023@n
@@ -799,14 +799,14 @@ TEST_F(em_orch_ctrl_t_TEST, ZeroCommands) {
  * **Test Procedure:**
  * | Variation / Step | Description                                                        | Test Data                                 | Expected Result                                   | Notes       |
  * | :--------------: | ------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------------------- | ----------- |
- * | 01               | Invoke submit_commands with a nullptr for the command array and num=3 | command = nullptr, num = 3                | Return value is non-zero and EXPECT_NE(result, 0) passes | Should Pass |
+ * | 01               | Invoke submit_commands with a nullptr for the command array and num=3 | command = nullptr, num = 3                | No commands submitted; returns 0 and EXPECT_EQ(result, 0) passes | Should Pass |
  */
 TEST_F(em_orch_ctrl_t_TEST, NullCommandsPointer) {
     std::cout << "Entering NullCommandsPointer test" << std::endl;
     std::cout << "Invoking submit_commands with a nullptr for the command array and num = 3" << std::endl;
     unsigned int result = orch->submit_commands(nullptr, 3);
     std::cout << "submit_commands returned: " << result << std::endl;
-    EXPECT_NE(result, 0);
+    EXPECT_EQ(result, 0);
     std::cout << "Exiting NullCommandsPointer test" << std::endl;
 }
 /**


### PR DESCRIPTION
RDKBWIFI-430: Update build.yml container with ubuntu 20.04 (#675)

Signed-off-by: prashant-singh1 <prashant.singh8521@gmail.com>

Issue 657 : Crash in handle_assoc_sta_ext_link_metrics_tlv (#658)

* Issue 657 : Crash in handle_assoc_sta_ext_link_metrics_tlv

Problem:

-The function processes the Associated STA Extended Link Metrics TLV without validating the TLV length against the specification. -It directly casts the bffer into a structure and accesses fields based on k (number of BSSIDs) -If the TLV length is:
     *less than 7 → mandatory fields are missing
     *not equal to (7 + k × 22) → metrics fields are incomplete
-The function crashes when TLV length is not validated against the specification and partial data is parsed. -As per spec, valid TLV length must be: Length = 7 + (k × 22), where 7 bytes = STA MAC (6) + k (1). -Valid cases: k=0 → 7, k=1 → 29, k=2 → 51, k=3 → 73, etc.
     *For k=1: any value between 7 + 22 = 29 (i.e., >7 and <29) causes crash due to incomplete metrics.
     *For k=2: any value between 29 and 51 (i.e., >29 and <51) causes crash due to partial second entry.
     *For k=3: any value between 51 and 73 (i.e., >51 and <73) also causes crash; hence only exact lengths are valid.
-This results in out-of-bounds memory access and leads to crashes. Therefore, TLV length must strictly match the expected value derived from k to ensure safe parsing.

Fixed:

   *Added Check 1: (buff == NULL || tlv_len == 0 || tlv_len < 7) → ensures mandatory fields
   *Added Check 2: (tlv_len == 7 + (k × sizeof(em_assoc_ext_link_metrics_t))) → enforces spec length (22 bytes per block)
-Invalid TLVs are now rejected safely with -1, preventing crashes.

Signed-off-by: Yashodha KB <yakshagowda37@gmail.com>

* addressed reviews

Signed-off-by: Yashodha KB <yakshagowda37@gmail.com>

* addressed reviews

Signed-off-by: Yashodha KB <yakshagowda37@gmail.com>

* addressed reviews

Signed-off-by: Yashodha KB <yakshagowda37@gmail.com>

---------

Signed-off-by: Yashodha KB <yakshagowda37@gmail.com>

Issue 637: Crash/Memory corruption in handle_bsta_cap_report (#639)

Problem/Opportunity

Problem 1: handle_bsta_cap_report does not handle TLVs of invalid lengths causing crashes.
Problem 2: handle_bsta_cap_report writes "dm->m_device.m_device_info.backhaul_sta" with contents of client info TLV, when two TLVs are received. Where first tlv is bsta_radio_cap with bsta_mac_present=0 and second tlv is client info tlv
Problem 3: (Optimisation) handle_bsta_cap_report contains repetitive code for handling TLVs

Fix provided
1. Handle tlv lengths properly in handle_bsta_cap_report
2. Handle bsta_mac_present flag in handle_bsta_radio_cap
3. Introduce process_tlv_loop to handle common tlv checks

Testing done
1. Function handle_bsta_cap_report is unit tested with ASAN in application space
2. 52 different combinations of BSTA CAP REPORT packet is tested.

Signed-off-by: Yashodha KB <yakshagowda37@gmail.com>
Co-authored-by: Yashodha KB <yashodhagowdakb@gmail.com>

Issue #654 : Crash in handle_assoc_sta_link_metrics_tlv (#655)

Problem:

    -The function processes the Associated STA Link Metrics TLV without validating the TLV length against the specification.

    -It directly casts the buffer into a structure and accesses fields based on k (number of BSSIDs)
    -If the TLV length is:
       *less than 7 → mandatory fields are missing
       *not equal to (7 + k × 19) → metrics fields are incomplete

Steps to reproduce:

    -Construct an Associated STA Link Metrics TLV with k = 1 but an invalid length (e.g., 14 instead of 26 as per spec).
    -Pass this TLV to handle_assoc_sta_link_metrics_tlv(buff, tlv_len).
    -Before the fix, the function directly casts the buffer and accesses metrics fields without validating length, leading to out-of-bounds access and crash.

Fixed:

    -Added Check 1: (buff == NULL || tlv_len == 0 || tlv_len < 7) ensures minimum mandatory fields are present.
    -Added Check 2: (tlv_len == 7 + (k × sizeof(em_assoc_link_metrics_t))) enforces spec-compliant length.
    -Invalid TLVs are now safely rejected with -1, preventing crashes and ensuring safe parsing.

Signed-off-by: Yashodha KB <yakshagowda37@gmail.com>

RDKBWIFI-385: [Easymesh] Disable ASAN by default for em_ctrl and align build flags with em_agent

RDKBWIFI-427: AP Metrics response processing failed.

Added a condition to include TLVs based on the actual profile. Instead of using a hardcoded profile_type , we now retrieve the profile_type dynamically and validating.

RDKBWIFI-387: Channel Scan Report - Fix BSS Load element handling (#622) (#622)

Problem:
BSS Load element fields were being populated even when the IE was not present. Station count was incorrectly hardcoded to zero.

Fix:
Populate BSS Load element fields only when the IE is present. When present, extract station count and channel utilization from the Probe Response. Propagate these values correctly into the Channel Scan Result TLV.

Impact:
Ensures accurate reporting of BSS Load information in Channel Scan Reports. Prevents invalid or misleading values when the IE is absent.

Signed-off-by: Sangeetha <sangeetha.s1@tataelxsi.co.in>

RDKBWIFI-364 : Generalizing bus abstraction functions for retrieving and setting bus data property types. (#670)

This reverts commit 8780ce2e9299b8fe17804ea996c86acf15be0526.

Bringing in bus abstraction related changes

RDKBWIFI-426: Trigger orchestration immediately on command queueing to improve responsiveness (#671)

Changes to trigger orchestration event on queuing a command for immediate processing
- Added em_event_type_orch to event enumeration
- Updated em_mgr_t::start() to call the orchestration handler on event
- Updated em_orch_t::submit_command() to trigger orchestration event on queuing command

This ensures commands are processed with minimal latency, improving orchestration responsiveness.

Signed-off-by: Sachin Chougale <cm.sachin@capgemini.com>

RDKBWIFI-408: SteerWiFiBackhaul (parse only), ChannelScanRequest and … (#652)

* RDKBWIFI-408: SteerWiFiBackhaul (parse only), ChannelScanRequest and Disassociate methods for TR-181 added

Reason for change: Getters, setters and methods of WFA datamodel parameters are needed for TR-181. Test Procedure: (RDKB) rbuscli may be used to get parameters. Some examples:
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.MultiAPDevice.Backhaul.SteerWiFiBackhaul()" TargetBSS string "81:12:13:14:15:16" TimeOut uint32 1000
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.Radio.1.ChannelScanRequest()" OpClass uint32 81 ChannelList string "6,9"
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.Radio.1.BSS.1.STA.1.MultiAPSTA.Disassociate()" DisassociationTimer uint32 3 ReasonCode uint32 5
Risks: Low

Signed-off-by: Engin Akca <engin.akca@airties.com>

* RDKBWIFI-408: SteerWiFiBackhaul (parse only), ChannelScanRequest and Disassociate methods for TR-181 added

Reason for change: Getters, setters and methods of WFA datamodel parameters are needed for TR-181. Test Procedure: (RDKB) rbuscli may be used to get parameters. Some examples:
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.MultiAPDevice.Backhaul.SteerWiFiBackhaul()" TargetBSS string "81:12:13:14:15:16" TimeOut uint32 1000
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.Radio.1.ChannelScanRequest()" OpClass uint32 81 ChannelList string "6,9"
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.Radio.1.BSS.1.STA.1.MultiAPSTA.Disassociate()" DisassociationTimer uint32 3 ReasonCode uint32 5
Risks: Low

Signed-off-by: Engin Akca <engin.akca@airties.com>

* RDKBWIFI-408: SteerWiFiBackhaul (parse only), ChannelScanRequest and Disassociate methods for TR-181 added

Reason for change: Getters, setters and methods of WFA datamodel parameters are needed for TR-181. Test Procedure: (RDKB) rbuscli may be used to get parameters. Some examples:
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.MultiAPDevice.Backhaul.SteerWiFiBackhaul()" TargetBSS string "81:12:13:14:15:16" TimeOut uint32 1000
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.Radio.1.ChannelScanRequest()" OpClass uint32 81 ChannelList string "6,9"
  rbuscli method_values "Device.WiFi.DataElements.Network.Device.1.Radio.1.BSS.1.STA.1.MultiAPSTA.Disassociate()" DisassociationTimer uint32 3 ReasonCode uint32 5
Risks: Low

Signed-off-by: Engin Akca <engin.akca@airties.com>

---------

Signed-off-by: Engin Akca <engin.akca@airties.com>

[RDKBWIFI-397][RDK Agent]Channel selection for different OPClass is not successful (#677)

Signed-off-by: sri-kanyaraasi.seelapalli@capgemini.com <sri-kanyaraasi.seelapalli@capgemini.com>

updated to send query once

[RDKBWIFI-436][RDK Controller] Channel Selection for Agents To send all OPCLASS and Channels in Channel Selection Request Implementation:
        Building the default MAP opclass->channel->preference (opclass_channel_prefs)
	-- Update map from m_e4_table and set default preference 1 for all Opclasses/Channels
	-- Marks non-operable channels in the supported operating classes from AP Capability Report with preference 0
	-- Updates non-operable/operable preference from Preference Report, Overrides operable/non-operable preference from Capability Report
	-- Remove unsupported opclasses from the map
        -- Create a merged list of anticipated entries for Global, Device and RUID
        -- Update map with preferences from merged list
        Building the message
        -- Add Channel preference TLV for each opclass from the map opclass_channel_prefs
	Initial tests: Channel change is working fine with PRPL Agent on all radio bands to set different channels in an opclass

RDKBWIFI-443: Orchestration optimisation - Triggering the proto process and orchestration on state change(#676) (#676)

- Refactor em_t::set_state() to trigger orchestration on state transitions
- Enqueue em_event_type_orch events to both EM thread and manager queues
- Add orch event handling in protocol loop to invoke agent/ctrl handlers

Ensures immediate processing after state updates, improving orchestration responsiveness.

Signed-off-by: akshaya3495 <akshaya.tatikonda@capgemini.com>

RDKBWIFI-322: AP capabilities - Channel sca, CAC, Device Inventory etc are enabled! (#673)

- Enable EHT ops and move handle eht tlv common in em.cpp

RDKBWIFI-438: Fixing warnings in em_agent (#680)

* Fixed logs warnigns

* Fixed agent warnings

* updated em_agent_t::handle_recv_wfa_action_frame and em_agent_t::input_listener with em_printfout

* update dm_easy_mesh_agent_t::analyze_scan_result and dm_easy_mesh_agent_t::analyze_btm_request_action_frame with em_printfout

RDKBWIFI-448: Fixing various easymesh issues (#682)

* RDKBWIFI-448: Fixing various easymesh issues

* Fixed tests

* updated log messages in em_capability reports

RDKBWIFI-451: EasyMesh controller failing on configuration due to failed validation of mandatory TLVs (#685)

Reason for change: The EasyMesh controller fails to receive a response to the AP query message because validation fails at the agent due to missing mandatory TLVs. As a result, the response is dropped at the em_agent, causing configuration failure. When these TLVs are marked as optional, validation passes, and the response is successfully sent and received.

Risks: Low

Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>

RDKBWIFI-450: Handle AP metrics response (#683)

TDK-11818: Fixed few runtime erros and failures

Refactor deserialization test case structure

Comment out the original test case for deserialization and retain the new test case structure.

RDKBWIFI-451: EasyMesh controller failing on configuration due to failed validation of mandatory TLVs (#688)

Reason for change: Enabled validation on AP CAP response msg. This adds additional protective measures on TLVs inserted in response.
Risks: Low

Refactor SetUp and TearDown methods in tests

This fixes runtime errors observed in latest unit test binary execution in BPI device.

Reverting orchestration changes done for fast onboarding -  which are causing some raceconditions  (#697)

* Revert "RDKBWIFI-443: Orchestration optimisation - Triggering the proto process and orchestration on state change(#676) (#676)"

This reverts commit 965c23a994b0694b8b823bd8f110d137d907613c.

* Revert "RDKBWIFI-426: Trigger orchestration immediately on command queueing to improve responsiveness (#671)"

This reverts commit 777db9a8f4903ae0a36d69e8cbd855d7c715d09b.

RDKBWIFI-463: Minor topology graph improvement for rdkb cli (#696)

Reason for change:
1. To persist the drag and zoom across refresh until browser is not reloaded.
2. if haultype is more than 3, the circle should also arrange accordingly.

Risks: Low

Signed-off-by: prashant-singh1 <prashant.singh8521@gmail.com>

RDKBWIFI-464: EasyMesh - Client Assoc/Disassoc notification (#698)

Reason for change: Added changes to update support for client Assoc/Disassoc notification in EasyMesh with MLO clients. Test Procedure: Ensure Client Assoc/Disassoc notification works properly. Risks:Medium
Priority:P1

Signed-off-by: Vadivel-M9791 <vadivel.m@tataelxsi.co.in>

Multi-ap policy config (#699)

* Added multi ap policy support for Backhaul BSS Config Policy, Report Unsuccessful Associations Policy QoS Management Policy

Signed-off-by: prashant-singh1 <prashant.singh8521@gmail.com>

easy-mesh: add radio supported standards vendor TLV support (#672)

Introduce Airties vendor-specific TLV to report supported IEEE 802.11 standards per radio interface within EasyMesh capability reporting.

This change adds:
- New supported standards bitmask representation (a/b/g/n/ac/ax/be/bn)
- Conversion logic from internal WiFi variant flags to TLV format
- Airties vendor-specific TLV creation and parsing logic
- Data model exposure via X_AIRTIES_OperatingStandards parameter
- JSON schema and TR-181 mapping updates
- EasyMesh controller propagation for radio capability updates

The supported standards are now included in AP capability reports and processed by controllers using a vendor OUI-based TLV extension.

Issue: RDKBWIFI-428

Signed-off-by: Nefi Guclu <guclunefi@gmail.com>
Co-authored-by: nikunjshah-cap <125440046+nikunjshah-cap@users.noreply.github.com>
Co-authored-by: Nikita Hakai <nikita_hakai@comcast.com>

RDKBWIFI-467: Multi-ap policy config (#703)

Reason for change:
    Fixed crash issue  while updating policy with extenders
    Fixed some minor CLI issue
Test procedure:
    Tested the changes by updating available policies with a extender onboarded. Observed able to update the policies

Risk: Medium
Priority: Low

Signed-off-by: Vadivel-M9791 <vadivel.m@tataelxsi.co.in>

RDKBWIFI-445: Fixed binary data comparison in webconfig (#691)

* RDKBWIFI-445: Fixed binary data comparison in webconfig

* fixed review comment - use clt mapped to buff properly

dm_policy_list_t::sync_db: restore missing net_id (#702)

Copy net_id from the parsed policy key to reconstruct the complete policy identifier.

Issue: RDKBWIFI-468

Signed-off-by: Nefi Guclu <guclunefi@gmail.com>

review comments

mlo client mapping fix

Add end-to-end Unassociated STA Link Metrics query/response handling (#684)

- Added Unassociated STA Link Metrics Query handling
- Added 1905 ACK generation with Error Code TLV and transmission for query messages
- Added forwarding of query details to OneWiFi through subdoc interface
- Added handling of OneWiFi response
- Added Unassociated STA Link Metrics TLV creation and parsing
- Added response message build and transmission to controller
- Added per-opclass response handling and storing the data in the dm
- Added debug logs for query, ACK, subdoc, and response flow

Signed-off-by: Sangeetha <sangeetha.s1@tataelxsi.co.in>

RDKBWIFI-464:  Fix issue with clients DB data override and empty stats value.

Reason for change: Added changes to fix issue observed with clients DB data override when a new STA joins the network and empty stats values for client disassoc notification message.
Test Procedure: Ensure Client Assoc/Disassoc notification works properly.
Risks: Medium
Priority: P1

Signed-off-by: Vadivel-M9791 <vadivel.m@tataelxsi.co.in>

Fixing dm_easy_mesh_list, dm_assoc_sta_mld and em_cmd_sta_assoc unit tests (#717)

* Fixing dm_easy_mesh_list and em_cmd_sta_assoc unit tests

* fixed dm_assoc_sta_mld by adding clamp for num_affiliated_sta

mlo non mlo bssid mapping fix

mlo client fixes for beaocn query

Fix onewifi_em_ctrl crash on Apply Radio Settings (#715)

Pressing "Apply Radio Settings" crashed and restarted the controller on every Apply (NULL em_cmd dereference in submit_commands).

Root cause: the anticipated channel preference is carried at Network scope in the subdoc, but it was parsed from Device scope. Parsing always failed and returned a negative error code, which the handler cast to a huge unsigned command count and passed to submit_commands over an all NULL array. This also meant the preference set from the UI was never applied.

Fix:
- Parse anticipated preference from Network scope (the canonical scope, per the get_channel_config producer) so Apply actually applies it.
- Treat a negative analyze_* result as no-submit (== 0 -> <= 0), and map non-zero errors to invalid_input instead of no_change.
- Harden submit_commands: NULL array check, clamp to EM_MAX_CMD, skip NULL slots; bound op-class/channel-list parsing to their array limits.
- Replace a strict op-class-count assert with a graceful no-op.
- Align the lagging Device-scope test fixtures and Channel.json sample to Network scope, and fix the NullCommandsPointer test expectation.

Issue: RDKBWIFI-480

Signed-off-by: Durmus Koyuncu <durmus.kyncu.kd@gmail.com>

Fix op-class profile counts and expose CapableOperatingClassProfile (#712)

Under Device.WiFi.DataElements.Network.Device.{i}.Radio.{i}:
- CurrentOperatingClassProfileNumberOfEntries and Capabilities.CapableOperatingClassProfileNumberOfEntries were hardcoded to 0 in em_ctrl, so they did not match the actual number of rows.
- The Capabilities.CapableOperatingClassProfile.{i} table had no getter bound and fell back to the default callback, so the radio's supported operating classes were not exposed.

Changes (dm_easy_mesh_ctrl, tr_181):
- Derive both NumberOfEntries counters from the data model by counting op-class entries matching the radio RUID, filtered by current / capability type.
- Implement the CapableOperatingClassProfile.{i} table mirroring the existing CurrentOperatingClassProfile path: capops_get/tget(+_inner), capops_tget_params, get_dm_capop, the tr_181_t wrappers, and the ELEMENT() registrations for Class, MaxTxPower, NumberOfNonOperChan and NonOperable (comma-separated channel list via get_capop_nonoper_str).

Issue: RDKBWIFI-475

Signed-off-by: Durmus Koyuncu <durmus.kyncu.kd@gmail.com>

RDKBWIFI-481: Observed Ctrl crash on wifi reset. (#729)

Reason for change:
Fixed controller crash while wifi reset.

Test procedure:
Tested the changes with wifi reset and did not observed any crash in ctrl or agent.

Risk: Medium

Priority: Low

Signed-off-by: prashant-singh1 <prashant.singh8521@gmail.com>

RDKBWIFI-495 EasyMesh Channel Scan Report Processing Crash for Non-Success Scan Status

Prevent crash during Channel Scan Report processing when scan results are returned with non-success scan status codes.
- Added validation to process Channel Scan Result TLVs based on the received scan_status
- Handled non-success scan responses according to EasyMesh Scan Status definitions
- Corrected incorrect bandwidth mapping for 80 MHz channels to use the appropriate bandwidth enum
- Ensured Timestamp and scan result data are parsed only when scan_status = 0x00 (Success)

Signed-off-by:
Alekhya Ambati <ambati.alekhya@capgemini.com>
Shaik Shaheeda <shaheeda.shaik@capgemini.com>

RDKBWIFI-497 : TR181 Channel Selection Request - Add TR-181 ChannelSelectionRequest support and fix RDKB CLI channel selection (#711)

1. Introduce TR-181 ChannelSelectionRequest/ChannelSelect support in tr_181 layer
2. Add channelselect_handler and cmd_channelselect to route TR-181 method calls into em_ctrl
3. Implement controller-side parsing, device/radio resolution, JSON payload construction, and channel selection command enqueue
4. Add handle_channel_select and analyze_channel_select support in DM controller
5. Update TR-181 method registration and constants for ChannelSelectionRequest
6. Fix RDKB CLI channel selection flow so ChannelSelect requests are handled correctly

Signed-off-by: Sachin Chougale <cm.sachin@capgemini.com>

RDKBWIFI-464:  Fix crash issue observed with disassoc sta

Signed-off-by: prashant-singh1 <prashant.singh8521@gmail.com>

RDKBWIFI-500 : Interoperability Issue: Controller is crashing while handling scan (#735)

result of third party extender.

Rootcause : Thirdparty Extender is sending SSID's whole length is more than standard length, which is causing crash.

Fix: Added protection to check ssid length

Signed-off-by: Sachin Chougale <cm.sachin@capgemini.com>

RDKBWIFI-502 Channel Selection Request - Update channel preference TLV to use only valid rows (#734)

Updating channel preference tlv creation implmentation to ignore the invalid rows

Signed-off-by: Sachin Chougale <cm.sachin@capgemini.com>

beacon metrics query's channel num and op class correction - fix for when sta connects over 8ghz client cap query, dont send if sta is already associated - testing still in progress