### PR TITLE
RDKBWIFI-530: EasyMesh-one_wifi_em_ctrl high cpu usage and Device.WiFi.DataElements timeout

### DIFF
--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -4869,6 +4869,10 @@ bus_error_t dm_easy_mesh_ctrl_t::network_get_inner(char *event_name, raw_data_t 
         unsigned int dev_cnt = 0;
         dm_easy_mesh_t *dm = dm_ctrl->get_first_dm();
         while (dm != NULL) {
+            if (dm->is_controller()) {
+                dm = dm_ctrl->get_next_dm(dm);
+                continue;
+            }
             dm_device_t *dev = dm->get_device();
             if (dev != NULL) {
                 em_device_info_t *di = dev->get_device_info();
@@ -5104,7 +5108,12 @@ bus_error_t dm_easy_mesh_ctrl_t::device_tget_inner(char *event_name, raw_data_t 
 
     /* Calculate device count */
     unsigned int device_cnt = 0;
+    int max_id = 0;
     while (dm != NULL) {
+        if (dm->is_controller()) {
+            dm = dm_ctrl->get_next_dm(dm);
+            continue;
+        }
         if (dm->get_id() < 0) {
             dm = dm_ctrl->get_next_dm(dm);
             continue;
@@ -5119,12 +5128,15 @@ bus_error_t dm_easy_mesh_ctrl_t::device_tget_inner(char *event_name, raw_data_t 
             dm = dm_ctrl->get_next_dm(dm);
             continue;
         }
+        if (dm->get_id() > max_id) {
+            max_id = dm->get_id();
+        }
         ++device_cnt;
         dm = dm_ctrl->get_next_dm(dm);
     }
 
     /* Iterate according to dm id */
-    for (unsigned int idx = 1, cnt = 0; cnt < device_cnt; idx++) {
+    for (unsigned int idx = 1, cnt = 0; cnt < device_cnt && idx <= static_cast<unsigned int>(max_id); idx++) {
         dm = dm_ctrl->get_first_dm();
         do {
             if (dm && (dm->get_id() == static_cast<int>(idx))) {
@@ -5135,15 +5147,22 @@ bus_error_t dm_easy_mesh_ctrl_t::device_tget_inner(char *event_name, raw_data_t 
         if (dm == NULL) {
             continue;
         }
-        ++cnt;
+
+	if (dm->is_controller()) {
+            continue;
+        }
+
         dm_device_t *dev = dm->get_device();
         if (dev == NULL) {
             continue;
         }
+
         em_device_info_t *di = dev->get_device_info();
         if (memcmp(di->id.dev_mac, ZERO_MAC_ADDR, sizeof(di->id.dev_mac)) == 0) {
             continue;
         }
+        ++cnt;
+
         em_ieee_1905_security_cap_t *sec_cap = dm->get_ieee_1905_security_cap();
 
         dm_ctrl->property_append_tail(&property, root, idx, "ID", di->id.dev_mac);


### PR DESCRIPTION
Root Cause:
The EasyMesh controller was incorrectly included in the DataElements Network.Device list together with agents. This created gaps in the DM IDs, causing the device enumeration logic to repeatedly traverse the DM list while searching for sequential IDs. As a result, one_wifi_em_ctrl consumed high CPU and Device.WiFi.DataElements DM queries took several minutes or timed out.

Fix:
- Skip controller entries during DataElements device enumeration.
- Track the maximum valid DM ID and limit the iteration range.
- Ignore controller entries while building the Network.Device table.

This prevents unnecessary repeated traversals, reduces CPU utilization, and allows Device.WiFi.DataElements queries to complete successfully.