### PR TITLE
RDKBWIFI-521: Remove extra closing brace from DataElements schema

### DIFF
--- a/src/ctrl/tr_181/wfa_data_model/Data_Elements_JSON_Schema_v3.0.json
+++ b/src/ctrl/tr_181/wfa_data_model/Data_Elements_JSON_Schema_v3.0.json
@@ -3065,7 +3065,6 @@
                                             "description": "List of 802.11 standards in operation for this radio instance",
                                             "enum": ["a", "b", "g", "n", "ac", "ax", "be", "bn"]
                                         }
-                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Data_Elements_JSON_Schema_v3.0.json has an extra closing brace in the
Radio object, shifting everything after it (NetworkSSIDList,
MSCS/SCSDisallowedStaList, notification) out of their "properties"
objects. Registration walks "properties" only, so
Device.WiFi.DataElements.Network.SSID.{i} was never registered.
Remove the extra brace.