### PR TITLE
RDKBWIFI-527: SetSSID: implement the AKMsAllowed input argument

### DIFF
--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -89,6 +89,7 @@ static const yang_to_tr181_map g_yang_map[] = {
 #define TR181_BAND_MAX_LEN         16
 #define TR181_ADDREMOVE_MAX_LEN    16
 #define TR181_HAULTYPE_MAX_LEN     32
+#define TR181_AKMS_MAX_LEN         32
 #define TR181_CHLIST_MAX_LEN       128
 #define TR181_BSSID_MAX_LEN        32
 #define TR181_REQMODE_MAX_LEN      24
@@ -714,6 +715,28 @@ public:
      * @retval false otherwise.
      */
     static bool item_matches_haultype(const cJSON *item, const char *haul_val);
+
+     /**!
+     * @brief Create a JSON array for the SetSSID() AKMsAllowed input.
+     *
+     * @param akms_val Single akm_t enum value (psk, sae or psk+sae).
+     *
+     * @returns cJSON*
+     * @retval non-null Newly allocated cJSON array on success.
+     * @retval null on validation or allocation failure.
+     */
+    static cJSON *create_akms_array(const char *akms_val);
+
+     /**!
+     * @brief Map an AKMsAllowed value to the internal NetworkSSID AuthType.
+     *
+     * @param akms_val Single akm_t enum value (psk, sae or psk+sae).
+     *
+     * @returns const char*
+     * @retval AuthType string (securityTypeMap name) on success.
+     * @retval null for unsupported values.
+     */
+    static const char *akms_to_auth_type(const char *akms_val);
 
     /**!
      * @brief Format the HaulType array as a comma-separated string.

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -75,6 +75,7 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_
     char band[TR181_BAND_MAX_LEN + 1] = {0};
     char addremove[TR181_ADDREMOVE_MAX_LEN + 1] = {0};
     char HaulType[TR181_HAULTYPE_MAX_LEN + 1] = {0};
+    char AKMsAllowed[TR181_AKMS_MAX_LEN + 1] = {0};
     size_t json_len = 0;
 
     (void)method_name;
@@ -97,6 +98,13 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_
             tr_181_t::tr181_copy_prop_string(prop, band, sizeof(band));
         } else if (strcmp(prop->name, "HaulType") == 0) {
             tr_181_t::tr181_copy_prop_string(prop, HaulType, sizeof(HaulType));
+        } else if (strcmp(prop->name, "AKMsAllowed") == 0) {
+            tr_181_t::tr181_copy_prop_string(prop, AKMsAllowed, sizeof(AKMsAllowed));
+            /* Full buffer = truncated input, longer than any valid akm_t value. */
+            if (strnlen(AKMsAllowed, sizeof(AKMsAllowed)) >= TR181_AKMS_MAX_LEN) {
+                if (output_params) *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+                return bus_error_invalid_input;
+            }
         }
     }
 
@@ -255,6 +263,28 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_
                 cJSON_ReplaceItemInObject(target, "HaulType", haul_arr);
                 haul_arr = NULL;
             }
+            if (AKMsAllowed[0]) {
+                /* BBF TR-181 SetSSID() input AKMsAllowed (since 2.17): update the
+                 * entry's AKMsAllowed and derive the internal AuthType used to
+                 * build the WSC M2 auth type. */
+                cJSON *akms_arr = tr_181_t::create_akms_array(AKMsAllowed);
+                if (!akms_arr) {
+                    cJSON_Delete(root);
+                    if (output_params) *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+                    return bus_error_invalid_input;
+                }
+                const char *auth_str =
+                    tr_181_t::akms_to_auth_type(cJSON_GetStringValue(cJSON_GetArrayItem(akms_arr, 0)));
+                cJSON *auth_item = (auth_str != NULL) ? cJSON_CreateString(auth_str) : NULL;
+                if (!auth_item) {
+                    cJSON_Delete(akms_arr);
+                    cJSON_Delete(root);
+                    if (output_params) *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+                    return bus_error_out_of_resources;
+                }
+                cJSON_ReplaceItemInObject(target, "AKMsAllowed", akms_arr);
+                cJSON_ReplaceItemInObject(target, "AuthType", auth_item);
+            }
         }
     } else if (is_add) {
         target = cJSON_CreateObject();
@@ -299,6 +329,25 @@ bus_error_t em_ctrl_t::cmd_setssid(const char *method_name, const bus_data_prop_
         if (haul_arr) {
             cJSON_AddItemToObject(target, "HaulType", haul_arr);
             haul_arr = NULL;
+        }
+        if (AKMsAllowed[0]) {
+            cJSON *akms_arr = tr_181_t::create_akms_array(AKMsAllowed);
+            if (!akms_arr) {
+                cJSON_Delete(root);
+                if (output_params) *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+                return bus_error_invalid_input;
+            }
+            const char *auth_str =
+                tr_181_t::akms_to_auth_type(cJSON_GetStringValue(cJSON_GetArrayItem(akms_arr, 0)));
+            cJSON *auth_item = (auth_str != NULL) ? cJSON_CreateString(auth_str) : NULL;
+            if (!auth_item) {
+                cJSON_Delete(akms_arr);
+                cJSON_Delete(root);
+                if (output_params) *output_params = tr_181_t::tr181_set_status_output_prop("Failure");
+                return bus_error_out_of_resources;
+            }
+            cJSON_AddItemToObject(target, "AKMsAllowed", akms_arr);
+            cJSON_AddItemToObject(target, "AuthType", auth_item);
         }
     } else {
         if (haul_arr) cJSON_Delete(haul_arr);

--- a/src/ctrl/tr_181/wfa_data_model/tr_181_helper.cpp
+++ b/src/ctrl/tr_181/wfa_data_model/tr_181_helper.cpp
@@ -257,3 +257,52 @@ bool tr_181_t::tr181_get_prop_bool(const bus_data_prop_t *prop, bool *value)
 
     return true;
 }
+
+cJSON *tr_181_t::create_akms_array(const char *akms_val)
+{
+    if (!akms_val || *akms_val == '\0') return NULL;
+    if (strchr(akms_val, ',')) {
+        em_printfout("ERROR: AKMsAllowed must be a single value (no commas): '%s'", akms_val);
+        return NULL;
+    }
+    char tok_buf[TR181_AKMS_MAX_LEN + 1];
+    size_t val_len = strnlen(akms_val, sizeof(tok_buf));
+    if (val_len >= sizeof(tok_buf)) {
+        em_printfout("ERROR: AKMsAllowed too long");
+        return NULL;
+    }
+    memcpy(tok_buf, akms_val, val_len + 1);
+    tr181_trim_whitespace(tok_buf);
+    if (*tok_buf == '\0') {
+        em_printfout("ERROR: AKMsAllowed empty after trimming");
+        return NULL;
+    }
+    /* akm_t enum values that map to a WSC M2 auth type on this stack. */
+    if (strcmp(tok_buf, "psk") != 0 && strcmp(tok_buf, "sae") != 0 &&
+        strcmp(tok_buf, "psk+sae") != 0) {
+        em_printfout("ERROR: Invalid/unsupported AKMsAllowed value '%s' (expected psk/sae/psk+sae)", tok_buf);
+        return NULL;
+    }
+    cJSON *arr = cJSON_CreateArray();
+    if (!arr) {
+        return NULL;
+    }
+    cJSON *val = cJSON_CreateString(tok_buf);
+    if (!val) {
+        cJSON_Delete(arr);
+        return NULL;
+    }
+    cJSON_AddItemToArray(arr, val);
+    return arr;
+}
+
+const char *tr_181_t::akms_to_auth_type(const char *akms_val)
+{
+    if (akms_val == NULL) {
+        return NULL;
+    }
+    if (strcmp(akms_val, "psk") == 0) return "WPA2 Personal";
+    if (strcmp(akms_val, "sae") == 0) return "WPA3 Personal";
+    if (strcmp(akms_val, "psk+sae") == 0) return "WPA3 Transition";
+    return NULL;
+}


### PR DESCRIPTION
The BBF TR-181 Device.WiFi.DataElements.Network.SetSSID() command defines an AKMsAllowed input argument (since 2.17, akm_t enumeration) to select the AKM suites / security mode of an SSID, but the rbus method implementation only parses SSID, AddRemoveChange, PassPhrase, Band and HaulType; AKMsAllowed is silently ignored and the method still returns Success.

Implement the AKMsAllowed input for Add and Change: validate the value, update the target entry's AKMsAllowed and derive its AuthType ("WPA2 Personal" / "WPA3 Personal" / "WPA3 Transition"), then let the existing SetSSID flow (decode -> autoconfig renew -> M2) apply it.

Only the akm_t values that map to a WSC M2 auth type are accepted (psk, sae, psk+sae). The dpp* and SuiteSelector enumeration values are rejected as invalid input for now, since there is no plumbing from a NetworkSSID entry to a DPP configuration object / suite selector; support can be added when that path exists.