### PR TITLE
RDKBWIFI-528: Convert STA link metrics TLV fields from network byte order

### DIFF
--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -80,8 +80,8 @@ int em_metrics_t::handle_assoc_sta_link_metrics_tlv(unsigned char *buff,
             continue;
         }
 
-        sta->m_sta_info.est_dl_rate = metrics->est_mac_data_rate_dl;
-        sta->m_sta_info.est_ul_rate = metrics->est_mac_data_rate_ul;
+        sta->m_sta_info.est_dl_rate = ntohl(metrics->est_mac_data_rate_dl);
+        sta->m_sta_info.est_ul_rate = ntohl(metrics->est_mac_data_rate_ul);
         sta->m_sta_info.rcpi = metrics->rcpi;
     }
 
@@ -119,10 +119,10 @@ int em_metrics_t::handle_assoc_sta_ext_link_metrics_tlv(unsigned char *buff, uns
             continue;
         }
 
-        sta->m_sta_info.last_dl_rate = metrics->last_data_dl_rate;
-        sta->m_sta_info.last_ul_rate = metrics->last_data_ul_rate;
-        sta->m_sta_info.util_rx = metrics->util_receive;
-        sta->m_sta_info.util_tx = metrics->util_transmit;
+        sta->m_sta_info.last_dl_rate = ntohl(metrics->last_data_dl_rate);
+        sta->m_sta_info.last_ul_rate = ntohl(metrics->last_data_ul_rate);
+        sta->m_sta_info.util_rx = ntohl(metrics->util_receive);
+        sta->m_sta_info.util_tx = ntohl(metrics->util_transmit);
     }
 
     return 0;


### PR DESCRIPTION
The agent encodes the 32-bit fields of the Associated STA Link Metrics and Associated STA Extended Link Metrics TLVs in network byte order (htonl in the send path), but the controller side decoders handle_assoc_sta_link_metrics_tlv and
handle_assoc_sta_ext_link_metrics_tlv store them without ntohl. On little endian targets the data model then holds byte swapped values, e.g. STA.{i}.EstMACDataRateDownlink = 2181038080 (0x82000000 = htonl(130)) instead of 130. The Associated STA Traffic Stats decoder in the same file already applies ntohl; do the same here.

Apply ntohl on est_mac_data_rate_dl/ul, last_data_dl/ul_rate and util_receive/util_transmit when storing into the sta info.