### PR TITLE
RDKBWIFI-531: Decode Radio and AP Extended Metrics TLVs

### DIFF
--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -320,7 +320,31 @@ class em_metrics_t {
 	 *
 	 * @note Ensure that the buffer is properly allocated.
 	 */
-	int handle_ap_metrics_tlv(unsigned char *buff, bssid_t bssid);
+	int handle_ap_metrics_tlv(unsigned char *buff, unsigned int tlv_len, bssid_t bssid);
+
+	/**!
+	 * @brief Handles the AP Extended Metrics tlv.
+	 *
+	 * This function stores the unicast/multicast/broadcast byte counters into the BSS.
+	 *
+	 * @param[in] buff Pointer to the buffer containing AP extended metrics.
+	 * @param[in] tlv_len Length of the TLV value.
+	 *
+	 * @returns int Status code indicating success or failure.
+	 */
+	int handle_ap_ext_metrics_tlv(unsigned char *buff, unsigned int tlv_len);
+
+	/**!
+	 * @brief Handles the Radio Metrics tlv.
+	 *
+	 * This function stores the radio noise and transmit/receive metrics into the radio.
+	 *
+	 * @param[in] buff Pointer to the buffer containing radio metrics.
+	 * @param[in] tlv_len Length of the TLV value.
+	 *
+	 * @returns int Status code indicating success or failure.
+	 */
+	int handle_radio_metrics_tlv(unsigned char *buff, unsigned int tlv_len);
 
 	int handle_link_stats_alarm_rprt_tlv(unsigned char *buff, size_t len);
 

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -5540,11 +5540,11 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_get_inner(char *event_name, raw_data_t *p
     } else if (strcmp(param, "Utilization") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, static_cast<unsigned int> (ri->utilization));
     } else if (strcmp(param, "Transmit") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, 0U);
+        rc = dm_ctrl->raw_data_set(p_data, static_cast<unsigned int> (ri->transmit));
     } else if (strcmp(param, "ReceiveSelf") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, 0U);
+        rc = dm_ctrl->raw_data_set(p_data, static_cast<unsigned int> (ri->receive_self));
     } else if (strcmp(param, "ReceiveOther") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, 0U);
+        rc = dm_ctrl->raw_data_set(p_data, static_cast<unsigned int> (ri->receive_other));
     } else if (strcmp(param, "ChipsetVendor") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, ri->chip_vendor);
     } else if (strcmp(param, "CurrentOperatingClassProfileNumberOfEntries") == 0) {
@@ -5634,9 +5634,9 @@ bus_error_t dm_easy_mesh_ctrl_t::radio_tget_params(dm_easy_mesh_t *dm, const cha
         dm_ctrl->property_append_tail(property, root, idx, "Enabled", ri->enabled);
         dm_ctrl->property_append_tail(property, root, idx, "Noise", static_cast<unsigned int> (ri->noise));
         dm_ctrl->property_append_tail(property, root, idx, "Utilization", static_cast<unsigned int> (ri->utilization));
-        dm_ctrl->property_append_tail(property, root, idx, "Transmit", 0U);
-        dm_ctrl->property_append_tail(property, root, idx, "ReceiveSelf", 0U);
-        dm_ctrl->property_append_tail(property, root, idx, "ReceiveOther", 0U);
+        dm_ctrl->property_append_tail(property, root, idx, "Transmit", static_cast<unsigned int> (ri->transmit));
+        dm_ctrl->property_append_tail(property, root, idx, "ReceiveSelf", static_cast<unsigned int> (ri->receive_self));
+        dm_ctrl->property_append_tail(property, root, idx, "ReceiveOther", static_cast<unsigned int> (ri->receive_other));
         dm_ctrl->property_append_tail(property, root, idx, "ChipsetVendor", ri->chip_vendor);
         unsigned int curop_count = 0;
         for (unsigned int i = 0; i < dm->get_num_op_class(); i++) {
@@ -6766,13 +6766,13 @@ bus_error_t dm_easy_mesh_ctrl_t::bss_get_inner(char *event_name, raw_data_t *p_d
     } else if (strcmp(param, "UnicastBytesReceived") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, bi->unicast_bytes_rcvd);
     } else if (strcmp(param, "MulticastBytesSent") == 0) {
-        //rc = dm_ctrl->raw_data_set(p_data, bi->);
+        rc = dm_ctrl->raw_data_set(p_data, bi->multicast_bytes_sent);
     } else if (strcmp(param, "MulticastBytesReceived") == 0) {
-        //rc = dm_ctrl->raw_data_set(p_data, bi->);
+        rc = dm_ctrl->raw_data_set(p_data, bi->multicast_bytes_rcvd);
     } else if (strcmp(param, "BroadcastBytesSent") == 0) {
-        //rc = dm_ctrl->raw_data_set(p_data, bi->);
+        rc = dm_ctrl->raw_data_set(p_data, bi->broadcast_bytes_sent);
     } else if (strcmp(param, "BroadcastBytesReceived") == 0) {
-        //rc = dm_ctrl->raw_data_set(p_data, bi->);
+        rc = dm_ctrl->raw_data_set(p_data, bi->broadcast_bytes_rcvd);
     } else if (strcmp(param, "EstServiceParametersBE") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, bi->est_svc_params_be);
     } else if (strcmp(param, "EstServiceParametersBK") == 0) {
@@ -7039,7 +7039,7 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_d
     } else if (strcmp(param, "EstMACDataRateUplink") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, si->est_ul_rate);
     } else if (strcmp(param, "SignalStrength") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, si->signal_strength);
+        rc = dm_ctrl->raw_data_set(p_data, static_cast<int32_t> (si->rcpi));
     } else if (strcmp(param, "LastConnectTime") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, si->last_conn_time);
     } else if (strcmp(param, "BytesSent") == 0) {
@@ -7168,7 +7168,7 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_tget_params(dm_easy_mesh_t *dm, const char 
         dm_ctrl->property_append_tail(property, root, idx, "UtilizationTransmit", si->util_tx);
         dm_ctrl->property_append_tail(property, root, idx, "EstMACDataRateDownlink", si->est_dl_rate);
         dm_ctrl->property_append_tail(property, root, idx, "EstMACDataRateUplink", si->est_ul_rate);
-        dm_ctrl->property_append_tail(property, root, idx, "SignalStrength", si->signal_strength);
+        dm_ctrl->property_append_tail(property, root, idx, "SignalStrength", static_cast<int32_t> (si->rcpi));
         dm_ctrl->property_append_tail(property, root, idx, "LastConnectTime", si->last_conn_time);
         dm_ctrl->property_append_tail(property, root, idx, "BytesSent", si->bytes_tx);
         dm_ctrl->property_append_tail(property, root, idx, "BytesReceived", si->bytes_rx);

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -394,16 +394,39 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
         return -1;
     }
 
+    if (len < sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)) {
+        em_printfout("Frame shorter than the 1905 headers");
+        return -1;
+    }
+
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tmp_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+    while ((tmp_len >= sizeof(em_tlv_t)) && (tlv->type != em_tlv_type_eom)) {
+        /* Stop before a TLV that runs past the received bytes; tmp_len would underflow. */
+        size_t tlv_total = sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len));
+        if (tmp_len < tlv_total) {
+            em_printfout("Truncated beacon metrics TLV, stopping");
+            break;
+        }
         if (tlv->type == em_tlv_type_bcon_metric_rsp) {
+            if (ntohs(tlv->len) < 8) {
+                em_printfout("Beacon metrics TLV too short");
+                return -1;
+            }
             report_len = static_cast<unsigned int>(ntohs(tlv->len) - 8);
+            if (report_len > sizeof(em_sta_info_t::beacon_report_elem)) {
+                report_len = sizeof(em_sta_info_t::beacon_report_elem);
+            }
             response = reinterpret_cast<em_beacon_metrics_resp_t *> (tlv->value);
             break;
         }
-        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= static_cast<unsigned int> (tlv_total);
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + tlv_total);
+    }
+
+    if (response == NULL) {
+        em_printfout("Beacon metrics TLV not found");
+        return -1;
     }
 
     sta = dm->get_first_sta(response->sta_mac_addr);
@@ -435,20 +458,101 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
     return 0;
 }
 
-int em_metrics_t::handle_ap_metrics_tlv(unsigned char *buff, bssid_t get_bssid)
+int em_metrics_t::handle_ap_metrics_tlv(unsigned char *buff, unsigned int tlv_len, bssid_t get_bssid)
 {
-    em_ap_metric_t *ap_metrics = reinterpret_cast<em_ap_metric_t *> (buff);
-    em_bss_info_t *bss = get_data_model()->get_bss_info_with_mac(ap_metrics->bssid);
+    em_ap_metric_t *ap_metrics;
+    em_bss_info_t *bss;
     mac_addr_str_t bss_str;
+    mac_address_t zero_bssid = {0};
+
+    if (buff == NULL || tlv_len < sizeof(em_ap_metric_t)) {
+        return -1;
+    }
+
+    ap_metrics = reinterpret_cast<em_ap_metric_t *> (buff);
+
+    /* Unconfigured VAP: its zeroed utilization would clobber the radio's real value. */
+    if (memcmp(ap_metrics->bssid, zero_bssid, sizeof(mac_address_t)) == 0) {
+        return 0;
+    }
+
+    bss = get_data_model()->get_bss_info_with_mac(ap_metrics->bssid);
 
     memcpy(get_bssid, ap_metrics->bssid, sizeof(mac_addr_t));
     if (bss != NULL) {
         bss->numberofsta = htons(ap_metrics->num_sta);
+        bss->channel_util = ap_metrics->channel_util;
+        /* ruid.mac holds the owning radio's interface MAC, which get_radio() matches. */
+        dm_radio_t *radio = get_data_model()->get_radio(bss->ruid.mac);
+        if (radio != NULL) {
+            radio->m_radio_info.utilization = ap_metrics->channel_util;
+        }
         dm_easy_mesh_t::macbytes_to_string(ap_metrics->bssid, bss_str);
     } else {
         dm_easy_mesh_t::macbytes_to_string(ap_metrics->bssid, bss_str);
         em_printfout("Error: BSS not found: %s", bss_str);
     }
+
+    return 0;
+}
+
+int em_metrics_t::handle_ap_ext_metrics_tlv(unsigned char *buff, unsigned int tlv_len)
+{
+    em_ap_ext_metric_t *ap_ext_metrics;
+    em_bss_info_t *bss;
+    mac_addr_str_t bss_str;
+    uint32_t bytes;
+
+    if (buff == NULL || tlv_len < sizeof(em_ap_ext_metric_t)) {
+        return -1;
+    }
+
+    ap_ext_metrics = reinterpret_cast<em_ap_ext_metric_t *> (buff);
+    bss = get_data_model()->get_bss_info_with_mac(ap_ext_metrics->bssid);
+    if (bss == NULL) {
+        dm_easy_mesh_t::macbytes_to_string(ap_ext_metrics->bssid, bss_str);
+        em_printfout("Error: BSS not found: %s", bss_str);
+        return -1;
+    }
+
+    memcpy(&bytes, ap_ext_metrics->uni_bytes_sent, sizeof(bytes));
+    bss->unicast_bytes_sent = ntohl(bytes);
+    memcpy(&bytes, ap_ext_metrics->uni_bytes_recv, sizeof(bytes));
+    bss->unicast_bytes_rcvd = ntohl(bytes);
+    memcpy(&bytes, ap_ext_metrics->multi_bytes_sent, sizeof(bytes));
+    bss->multicast_bytes_sent = ntohl(bytes);
+    memcpy(&bytes, ap_ext_metrics->multi_bytes_recv, sizeof(bytes));
+    bss->multicast_bytes_rcvd = ntohl(bytes);
+    memcpy(&bytes, ap_ext_metrics->bcast_bytes_sent, sizeof(bytes));
+    bss->broadcast_bytes_sent = ntohl(bytes);
+    memcpy(&bytes, ap_ext_metrics->bcast_bytes_recv, sizeof(bytes));
+    bss->broadcast_bytes_rcvd = ntohl(bytes);
+
+    return 0;
+}
+
+int em_metrics_t::handle_radio_metrics_tlv(unsigned char *buff, unsigned int tlv_len)
+{
+    em_radio_metric_t *radio_metrics;
+    dm_radio_t *radio;
+    mac_addr_str_t radio_str;
+
+    if (buff == NULL || tlv_len < sizeof(em_radio_metric_t)) {
+        return -1;
+    }
+
+    radio_metrics = reinterpret_cast<em_radio_metric_t *> (buff);
+    radio = get_data_model()->get_radio(radio_metrics->ruid);
+    if (radio == NULL) {
+        dm_easy_mesh_t::macbytes_to_string(radio_metrics->ruid, radio_str);
+        em_printfout("Error: Radio not found: %s", radio_str);
+        return -1;
+    }
+
+    radio->m_radio_info.noise = radio_metrics->noise;
+    radio->m_radio_info.transmit = radio_metrics->transmit;
+    radio->m_radio_info.receive_self = radio_metrics->rece_self;
+    radio->m_radio_info.receive_other = radio_metrics->rece_other;
 
     return 0;
 }
@@ -542,6 +646,14 @@ int em_metrics_t::handle_link_stats_alarm_rprt_tlv(unsigned char *buff, size_t l
         em_printfout("\t\tLink Quality Threshold: %.2f", sta->m_sta_info.link_stats_report.link_quality_threshold);
         em_printfout("\t\tAlarm Triggered: %s", sta->m_sta_info.link_stats_report.alarm_triggered ? "True" : "False");
 
+        /* sample_count is wire data: reject counts past the array or the received bytes. */
+        if (link_report->sample_count < 0 ||
+            static_cast<size_t>(link_report->sample_count) > EM_MAX_SAMPLES_PER_LINK_REPORT ||
+            len < alarm_offset + static_cast<size_t>(link_report->sample_count) * sizeof(em_alarm_samples_t)) {
+            em_printfout("Invalid alarm sample_count %d (len %zu)", link_report->sample_count, len);
+            break;
+        }
+
         sta->m_sta_info.link_stats_report.sample_count = link_report->sample_count;
         em_printfout("    Number of Samples: %d", sta->m_sta_info.link_stats_report.sample_count);
 
@@ -584,6 +696,11 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
         return -1;
     }
 
+    if (len < sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)) {
+        em_printfout("Frame shorter than the 1905 headers");
+        return -1;
+    }
+
     tlv_start =  reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     base_len = static_cast<size_t> (len) - (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
 
@@ -591,17 +708,29 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
     tlv = tlv_start;
     tmp_len = base_len;
 
-    while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
+    while ((tmp_len >= sizeof(em_tlv_t)) && (tlv->type != em_tlv_type_eom)) {
+        /* Stop before a TLV that runs past the received bytes; tmp_len would underflow. */
+        size_t tlv_total = sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len));
+        if (tmp_len < tlv_total) {
+            em_printfout("Truncated AP metrics TLV, stopping");
+            break;
+        }
         switch (tlv->type) {
             case em_tlv_type_ap_metrics:
                 // Update current BSSID context; subsequent per-STA TLVs use this value.
-                handle_ap_metrics_tlv(tlv->value, bssid);
+                if (handle_ap_metrics_tlv(tlv->value, ntohs(tlv->len), bssid) != 0) {
+                    em_printfout("ap_metrics_tlv failed, skipping TLV");
+                }
                 break;
             case em_tlv_type_ap_ext_metric:
-                /* future implementation */
+                if (handle_ap_ext_metrics_tlv(tlv->value, ntohs(tlv->len)) != 0) {
+                    em_printfout("ap_ext_metrics_tlv failed, skipping TLV");
+                }
                 break;
             case em_tlv_type_radio_metric:
-                /* future implementation */
+                if (handle_radio_metrics_tlv(tlv->value, ntohs(tlv->len)) != 0) {
+                    em_printfout("radio_metrics_tlv failed, skipping TLV");
+                }
                 break;
             case em_tlv_type_assoc_sta_traffic_sts:
                 if (handle_assoc_sta_traffic_stats(tlv->value, bssid) != 0) {
@@ -629,8 +758,8 @@ int em_metrics_t::handle_ap_metrics_response(unsigned char *buff, unsigned int l
             default:
                 break;
         }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
+        tmp_len -= tlv_total;
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + tlv_total);
     }
 
     dm->set_db_cfg_param(db_cfg_type_sta_metrics_update, "");
@@ -1140,6 +1269,12 @@ int em_metrics_t::send_ap_metrics_response()
 
         if(dm->m_bss[bss_index].get_bss_info()->vap_mode != em_vap_mode_ap) {
             em_printfout("Vap mode is not ap, skipping");
+            continue;
+        }
+
+        mac_address_t zero_bssid = {0};
+        if (memcmp(dm->m_bss[bss_index].get_bss_info()->bssid.mac, zero_bssid, sizeof(mac_address_t)) == 0) {
+            /* Unconfigured VAP with no BSSID assigned; do not emit metrics for it. */
             continue;
         }
 


### PR DESCRIPTION
Radio.{i}.Noise/Utilization/Transmit/ReceiveSelf/ReceiveOther and the BSS byte counters were always 0: the radio metric and AP extended metric TLVs the agent sends were left undecoded. STA.{i}.SignalStrength read signal_strength, which the metrics path never writes; RCPI is stored in rcpi.

Add handle_radio_metrics_tlv() and handle_ap_ext_metrics_tlv(), report the radio metrics and byte counters from the data model, and read SignalStrength from rcpi. Skip AP metrics for an all zero BSSID, which an unconfigured VAP reports and which would otherwise overwrite the owning radio's utilization; the agent no longer emits that TLV either.

Bound the wire driven lengths in the same parser: reject a link report whose sample count exceeds the fixed array or the received bytes, clamp the beacon report length, and stop the TLV walk before the length subtraction underflows.