### PR TITLE
RDKBWIFI-442:Beacon Report Query/Response.

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -1756,6 +1756,7 @@ public:
 	static void update_assoc_sta_mld_info(void *dm, em_assoc_sta_mld_info_t *assoc_sta_mld_info) { (static_cast<dm_easy_mesh_t *>(dm))->update_assoc_sta_mld_info(assoc_sta_mld_info); }
 
 	void remove_assoc_sta_mld_info(mac_address_t sta_mld_mac);
+	void apply_sta_cap_to_maps(const char *key, em_sta_info_t *info);
 	bool is_ap_mld_mac(const mac_address_t mac);
 	bool resolve_ap_mld_to_fallback_ruid(const mac_address_t ap_mld_mac, mac_address_t fallback_ruid);
 
@@ -2313,7 +2314,8 @@ public:
 	 */
 	int get_num_bss_for_associated_sta(mac_address_t sta_mac);
     
-    
+    bool is_sta_mld(mac_address_t sta_mac);
+
 	/**!
 	 * @brief Converts a byte array to a hexadecimal string representation.
 	 *

--- a/inc/dm_sta.h
+++ b/inc/dm_sta.h
@@ -118,6 +118,15 @@ public:
 	 * calling this function.
 	 */
 	static void decode_sta_capability(dm_sta_t *sta);
+
+    /**!
+     * @brief Returns true if the STA advertises support for at least one 802.11k
+     *        beacon measurement mode (Passive, Active, or Table).
+     *
+     * Reads m_sta_info.rm_cap (a compact hex string) and tests bits 4-6 of the
+     * first RM Enabled Capabilities octet (IEEE 802.11-2020 Table 9-157).
+     */
+    bool supports_beacon_measurement() const;
     
 	/**!
 	 * @brief Decodes the beacon report for the given station.

--- a/inc/em_agent.h
+++ b/inc/em_agent.h
@@ -376,6 +376,7 @@ class em_agent_t : public em_mgr_t {
 	 */
 	bool send_action_frame(uint8_t dest_mac[ETH_ALEN], uint8_t *action_frame, size_t action_frame_len, uint8_t vap_idx, unsigned int frequency=0, unsigned int wait_time_ms=0);
 
+	void send_beacon_query(em_bus_event_t *evt);
 public:
 
     bus_handle_t m_bus_hdl;

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -30,6 +30,7 @@ extern "C"
 #endif
 
 #include "wifi_webconfig.h"
+#include <time.h>
 #include <openssl/evp.h>
 #include <uuid/uuid.h>
 #include <sys/socket.h>
@@ -1139,7 +1140,7 @@ typedef struct {
 typedef struct {
     unsigned char ap_channel_rprt_len;
     unsigned char ap_channel_op_class;
-    unsigned char ap_channel_list[6];
+    unsigned char ap_channel_list[EM_MAX_CHANNELS_IN_LIST];
 }__attribute__((__packed__)) em_beacon_ap_channel_rprt_t;
 
 typedef struct {
@@ -1156,8 +1157,7 @@ typedef struct {
     unsigned char ssid_len;
     ssid_t ssid;
     unsigned char num_ap_channel_rprt;
-    em_beacon_ap_channel_rprt_t ap_channel_rprt[6];
-    unsigned char num_element_id;
+    em_beacon_ap_channel_rprt_t ap_channel_rprt[EM_MAX_NEIGHBORS];
     em_beacon_element_list_t element_list;
 }__attribute__((__packed__)) em_beacon_metrics_query_t;
 
@@ -2277,7 +2277,6 @@ typedef enum {
     em_state_agent_client_cap_report,
     em_state_agent_sta_link_metrics_pending,
     em_state_agent_steer_btm_res_pending,
-    em_state_agent_beacon_report_pending,
     em_state_agent_link_quality_report_pending,
 
     em_state_ctrl_unconfigured = 0x100,
@@ -2311,7 +2310,11 @@ typedef enum {
     em_state_ctrl_avail_spectrum_inquiry_pending,
     em_state_ctrl_bsta_cap_pending,
     em_state_ctrl_topo_publish_pending,
-    em_state_ctrl_unassoc_sta_link_metrics_pending, 
+    em_state_ctrl_unassoc_sta_link_metrics_pending,
+
+    //common states
+    em_state_beacon_report_pending,
+    em_state_beacon_report_complete,
 
     em_state_max,
 } em_state_t;
@@ -2602,6 +2605,7 @@ typedef struct {
     unsigned char	frame_body[EM_MAX_FRAME_BODY_LEN];
     unsigned int    num_vendor_infos;
     bool            multi_band_cap;
+    time_t          beacon_query_sent_time;
     unsigned int    num_beacon_meas_report;
     unsigned int    beacon_report_len;
     unsigned char   beacon_report_elem[EM_MAX_BEACON_MEASUREMENT_LEN];
@@ -2753,7 +2757,7 @@ typedef struct {
 
 typedef struct {
     mac_address_t  bssid;
-    mac_address_t  mac_addr;
+    mac_address_t  link_addr;
 } em_affiliated_sta_info_t;
 
 typedef struct {
@@ -3051,6 +3055,7 @@ typedef enum {
 	em_bus_event_type_channel_scan_params,
     em_bus_event_type_get_mld_config,
     em_bus_event_type_mld_reconfig,
+    em_bus_event_type_beacon_query,
     em_bus_event_type_beacon_report,
     em_bus_event_type_recv_wfa_action_frame,
     em_bus_event_type_recv_gas_frame,
@@ -3340,6 +3345,8 @@ typedef struct {
 } em_cmd_unassoc_sta_query_params_t;
 
 typedef em_scan_params_t em_cmd_scan_params_t;
+typedef em_beacon_metrics_query_t em_cmd_beacon_metrics_param_t;
+
 typedef struct {
     union {
         em_cmd_args_t	args;
@@ -3349,6 +3356,7 @@ typedef struct {
 		em_cmd_scan_params_t	scan_params;
         em_cmd_ap_metrics_rprt_params_t ap_metrics_params;
         em_cmd_unassoc_sta_query_params_t unassoc_sta_query_params;
+        em_cmd_beacon_metrics_param_t beacon_metrics_params;
     } u;
 	em_network_node_t *net_node;
 } em_cmd_params_t;
@@ -3527,9 +3535,8 @@ typedef enum {
     tag_vht_capability = 191,
     tag_vendor_specific = 221,
     tag_extended_tags = 255,
-    //he
-    //he_6ghz
-    //eht
+    tag_ext_he_cap = 35,
+    tag_ext_eht_cap = 108,
     //other tags can be added here
 } tag_type_t;
 

--- a/inc/em_cmd.h
+++ b/inc/em_cmd.h
@@ -555,6 +555,10 @@ public:
 	 */
 	void reset_cmd_ctx() { m_data_model.reset_cmd_ctx(); }
 
+	virtual bool supports_retry_state() const { return false; }
+	virtual time_t get_query_tx_time() const { return 0; }
+	virtual void set_query_tx_time(time_t tx_time) { (void)tx_time; }
+	virtual void clear_query_tx_time() {}
     
 	/**!
 	 * @brief Retrieves the database configuration type.

--- a/inc/em_cmd_beacon_report.h
+++ b/inc/em_cmd_beacon_report.h
@@ -16,15 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef EM_CMD_BTM_REPORT_H
-#define EM_CMD_BTM_REPORT_H
+#ifndef EM_CMD_BEACON_REPORT_H
+#define EM_CMD_BEACON_REPORT_H
 
 #include "em_cmd.h"
 
 class em_cmd_beacon_report_t : public em_cmd_t {
 
-public:
-    
+private:
+	time_t m_beacon_query_tx_time = 0;
+
+public:    
+	bool supports_retry_state() const override { return true; }
+	time_t get_query_tx_time() const override { return m_beacon_query_tx_time; }
+	void set_query_tx_time(time_t tx_time) override { m_beacon_query_tx_time = tx_time; }
+	void clear_query_tx_time() override { m_beacon_query_tx_time = 0; }
+
 	/**!
 	 * @brief 
 	 *

--- a/inc/em_cmd_sta_assoc.h
+++ b/inc/em_cmd_sta_assoc.h
@@ -22,9 +22,15 @@
 #include "em_cmd.h"
 
 class em_cmd_sta_assoc_t : public em_cmd_t {
+private:
+	time_t m_beacon_query_tx_time = 0;
 
 public:
-    
+    bool supports_retry_state() const override { return true; }
+	time_t get_query_tx_time() const override { return m_beacon_query_tx_time; }
+	void set_query_tx_time(time_t tx_time) override { m_beacon_query_tx_time = tx_time; }
+	void clear_query_tx_time() override { m_beacon_query_tx_time = 0; }
+
 	/**!
 	 * @brief Associates a station with the given parameters and mesh configuration.
 	 *

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -470,21 +470,21 @@ public:
 	void handle_link_stats_alarm_report(em_bus_event_t *evt);
 	void handle_failed_conn_msg(unsigned char *data, unsigned int len) override;
 
-        /**!
-         * @brief Handles an Unassociated STA Link Metrics Query event.
-         *
-         * This function processes the Unassociated STA Link Metrics Query
-         * received from the controller, validates the requested operating
-         * classes, channels and STA MAC entries, and initiates the
-         * corresponding agent-side RCPI measurement workflow.
-         *
-         * @param[in] evt Pointer to the event structure containing the
-         *                Unassociated STA Link Metrics Query payload.
-         *
-         * @note Ensure that the event structure is properly initialized
-         *       before calling this function.
-         */
-        void handle_unassoc_sta_metrics_query(em_bus_event_t *evt);
+	/**!
+	 * @brief Handles an Unassociated STA Link Metrics Query event.
+	 *
+	 * This function processes the Unassociated STA Link Metrics Query
+	 * received from the controller, validates the requested operating
+	 * classes, channels and STA MAC entries, and initiates the
+	 * corresponding agent-side RCPI measurement workflow.
+	 *
+	 * @param[in] evt Pointer to the event structure containing the
+	 *                Unassociated STA Link Metrics Query payload.
+	 *
+	 * @note Ensure that the event structure is properly initialized
+	 *       before calling this function.
+	 */
+	void handle_unassoc_sta_metrics_query(em_bus_event_t *evt);
 
 	/**!
 	 * @brief 

--- a/inc/em_metrics.h
+++ b/inc/em_metrics.h
@@ -391,22 +391,23 @@ class em_metrics_t {
 	 */
 	short create_beacon_metrics_query_tlv(unsigned char *buff, mac_address_t sta_mac, bssid_t bssid);
     
+	short send_single_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid);
+
 	/**!
-	 * @brief Sends a beacon metrics query to a specified station.
-	 *
-	 * This function initiates a query to gather beacon metrics from a station identified by its MAC address.
-	 *
-	 * @param[in] sta_mac The MAC address of the station to which the beacon metrics query is sent.
-	 * @param[in] bssid The BSSID of the network to which the station is connected.
-	 *
-	 * @returns A short integer indicating the success or failure of the operation.
-	 * @retval 0 on success.
-	 * @retval -1 on failure.
-	 *
-	 * @note Ensure that the station is within range and the MAC address is correct before sending the query.
+	 * @brief Sends a 1905 ACK for a received Beacon Metrics Response.
+	 * @param[in] msg_id The message ID from the CMDU being acknowledged.
 	 */
-	short send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid);
-    
+	int send_beacon_metrics_ack(unsigned short msg_id);
+
+	/**!
+	 * @brief Sends a 1905 ACK to the controller after receiving a Beacon Metrics Query.
+	 *        Includes an Error Code TLV (Reason 0x02) if the STA is not associated.
+	 * @param[in] sta_mac STA MAC address from the query.
+	 * @param[in] msg_id  Message ID from the CMDU being acknowledged.
+	 * @param[in] reason  0 = success; 0x02 = STA not associated with any BSS.
+	 */
+	int send_beacon_metrics_query_ack(mac_address_t sta_mac, unsigned short msg_id, unsigned char reason);
+
 	/**!
 	 * @brief Sends a beacon metrics response.
 	 *
@@ -671,6 +672,8 @@ public:
 	 * @note Ensure that the buffer is large enough to hold the TLV data.
 	 */
 	virtual short create_assoc_sta_traffic_stats_tlv(unsigned char *buff, const dm_sta_t *const sta);
+
+	short send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid);
 
 	/**!
 	 * @brief Retrieves the manager instance.

--- a/inc/em_msg.h
+++ b/inc/em_msg.h
@@ -236,6 +236,8 @@ public:
 	 * @note Ensure that the mac pointer is valid and points to a properly allocated mac_address_t structure.
 	 */
 	bool get_bss_id(mac_address_t *mac);
+
+	bool get_sta_mac(mac_address_t *mac);
     
 	/**!
 	* @brief Retrieves the profile information.

--- a/src/agent/dm_easy_mesh_agent.cpp
+++ b/src/agent/dm_easy_mesh_agent.cpp
@@ -145,7 +145,6 @@ int dm_easy_mesh_agent_t::analyze_sta_list(em_bus_event_t *evt, em_cmd_t *pcmd[]
         update_assoc_sta_mld_info(&dm.m_assoc_sta_mld[idx].m_assoc_sta_mld_info);
     }
 
-
     for ( i = 0; i < num_radios; i++) {
         evt->params.u.args.num_args = 1;
         dm_easy_mesh_t::macbytes_to_string(get_radio_by_ref(i).get_radio_interface_mac(), radio_str);
@@ -906,7 +905,7 @@ int dm_easy_mesh_agent_t::analyze_unassoc_sta_result(em_bus_event_t *evt, em_cmd
 
     em_unassoc_sta_metrics_rsp_t *rsp;
 
-    translate_and_decode_onewifi_subdoc(reinterpret_cast<char *>(evt->u.raw_buff), webconfig_subdoc_type_nasta_query, "Unassoc STA Metrics Response");
+    translate_and_decode_onewifi_subdoc((char *)evt->u.raw_buff, webconfig_subdoc_type_nasta_query, "Unassoc STA Metrics Response");
 
     json = cJSON_Parse((const char *)evt->u.raw_buff);
 

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1078,17 +1078,118 @@ void em_agent_t::handle_set_policy(em_bus_event_t *evt)
     }
 }
 
+void em_agent_t::send_beacon_query(em_bus_event_t *evt)
+{
+    raw_data_t l_bus_data;
+    beacon_query_params_t beacon_query = {0};
+    wifi_BeaconRequest_t *beacon_req = &beacon_query.data;
+    em_beacon_metrics_query_t *query_params = reinterpret_cast<em_beacon_metrics_query_t *>(evt->u.raw_buff);
+    bus_error_t rc;
+    wifi_bus_desc_t *desc;
+    int total_ch = 0;
+    const int max_hal_ch = MAX_CHANNELS_REPORT;
+
+    if (evt->data_len < sizeof(em_beacon_metrics_query_t)) {
+         em_printfout("Beacon Query event payload too short (len=%u)", evt->data_len);
+         return;
+    }
+    if ((memcmp(query_params->sta_mac_addr, ZERO_MAC_ADDR, sizeof(mac_address_t)) == 0)) {
+        em_beacon_metrics_query_t *subdoc_query = reinterpret_cast<em_beacon_metrics_query_t *>(evt->u.subdoc.buff);
+        if (memcmp(subdoc_query->sta_mac_addr, ZERO_MAC_ADDR, sizeof(mac_address_t)) != 0) {
+            em_printfout("Beacon Query payload found in subdoc buffer, using fallback decode path");
+            query_params = subdoc_query;
+        }
+    }
+
+    em_printfout("Beacon Query forwarding to OW for sta: %s", util::mac_to_string(query_params->sta_mac_addr).c_str());
+    beacon_req->opClass = query_params->op_class;
+    beacon_req->channel = query_params->channel_num;
+
+    // channel_num==0 means current channel; 255 is wildcard (all channels).
+    // Passive mode avoids probe-request transmission on off-channel/DFS channels.
+    bool is_off_channel = true;
+    if (query_params->channel_num == 0) {
+        is_off_channel = false;
+    } else if (query_params->channel_num != 255) {
+        em_bss_info_t *bss_info = m_data_model.get_bss_info_with_mac(query_params->bssid);
+        if (bss_info != NULL) {
+            for (unsigned int i = 0; i < m_data_model.m_num_opclass; i++) {
+                em_op_class_info_t *oc = &m_data_model.m_op_class[i].m_op_class_info;
+                if (memcmp(oc->id.ruid, bss_info->ruid.mac, sizeof(mac_address_t)) == 0 &&
+                        oc->id.type == em_op_class_type_current && oc->channel != 0) {
+                    is_off_channel = (query_params->channel_num != static_cast<unsigned char>(oc->channel));
+                    break;
+                }
+            }
+        }
+    }
+    // Measurement mode: 0=Passive, 1=Active
+    beacon_req->mode = is_off_channel ? 0 : 1;
+    em_printfout("Beacon Query: channel=%u is_off_channel=%d mode=%u",
+        query_params->channel_num, (int)is_off_channel, beacon_req->mode);
+
+    beacon_req->duration = 200;
+    memcpy(beacon_req->bssid, query_params->bssid, sizeof(mac_address_t));
+    beacon_req->ssidPresent = (query_params->ssid_len > 0);
+    if (beacon_req->ssidPresent) {
+        size_t ssid_copy_len = query_params->ssid_len;
+        if (ssid_copy_len >= sizeof(beacon_req->ssid)) {
+            ssid_copy_len = sizeof(beacon_req->ssid) - 1;
+        }
+        memcpy(beacon_req->ssid, query_params->ssid, ssid_copy_len);
+        beacon_req->ssid[ssid_copy_len] = '\0';
+    }
+    em_printfout("SSID Name: %s[%s]", beacon_req->ssid, util::mac_to_string(beacon_req->bssid).c_str());
+    beacon_req->reportingDetail = query_params->rprt_detail;
+
+    for (int i = 0; i < query_params->num_ap_channel_rprt && total_ch < max_hal_ch; i++) {
+        // All entries share the same op_class (single-band query); use the first.
+        if (i == 0) {
+            beacon_req->channelReport.opClass = query_params->ap_channel_rprt[i].ap_channel_op_class;
+        }
+        int num_ch = query_params->ap_channel_rprt[i].ap_channel_rprt_len - 1;
+        for (int j = 0; j < num_ch && total_ch < max_hal_ch; j++) {
+            uint8_t ch = query_params->ap_channel_rprt[i].ap_channel_list[j];
+            em_printfout("Ap Channel Report[%d] - OpClass: %d Channel: %d", i,
+                beacon_req->channelReport.opClass, ch);
+            beacon_req->channelReport.channels[total_ch++] = ch;
+        }
+    }
+    em_printfout("Total channels accumulated into HAL channelReport: %d", total_ch);
+    beacon_req->channelReportPresent = (query_params->num_ap_channel_rprt > 0);
+    for (int i = 0; i < query_params->element_list.num_element_id; i++) {
+        beacon_req->requestedElementIDS.ids[i] = query_params->element_list.element_list[i];
+        em_printfout("Requested Element ID: %d", beacon_req->requestedElementIDS.ids[i]);
+    }
+
+    if((desc = get_bus_descriptor()) == NULL) {
+       em_printfout("descriptor is null");
+       return;
+    }
+
+    l_bus_data.data_type = bus_data_type_bytes;
+    l_bus_data.raw_data.bytes = (void *)&beacon_query;
+    l_bus_data.raw_data_len = sizeof(beacon_query_params_t);
+
+    memcpy(beacon_query.sta_mac, query_params->sta_mac_addr, sizeof(mac_address_t));
+    if ((rc = desc->bus_set_fn(&m_bus_hdl, "Device.WiFi.EM.BeaconQuery", &l_bus_data)) != 0) {
+        em_printfout("Failed to send Beacon Query to bus rc=%d len=%u", rc, l_bus_data.raw_data_len);
+        return;
+    }
+    em_printfout("Successfully sent Beacon Query to bus");
+}
+
 void em_agent_t::handle_beacon_report(em_bus_event_t *evt)
 {
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     unsigned int num = 0;
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
-        printf("analyze_beacon_report in progress\n");
+        em_printfout("analyze_beacon_report in progress");
     } else if ((num = static_cast<unsigned int>(m_data_model.analyze_beacon_report(evt, pcmd))) == 0) {
-        printf("analyze_beacon_report failed\n");
+        em_printfout("analyze_beacon_report failed");
     } else if (m_orch->submit_commands(pcmd, num) > 0) {
-        printf("submitted beacon report cmd for orch\n");
+        em_printfout("submitted beacon report cmd for orchestration");
     }
 }
 
@@ -1233,6 +1334,10 @@ void em_agent_t::handle_bus_event(em_bus_event_t *evt)
 
         case em_bus_event_type_set_policy:
             handle_set_policy(evt);
+            break;
+
+        case em_bus_event_type_beacon_query:
+            send_beacon_query(evt);
             break;
 
         case em_bus_event_type_beacon_report:
@@ -1693,7 +1798,7 @@ int em_agent_t::report_cb(char *event_name, bus_data_prop_t *data, void *userDat
                     cJSON_Delete(json);
                     return -1;
                 }
-                em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
+                //em_printfout("Received Frame data for event [%s] and data :\n%s", event_name, data->value.raw_data.bytes);
             }
             cJSON_Delete(json);
         }
@@ -1884,8 +1989,8 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
     bool found = false;
     em_string_t al_mac_str;
     em_bss_info_t *em_bss = NULL;
-    mac_address_t fallback_ruid = {0};
     unsigned int i = 0, j = 0;
+    mac_addr_t fallback_ruid;
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
     if (len < ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)))) {
@@ -2074,6 +2179,7 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
                     em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str2));
                     if (em != NULL) {
                         em_printfout("Client cap query AP-MLD bss=%s resolved to radio=%s", mac_str1, mac_str2);
+                        break;
                     }
                 }
             }
@@ -2165,10 +2271,12 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 		case em_msg_type_channel_scan_rprt:
         case em_msg_type_beacon_metrics_rsp:
         case em_msg_type_ap_mld_config_resp:
-        case em_msg_type_beacon_metrics_query:
         case em_msg_type_ap_metrics_rsp:
             break;
 
+        case em_msg_type_beacon_metrics_query:
+            em = al_em;
+            break;
         case em_msg_type_proxied_encap_dpp:
         case em_msg_type_direct_encap_dpp:
         case em_msg_type_chirp_notif:
@@ -2219,11 +2327,11 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
             break;
 
         case em_msg_type_unassoc_sta_link_metrics_rsp:
-           printf("%s:%d: Sending Unassoc STA Link Metrics response\n", __func__, __LINE__);
-           break;
+            em_printfout("Sending Unassoc STA Link Metrics response");
+            break;
 
         default:
-            printf("%s:%d: Frame: %d not handled in agent\n", __func__, __LINE__, htons(cmdu->type));
+            em_printfout("Frame: %d not handled in agent", htons(cmdu->type));
             em = NULL;
             break;	
 	}

--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1157,7 +1157,18 @@ void em_agent_t::send_beacon_query(em_bus_event_t *evt)
     }
     em_printfout("Total channels accumulated into HAL channelReport: %d", total_ch);
     beacon_req->channelReportPresent = (query_params->num_ap_channel_rprt > 0);
-    for (int i = 0; i < query_params->element_list.num_element_id; i++) {
+    // Clamp to both the HAL destination capacity and the source array size: the
+    // subdoc path reaches here without the wire-TLV parser's num_element_id clamp.
+    size_t max_ids = sizeof(beacon_req->requestedElementIDS.ids) / sizeof(beacon_req->requestedElementIDS.ids[0]);
+    size_t src_ids = sizeof(query_params->element_list.element_list) / sizeof(query_params->element_list.element_list[0]);
+    if (src_ids < max_ids) {
+        max_ids = src_ids;
+    }
+    size_t ids_to_copy = static_cast<size_t>(query_params->element_list.num_element_id);
+    if (ids_to_copy > max_ids) {
+        ids_to_copy = max_ids;
+    }
+    for (size_t i = 0; i < ids_to_copy; i++) {
         beacon_req->requestedElementIDS.ids[i] = query_params->element_list.element_list[i];
         em_printfout("Requested Element ID: %d", beacon_req->requestedElementIDS.ids[i]);
     }

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -2263,6 +2263,9 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     bool radio_matched = false, found = false;
     em_orch_desc_t desc;
     mac_address_t fallback_ruid = {0};
+    bool is_ap_mld = false;
+    bool is_assoc = false;
+    bool sta_exists = false;
 
     if (evt == NULL) {
         em_printfout("NULL event");
@@ -2274,8 +2277,8 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     dm_easy_mesh_t::macbytes_to_string(params->assoc.cli_mac_address, sta_mac_str);
     dm_easy_mesh_t::macbytes_to_string(params->assoc.bssid, bss_mac_str);
     
-    //printf("%s:%d: Client:%s %s BSS: %s of Device: %s\n", __func__, __LINE__,
-        //sta_mac_str, (params->assoc.assoc_event == 1)?"associated with":"disassociated from", bss_mac_str, dev_mac_str);
+    // em_printfout("%s:%d: Client:%s %s BSS: %s of Device: %s\n", __func__, __LINE__,
+    //     sta_mac_str, (params->assoc.assoc_event == 1)?"associated with":"disassociated from", bss_mac_str, dev_mac_str);
 
     evt->params.u.args.num_args = 4;
     strncpy(evt->params.u.args.args[0], dev_mac_str, sizeof(em_long_string_t));
@@ -2285,13 +2288,15 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     strncpy(evt->params.u.args.args[3], (params->assoc.assoc_event == 1)?"Assoc":"Disassoc", len);
     pdm = get_data_model(GLOBAL_NET_ID, params->dev);
     if (pdm == NULL) {
-        printf("%s:%d: Could not find data model for dev: %s\n", __func__, __LINE__, dev_mac_str);
+        em_printfout("Could not find data model for dev: %s", dev_mac_str);
         return -1;
     }
 
     pdm->set_topo_state(true);
 
-    if (pdm->is_ap_mld_mac(params->assoc.bssid) == false) {
+    is_ap_mld = pdm->is_ap_mld_mac(params->assoc.bssid);
+
+    if (is_ap_mld == false) {
         em_printfout("bssid=%s is not AP-MLD MAC, using direct BSS lookup for STA assoc event", bss_mac_str);
         found = false;
         for (i = 0; i < pdm->get_num_radios(); i++) {
@@ -2307,8 +2312,8 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
 
             // confirm that the radio is on this device
             for (i = 0; i < pdm->m_num_radios; i++) {
-                    if (memcmp(pbss->m_bss_info.ruid.mac, pdm->m_radio[i].m_radio_info.intf.mac,
-                           sizeof(mac_address_t)) == 0) {
+                if (memcmp(pbss->m_bss_info.ruid.mac, pdm->m_radio[i].m_radio_info.intf.mac,
+                        sizeof(mac_address_t)) == 0) {
                     radio_matched = true;
                     break;
                 }
@@ -2333,7 +2338,37 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
     tmp = pcmd[num];
     num++;
 
-    if (params->assoc.assoc_event == false) {
+    is_assoc = (params->assoc.assoc_event == true) ? true : false;
+    // Look up STA in datamodel (m_sta_map)
+    dm_sta_t *iter = static_cast<dm_sta_t *>(hash_map_get_first(pdm->m_sta_map));
+    while (iter != NULL) {
+        if (memcmp(iter->m_sta_info.id, params->assoc.cli_mac_address, sizeof(mac_address_t)) == 0) {
+            if (is_ap_mld) {
+                // MLD STA is "known" only if we already have its capability data
+                sta_exists = (iter->m_sta_info.frame_body_len > 0);
+            } else {
+                // Legacy STA: verify BSSID matches and we have capability data
+                if (memcmp(iter->m_sta_info.bssid, params->assoc.bssid, sizeof(mac_address_t)) == 0) {
+                    sta_exists = (iter->m_sta_info.frame_body_len > 0);
+                }
+            }
+            em_printfout("sta found in m_sta_map %s, sta_exists=%d", sta_mac_str, sta_exists);
+            break;
+        }
+        iter = static_cast<dm_sta_t *>(hash_map_get_next(pdm->m_sta_map, iter));
+    }
+
+    // Look up STA in persistent DB map (m_sta_assoc_map)
+    iter = static_cast<dm_sta_t *>(hash_map_get_first(pdm->m_sta_assoc_map));
+    while (iter != NULL) {
+        if (memcmp(iter->m_sta_info.id, params->assoc.cli_mac_address, sizeof(mac_address_t)) == 0) {
+            em_printfout("sta found in m_assoc_map %s", sta_mac_str);
+            break;
+        }
+        iter = static_cast<dm_sta_t *>(hash_map_get_next(pdm->m_sta_assoc_map, iter));
+    }
+
+    if (is_assoc == false) {
         desc.op = dm_orch_type_topo_update;
         desc.submit = false;
         pcmd[num - 1]->override_op(0, &desc);
@@ -2341,17 +2376,48 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
         desc.submit = true;
         pcmd[num - 1]->override_op(1, &desc);
         pcmd[num - 1]->m_num_orch_desc = 2;
-    } else if ((params->assoc.assoc_event == true) && (found == true) &&
-               (pdm->is_ap_mld_mac(params->assoc.bssid) == false)) {
-        // BSS is directly resolvable for a non-MLO client — topology query not needed;
-        // skip dm_orch_type_topo_sync and go straight to client capability query + publish.
-        desc.op = dm_orch_type_sta_cap;
-        desc.submit = true;
-        pcmd[num - 1]->override_op(0, &desc);
-        desc.op = dm_orch_type_topo_publish;
-        desc.submit = true;
-        pcmd[num - 1]->override_op(1, &desc);
-        pcmd[num - 1]->m_num_orch_desc = 2;
+    } else {
+        if (sta_exists == true) {
+            if (is_ap_mld == false) {
+                // Non-MLO: STA already known with full capability data - skip topo_sync.
+                desc.op = dm_orch_type_topo_update;
+                desc.submit = false;
+                pcmd[num - 1]->override_op(0, &desc);
+                desc.op = dm_orch_type_topo_publish;
+                desc.submit = true;
+                pcmd[num - 1]->override_op(1, &desc);
+                pcmd[num - 1]->m_num_orch_desc = 2;
+                em_printfout("STA info already present in data model, skipping topology query. Do a topology update + publish for STA assoc event");
+            } else {
+                // MLO: even if STA capability data is known, per-link association state
+                // (which BSSIDs are active) can change on every assoc event.  We must
+                // trigger a topo_sync so that handle_assoc_sta_mld_topology_update()
+                // runs against fresh assoc_sta_mld_conf_rep data and correctly refreshes
+                // all per-link entries in m_sta_assoc_map / DB.
+                em_printfout("MLO STA %s re-association: triggering topo_sync to refresh per-link state", sta_mac_str);
+                for (unsigned int i = 0; i < pcmd[num - 1]->m_num_orch_desc; i++) {
+                    em_printfout("Orch desc %u: op = %d, submit = %d", i, pcmd[num - 1]->m_orch_desc[i].op, pcmd[num - 1]->m_orch_desc[i].submit);
+                    if (pcmd[num - 1]->m_orch_desc[i].op == dm_orch_type_sta_cap) {
+                        em_orch_desc_t updated = pcmd[num - 1]->m_orch_desc[i];
+                        updated.submit = false;
+                        pcmd[num - 1]->override_op(i, &updated);
+                    }
+                }
+            }
+        } else {
+            // New Non-MLO client: STA doesn't exist
+            if ((found == true) && (is_ap_mld == false)) {
+                // BSS is directly resolvable for a non-MLO client - topology query not needed;
+                em_printfout("New non-mlo STA identified Send a cap query....");
+                desc.op = dm_orch_type_sta_cap;
+                desc.submit = true;
+                pcmd[num - 1]->override_op(0, &desc);
+                desc.op = dm_orch_type_topo_publish;
+                desc.submit = true;
+                pcmd[num - 1]->override_op(1, &desc);
+                pcmd[num - 1]->m_num_orch_desc = 2;
+            }
+        }
     }
 
     while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
@@ -2817,7 +2883,7 @@ int dm_easy_mesh_ctrl_t::analyze_set_policy(em_bus_event_t *evt, em_cmd_t *pcmd[
                         dm.set_num_policy(index + 1);
                     }
                 }
-                // Don't break — there may be broadcast entries of both types
+                // Don't break - there may be broadcast entries of both types
             }
 
             // Compare each incoming policy by type against the existing dm.
@@ -8144,7 +8210,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     em_sta_info_t *si = NULL;
     while (sta != NULL) {
         si = sta->get_sta_info();
-        if (si->associated && memcmp(asi->mac_addr, si->id, sizeof(mac_addr_t)) != 0) {
+        if (si->associated && memcmp(asi->link_addr, si->id, sizeof(mac_addr_t)) != 0) {
             break;
         }
         sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
@@ -8152,7 +8218,7 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_get_inner(char *event_name, raw_data_t *
     }
 
     if (strcmp(param, "MACAddress") == 0) {
-        rc = dm_ctrl->raw_data_set(p_data, asi->mac_addr);
+        rc = dm_ctrl->raw_data_set(p_data, asi->link_addr);
     } else if (strcmp(param, "BSSID") == 0) {
         rc = dm_ctrl->raw_data_set(p_data, asi->bssid);
     } else if (strcmp(param, "BytesSent") == 0) {
@@ -8249,14 +8315,14 @@ bus_error_t dm_easy_mesh_ctrl_t::affsta_tget_params(dm_easy_mesh_t *dm, const ch
         em_sta_info_t *si = NULL;
         while (sta != NULL) {
             si = sta->get_sta_info();
-            if (si->associated && memcmp(asi->mac_addr, si->id, sizeof(mac_addr_t)) != 0) {
+            if (si->associated && memcmp(asi->link_addr, si->id, sizeof(mac_addr_t)) != 0) {
                 break;
             }
             sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
             si = NULL;
         }
 
-        dm_ctrl->property_append_tail(property, root, idx, "MACAddress", asi->mac_addr);
+        dm_ctrl->property_append_tail(property, root, idx, "MACAddress", asi->link_addr);
         dm_ctrl->property_append_tail(property, root, idx, "BSSID", asi->bssid);
         dm_ctrl->property_append_tail(property, root, idx, "BytesSent", si ? si->bytes_tx : 0);
         dm_ctrl->property_append_tail(property, root, idx, "BytesReceived", si ? si->bytes_rx : 0);

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -989,7 +989,6 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
     mac_addr_str_t mac_str1 = {0}, mac_str2 = {0};
     unsigned int i = 0;
     em_commit_info_t dm_commit = {};
-    mac_address_t fallback_ruid = {0};
     em_supported_service_t svc = {};
     uint8_t is_emplus;
 

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -960,14 +960,12 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
     em_freq_band_t band;
     dm_easy_mesh_t *dm;
     em_t *em = NULL;
-    mac_address_t ruid;
+    mac_address_t ruid, sta_mac;
     bssid_t	bssid;
-    dm_bss_t *bss;
     em_profile_type_t profile;
-    unsigned int i;
     mac_addr_str_t mac_str1 = {0}, mac_str2 = {0};
     em_commit_info_t dm_commit;
-    mac_address_t fallback_ruid = {0};
+    unsigned int i = 0;
 
     assert(len > ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))));
     if (len < ((sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)))) {
@@ -1084,61 +1082,12 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
         case em_msg_type_client_cap_rprt:
         case em_msg_type_ap_metrics_rsp:
         case em_msg_type_failed_conn:
-           if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
+            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
                     len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_bss_id(&bssid) == false) {
-                printf("%s:%d: Could not find bss id in msg:0x%04x\n", __func__, __LINE__, htons(cmdu->type));
+                em_printfout("Could not find bss id in msg:0x%04x", htons(cmdu->type));
                 return NULL;
             }
-
-            if ((dm = get_data_model(GLOBAL_NET_ID, const_cast<const unsigned char *> (hdr->src))) == NULL) {
-                printf("%s:%d: Can not find data model\n", __func__, __LINE__);
-                return NULL;
-            }
-
-            if (dm->is_ap_mld_mac(bssid) == false) {
-                bss = NULL;
-                for (i = 0; i < dm->get_num_radios(); i++) {
-                    bss = dm->get_bss(dm->get_radio_info(i)->id.ruid, bssid);
-                    if (bss != NULL) {
-                        break;
-                    }
-                }
-
-                if (bss == NULL) {
-                    em_printfout("Could not find bss=%s from data model",
-                        util::mac_to_string(bssid).c_str());
-                    return NULL;
-                }
-
-                dm_easy_mesh_t::macbytes_to_string(bss->m_bss_info.ruid.mac, mac_str1);
-                if ((em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1))) == NULL) {
-                    em_printfout("Could not find radio:%s", mac_str1);
-                    return NULL;
-                }
-            } else {
-                if ((htons(cmdu->type) == em_msg_type_topo_notif) ||
-                    (htons(cmdu->type) == em_msg_type_client_cap_rprt)) {
-                    if (dm->resolve_ap_mld_to_fallback_ruid(bssid, fallback_ruid)) {
-                        dm_easy_mesh_t::macbytes_to_string(fallback_ruid, mac_str1);
-                        em = static_cast<em_t *>(hash_map_get(m_em_map, mac_str1));
-                        if (em != NULL) {
-                            em_printfout("Resolved AP-MLD bssid=%s to radio=%s for msg=0x%04x",
-                                util::mac_to_string(bssid).c_str(),
-                                util::mac_to_string(fallback_ruid).c_str(),
-                                htons(cmdu->type));
-                        }
-                    }
-                    if (em == NULL) {
-                        em_printfout("fallback em not found for msg 0x%04x", htons(cmdu->type));
-                        return NULL;
-                    }
-                } else {
-                    em_printfout("Could not find bss=%s from data model",
-                        util::mac_to_string(bssid).c_str());
-                    return NULL;
-                }
-            }
-
+            em = al_em;
             break;
 
         case em_msg_type_autoconf_resp:
@@ -1203,13 +1152,12 @@ em_t *em_ctrl_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em_
             break;
 
         case em_msg_type_beacon_metrics_rsp:
-            em = static_cast<em_t *> (hash_map_get_first(m_em_map));
-            while(em != NULL) {
-                if ((em->is_al_interface_em() == false) && (em->has_at_least_one_associated_sta() == true)) {
-                    break;
-                }
-                em = static_cast<em_t *> (hash_map_get_next(m_em_map, em));
+            if (em_msg_t(data + (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t)),
+                    len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t))).get_sta_mac(&sta_mac) == false) {
+                em_printfout("Could not find sta mac in msg:0x%04x", htons(cmdu->type));
+                return NULL;
             }
+            em = al_em;
             break;
 
         case em_msg_type_chirp_notif:

--- a/src/dm/dm_assoc_sta_mld.cpp
+++ b/src/dm/dm_assoc_sta_mld.cpp
@@ -61,8 +61,8 @@ void dm_assoc_sta_mld_t::operator = (const dm_assoc_sta_mld_t& obj)
     for (unsigned int i = 0; i < this->m_assoc_sta_mld_info.num_affiliated_sta; i++) {
         memcpy(&this->m_assoc_sta_mld_info.affiliated_sta[i].bssid,
             &obj.m_assoc_sta_mld_info.affiliated_sta[i].bssid, sizeof(mac_address_t));
-        memcpy(&this->m_assoc_sta_mld_info.affiliated_sta[i].mac_addr,
-            &obj.m_assoc_sta_mld_info.affiliated_sta[i].mac_addr, sizeof(mac_address_t));
+        memcpy(&this->m_assoc_sta_mld_info.affiliated_sta[i].link_addr,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].link_addr, sizeof(mac_address_t));
     }
 }
 
@@ -82,8 +82,8 @@ bool dm_assoc_sta_mld_t::operator == (const dm_assoc_sta_mld_t& obj)
     for (unsigned int i = 0; i < num_sta; i++) {
         ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].bssid,
             &obj.m_assoc_sta_mld_info.affiliated_sta[i].bssid, sizeof(mac_address_t)) != 0);
-        ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].mac_addr,
-            &obj.m_assoc_sta_mld_info.affiliated_sta[i].mac_addr, sizeof(mac_address_t)) != 0);
+        ret += (memcmp(&this->m_assoc_sta_mld_info.affiliated_sta[i].link_addr,
+            &obj.m_assoc_sta_mld_info.affiliated_sta[i].link_addr, sizeof(mac_address_t)) != 0);
     }
 
     if (ret > 0)

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -3021,6 +3021,17 @@ int dm_easy_mesh_t::get_num_bss_for_associated_sta(mac_address_t sta_mac)
     return num_bssids;
 }
 
+bool dm_easy_mesh_t::is_sta_mld(mac_address_t sta_mac)
+{
+    for (unsigned int i = 0; i < m_num_assoc_sta_mld; i++) {
+        if (memcmp(sta_mac, m_assoc_sta_mld[i].m_assoc_sta_mld_info.mac_addr, sizeof(mac_address_t)) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void dm_easy_mesh_t::clone_hash_maps(dm_easy_mesh_t& obj)
 {
     mac_addr_str_t  sta_mac_str, bss_mac_str, radio_mac_str;
@@ -3079,6 +3090,7 @@ void dm_easy_mesh_t::deinit()
 		snprintf(key, sizeof(em_2xlong_string_t), "%s@%s@%s@%d@%d@%d", tmp_res->m_scan_result.id.net_id, dev_mac_str, scanner_mac_str,
 					tmp_res->m_scan_result.id.op_class, tmp_res->m_scan_result.id.channel, tmp_res->m_scan_result.id.scanner_type);
 		hash_map_remove(m_scan_result_map, key);
+        delete tmp_res;
 	}
 
 	hash_map_destroy(m_scan_result_map);	
@@ -3567,9 +3579,8 @@ void dm_easy_mesh_t::update_assoc_sta_mld_info(em_assoc_sta_mld_info_t *assoc_st
         }
 
         memcpy(target_aff_sta->bssid, input_sta->bssid, sizeof(mac_address_t));
-        memcpy(target_aff_sta->mac_addr, input_sta->mac_addr, sizeof(mac_address_t));
+        memcpy(target_aff_sta->link_addr, input_sta->link_addr, sizeof(mac_address_t));
     }
-
 }
 
 void dm_easy_mesh_t::remove_assoc_sta_mld_info(mac_address_t sta_mld_mac)
@@ -3598,6 +3609,28 @@ void dm_easy_mesh_t::remove_assoc_sta_mld_info(mac_address_t sta_mld_mac)
     //memset(&m_assoc_sta_mld[m_num_assoc_sta_mld - 1], 0, sizeof(dm_assoc_sta_mld_t));
     m_assoc_sta_mld[m_num_assoc_sta_mld - 1].init();
     m_num_assoc_sta_mld--;
+}
+
+void dm_easy_mesh_t::apply_sta_cap_to_maps(const char *key, em_sta_info_t *info)
+{
+    // Write to m_sta_assoc_map for DB persistence on the next update_tables() flush.
+    dm_sta_t *entry = static_cast<dm_sta_t *>(hash_map_get(m_sta_assoc_map, key));
+    if (entry == NULL) {
+        hash_map_put(m_sta_assoc_map, strdup(key), new dm_sta_t(info));
+        em_printfout("Client cap assoc_map new: %s len=%u assoc=%d", key, info->frame_body_len, info->associated);
+    } else {
+        memcpy(&entry->m_sta_info, info, sizeof(em_sta_info_t));
+        em_printfout("Client cap assoc_map update: %s len=%u assoc=%d", key, info->frame_body_len, info->associated);
+    }
+
+    // Also update m_sta_map immediately so the topology reflects decoded
+    // caps in the current session without waiting for a DB sync.
+    dm_sta_t *map_sta = static_cast<dm_sta_t *>(hash_map_get(m_sta_map, key));
+    if (map_sta != NULL) {
+        map_sta->m_sta_info.frame_body_len = info->frame_body_len;
+        memcpy(map_sta->m_sta_info.frame_body, info->frame_body, info->frame_body_len);
+        dm_sta_t::decode_sta_capability(map_sta);
+    }
 }
 
 void dm_easy_mesh_t::reset_db_cfg_type(db_cfg_type_t type) 

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -738,7 +738,7 @@ void dm_easy_mesh_list_t::put_sta(const char *key, const dm_sta_t *sta)
     }
 
     if ((psta = static_cast<dm_sta_t *> (hash_map_get(dm->m_sta_map, key))) != NULL) {
-        //printf("%s:%d: STA:%s already present on BSS:%s of radio:%s dm:%p dm_mac:%s\n", __func__, __LINE__,
+        // em_printfout("%s:%d: STA:%s already present on BSS:%s of radio:%s dm:%p dm_mac:%s\n", __func__, __LINE__,
         //    sta_mac_str, bssid_str, radio_mac_str, dm, util::mac_to_string(dm->m_device.m_device_info.intf.mac).c_str());
         memcpy(&psta->m_sta_info, &sta->m_sta_info, sizeof(em_sta_info_t));
         return;
@@ -747,8 +747,8 @@ void dm_easy_mesh_list_t::put_sta(const char *key, const dm_sta_t *sta)
     psta = new dm_sta_t(*sta);
     hash_map_put(dm->m_sta_map, strdup(key), psta);
 
-    //printf("%s:%d: STA:%s added to BSS:%s of radio:%s dm:%p dm_mac:%s\n", __func__, __LINE__,
-    //        sta_mac_str, bssid_str, radio_mac_str, dm, util::mac_to_string(dm->m_device.m_device_info.intf.mac).c_str());
+    // em_printfout("%s:%d: STA:%s added to BSS:%s of radio:%s dm:%p dm_mac:%s\n", __func__, __LINE__,
+    //     sta_mac_str, bssid_str, radio_mac_str, dm, util::mac_to_string(dm->m_device.m_device_info.intf.mac).c_str());
 }
 
 dm_network_ssid_t *dm_easy_mesh_list_t::get_first_network_ssid()

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -288,6 +288,8 @@ void dm_sta_t::encode_beacon_report(cJSON *obj)
 		cJSON_AddNumberToObject(neighbor_obj, "OpClass", m_sta_info.beacon_reports[i].opClass);
 		cJSON_AddNumberToObject(neighbor_obj, "Channel", m_sta_info.beacon_reports[i].channel);
 		cJSON_AddNumberToObject(neighbor_obj, "RCPI", m_sta_info.beacon_reports[i].rcpi);
+		cJSON_AddNumberToObject(neighbor_obj, "RSNI", m_sta_info.beacon_reports[i].rsni);
+		cJSON_AddNumberToObject(neighbor_obj, "Antenna", m_sta_info.beacon_reports[i].antenna);
 
 		cJSON_AddItemToArray(neighbors_arr_obj, neighbor_obj);
 	}
@@ -600,6 +602,8 @@ void dm_sta_t::decode_beacon_report(dm_sta_t *sta)
 
     em_sta_info_t *sta_info = &sta->m_sta_info;
     ie = static_cast<unsigned char *>(sta->m_sta_info.beacon_report_elem);
+
+    memset(sta_info->beacon_reports, 0, sizeof(sta_info->beacon_reports));
 
     for (i = 0; i < sta_info->num_beacon_meas_report; i++) {
         current_pkt_len = ie[1];

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -597,6 +597,7 @@ void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
 void dm_sta_t::decode_beacon_report(dm_sta_t *sta)
 {
     unsigned int i =0;
+    unsigned int num_reports;
     unsigned char *ie;
     int current_pkt_len = 0;
 
@@ -605,7 +606,17 @@ void dm_sta_t::decode_beacon_report(dm_sta_t *sta)
 
     memset(sta_info->beacon_reports, 0, sizeof(sta_info->beacon_reports));
 
-    for (i = 0; i < sta_info->num_beacon_meas_report; i++) {
+    // Clamp to array size to avoid out-of-bounds writes from a malformed/oversized count.
+    num_reports = sta_info->num_beacon_meas_report;
+    if (num_reports > EM_MAX_BEACON_REPORTS_PER_SCAN) {
+        num_reports = EM_MAX_BEACON_REPORTS_PER_SCAN;
+    }
+
+    for (i = 0; i < num_reports; i++) {
+        if ((ie + 25) > (sta_info->beacon_report_elem + sta_info->beacon_report_len)) {
+            break;
+        }
+
         current_pkt_len = ie[1];
         ie += 2;
 

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -142,6 +142,10 @@ int dm_sta_t::decode(const cJSON *obj, void *parent_id)
         snprintf(m_sta_info.cellular_data_pref, sizeof(m_sta_info.cellular_data_pref), "%s", cJSON_GetStringValue(tmp));
     }
 
+    if ((tmp = cJSON_GetObjectItem(obj, "RMEnabledCapabilities")) != NULL) {
+        snprintf(m_sta_info.rm_cap, sizeof(m_sta_info.rm_cap), "%s", cJSON_GetStringValue(tmp));
+    }
+
     return 0;
 
 }
@@ -497,7 +501,9 @@ void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
                 break;
 
             case tag_extended_tags: {
-                if (tag->value[0] == tag_ext_multi_link) {
+                if (tag->length < 1) { break; }
+                unsigned char ext_id = tag->value[0];
+                if (ext_id == tag_ext_multi_link) {
                     ext_ptr = tag->value + 1;
                     ext_len = tag->length - 1;
 
@@ -510,6 +516,18 @@ void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
                         if (common_info_len >= EM_MAC_ADDR_LEN) {
                             strncpy(sta->m_sta_info.multi_link, util::mac_to_string(ext_ptr).c_str(), sizeof(em_long_string_t));
                         }
+                    }
+                } else if (ext_id == tag_ext_he_cap) {
+                    // HE Capabilities (ext tag 35): skip the 1-byte ext ID, hex-encode the rest
+                    if (tag->length > 1) {
+                        dm_easy_mesh_t::hex(static_cast<unsigned int>(tag->length - 1), tag->value + 1,
+                                            sizeof(em_long_string_t), sta->m_sta_info.he_cap);
+                    }
+                } else if (ext_id == tag_ext_eht_cap) {
+                    // EHT Capabilities (ext tag 108) — encode as ClientCapabilities string
+                    if (tag->length > 1) {
+                        dm_easy_mesh_t::hex(static_cast<unsigned int>(tag->length - 1), tag->value + 1,
+                                            sizeof(em_long_string_t), sta->m_sta_info.cap);
                     }
                 }
                 break;
@@ -547,6 +565,24 @@ void dm_sta_t::decode_beacon_report(dm_sta_t *sta)
 
        ie += current_pkt_len;
    }
+}
+
+bool dm_sta_t::supports_beacon_measurement() const
+{
+    // IEEE 802.11 (RM Enabled Capabilities, Octet 1):
+    //   bit 4 = Beacon Passive measurement
+    //   bit 5 = Beacon Active measurement
+    //   bit 6 = Beacon Table measurement
+    // Mask 0x70 covers all three.
+    if (m_sta_info.rm_cap[0] == '\0') {
+        return false;
+    }
+    unsigned int byte0 = 0;
+    if (sscanf(m_sta_info.rm_cap, "%02x", &byte0) != 1) {
+        return false;
+    }
+    //return true if any of the three beacon measurement bits are set
+    return (byte0 & 0x70) != 0;
 }
 
 dm_sta_t::dm_sta_t(em_sta_info_t *sta)

--- a/src/em/capability/em_capability.cpp
+++ b/src/em/capability/em_capability.cpp
@@ -748,8 +748,6 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     dm_easy_mesh_t  *dm;
     em_assoc_sta_mld_info_t *assoc_info = NULL;
     dm_bss_t *aff_bss = NULL;
-    dm_sta_t *existing_link_sta = NULL;
-    dm_sta_t *existing_sta = NULL;
     em_sta_info_t link_sta_info;
     em_long_string_t link_key;
     bool found_client_info = false;
@@ -757,6 +755,7 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
     bool updated_any = false;
     unsigned int i, j, k;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    dm_bss_t *bss = NULL;
 
     dm = get_data_model();
 
@@ -772,7 +771,21 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
             memset(&sta_info, 0, sizeof(em_sta_info_t));
             memcpy(sta_info.bssid, tlv->value, sizeof(mac_address_t));
             memcpy(sta_info.id, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
-            memcpy(sta_info.radiomac, get_radio_interface_mac(), sizeof(mac_address_t));
+            // Resolve the radio MAC from the BSSID so the key is correct regardless
+            // of which EM instance handled this message.
+            bool radio_found = false;
+            for (unsigned int r = 0; r < dm->get_num_radios() && !radio_found; r++) {
+                bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, sta_info.bssid);
+                if (bss != NULL) {
+                    memcpy(sta_info.radiomac, bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+                    radio_found = true;
+                    em_printfout("client_cap_report: resolved radio %s for sta %s bssid %s",
+                        util::mac_to_string(sta_info.radiomac).c_str(),
+                        util::mac_to_string(sta_info.id).c_str(),
+                        util::mac_to_string(sta_info.bssid).c_str());
+                }
+            }
+
             found_client_info = true;
             break;
         }
@@ -786,7 +799,7 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
         return -1;
     }
 
-    if ((dm->get_bss(get_radio_interface_mac(), sta_info.bssid) == NULL) && dm->is_ap_mld_mac(sta_info.bssid)) {
+    if ((bss == NULL) && dm->is_ap_mld_mac(sta_info.bssid)) {
         em_printfout("Client cap: STA %s is affiliated with MLD BSSID %s, remapping to affiliated link BSSID",
             util::mac_to_string(sta_info.id).c_str(), util::mac_to_string(sta_info.bssid).c_str());
         assoc_info = NULL;
@@ -838,9 +851,24 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
 
     set_state(em_state_ctrl_sta_cap_confirmed);
 
+    // The cap report may be routed to a different radio than the one running
+    // the sta_assoc command (e.g. MLD: report arrives on 2.4GHz radio but
+    // sta_assoc was dispatched to 6GHz radio which is in sta_cap_pending).
+    // Set sta_cap_confirmed on any AL radio in sta_cap_pending so the
+    // orchestrator's fini check passes.
+    std::vector<em_t *> al_radios;
+    get_mgr()->get_all_em_for_al_mac(get_data_model()->get_agent_al_interface_mac(), al_radios);
+    for (auto *em : al_radios) {
+        if (em->get_state() == em_state_ctrl_sta_cap_pending) {
+            em_printfout("cap report: setting sta_cap_confirmed on radio %s (was sta_cap_pending)",
+                util::mac_to_string(em->get_radio_interface_mac()).c_str());
+            em->set_state(em_state_ctrl_sta_cap_confirmed);
+        }
+    }
+
     dm_easy_mesh_t::macbytes_to_string(sta_info.id, sta_mac_str);
     dm_easy_mesh_t::macbytes_to_string(sta_info.bssid, bssid_str);
-    dm_easy_mesh_t::macbytes_to_string(get_radio_interface_mac(), radio_mac_str);
+    dm_easy_mesh_t::macbytes_to_string(sta_info.radiomac, radio_mac_str);
     snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
 
     // For MLO STA, update all affiliated link rows.
@@ -873,32 +901,14 @@ int em_capability_t::handle_client_cap_report(unsigned char *buff, unsigned int 
             dm_easy_mesh_t::macbytes_to_string(link_sta_info.radiomac, link_radio_str);
             snprintf(link_key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, link_bssid_str, link_radio_str);
 
-            existing_link_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, link_key));
-            if (existing_link_sta == NULL) {
-                hash_map_put(dm->m_sta_assoc_map, strdup(link_key), new dm_sta_t(&link_sta_info));
-                em_printfout("Client cap DB new link: %s len=%u assoc=%d",
-                        link_key, link_sta_info.frame_body_len, link_sta_info.associated);
-            } else {
-                memcpy(&existing_link_sta->m_sta_info, &link_sta_info, sizeof(em_sta_info_t));
-                em_printfout("Client cap DB update link: %s len=%u assoc=%d",
-                        link_key, link_sta_info.frame_body_len, link_sta_info.associated);
-            }
+            dm->apply_sta_cap_to_maps(link_key, &link_sta_info);
             updated_any = true;
         }
         break;
     }
 
     if (updated_any == false) {
-        existing_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, key));
-        if (existing_sta == NULL) {
-            hash_map_put(dm->m_sta_assoc_map, strdup(key), new dm_sta_t(&sta_info));
-            em_printfout("Client cap DB new: %s len=%u assoc=%d",
-                    key, sta_info.frame_body_len, sta_info.associated);
-        } else {
-            memcpy(&existing_sta->m_sta_info, &sta_info, sizeof(em_sta_info_t));
-            em_printfout("Client cap DB update: %s len=%u assoc=%d",
-                    key, sta_info.frame_body_len, sta_info.associated);
-        }
+        dm->apply_sta_cap_to_maps(key, &sta_info);
     }
 
     dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
@@ -1624,110 +1634,120 @@ void em_capability_t::process_msg(unsigned char *data, unsigned int len)
 {
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (data + sizeof(em_raw_hdr_t));
     em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(data);
+    std::vector<em_t *> em_radios;
 
     switch (htons(cmdu->type)) {
         case em_msg_type_ap_cap_query:
-            {
-                std::vector<em_t *> em_radios;
-                get_mgr()->get_all_em_for_al_mac(hdr->dst, em_radios);
-                for (auto &em : em_radios){
-                    em_printfout("em_msg_type_ap_cap_query received, state: %s", em_t::state_2_str(em->get_state()));
-                    if ((em->get_service_type() == em_service_type_agent) && (em->get_state() < em_state_agent_topo_synchronized)){
-                        em_printfout("radio %s is not configured, ignoring", util::mac_to_string(em->get_radio_interface_mac()).c_str());
-                        em_radios.clear();
-                        return;
-                    }
+            get_mgr()->get_all_em_for_al_mac(hdr->dst, em_radios);
+            for (auto &em : em_radios){
+                em_printfout("em_msg_type_ap_cap_query received, state: %s", em_t::state_2_str(em->get_state()));
+                if ((em->get_service_type() == em_service_type_agent) && (em->get_state() < em_state_agent_topo_synchronized)){
+                    em_printfout("radio %s is not configured, ignoring", util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                    em_radios.clear();
+                    return;
                 }
-                em_radios.clear();
-                em_printfout("All radios are configured for al_mac:%s, sending AP capability response", util::mac_to_string(hdr->dst).c_str());
-                if ((get_service_type() == em_service_type_agent)){
-                    send_ap_cap_report_msg(data, ntohs(cmdu->id));
+            }
+            em_radios.clear();
+            em_printfout("All radios are configured for al_mac:%s, sending AP capability response", util::mac_to_string(hdr->dst).c_str());
+            if ((get_service_type() == em_service_type_agent)){
+                send_ap_cap_report_msg(data, ntohs(cmdu->id));
+            }
+            break;
+        case em_msg_type_ap_cap_rprt:
+            if (get_service_type() == em_service_type_ctrl) {
+                if (handle_ap_cap_report(data, len) == 0){
+                    set_state(em_state_ctrl_ap_cap_report_received);
+                    std::vector<em_t *> em_radios;
+                    dm_easy_mesh_t *dm = get_data_model();
+                    em_printfout("AP capability report handled successfully by em radio:%s agent al_mac:%s src_mac:%s",
+                                    util::mac_to_string(get_radio_interface_mac()).c_str(), util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
+                                    util::mac_to_string(hdr->src).c_str());
+                    get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
+                    for (auto &em : em_radios)
+                    {
+                        em->set_state(em_state_ctrl_ap_cap_report_received);
+                        em_printfout("em_msg_type_ap_cap_rprt handle success, state: %s", em_t::state_2_str(em->get_state()));
+                    }
+                    em_radios.clear();
+                } else {
+                    em_printfout("em_msg_type_ap_cap_rprt handle failed");
                 }
             }
             break;
-            case em_msg_type_ap_cap_rprt:
-                if (get_service_type() == em_service_type_ctrl)
-                {
-                    if (handle_ap_cap_report(data, len) == 0){
-                        set_state(em_state_ctrl_ap_cap_report_received);
-                        std::vector<em_t *> em_radios;
-                        dm_easy_mesh_t *dm = get_data_model();
-                        em_printfout("AP capability report handled successfully by em radio:%s agent al_mac:%s src_mac:%s",
-                                     util::mac_to_string(get_radio_interface_mac()).c_str(), util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
-                                     util::mac_to_string(hdr->src).c_str());
-                        get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
-                        for (auto &em : em_radios)
-                        {
-                            em->set_state(em_state_ctrl_ap_cap_report_received);
-                            em_printfout("em_msg_type_ap_cap_rprt handle success, state: %s", em_t::state_2_str(em->get_state()));
-                        }
-                        em_radios.clear();
-                    } else {
-                        em_printfout("em_msg_type_ap_cap_rprt handle failed");
-                    }
-                }
-                break;
-            case em_msg_type_client_cap_rprt:
+        case em_msg_type_client_cap_rprt:
+            em_radios.clear();
+            get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
+            for (auto &em : em_radios) {
                 if (get_service_type() == em_service_type_ctrl){
-                    handle_client_cap_report(data, len);
+                    em->handle_client_cap_report(data, len);
+                    break;
                 }
-                break;
-
-            case em_msg_type_client_cap_query:
-                if (get_service_type() == em_service_type_agent){
-                    handle_client_cap_query(data, len);
-                }
-                break;
-
-            case em_msg_type_bh_sta_cap_query:
-                handle_bsta_cap_query(data, len);
-                break;
-
-            case em_msg_type_bh_sta_cap_rprt:
-                handle_bsta_cap_report(data, len);
-                break;
-
-            default:
-                break;
             }
+            break;
+
+        case em_msg_type_client_cap_query:
+            if (get_service_type() == em_service_type_agent){
+                handle_client_cap_query(data, len);
+            }
+            break;
+
+        case em_msg_type_bh_sta_cap_query:
+            handle_bsta_cap_query(data, len);
+            break;
+
+        case em_msg_type_bh_sta_cap_rprt:
+            handle_bsta_cap_report(data, len);
+            break;
+
+        default:
+            break;
+    }
 }
 
 void em_capability_t::process_ctrl_state()
 {
+    std::vector<em_t *> em_radios;
+    dm_easy_mesh_t *dm = NULL;
+
     switch (get_state()) {
         case em_state_ctrl_ap_cap_query_pending:
-            {
-                std::vector<em_t *> em_radios;
-                dm_easy_mesh_t *dm = get_data_model();
-                get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
-                for (auto &em : em_radios)
-                {
-                    if (em->get_state() != em_state_ctrl_ap_cap_query_pending){
-                        em_printfout("radio %s is not in AP Capability query pending state, ignoring",
-                                     util::mac_to_string(em->get_radio_interface_mac()).c_str());
-                        em_radios.clear();
-                        return;
-                    }
+            dm = get_data_model();
+            get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
+            for (auto &em : em_radios) {
+                if (em->get_state() != em_state_ctrl_ap_cap_query_pending){
+                    em_printfout("radio %s is not in AP Capability query pending state, ignoring",
+                                    util::mac_to_string(em->get_radio_interface_mac()).c_str());
+                    em_radios.clear();
+                    return;
                 }
-                if (this == em_radios.front()){
-                    em_printfout("Sending the AP query message to agent al_mac:%s on radio: %s",
-                        util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
-                        util::mac_to_string(get_radio_interface_mac()).c_str());
-                    send_ap_cap_query_msg();
-                }
-                em_radios.clear();
             }
+            if (this == em_radios.front()) {
+                em_printfout("Sending the AP query message to agent al_mac:%s on radio: %s",
+                    util::mac_to_string(dm->get_agent_al_interface_mac()).c_str(),
+                    util::mac_to_string(get_radio_interface_mac()).c_str());
+                send_ap_cap_query_msg();
+            }
+            em_radios.clear();
             break;
         case em_state_ctrl_bsta_cap_pending:
             send_bsta_cap_query_msg();
             break;
 
         case em_state_ctrl_sta_cap_pending:
-            send_client_cap_query();
+            // Only one radio per AL needs to send the Client Capability Query.
+            // Use the same front-radio guard as em_state_ctrl_ap_cap_query_pending.
+            get_mgr()->get_all_em_for_al_mac(get_data_model()->get_agent_al_interface_mac(), em_radios);
+            if (this == em_radios.front()) {
+                send_client_cap_query();
+            }
+            break;
+
+        case em_state_ctrl_topo_sync_pending:
+            // Handled by em_configuration_t::process_ctrl_state() for sta_assoc.
             break;
 
         default:
-            printf("%s:%d: unhandled case %s\n", __func__, __LINE__, em_t::state_2_str(get_state()));
+            em_printfout("unhandled case %s", em_t::state_2_str(get_state()));
             break;
     }
 }

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -139,7 +139,7 @@ static unsigned short create_affiliated_sta_metrics_tlvs(unsigned char *buff,
         tlv->type = em_tlv_type_affiliated_sta_metrics;
         metrics = reinterpret_cast<em_affiliated_sta_metrics_t *>(tlv->value);
         memset(metrics, 0, sizeof(*metrics));
-        memcpy(metrics->sta_mac_addr, aff_sta->mac_addr, sizeof(mac_address_t));
+        memcpy(metrics->sta_mac_addr, aff_sta->link_addr, sizeof(mac_address_t));
         memcpy(aff_bssid, aff_sta->bssid, sizeof(bssid_t));
 
         aff_bss = NULL;
@@ -152,7 +152,7 @@ static unsigned short create_affiliated_sta_metrics_tlvs(unsigned char *buff,
 
         aff_sta_info = NULL;
         if (aff_bss != NULL) {
-            memcpy(aff_sta_mac, aff_sta->mac_addr, sizeof(mac_address_t));
+            memcpy(aff_sta_mac, aff_sta->link_addr, sizeof(mac_address_t));
             memcpy(aff_radio_mac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
 
             aff_sta_info = dm->get_sta_info(aff_sta_mac, aff_bssid, aff_radio_mac, target_map);
@@ -191,6 +191,25 @@ static bool handle_assoc_sta_mld_topology_update(dm_easy_mesh_t *dm)
 
     for (i = 0; i < dm->get_num_assoc_sta_mld(); i++) {
         assoc_info = &dm->m_assoc_sta_mld[i].m_assoc_sta_mld_info;
+
+        // mark currently-associated entries for this STA as disassociated.(to clear stale entries)
+        // Write the complete existing entry (caps/stats intact) to m_sta_assoc_map
+        // with only the associated flag changed - same pattern as the disassoc path.
+        // update_tables()->update_list() will then sync m_sta_map from m_sta_assoc_map.
+        existing_sta = static_cast<dm_sta_t *>(hash_map_get_first(dm->m_sta_map));
+        while (existing_sta != NULL) {
+            if (memcmp(existing_sta->m_sta_info.id, assoc_info->mac_addr, sizeof(mac_address_t)) == 0 &&
+                existing_sta->m_sta_info.associated) {
+                existing_sta->m_sta_info.associated = false;
+                update_sta_map_assoc_row(dm->m_sta_assoc_map, &existing_sta->m_sta_info);
+                sta_db_update_needed = true;
+            }
+            existing_sta = static_cast<dm_sta_t *>(hash_map_get_next(dm->m_sta_map, existing_sta));
+        }
+
+        // Now mark the current affiliated links as associated=true.
+        // If the entry already exists in m_sta_map it already has all its data
+        // (caps, stats) - only the associated flag needs to change.
         for (j = 0; j < assoc_info->num_affiliated_sta; j++) {
             aff_bss = NULL;
             for (r = 0; r < dm->get_num_radios(); r++) {
@@ -217,13 +236,14 @@ static bool handle_assoc_sta_mld_topology_update(dm_easy_mesh_t *dm)
             existing_sta = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_map, exist_key));
             if (existing_sta != NULL) {
                 em_printfout("Existing sta row found for %s, preserving stats", exist_key);
-                memcpy(&sta_info, &existing_sta->m_sta_info, sizeof(em_sta_info_t));
-                sta_info.associated = true;
+                // Only the flag changes - all other fields (caps, stats) stay.
+                existing_sta->m_sta_info.associated = true;
+                update_sta_map_assoc_row(dm->m_sta_assoc_map, &existing_sta->m_sta_info);
+            } else {
+                em_printfout("MLO STA per-link entry not matched in m_sta_map: %s", exist_key);
+                update_sta_map_assoc_row(dm->m_sta_assoc_map, &sta_info);
             }
-
-            if (update_sta_map_assoc_row(dm->m_sta_assoc_map, &sta_info)) {
-                sta_db_update_needed = true;
-            }
+            sta_db_update_needed = true;
         }
     }
 
@@ -657,20 +677,19 @@ int em_configuration_t::send_topology_notification_by_client(mac_address_t sta, 
     tmp += (sizeof (em_tlv_t));
     len += static_cast<unsigned int> (sizeof (em_tlv_t));
 
-    printf("%s:%d Create topology notification msg successful, len:%d\n", __func__, __LINE__, len);
+    em_printfout("Create topology notification msg successful, len:%d", len);
 
     if (em_msg_t(em_msg_type_topo_notif, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("Topology notification msg validation failed\n");
-
+        em_printfout("Topology notification msg validation failed");
         return -1;
     }
 
     if (send_frame(buff, len)  < 0) {
-        printf("%s:%d: Topology notification send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Topology notification send failed for sta %s, error:%d", util::mac_to_string(sta).c_str(), errno);
         return -1;
     }
 
-    printf("%s:%d: Topology notification Send Successful\n", __func__, __LINE__);
+    em_printfout("Topology notification Send Successful for sta %s", util::mac_to_string(sta).c_str());
 
     return static_cast<int> (len);
 }
@@ -687,6 +706,7 @@ void em_configuration_t::handle_state_topology_notify()
 
     sta = static_cast<dm_sta_t *>(hash_map_get_first(dm->m_sta_assoc_map));
     while (sta != NULL) {
+        em_printfout("Sending topology notification for associated sta %s", util::mac_to_string(sta->m_sta_info.id).c_str());
         send_topology_notification_by_client(sta->m_sta_info.id, sta->m_sta_info.bssid, true);
         sta = static_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_assoc_map, sta));
     }
@@ -697,9 +717,7 @@ void em_configuration_t::handle_state_topology_notify()
             notif_ret = send_topology_notification_by_client(sta->m_sta_info.id, sta->m_sta_info.bssid, false);
             if (notif_ret >= 0) {
                 disassoc_stats_ret = send_client_disassoc_stats_msg(sta);
-                if (disassoc_stats_ret >= 0) {
-                    dm->remove_assoc_sta_mld_info(sta->m_sta_info.id);
-                } else {
+                if (disassoc_stats_ret < 0) {
                     em_printfout("topo notification: stats send failed for sta=%s", sta_str.c_str());
                 }
             } else {
@@ -1222,7 +1240,7 @@ int em_configuration_t::create_assoc_sta_mld_config_report_tlv(unsigned char *bu
             em_affiliated_sta_info_t &affiliated_sta_info = assoc_sta_mld_info.affiliated_sta[j];
             memset(affiliated_sta_mld, 0, sizeof(em_affiliated_sta_mld_t));
             memcpy(affiliated_sta_mld->bssid, affiliated_sta_info.bssid, sizeof(mac_address_t));
-            memcpy(affiliated_sta_mld->affiliated_sta_mac_addr, affiliated_sta_info.mac_addr, sizeof(mac_address_t));
+            memcpy(affiliated_sta_mld->affiliated_sta_mac_addr, affiliated_sta_info.link_addr, sizeof(mac_address_t));
 
             affiliated_sta_mld = reinterpret_cast<em_affiliated_sta_mld_t *>(reinterpret_cast<unsigned char *>(affiliated_sta_mld) + sizeof(em_affiliated_sta_mld_t));
             affiliated_sta_len += static_cast<short unsigned int>(sizeof(em_affiliated_sta_mld_t));
@@ -1548,17 +1566,17 @@ int em_configuration_t::send_topology_response_msg(unsigned char *dst, unsigned 
 
     // Validate the frame
     if (em_msg_t(em_msg_type_topo_resp, em_profile_type_3, buff, len).validate(errors) == 0) {
-        printf("Topology Response msg failed validation in tnx end\n");
+        em_printfout("Topology Response msg failed validation in tnx end");
 
         return -1;
     }
 
     em_printfout("frame length: %d", len);
     if (send_frame(buff, len)  < 0) {
-        printf("%s:%d: Topology Response send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Topology Response send failed, error:%d", errno);
         return -1;
     }
-    printf("setting state to em_state_agent_topo_synchronized\n");
+    em_printfout("setting state to em_state_agent_topo_synchronized");
     set_state(em_state_agent_topo_synchronized);
     return static_cast<int> (len);
 }
@@ -2008,13 +2026,13 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
     bool assoc_event;
     unsigned int mld_i, aff_j, r;
     em_assoc_sta_mld_info_t *assoc_info = NULL;
-    em_sta_info_t link_sta;
     dm_bss_t *aff_bss = NULL;
     mac_addr_str_t b_str, r_str;
     em_long_string_t link_key;
     dm_sta_t *assoc_row = NULL;
     dm_sta_t *sta_row = NULL;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    em_bss_info_t *bss_info = NULL;
 
 	dm = get_data_model();
 	em_printfout("Topology Notification received, length: %u", len);
@@ -2047,26 +2065,35 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
     while ((tlv->type != em_tlv_type_eom) && (tmp_len > 0)) {
         if (tlv->type == em_tlv_type_client_assoc_event) {
             assoc_evt_tlv = reinterpret_cast<em_client_assoc_event_t *> (tlv->value);
-            dm_easy_mesh_t::macbytes_to_string(assoc_evt_tlv->cli_mac_address, sta_mac_str);
-            dm_easy_mesh_t::macbytes_to_string(assoc_evt_tlv->bssid, bssid_str);
-            dm_easy_mesh_t::macbytes_to_string(get_radio_interface_mac(), radio_mac_str);
-            snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
             assoc_event = assoc_evt_tlv->assoc_event;
 
-            //em_printfout("Client Device:%s %s to BSSID: %s\n", sta_mac_str,
-            //        (assoc_evt_tlv->assoc_event == 1)?"associated":"disassociated", bssid_str);
-            if (assoc_event == false) {
-                em_printfout("topo notification disassoc: sta=%s bssid=%s key=%s",
-                        util::mac_to_string(assoc_evt_tlv->cli_mac_address).c_str(),
-                        util::mac_to_string(assoc_evt_tlv->bssid).c_str(), key);
-            }
+            // Build sta_info from TLV data. Resolve the radio MAC via BSS lookup
+            // (non-MLO: BSSID is a real BSS address; MLO: BSSID is AP-MLD MAC so
+            // lookup returns NULL and we fall back to getradio using bssid).
+            dm_easy_mesh_t::macbytes_to_string(assoc_evt_tlv->cli_mac_address, sta_mac_str);
+            dm_easy_mesh_t::macbytes_to_string(assoc_evt_tlv->bssid, bssid_str);
             memset(&sta_info, 0, sizeof(em_sta_info_t));
             memcpy(sta_info.id, assoc_evt_tlv->cli_mac_address, sizeof(mac_address_t));
             memcpy(sta_info.bssid, assoc_evt_tlv->bssid, sizeof(mac_address_t));
-            memcpy(sta_info.radiomac, get_radio_interface_mac(), sizeof(mac_address_t));
             sta_info.associated = assoc_event;
+            bss_info = dm->get_bss_info_with_mac(assoc_evt_tlv->bssid);
+            if (bss_info != NULL) {
+                memcpy(sta_info.radiomac, bss_info->ruid.mac, sizeof(mac_address_t));
+            } else if (dm->is_ap_mld_mac(assoc_evt_tlv->bssid)) {
+                mac_address_t fallback_ruid = {0};
+                if (dm->resolve_ap_mld_to_fallback_ruid(assoc_evt_tlv->bssid, fallback_ruid)) {
+                    memcpy(sta_info.radiomac, fallback_ruid, sizeof(mac_address_t));
+                }
+            }
+            dm_easy_mesh_t::macbytes_to_string(sta_info.radiomac, radio_mac_str);
+            snprintf(key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, bssid_str, radio_mac_str);
+
+            // em_printfout("Client Device:%s %s to BSSID: %s", sta_mac_str,
+            //        assoc_event ? "associated" : "disassociated", bssid_str);
 
             if (assoc_event == false) {
+                 em_printfout("topo notification disassoc: sta=%s bssid=%s key=%s",
+                    sta_mac_str, bssid_str, key);
                 updated_any = false;
 
                 for (mld_i = 0; mld_i < dm->get_num_assoc_sta_mld(); mld_i++) {
@@ -2076,16 +2103,16 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
                     }
                     for (aff_j = 0; aff_j < assoc_info->num_affiliated_sta; aff_j++) {
                         bool link_radio_resolved = false;
-                        memset(&link_sta, 0, sizeof(em_sta_info_t));
-                        memcpy(link_sta.id, sta_info.id, sizeof(mac_address_t));
-                        memcpy(link_sta.bssid, assoc_info->affiliated_sta[aff_j].bssid, sizeof(mac_address_t));
-                        link_sta.associated = false;
+                        memset(&sta_info, 0, sizeof(em_sta_info_t));
+                        memcpy(sta_info.id, assoc_evt_tlv->cli_mac_address, sizeof(mac_address_t));
+                        memcpy(sta_info.bssid, assoc_info->affiliated_sta[aff_j].bssid, sizeof(mac_address_t));
+                        sta_info.associated = false;
 
                         aff_bss = NULL;
                         for (r = 0; r < dm->get_num_radios(); r++) {
-                            aff_bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, link_sta.bssid);
+                            aff_bss = dm->get_bss(dm->get_radio_info(r)->id.ruid, sta_info.bssid);
                             if (aff_bss != NULL) {
-                                memcpy(link_sta.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
+                                memcpy(sta_info.radiomac, aff_bss->m_bss_info.ruid.mac, sizeof(mac_address_t));
                                 link_radio_resolved = true;
                                 break;
                             }
@@ -2093,29 +2120,28 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
 
                         if (link_radio_resolved == false) {
                             em_printfout("TOPO_NOTIF_DISASSOC: skipping unresolved affiliated link sta=%s bssid=%s",
-                                    util::mac_to_string(link_sta.id).c_str(),
-                                    util::mac_to_string(link_sta.bssid).c_str());
+                                    util::mac_to_string(sta_info.id).c_str(),
+                                    util::mac_to_string(sta_info.bssid).c_str());
                             continue;
                         }
 
-                        dm_easy_mesh_t::macbytes_to_string(link_sta.bssid, b_str);
-                        dm_easy_mesh_t::macbytes_to_string(link_sta.radiomac, r_str);
+                        dm_easy_mesh_t::macbytes_to_string(sta_info.bssid, b_str);
+                        dm_easy_mesh_t::macbytes_to_string(sta_info.radiomac, r_str);
                         snprintf(link_key, sizeof(em_long_string_t), "%s@%s@%s", sta_mac_str, b_str, r_str);
-
-                        assoc_row = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, link_key));
-                        if (assoc_row != NULL) {
-                            assoc_row->m_sta_info.associated = false;
-                            assoc_row->m_sta_info.frame_body_len = 0;
-                            memset(assoc_row->m_sta_info.frame_body, 0, sizeof(assoc_row->m_sta_info.frame_body));
-                        } else {
-                            hash_map_put(dm->m_sta_assoc_map, strdup(link_key), new dm_sta_t(&link_sta));
-                        }
 
                         sta_row = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_map, link_key));
                         if (sta_row != NULL) {
+                            // Update only the assoc status (preserves caps/stats).
                             sta_row->m_sta_info.associated = false;
-                            sta_row->m_sta_info.frame_body_len = 0;
-                            memset(sta_row->m_sta_info.frame_body, 0, sizeof(sta_row->m_sta_info.frame_body));
+                            memcpy(&sta_info, &sta_row->m_sta_info, sizeof(em_sta_info_t));
+                            sta_info.associated = false;
+                        }
+
+                        assoc_row = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_assoc_map, link_key));
+                        if (assoc_row != NULL) {
+                            memcpy(&assoc_row->m_sta_info, &sta_info, sizeof(em_sta_info_t));
+                        } else {
+                            hash_map_put(dm->m_sta_assoc_map, strdup(link_key), new dm_sta_t(&sta_info));
                         }
 
                         em_printfout("topo notification disassoc key=%s", link_key);
@@ -2127,13 +2153,23 @@ int em_configuration_t::handle_topology_notification(unsigned char *buff, unsign
                 if (updated_any) {
                     dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
                 } else {
-                    em_printfout("topo notification disassoc: no MLD info for sta=%s",
-                            util::mac_to_string(sta_info.id).c_str());
+                    // Non-MLO client: sta_info is already initialised with the correct
+                    // radio MAC (resolved at the top of this block via get_bss_info_with_mac).
+                    em_printfout("topo notification disassoc: no MLD info for sta=%s, handling as non-MLO",
+                            sta_mac_str);
+                    sta_row = static_cast<dm_sta_t *>(hash_map_get(dm->m_sta_map, key));
+                    if (sta_row != NULL) {
+                        sta_row->m_sta_info.associated = false;
+                        update_sta_map_assoc_row(dm->m_sta_assoc_map, &sta_row->m_sta_info);
+                    } else {
+                        // STA not yet in m_sta_map; write minimal entry with associated=false for DB update
+                        update_sta_map_assoc_row(dm->m_sta_assoc_map, &sta_info);
+                    }
+                    dm->set_db_cfg_param(db_cfg_type_sta_list_update, "");
                 }
             } else {
                 em_printfout("topo notification assoc defer: sta=%s bssid=%s",
-                        util::mac_to_string(sta_info.id).c_str(),
-                        util::mac_to_string(sta_info.bssid).c_str());
+                        sta_mac_str, bssid_str);
             }
 
             memcpy(raw.dev, dev_mac, sizeof(mac_address_t));
@@ -2418,6 +2454,7 @@ int em_configuration_t::handle_assoc_sta_mld_conf_rep_tlv(unsigned char *buff, u
     unsigned int max_affiliated_in_tlv;
     unsigned int reported_affiliated_count;
 
+
     dm = get_data_model();
 
     if (buff == NULL || len < sizeof(em_assoc_sta_mld_t)) {
@@ -2454,7 +2491,7 @@ int em_configuration_t::handle_assoc_sta_mld_conf_rep_tlv(unsigned char *buff, u
     for (j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
         memcpy(assoc_sta_mld_info.affiliated_sta[j].bssid,
                affiliated_sta_mld->bssid, sizeof(mac_address_t));
-        memcpy(assoc_sta_mld_info.affiliated_sta[j].mac_addr,
+        memcpy(assoc_sta_mld_info.affiliated_sta[j].link_addr,
                affiliated_sta_mld->affiliated_sta_mac_addr, sizeof(mac_address_t));
         affiliated_sta_mld = reinterpret_cast<em_affiliated_sta_mld_t *>(
             reinterpret_cast<unsigned char *>(affiliated_sta_mld) + sizeof(em_affiliated_sta_mld_t));
@@ -2468,10 +2505,70 @@ int em_configuration_t::handle_assoc_sta_mld_conf_rep_tlv(unsigned char *buff, u
         assoc_sta_mld_info.num_affiliated_sta);
 
     for (j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
-        em_printfout("affiliated_sta[%u]: bssid=%s mac_addr=%s", j,
+        em_printfout("affiliated_sta[%u]: bssid=%s link_addr=%s", j,
             util::mac_to_string(assoc_sta_mld_info.affiliated_sta[j].bssid).c_str(),
-            util::mac_to_string(assoc_sta_mld_info.affiliated_sta[j].mac_addr).c_str());
+            util::mac_to_string(assoc_sta_mld_info.affiliated_sta[j].link_addr).c_str());
     }
+
+    // Dbg purpose 
+    /* // Detect link changes before replacing the entry.
+    for (unsigned int k = 0; k < dm->get_num_assoc_sta_mld(); k++) {
+        if (memcmp(dm->m_assoc_sta_mld[k].m_assoc_sta_mld_info.mac_addr,
+                    assoc_sta_mld_info.mac_addr, sizeof(mac_address_t)) == 0) {
+            existing = &dm->m_assoc_sta_mld[k].m_assoc_sta_mld_info;
+            break;
+        }
+    }
+    if (existing == nullptr) {
+        em_printfout("STA-MLD %s: first-time entry, %u link(s)",
+            util::mac_to_string(assoc_sta_mld_info.mac_addr).c_str(),
+            assoc_sta_mld_info.num_affiliated_sta);
+    } else {
+        // Check for added links (in new but not in existing).
+        for (unsigned char j = 0; j < assoc_sta_mld_info.num_affiliated_sta; j++) {
+            bool found = false;
+            for (unsigned char k = 0; k < existing->num_affiliated_sta; k++) {
+                if (memcmp(assoc_sta_mld_info.affiliated_sta[j].bssid,
+                            existing->affiliated_sta[k].bssid,
+                            sizeof(mac_address_t)) == 0) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                em_printfout("STA-MLD %s: link ADDED   bssid=%s",
+                    util::mac_to_string(assoc_sta_mld_info.mac_addr).c_str(),
+                    util::mac_to_string(assoc_sta_mld_info.affiliated_sta[j].bssid).c_str());
+            }
+        }
+        // Check for removed links (in existing but not in new).
+        for (unsigned char j = 0; j < existing->num_affiliated_sta; j++) {
+            bool found = false;
+            for (unsigned char k = 0; k < assoc_sta_mld_info.num_affiliated_sta; k++) {
+                if (memcmp(existing->affiliated_sta[j].bssid,
+                            assoc_sta_mld_info.affiliated_sta[k].bssid,
+                            sizeof(mac_address_t)) == 0) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                em_printfout("STA-MLD %s: link REMOVED bssid=%s",
+                    util::mac_to_string(assoc_sta_mld_info.mac_addr).c_str(),
+                    util::mac_to_string(existing->affiliated_sta[j].bssid).c_str());
+            }
+        }
+        if (existing->num_affiliated_sta == assoc_sta_mld_info.num_affiliated_sta) {
+            em_printfout("STA-MLD %s: link count unchanged (%u link(s))",
+                util::mac_to_string(assoc_sta_mld_info.mac_addr).c_str(),
+                assoc_sta_mld_info.num_affiliated_sta);
+        } else {
+            em_printfout("STA-MLD %s: link count changed %u -> %u",
+                util::mac_to_string(assoc_sta_mld_info.mac_addr).c_str(),
+                existing->num_affiliated_sta,
+                assoc_sta_mld_info.num_affiliated_sta);
+        }
+    } */
 
     // Replace existing STA-MLD row to avoid stale affiliated links.
     dm->remove_assoc_sta_mld_info(assoc_sta_mld_info.mac_addr);
@@ -3836,7 +3933,7 @@ int em_configuration_t::create_autoconfig_wsc_m2_msg(unsigned char *buff, unsign
 
     // first compute keys
     if (compute_keys(get_e_public(), static_cast<short unsigned int> (get_e_public_len()), get_r_private(), static_cast<short unsigned int> (get_r_private_len())) != 1) {
-        printf("%s:%d: Keys computation failed\n", __func__, __LINE__);
+        em_printfout("%s:%d: Keys computation failed\n", __func__, __LINE__);
         return 0;
     }
 
@@ -5888,6 +5985,8 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
 {
     unsigned char *tlvs;
     unsigned int tlvs_len;
+    std::vector<em_t *> em_radios;
+    bool any_al_topo_sync_pending = false;
 
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(data + sizeof(em_raw_hdr_t));
             
@@ -5960,7 +6059,19 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
 			break;
 
         case em_msg_type_topo_resp:
-            if ((get_service_type() == em_service_type_ctrl) && (get_state() == em_state_ctrl_topo_sync_pending)){
+            // Accept topo_resp if this radio is in topo_sync_pending, OR if any
+            // AL radio for sta_assoc (sta_assoc dispatches only one radio so the response
+            // may land on a different radio than the one that sent the query).
+            get_mgr()->get_all_em_for_al_mac(get_data_model()->get_agent_al_interface_mac(), em_radios);
+            any_al_topo_sync_pending = false;
+            for (auto *radio : em_radios) {
+                if (radio->get_state() == em_state_ctrl_topo_sync_pending) {
+                    any_al_topo_sync_pending = true;
+                    break;
+                }
+            }
+            if ((get_service_type() == em_service_type_ctrl) &&
+                (get_state() == em_state_ctrl_topo_sync_pending || any_al_topo_sync_pending)) {
                 if (handle_topology_response(data, len) == 0) {
                     set_state(em_state_ctrl_topo_synchronized);
                     static_cast<em_t*>(this)->set_ssid_mismatch(false);
@@ -5990,8 +6101,13 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
             break;
 
         case em_msg_type_topo_notif:
-            if ((get_service_type() == em_service_type_ctrl) && (get_state() >= em_state_ctrl_topo_synchronized)) {
-                handle_topology_notification(data, len);
+            em_radios.clear();
+            get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
+            for (auto *get_em : em_radios) {
+                if ((get_service_type() == em_service_type_ctrl) && (get_em->get_state() >= em_state_ctrl_topo_synchronized)) {
+                    get_em->handle_topology_notification(data, len);
+                    break;
+                }
             }
             break;
 
@@ -6208,6 +6324,9 @@ void em_configuration_t::process_agent_state()
 void em_configuration_t::process_ctrl_state()
 {
     dm_easy_mesh_t *dm = get_data_model();
+    std::vector<em_t *> em_radios;
+    bool allow_single_radio_topo_query = false;
+    bool ssid_mismatch_present = false;
 
     switch (get_state()) {
         case em_state_ctrl_misconfigured:
@@ -6215,25 +6334,31 @@ void em_configuration_t::process_ctrl_state()
             break;
 
         case em_state_ctrl_topo_sync_pending:
-        {
-            std::vector<em_t *> em_radios;
-            dm_easy_mesh_t *dm = get_data_model();
+            /* This is needed as for cases like sta_assoc where we send out topo query and client cap query which is per device
+            and not per radio. So we need to allow single radio topo query for sta_assoc case */
+            allow_single_radio_topo_query = (get_current_cmd() != NULL &&
+                get_current_cmd()->m_type == em_cmd_type_sta_assoc);
             get_mgr()->get_all_em_for_al_mac(dm->get_agent_al_interface_mac(), em_radios);
 
             // Evaluate SSID mismatch across this AL's radios only.
-            bool ssid_mismatch_present = std::any_of(em_radios.begin(), em_radios.end(), [](em_t *radio) {
+            ssid_mismatch_present = std::any_of(em_radios.begin(), em_radios.end(), [](em_t *radio) {
                 return radio->get_ssid_mismatch();
             });
 
             if (ssid_mismatch_present == false)
             {
-                for (auto &em : em_radios) {
-                    if (em->get_state() != em_state_ctrl_topo_sync_pending) {
-                        em_printfout("radio %s is in state:%d, not in topo sync pending state, ignoring",
-                            util::mac_to_string(em->get_radio_interface_mac()).c_str(), em->get_state());
-                        em_radios.clear();
-                        return;
+                if (allow_single_radio_topo_query == false) {
+                    for (auto &em : em_radios) {
+                        if (em->get_state() != em_state_ctrl_topo_sync_pending) {
+                            em_printfout("radio %s is in state:%s, not in topo sync pending state, ignoring",
+                                util::mac_to_string(em->get_radio_interface_mac()).c_str(), em_t::state_2_str(em->get_state()));
+                            em_radios.clear();
+                            return;
+                        }
                     }
+                } else {
+                    em_printfout("sta_assoc single-radio topo query: skipping all-radios check for radio %s",
+                        util::mac_to_string(get_radio_interface_mac()).c_str());
                 }
                 // Reset the mismatch and topo_query_last sent values before sending topo query
                 dm->set_ssid_mismatch_check_time(0);
@@ -6247,10 +6372,13 @@ void em_configuration_t::process_ctrl_state()
                     em_t *al_em = get_mgr()->get_al_node();
                     al_em->set_state(em_state_ctrl_topo_sync_pending);
                     send_topology_query_msg();
+                } else {
+                    em_printfout("topo_sync_pending: radio %s is not front radio %s, skipping topo query",
+                        util::mac_to_string(get_radio_interface_mac()).c_str(),
+                        util::mac_to_string(em_radios.front()->get_radio_interface_mac()).c_str());
                 }
                 em_radios.clear();
             }
-        }
             break;
 
         case em_state_ctrl_ap_mld_config_pending:
@@ -6262,7 +6390,22 @@ void em_configuration_t::process_ctrl_state()
                 em_printfout("Topology has changed for device: %s", util::mac_to_string(dm->get_agent_al_interface_mac()).c_str());
                 dm->set_topo_state(false);
                 get_mgr()->publish_network_topology();
+                //Send beacon metrics query for the sta assoc case to get the beacon metrics from the STA
+                if (get_current_cmd() != NULL && get_current_cmd()->m_type == em_cmd_type_sta_assoc) {
+                    em_cmd_params_t *evt_param = &get_current_cmd()->m_param;
+                    // args[3] is "Assoc" or "Disassoc" - skip beacon query on disassociation
+                    if (strncmp(evt_param->u.args.args[3], "Assoc", 5) == 0) {
+                        mac_address_t sta_mac, bssid;
+                        dm_easy_mesh_t::string_to_macbytes(evt_param->u.args.args[2], sta_mac);
+                        dm_easy_mesh_t::string_to_macbytes(evt_param->u.args.args[1], bssid);
+                        em_printfout("Sending beacon metrics query for sta:%s bssid:%s",
+                            evt_param->u.args.args[2], evt_param->u.args.args[1]);
+                        static_cast<em_t*>(this)->send_beacon_metrics_query(sta_mac, bssid);
+                        break;
+                    }
+                }
             }
+
             set_state(em_state_ctrl_configured);
             break;
 

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -239,16 +239,16 @@ void em_t::orch_execute(em_cmd_t *pcmd)
             m_sm.set_state(em_state_ctrl_ap_mld_config_pending);
             break;
 
-        case em_cmd_type_beacon_report:
-            m_sm.set_state(em_state_agent_beacon_report_pending);
-            break;
-
         case em_cmd_type_bsta_cap:
             m_sm.set_state(em_state_ctrl_bsta_cap_pending);
             break;
 
         case em_cmd_type_get_link_quality_report:
             m_sm.set_state(em_state_agent_link_quality_report_pending);
+            break;
+
+        case em_cmd_type_beacon_report:
+            m_sm.set_state(em_state_beacon_report_pending);
             break;
 
         case em_cmd_type_unassoc_sta_query:
@@ -313,6 +313,7 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_client_cap_query:
         case em_msg_type_client_cap_rprt:
             em_capability_t::process_msg(data, len);
+            em_metrics_t::process_msg(data, len);
             break;
 
         case em_msg_type_channel_pref_query:
@@ -332,7 +333,7 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
         case em_msg_type_beacon_metrics_rsp:
         case em_msg_type_ap_metrics_rsp:
         case em_msg_type_topo_vendor:
-	case em_msg_type_unassoc_sta_link_metrics_query: 
+	    case em_msg_type_unassoc_sta_link_metrics_query: 
         case em_msg_type_unassoc_sta_link_metrics_rsp:	    
             em_metrics_t::process_msg(data, len);
             break;
@@ -485,7 +486,7 @@ void em_t::handle_agent_state()
 			break;
 
         case em_cmd_type_beacon_report:
-            if (m_sm.get_state() == em_state_agent_beacon_report_pending) {
+            if (m_sm.get_state() == em_state_beacon_report_pending) {
                 em_metrics_t::process_agent_state();
             }
             break;
@@ -2896,7 +2897,6 @@ const char *em_t::state_2_str(em_state_t state)
         EM_STATE_2S(em_state_agent_client_cap_report)
         EM_STATE_2S(em_state_agent_channel_pref_query)
         EM_STATE_2S(em_state_agent_sta_link_metrics_pending)
-        EM_STATE_2S(em_state_agent_beacon_report_pending)
         EM_STATE_2S(em_state_agent_channel_select_configuration_pending)
 	EM_STATE_2S(em_state_agent_unassoc_sta_metrics_report_pending)
         EM_STATE_2S(em_state_max)

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -369,6 +369,7 @@ void em_t::proto_process(unsigned char *data, unsigned int len)
             } else {
                 em_policy_cfg_t::process_msg(data, len);
                 em_channel_t::process_msg(data, len);
+                em_metrics_t::process_msg(data, len);
             }
             break;
 

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -174,7 +174,7 @@ bool em_msg_t::get_sta_mac(mac_address_t *mac)
     unsigned int len;
 
     tlv = reinterpret_cast<em_tlv_t *> (m_buff); len = m_len;
-    while ((tlv->type != em_tlv_type_eom) && (len >= sizeof(em_tlv_t)) {
+    while ((tlv->type != em_tlv_type_eom) && (len >= sizeof(em_tlv_t))) {
         if (tlv->type == em_tlv_type_client_info) {
             memcpy(mac, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
             return true;

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -174,7 +174,7 @@ bool em_msg_t::get_sta_mac(mac_address_t *mac)
     unsigned int len;
 
     tlv = reinterpret_cast<em_tlv_t *> (m_buff); len = m_len;
-    while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
+    while ((tlv->type != em_tlv_type_eom) && (len >= sizeof(em_tlv_t)) {
         if (tlv->type == em_tlv_type_client_info) {
             memcpy(mac, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
             return true;
@@ -192,8 +192,8 @@ bool em_msg_t::get_sta_mac(mac_address_t *mac)
             return true;
         }
 
-        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + ntohs(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     return false;

--- a/src/em/em_msg.cpp
+++ b/src/em/em_msg.cpp
@@ -105,6 +105,37 @@ bool em_msg_t::get_profile(em_profile_type_t *profile)
     return false;
 }
 
+bool em_msg_t::get_sta_mac(mac_address_t *mac)
+{
+    em_tlv_t    *tlv;
+    unsigned int len;
+
+    tlv = reinterpret_cast<em_tlv_t *> (m_buff); len = m_len;
+    while ((tlv->type != em_tlv_type_eom) && (len > 0)) {
+        if (tlv->type == em_tlv_type_client_info) {
+            memcpy(mac, tlv->value + sizeof(mac_address_t), sizeof(mac_address_t));
+            return true;
+        } else if (tlv->type == em_tlv_type_client_assoc_event) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
+        } else if (tlv->type == em_tlv_type_bcon_metric_query) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
+        } else if (tlv->type == em_tlv_type_bcon_metric_rsp) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
+        } else if (tlv->type == em_tlv_type_assoc_sta_link_metric) {
+            memcpy(mac, tlv->value, sizeof(mac_address_t));
+            return true;
+        }
+
+        len -= static_cast<unsigned int> (sizeof(em_tlv_t) + htons(tlv->len));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+    }
+
+    return false;
+}
+
 bool em_msg_t::get_bss_id(mac_address_t *mac)
 {
     em_tlv_t    *tlv;

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -83,6 +83,34 @@ int em_metrics_t::handle_assoc_sta_link_metrics_tlv(unsigned char *buff,
         sta->m_sta_info.est_dl_rate = ntohl(metrics->est_mac_data_rate_dl);
         sta->m_sta_info.est_ul_rate = ntohl(metrics->est_mac_data_rate_ul);
         sta->m_sta_info.rcpi = metrics->rcpi;
+
+        // RCPI-based beacon query trigger: if STA supports 802.11k beacon measurement
+        // and its RCPI is below the configured steering threshold, request a beacon report.
+        if (sta->m_sta_info.rcpi == 0 || !sta->m_sta_info.associated) {
+            continue;
+        }
+
+        if (sta->supports_beacon_measurement() == false) {
+            continue;
+        }
+        // Find the radio this BSS belongs to and check its RCPI threshold
+        dm_radio_t *radio = NULL;
+        for (unsigned int b = 0; b < dm->get_num_bss(); b++) {
+            if (memcmp(dm->m_bss[b].m_bss_info.bssid.mac, metrics->bssid, sizeof(mac_address_t)) == 0) {
+                radio = dm->get_radio(dm->m_bss[b].m_bss_info.id.ruid);
+                break;
+            }
+        }
+        if (radio != NULL) {
+            em_radio_info_t *radio_info = radio->get_radio_info();
+            unsigned int threshold = (radio_info != NULL) ? radio_info->rcpi_steering_threshold : 0;
+            if (threshold > 0 && sta->m_sta_info.rcpi < static_cast<unsigned char>(threshold)) {
+                em_printfout("STA %s RCPI=%u below threshold=%u, triggering beacon query",
+                    util::mac_to_string(sta->m_sta_info.id).c_str(),
+                    sta->m_sta_info.rcpi, threshold);
+                send_beacon_metrics_query(sta->m_sta_info.id, sta->m_sta_info.bssid);
+            }
+        }
     }
 
     return 0;
@@ -212,8 +240,8 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
             break;
         }
 
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     tlv = tlv_start;
@@ -236,8 +264,8 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
             handle_assoc_sta_vendor_link_metrics_tlv(tlv->value, ntohs(tlv->len));
         }
 
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
     dm->set_db_cfg_param(db_cfg_type_sta_metrics_update, "");
     set_state(em_state_ctrl_configured);
@@ -247,32 +275,157 @@ int em_metrics_t::handle_associated_sta_link_metrics_resp(unsigned char *buff, u
 
 int em_metrics_t::handle_beacon_metrics_query(unsigned char *buff, unsigned int len)
 {
-    mac_address_t sta;
     em_tlv_t *tlv;
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    size_t sz = 0;
 
     if (em_msg_t(em_msg_type_beacon_metrics_query, em_profile_type_2, buff, len).validate(errors) == 0) {
-        printf("%s:%d:Beacon Metrics query message validation failed\n",__func__,__LINE__);
+        em_printfout("Beacon Metrics query message validation failed");
         return -1;
     }
 
+    em_printfout(" Rcvd Beacon Metrics Query");
+
     tlv = reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
 
-    em_beacon_metrics_query_t *beacon_metrics = reinterpret_cast<em_beacon_metrics_query_t*> (tlv->value);
-    printf("\n\n    STA MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n",
-        beacon_metrics->sta_mac_addr[0], beacon_metrics->sta_mac_addr[1], beacon_metrics->sta_mac_addr[2],
-        beacon_metrics->sta_mac_addr[3], beacon_metrics->sta_mac_addr[4], beacon_metrics->sta_mac_addr[5]);
-    printf("   Operating Class: %u\n", beacon_metrics->op_class);
-    printf("   Channel Number: %u\n", beacon_metrics->channel_num);
-    printf("   BSSID: %02x:%02x:%02x:%02x:%02x:%02x\n",
-        beacon_metrics->bssid[0], beacon_metrics->bssid[1], beacon_metrics->bssid[2],
-        beacon_metrics->bssid[3], beacon_metrics->bssid[4], beacon_metrics->bssid[5]);
-    printf("   Reporting Detail: %u\n", beacon_metrics->rprt_detail);
-    printf("   SSID Length: %u\n", beacon_metrics->ssid_len);
-    printf("\n\n");
+    unsigned char *tmp = tlv->value;
+
+    const unsigned int tlv_payload_len = ntohs(tlv->len);
+    const unsigned int max_ssid_len = sizeof(em_beacon_metrics_query_t{}.ssid);
+    const unsigned int max_ap_channel_rprt = sizeof(em_beacon_metrics_query_t{}.ap_channel_rprt) /
+        sizeof(em_beacon_metrics_query_t{}.ap_channel_rprt[0]);
+    const unsigned int max_channels_in_list = sizeof(em_beacon_metrics_query_t{}.ap_channel_rprt[0].ap_channel_list) /
+        sizeof(em_beacon_metrics_query_t{}.ap_channel_rprt[0].ap_channel_list[0]);
+    const unsigned int max_element_ids = sizeof(em_beacon_metrics_query_t{}.element_list.element_list) /
+        sizeof(em_beacon_metrics_query_t{}.element_list.element_list[0]);
+    const unsigned int min_fixed_len = sizeof(mac_address_t) + sizeof(unsigned char) + sizeof(unsigned char) +
+        sizeof(mac_address_t) + sizeof(unsigned char) + sizeof(unsigned char);
+
+    if (tlv_payload_len < min_fixed_len) {
+        em_printfout("Malformed Beacon Metrics Query TLV: payload too short (%u)", tlv_payload_len);
+        return -1;
+    }
+
+    em_beacon_metrics_query_t query_params = {};
+    memcpy(query_params.sta_mac_addr, tmp + sz, sizeof(mac_address_t));
+    sz += sizeof(mac_address_t);
+
+    query_params.op_class = *(tmp + sz);
+    sz += sizeof(unsigned char);
+    query_params.channel_num = *(tmp + sz);
+    sz += sizeof(unsigned char);
+    memcpy(query_params.bssid, tmp + sz, sizeof(mac_address_t));
+    sz += sizeof(mac_address_t);
+
+    query_params.rprt_detail = *(tmp + sz);
+    sz += sizeof(unsigned char);
+
+    unsigned int ssid_len = *(tmp + sz);
+    sz += sizeof(unsigned char);
+    if (sz + ssid_len > tlv_payload_len) {
+        em_printfout("Malformed Beacon Metrics Query TLV: ssid_len %u exceeds payload %u",
+            ssid_len, tlv_payload_len);
+        return -1;
+    }
+    query_params.ssid_len = (ssid_len > max_ssid_len) ? max_ssid_len : ssid_len;
+    if (query_params.ssid_len > 0) {
+        memcpy(query_params.ssid, tmp + sz, query_params.ssid_len);
+    }
+    sz += ssid_len;
+
+    if (sz + sizeof(unsigned char) > tlv_payload_len) {
+        em_printfout("Malformed Beacon Metrics Query TLV: missing AP Channel Report count");
+        return -1;
+    }
+
+    unsigned int num_ap_channel_rprt = *(tmp + sz);
+    sz += sizeof(unsigned char);
+    query_params.num_ap_channel_rprt = (num_ap_channel_rprt > max_ap_channel_rprt) ?
+        max_ap_channel_rprt : num_ap_channel_rprt;
+
+    for (unsigned int i = 0; i < num_ap_channel_rprt; i++) {
+        unsigned int ap_channel_rprt_len;
+        unsigned int num_channels;
+
+        if (sz + sizeof(unsigned char) > tlv_payload_len) {
+            em_printfout("Malformed Beacon Metrics Query TLV: missing AP Channel Report length");
+            return -1;
+        }
+
+        ap_channel_rprt_len = *(tmp + sz);
+        sz += sizeof(unsigned char);
+        if (ap_channel_rprt_len < 1) {
+            em_printfout("Malformed Beacon Metrics Query TLV: invalid AP Channel Report length %u",
+                ap_channel_rprt_len);
+            return -1;
+        }
+        if (sz + ap_channel_rprt_len > tlv_payload_len) {
+            em_printfout("Malformed Beacon Metrics Query TLV: AP Channel Report overruns payload");
+            return -1;
+        }
+
+        num_channels = ap_channel_rprt_len - 1;
+        if (i < query_params.num_ap_channel_rprt) {
+            query_params.ap_channel_rprt[i].ap_channel_rprt_len =
+                (ap_channel_rprt_len > (max_channels_in_list + 1)) ?
+                (max_channels_in_list + 1) : ap_channel_rprt_len;
+            query_params.ap_channel_rprt[i].ap_channel_op_class = *(tmp + sz);
+        }
+        sz += sizeof(unsigned char);
+
+        for (unsigned int j = 0; j < num_channels; j++) {
+            if (i < query_params.num_ap_channel_rprt && j < max_channels_in_list) {
+                query_params.ap_channel_rprt[i].ap_channel_list[j] = *(tmp + sz);
+            }
+            sz += sizeof(unsigned char);
+        }
+    }
+
+    if (sz < tlv_payload_len) {
+        unsigned int num_element_id = *(tmp + sz);
+        sz += sizeof(unsigned char);
+        if (sz + num_element_id > tlv_payload_len) {
+            em_printfout("Malformed Beacon Metrics Query TLV: element list overruns payload");
+            return -1;
+        }
+        query_params.element_list.num_element_id = (num_element_id > max_element_ids) ?
+            max_element_ids : num_element_id;
+        for (unsigned int i = 0; i < num_element_id; i++) {
+            if (i < query_params.element_list.num_element_id) {
+                query_params.element_list.element_list[i] = *(tmp + sz);
+            }
+            sz += sizeof(unsigned char);
+        }
+    }
+
+    em_printfout("   STA MAC Address: %s", util::mac_to_string(query_params.sta_mac_addr).c_str());
+    em_printfout("   Operating Class: %u", query_params.op_class);
+    em_printfout("   Channel Number: %u", query_params.channel_num);
+    em_printfout("   BSSID: %s", util::mac_to_string(query_params.bssid).c_str());
+    em_printfout("   Reporting Detail: %u", query_params.rprt_detail);
+    em_printfout("   SSID Length: %u", query_params.ssid_len);
+    em_printfout("   SSID: %.*s", query_params.ssid_len, query_params.ssid);
 
 
-    memcpy(sta, tlv->value, sizeof(mac_address_t));
+    // Extract message ID for the ACK
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+    unsigned short msg_id = ntohs(cmdu->id);
+    em_printfout("   msg_id: %u", msg_id);
+
+    // Check if the STA is associated with any BSS on this agent
+    dm_easy_mesh_t *dm = get_data_model();
+    dm_sta_t *sta = dm->get_first_sta(query_params.sta_mac_addr);
+    if (sta == NULL) {
+        em_printfout("STA %s not associated, sending error ACK (reason 0x02)",
+            util::mac_to_string(query_params.sta_mac_addr).c_str());
+        send_beacon_metrics_query_ack(query_params.sta_mac_addr, msg_id, 0x02);
+        return -1;
+    }
+
+    // STA is associated — send ACK before forwarding the request to OneWifi
+    send_beacon_metrics_query_ack(query_params.sta_mac_addr, msg_id, 0);
+
+    get_mgr()->io_process(em_bus_event_type_beacon_query, reinterpret_cast<unsigned char *>(&query_params), sizeof(em_beacon_metrics_query_t));
 
     return 0;
 }
@@ -390,7 +543,7 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
     dm = get_data_model();
 
     if (em_msg_t(em_msg_type_beacon_metrics_rsp, em_profile_type_2, buff, len).validate(errors) == 0) {
-        printf("%s:%d: Beacon Metrics Response message validation failed\n",__func__,__LINE__);
+        em_printfout("Beacon Metrics Response message validation failed on controller");
         return -1;
     }
 
@@ -402,8 +555,30 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
             response = reinterpret_cast<em_beacon_metrics_resp_t *> (tlv->value);
             break;
         }
-        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= static_cast<unsigned int> (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
+    }
+
+    if (response == NULL) {
+        em_printfout("Beacon Metrics Response: no beacon metrics response TLV found");
+        return -1;
+    }
+
+    // Raw 802.11 Measurement Report IE layout (beacon type):
+    //   [0]=elem-id [1]=length [2]=token [3]=report-mode [4]=report-type
+    //   [5]=op-class [6]=channel [7..14]=start-time [15..16]=duration
+    //   [17]=frame-info [18]=RCPI [19]=RSNI [20..25]=BSSID
+    static constexpr unsigned int BSSID_OFFSET_IN_BEACON_RPT_IE = 20;
+    static constexpr unsigned int MIN_BEACON_RPT_IE_LEN = 26; // through BSSID
+    if (response->meas_rprt_count > 0 &&
+            report_len >= MIN_BEACON_RPT_IE_LEN) {
+        const unsigned char *first_ie = response->meas_reports;
+        mac_address_t null_bssid = {};
+        if (memcmp(first_ie + BSSID_OFFSET_IN_BEACON_RPT_IE, null_bssid, sizeof(mac_address_t)) == 0) {
+            em_printfout("Beacon Metrics Response: null BSSID in report, discarding stub measurement for sta:%s",
+                util::mac_to_string(response->sta_mac_addr).c_str());
+            return 0;
+        }
     }
 
     sta = dm->get_first_sta(response->sta_mac_addr);
@@ -416,7 +591,7 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
 
     if(sta == NULL)
     {
-        printf("%s:%d: sta not found\n", __func__, __LINE__);
+        em_printfout("Beacon Metrics Response: sta not found in controller data model");
         return -1;
     }
 
@@ -424,15 +599,70 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
     sta->m_sta_info.beacon_report_len = report_len;
     memcpy(sta->m_sta_info.beacon_report_elem, response->meas_reports, static_cast<size_t> (report_len));
 
-    printf("%s:%d Beacon Metrics Response rcvd\n", __func__, __LINE__);
-    printf("%s:%d No of reports %d\n", __func__, __LINE__, sta->m_sta_info.num_beacon_meas_report);
-    printf("%s:%d Report len %d\n", __func__, __LINE__, sta->m_sta_info.beacon_report_len);
+    // Clear the timestamp so new queries can be sent immediately after a response
+    sta->m_sta_info.beacon_query_sent_time = 0;
 
-    //get_data_model()->set_db_cfg_param(db_cfg_type_sta_list_update, "");
+    em_printfout("Beacon Metrics Response rcvd for sta:%s reports:%u len:%u",
+        util::mac_to_string(sta->m_sta_info.id).c_str(),
+        sta->m_sta_info.num_beacon_meas_report, sta->m_sta_info.beacon_report_len);
 
-    //send_ack(sta);
+    // Send 1905 ACK back to the agent
+    em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+    send_beacon_metrics_ack(ntohs(cmdu->id));
 
     return 0;
+}
+
+int em_metrics_t::send_beacon_metrics_ack(unsigned short msg_id)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ] = {0};
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    // dst = agent, src = controller
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(em_msg_type_1905_ack);
+    cmdu->id   = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len  = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_2, buff, len).validate(errors) == 0) {
+        em_printfout("Beacon Metrics ACK validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        em_printfout("Beacon Metrics response ACK send failed, error:%d", errno);
+        return -1;
+    }
+
+    em_printfout("Beacon Metrics response ACK sent for msg_id=%u", msg_id);
+    return static_cast<int>(len);
 }
 
 int em_metrics_t::handle_ap_metrics_tlv(unsigned char *buff, bssid_t get_bssid)
@@ -659,8 +889,8 @@ int em_metrics_t::handle_vendor_msg(unsigned char *buff, unsigned int len)
         if (tlv->type == em_tlv_type_vendor_specific) {
             handle_link_stats_alarm_rprt_tlv(tlv->value, ntohs(tlv->len));
         }
-        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (htons(tlv->len)));
-        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + htons(tlv->len));
+        tmp_len -= (sizeof(em_tlv_t) + static_cast<size_t> (ntohs(tlv->len)));
+        tlv = reinterpret_cast<em_tlv_t *> (reinterpret_cast<unsigned char *> (tlv) + sizeof(em_tlv_t) + ntohs(tlv->len));
     }
 
     return 0;
@@ -875,7 +1105,7 @@ int em_metrics_t::send_associated_link_metrics_response(mac_address_t sta_mac, u
     return static_cast<int> (len);
 }
 
-short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid)
+short em_metrics_t::send_single_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid)
 {
     unsigned char buff[MAX_EM_BUFF_SZ];
     char *errors[EM_MAX_TLV_MEMBERS] = {0};
@@ -887,6 +1117,37 @@ short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bss
     dm_easy_mesh_t *dm;
     unsigned char *tmp = buff;
     unsigned short type = htons(ETH_P_1905);
+
+    dm = get_data_model();
+    em_cmd_t *cmd = get_current_cmd();
+    bool ack_gated_retry = (cmd != NULL && cmd->get_data_model() != NULL &&
+        cmd->supports_retry_state());
+
+    // For assoc/beacon_report commands: retry once per second until ACK is received for the tracked MID.
+    static constexpr time_t BEACON_QUERY_RETRY_SECS = 1;
+    static constexpr time_t BEACON_QUERY_TIMEOUT_SECS = 10;
+
+    time_t now = time(NULL);
+    if (ack_gated_retry == TRUE) {
+        time_t last_tx = cmd->get_query_tx_time();
+        int elapsed = now - last_tx;
+        if (last_tx != 0 && elapsed < BEACON_QUERY_RETRY_SECS) {
+            // em_printfout("Beacon Metrics Query retry window active for sta:%s (sent %lds ago), skipping.......",
+            //     util::mac_to_string(sta_mac).c_str(),
+            // static_cast<long>(elapsed));
+            return 0;
+        }
+    } else {
+        dm_sta_t *dm_sta = dm->find_sta(sta_mac, bssid);
+        if (dm_sta != NULL && dm_sta->m_sta_info.beacon_query_sent_time != 0) {
+            if ((now - dm_sta->m_sta_info.beacon_query_sent_time) < BEACON_QUERY_TIMEOUT_SECS) {
+                // em_printfout("Beacon Metrics Query retry window active for sta:%s (sent %lds ago), skipping.......",
+                // util::mac_to_string(sta_mac).c_str(),
+                // static_cast<long>(now - dm_sta->m_sta_info.beacon_query_sent_time));
+            return 0;
+            }
+        }
+    }
 
     dm = get_data_model();
 
@@ -906,7 +1167,14 @@ short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bss
 
     memset(tmp, 0, sizeof(em_cmdu_t));
     cmdu->type = htons(msg_type);
-    cmdu->id = htons(get_mgr()->get_next_msg_id());
+    unsigned short tracked_msg_id = 0;
+    if (ack_gated_retry) {
+        tracked_msg_id = cmd->get_data_model()->get_msg_id();
+    }
+    unsigned short query_msg_id = (tracked_msg_id != 0) ? tracked_msg_id : get_mgr()->get_next_msg_id();
+    // em_printfout("  MID=%u for sta:%s", query_msg_id, util::mac_to_string(sta_mac).c_str());
+
+    cmdu->id = htons(query_msg_id);
     cmdu->last_frag_ind = 1;
     cmdu->relay_ind = 0;
 
@@ -916,7 +1184,17 @@ short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bss
     //Beacon Metrics Query TLV (see section 17.2.27).
     tlv = reinterpret_cast<em_tlv_t *> (tmp);
     tlv->type = em_tlv_type_bcon_metric_query;
-    sz = create_beacon_metrics_query_tlv(tlv->value, sta_mac, bssid);
+    // When the controller is forwarding a received beacon query, use its cmd params directly.
+    if (get_state() == em_state_beacon_report_pending && cmd != NULL) {
+        em_cmd_beacon_metrics_param_t *params = &cmd->get_param()->u.beacon_metrics_params;
+        sz = create_beacon_metrics_query_tlv(tlv->value, params->sta_mac_addr, params->bssid);
+    } else {
+        sz = create_beacon_metrics_query_tlv(tlv->value, sta_mac, bssid);
+    }
+    if (sz < 0) {
+        em_printfout("Failed to create beacon metrics query tlv for sta:%s and bssid:%s", util::mac_to_string(sta_mac).c_str(), util::mac_to_string(bssid).c_str());
+        return -1;
+    }
     tlv->len = htons(static_cast<short unsigned int> (sz));
 
     tmp += (sizeof (em_tlv_t) + static_cast<size_t> (sz));
@@ -931,17 +1209,74 @@ short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bss
     len += (sizeof (em_tlv_t));
 
     if (em_msg_t(em_msg_type_beacon_metrics_query, em_profile_type_2, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        printf("Beacon Metrics Query msg validation failed\n");
+        em_printfout("Beacon Metrics Query msg validation failed");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: Beacon Metrics Query send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Beacon Metrics Query send failed, error:%d", errno);
         return -1;
     }
 
-    printf("%s:%d: Beacon Metrics Query send success\n", __func__, __LINE__);
+    // Track outstanding query MID in the current command DM for ACK correlation.
+    if (ack_gated_retry && tracked_msg_id == 0) {
+        cmd->get_data_model()->set_msg_id(query_msg_id);
+    }
+
+    if (ack_gated_retry) {
+        cmd->set_query_tx_time(now);
+    }
+
+    em_printfout("Beacon Metrics Query send success for sta:%s", util::mac_to_string(sta_mac).c_str());
+
+    // For non command-local
+    if (!ack_gated_retry) {
+        dm_sta_t *sta_sent = dm->find_sta(sta_mac, bssid);
+        if (sta_sent != NULL) {
+            sta_sent->m_sta_info.beacon_query_sent_time = now;
+        }
+    }
+
     return static_cast<short> (len);
+}
+
+short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid)
+{
+    dm_easy_mesh_t *dm = get_data_model();
+    em_assoc_sta_mld_info_t *mld_info = NULL;
+
+    if (dm == NULL) {
+        return 0;
+    }
+
+    //check if mlo, then trigger multiple query based on links
+    if (dm->is_sta_mld(sta_mac) == true) {
+        // Resolve whether this STA belongs to an MLD client.
+        for (unsigned int mld = 0; mld < dm->get_num_assoc_sta_mld(); mld++) {
+            em_assoc_sta_mld_info_t &assoc_sta_mld_info = dm->m_assoc_sta_mld[mld].m_assoc_sta_mld_info;
+            if (memcmp(assoc_sta_mld_info.mac_addr, sta_mac, sizeof(mac_address_t)) == 0) {
+                mld_info = &assoc_sta_mld_info;
+                //mld info found
+                break;
+            }
+        }
+        if (mld_info == NULL) {
+            em_printfout("No MLD info found for STA: %s", util::mac_to_string(sta_mac).c_str());
+            return -1;
+        }
+        for (int i = 0; i < mld_info->num_affiliated_sta; i++) {
+            em_printfout("For sta %s, bssid is %s and link_addr is %s", util::mac_to_string(mld_info->mac_addr).c_str(),
+                util::mac_to_string(mld_info->affiliated_sta[i].bssid).c_str(), util::mac_to_string(mld_info->affiliated_sta[i].link_addr).c_str());
+            em_printfout("Sending %d beacon metrics query for affiliated STA: %s", i, util::mac_to_string(mld_info->mac_addr).c_str());
+
+            send_single_beacon_metrics_query(sta_mac, mld_info->affiliated_sta[i].bssid);
+        }
+    } else {
+        em_printfout("Sending beacon metrics query for STA: %s", util::mac_to_string(sta_mac).c_str());
+        send_single_beacon_metrics_query(sta_mac, bssid);
+    }
+
+    return 0;
 }
 
 int em_metrics_t::send_beacon_metrics_response()
@@ -956,11 +1291,14 @@ int em_metrics_t::send_beacon_metrics_response()
     short sz = 0;
     unsigned short type = htons(ETH_P_1905);
     dm_easy_mesh_t *dm = get_data_model();
-    mac_addr_str_t mac_str;
     bool sta_found = false;
     dm_sta_t *sta;
 
     sta = reinterpret_cast<dm_sta_t *> (hash_map_get_first(get_current_cmd()->get_data_model()->m_sta_map));
+    if (sta == NULL) {
+        em_printfout("No STA in beacon report data model, cannot send response");
+        return -1;
+    }
 
     memcpy(tmp, dm->get_ctl_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
@@ -978,7 +1316,6 @@ int em_metrics_t::send_beacon_metrics_response()
 
     memset(tmp, 0, sizeof(em_cmdu_t));
     cmdu->type = htons(msg_type);
-    //TBD: MID should be same as beacon metrics query msg id
     cmdu->id = htons(get_mgr()->get_next_msg_id());
     cmdu->last_frag_ind = 1;
 
@@ -1012,17 +1349,19 @@ int em_metrics_t::send_beacon_metrics_response()
     len += (sizeof(em_tlv_t));
 
     if (em_msg_t(em_msg_type_beacon_metrics_rsp, em_profile_type_2, buff, static_cast<unsigned int> (len)).validate(errors) == 0) {
-        printf("%s:%d: Beacon Metrics Response validation failed for %s\n", __func__, __LINE__, mac_str);
+        em_printfout("Beacon Metrics Response validation failed");
         return -1;
     }
 
     if (send_frame(buff, static_cast<unsigned int> (len))  < 0) {
-        printf("%s:%d: Beacon Metrics Response send failed, error:%d\n", __func__, __LINE__, errno);
+        em_printfout("Beacon Metrics Response send failed, error:%d", errno);
         return -1;
     }
 
-    printf("%s:%d: Beacon Metrics Response send success\n", __func__, __LINE__);
+    em_printfout("Beacon Metrics Response send success for sta:%s reports:%u",
+        util::mac_to_string(sta->m_sta_info.id).c_str(), sta->m_sta_info.num_beacon_meas_report);
 
+    set_state(em_state_beacon_report_complete);
     return static_cast<int> (len);
 }
 
@@ -1402,10 +1741,11 @@ short em_metrics_t::create_beacon_metrics_query_tlv(unsigned char *buff, mac_add
 {
     size_t len = 0;
     dm_easy_mesh_t *dm;
-    ssid_t ssid;
+    ssid_t ssid = {0};
     dm_sta_t *sta;
     unsigned int j;
-    unsigned char ap_channel_list[] = {1, 6, 11};
+    bool ssid_found = false;
+    em_op_class_info_t *op_class = nullptr;
     
 	dm = get_data_model();
 
@@ -1417,78 +1757,122 @@ short em_metrics_t::create_beacon_metrics_query_tlv(unsigned char *buff, mac_add
         sta = reinterpret_cast<dm_sta_t *> (hash_map_get_next(dm->m_sta_map, sta));
     }
 
+    if (sta == NULL) {
+        em_printfout("STA not found for mac:%s", util::mac_to_string(sta_mac).c_str());
+        return -1;
+    }
+
+    em_printfout("BSS lookup: sta_mac:%s sta->bssid:%s bssid_param:%s num_bss:%u",
+        util::mac_to_string(sta_mac).c_str(),
+        util::mac_to_string(sta->m_sta_info.bssid).c_str(),
+        util::mac_to_string(bssid).c_str(),
+        dm->get_num_bss());
+
+    // Try bssid parameter first (from em_sta->bssid), then fall back to sta->m_sta_info.bssid
     for (j = 0; j < dm->get_num_bss(); j++) {
-        if (memcmp(&dm->m_bss[j].m_bss_info.bssid, sta->m_sta_info.bssid, sizeof(bssid_t)) != 0) {
+        em_printfout("  BSS[%u] bssid:%s ssid:%s", j,
+            util::mac_to_string(dm->m_bss[j].m_bss_info.bssid.mac).c_str(),
+            dm->m_bss[j].m_bss_info.ssid);
+        if (memcmp(dm->m_bss[j].m_bss_info.bssid.mac, bssid, sizeof(bssid_t)) == 0) {
             snprintf(ssid, sizeof(ssid_t), "%s", dm->m_bss[j].m_bss_info.ssid);
+            ssid_found = true;
+            em_printfout("BSS found via bssid param: ssid:%s", ssid);
             break;
         }
     }
 
-
-    em_beacon_metrics_query_t *beacon_metrics = reinterpret_cast<em_beacon_metrics_query_t*> (buff);
-
-    if (sta == NULL) {
-
-    }
-    else {
-
-        memcpy(beacon_metrics->sta_mac_addr, sta_mac, sizeof(mac_addr_t));
-        len += sizeof(beacon_metrics->sta_mac_addr);
-
-        beacon_metrics->op_class = 10;
-        len += sizeof(beacon_metrics->op_class);
-
-        beacon_metrics->channel_num = 6;
-        len += sizeof(beacon_metrics->channel_num);
-
-        memcpy(beacon_metrics->bssid, bssid, sizeof(bssid_t));
-        len += sizeof(beacon_metrics->bssid);
-
-        beacon_metrics-> rprt_detail = 1;
-        len += sizeof(beacon_metrics-> rprt_detail);
-
-        beacon_metrics->ssid_len = sizeof(ssid);
-        len += sizeof(beacon_metrics->ssid_len);
-
-        memcpy(beacon_metrics->ssid, ssid, sizeof(ssid));
-        len += sizeof(ssid);
-
-        beacon_metrics->num_ap_channel_rprt = 2;
-        len += sizeof(beacon_metrics->num_ap_channel_rprt);
-
-        em_beacon_ap_channel_rprt_t *ap_chann_rprt;// = buff + len;
-
-        for (int i = 0; i < beacon_metrics->num_ap_channel_rprt; i++) {
-            ap_chann_rprt = reinterpret_cast<em_beacon_ap_channel_rprt_t *> (buff + len);
-            ap_chann_rprt->ap_channel_rprt_len = 4;
-            len += sizeof(ap_chann_rprt->ap_channel_rprt_len);
-
-            ap_chann_rprt->ap_channel_op_class = 10;
-            len += sizeof(ap_chann_rprt->ap_channel_op_class);
-
-            for(int j = 0; j < ap_chann_rprt->ap_channel_rprt_len - 1; j++) {
-                ap_chann_rprt->ap_channel_list[j] = ap_channel_list[j];
-                len += sizeof(unsigned char);
+    if (ssid_found == false) {
+        // Fallback: try sta->m_sta_info.bssid
+        for (j = 0; j < dm->get_num_bss(); j++) {
+            if (memcmp(dm->m_bss[j].m_bss_info.bssid.mac, sta->m_sta_info.bssid, sizeof(bssid_t)) == 0) {
+                snprintf(ssid, sizeof(ssid_t), "%s", dm->m_bss[j].m_bss_info.ssid);
+                ssid_found = true;
+                em_printfout("BSS found via sta->bssid fallback: ssid:%s", ssid);
+                break;
             }
         }
     }
 
+    if (!ssid_found) {
+        em_printfout("BSS not found for bssid_param:%s sta->bssid:%s, cannot populate SSID",
+            util::mac_to_string(bssid).c_str(),
+            util::mac_to_string(sta->m_sta_info.bssid).c_str());
+        return -1;
+    }
+
+    // Derive op_class and channel from the operating channel report data
+    for (unsigned int i = 0; i < dm->m_num_opclass; i++) {
+        em_op_class_info_t *candidate = &dm->m_op_class[i].m_op_class_info;
+        if ((memcmp(candidate->id.ruid, dm->m_bss[j].m_bss_info.id.ruid, sizeof(mac_address_t)) == 0) &&
+                (candidate->id.type == em_op_class_type_current)) {
+            op_class = candidate;
+            break;
+        }
+    }
+    if (op_class == nullptr) {
+        em_printfout("Could not get current op_class from operating channel report for ruid, cannot build beacon query");
+        return -1;
+    }
+
+    unsigned char def_channel = (op_class->channel == 0) ? 255 : static_cast<unsigned char>(op_class->channel);
+    if (op_class->channel == 0) {
+        em_printfout("Operating channel report had channel 0, falling back to channel 255 (wildcard)");
+    } else {
+        em_printfout("Using AP operating channel %u from operating channel report for beacon request", op_class->channel);
+    }
+
+    em_beacon_metrics_query_t *beacon_metrics = reinterpret_cast<em_beacon_metrics_query_t*> (buff);
+
+    memcpy(beacon_metrics->sta_mac_addr, sta_mac, sizeof(mac_addr_t));
+    len += sizeof(beacon_metrics->sta_mac_addr);
+
+    beacon_metrics->op_class = op_class->op_class;
+    len += sizeof(beacon_metrics->op_class);
+
+    beacon_metrics->channel_num = def_channel;
+    len += sizeof(beacon_metrics->channel_num);
+
+    memcpy(beacon_metrics->bssid, bssid, sizeof(bssid_t));
+    len += sizeof(beacon_metrics->bssid);
+
+    beacon_metrics->rprt_detail = 1;
+    len += sizeof(beacon_metrics->rprt_detail);
+
+    beacon_metrics->ssid_len = strlen(ssid);
+    len += sizeof(beacon_metrics->ssid_len);
+
+    memcpy(beacon_metrics->ssid, ssid, beacon_metrics->ssid_len);
+    len += beacon_metrics->ssid_len;
+
+    // Single AP Channel Report with only the current operating channel
+    uint8_t num_rprts = 1;
+    *(buff + len) = num_rprts;
+    len += sizeof(uint8_t);
+
+    // AP Channel Report: length = 2 (1 byte op_class + 1 byte channel)
+    uint8_t rprt_len = 2;
+    *(buff + len) = rprt_len;
+    len += sizeof(uint8_t);
+
+    *(buff + len) = static_cast<uint8_t>(op_class->op_class);
+    len += sizeof(uint8_t);
+
+    *(buff + len) = def_channel;
+    len += sizeof(uint8_t);
+
     // Print the filled data
-    printf("STA MAC Address: %02x:%02x:%02x:%02x:%02x:%02x\n",
-           beacon_metrics->sta_mac_addr[0], beacon_metrics->sta_mac_addr[1], beacon_metrics->sta_mac_addr[2],
-           beacon_metrics->sta_mac_addr[3], beacon_metrics->sta_mac_addr[4], beacon_metrics->sta_mac_addr[5]);
-    printf("Operating Class: %u\n", beacon_metrics->op_class);
-    printf("Channel Number: %u\n", beacon_metrics->channel_num);
-    mac_addr_str_t mac_str;
-    dm_easy_mesh_t::macbytes_to_string(beacon_metrics->bssid, mac_str);
-    printf("BSSID: %s\n", mac_str);
-    printf("Reporting Detail: %u\n", beacon_metrics->rprt_detail);
-    printf("SSID Length: %u\n", beacon_metrics->ssid_len);
-    printf("SSID: %s\n", beacon_metrics->ssid);
-    printf("Number of AP Channel Reports: %u\n", beacon_metrics->num_ap_channel_rprt);
+    em_printfout("STA MAC Address: %s", util::mac_to_string(beacon_metrics->sta_mac_addr).c_str());
+    em_printfout("Operating Class: %u", beacon_metrics->op_class);
+    em_printfout("Channel Number: %u", beacon_metrics->channel_num);
+    em_printfout("BSSID: %s", util::mac_to_string(beacon_metrics->bssid).c_str());
+    em_printfout("Reporting Detail: %u", beacon_metrics->rprt_detail);
+    em_printfout("SSID Length: %u", beacon_metrics->ssid_len);
+    em_printfout("SSID: %.*s", beacon_metrics->ssid_len, beacon_metrics->ssid);
+    em_printfout("Number of AP Channel Reports: %u", num_rprts);
 
     return static_cast<short> (len);
 }
+
 
 short em_metrics_t::create_beacon_metrics_response_tlv(unsigned char *buff)
 {
@@ -1787,6 +2171,9 @@ int em_metrics_t::handle_1905_ack(unsigned char *buff, unsigned int len)
     std::vector<em_t *> em_radios;
     em_t *matched_em = nullptr;
     mac_address_t src_mac;
+    bool is_beacon_query_ack = false;
+
+    (void)len;
 
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
 
@@ -1798,23 +2185,40 @@ int em_metrics_t::handle_1905_ack(unsigned char *buff, unsigned int len)
 
     get_mgr()->get_all_em_for_al_mac(src_mac, em_radios);
 
-    for (auto &em : em_radios)
-    {
+    for (auto &em : em_radios) {
         if ((em->get_state() == em_state_ctrl_unassoc_sta_link_metrics_pending) &&
-            (response_msg_id == em->get_unassoc_sta_query_msg_id()))
-        {
+            (response_msg_id == em->get_unassoc_sta_query_msg_id())) {
             matched_em = em;
-	    em->clear_unassoc_sta_query_msg_id();
+            em->clear_unassoc_sta_query_msg_id();
+            break;
+        }
+
+        em_cmd_t *cmd = em->get_current_cmd();
+        if (cmd != NULL &&
+            cmd->supports_retry_state() &&
+            em->get_state() == em_state_beacon_report_pending &&
+            cmd->get_data_model() != NULL &&
+            response_msg_id == cmd->get_data_model()->get_msg_id()) {
+            matched_em = em;
+            is_beacon_query_ack = true;
+            cmd->get_data_model()->set_msg_id(0);
+            cmd->clear_query_tx_time();
             break;
         }
     }
 
     if (matched_em != nullptr) {
-        matched_em->set_state(em_state_ctrl_configured);
+        if (is_beacon_query_ack) {
+            matched_em->set_state(em_state_beacon_report_complete);
+        }
     }
 
     em_radios.clear();
-    em_printfout("Unassociated STA Link Metrics Query Ack handled successfully");
+    if (is_beacon_query_ack) {
+        em_printfout("Beacon Metrics Query ACK handled successfully, moving beacon_report to fini");
+    } else {
+        em_printfout("Unassociated STA Link Metrics Query Ack handled successfully");
+    }
     return 0;
 }
 
@@ -2394,6 +2798,8 @@ void em_metrics_t::send_unassoc_sta_link_metrics_resp_msg()
 void em_metrics_t::process_msg(unsigned char *data, unsigned int len)
 {
     em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *> (data + sizeof(em_raw_hdr_t));
+    em_raw_hdr_t *hdr = reinterpret_cast<em_raw_hdr_t *>(data);
+    std::vector<em_t *> em_radios;
 
     switch (htons(cmdu->type)) {
         case em_msg_type_assoc_sta_link_metrics_rsp:
@@ -2409,7 +2815,12 @@ void em_metrics_t::process_msg(unsigned char *data, unsigned int len)
             break;
 
         case em_msg_type_beacon_metrics_rsp:
-            handle_beacon_metrics_response(data, len);
+            em_radios.clear();
+            get_mgr()->get_all_em_for_al_mac(hdr->src, em_radios);
+            for (auto &em : em_radios) {
+                em->handle_beacon_metrics_response(data, len);
+                break;
+            }
             break;
 
         case em_msg_type_ap_metrics_rsp:
@@ -2455,13 +2866,11 @@ void em_metrics_t::process_ctrl_state()
 
 void em_metrics_t::process_agent_state()
 {
+    em_cmd_t *cmd = get_current_cmd();
+
     switch (get_state()) {
         case em_state_agent_sta_link_metrics_pending:
             send_associated_sta_link_metrics_resp_msg();
-            break;
-
-        case em_state_agent_beacon_report_pending:
-            send_beacon_metrics_response();
             break;
 
         case em_state_agent_link_quality_report_pending:
@@ -2470,6 +2879,10 @@ void em_metrics_t::process_agent_state()
 
         case em_state_agent_unassoc_sta_metrics_report_pending:
             send_unassoc_sta_link_metrics_resp_msg();
+            break;
+
+        case em_state_beacon_report_pending:
+            send_beacon_metrics_response();
             break;
 
         default:
@@ -2487,6 +2900,71 @@ void em_metrics_t::process_agent_state(em_cmd_event_type_t type)
         default:
             break;
     }
+}
+
+int em_metrics_t::send_beacon_metrics_query_ack(mac_address_t sta_mac, unsigned short msg_id, unsigned char reason)
+{
+    unsigned char buff[MAX_EM_BUFF_SZ] = {0};
+    char *errors[EM_MAX_TLV_MEMBERS] = {0};
+    unsigned int len = 0;
+    em_cmdu_t *cmdu;
+    em_tlv_t *tlv;
+    unsigned char *tmp = buff;
+    unsigned short type = htons(ETH_P_1905);
+    dm_easy_mesh_t *dm = get_data_model();
+
+    memcpy(tmp, dm->get_ctrl_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
+    tmp += sizeof(mac_address_t);
+    len += sizeof(mac_address_t);
+
+    memcpy(tmp, reinterpret_cast<unsigned char *>(&type), sizeof(unsigned short));
+    tmp += sizeof(unsigned short);
+    len += sizeof(unsigned short);
+
+    cmdu = reinterpret_cast<em_cmdu_t *>(tmp);
+    memset(tmp, 0, sizeof(em_cmdu_t));
+    cmdu->type = htons(em_msg_type_1905_ack);
+    cmdu->id   = htons(msg_id);
+    cmdu->last_frag_ind = 1;
+    tmp += sizeof(em_cmdu_t);
+    len += sizeof(em_cmdu_t);
+
+    if (reason != 0) {
+        // 17.2.36 Error Code TLV
+        tlv = reinterpret_cast<em_tlv_t *>(tmp);
+        tlv->type = em_tlv_type_error_code;
+        unsigned char *ec = tlv->value;
+        *ec = reason;
+        ec += sizeof(unsigned char);
+        memcpy(ec, sta_mac, sizeof(mac_address_t));
+        ec += sizeof(mac_address_t);
+        tlv->len = htons(static_cast<unsigned short>(sizeof(unsigned char) + sizeof(mac_address_t)));
+        tmp += sizeof(em_tlv_t) + sizeof(unsigned char) + sizeof(mac_address_t);
+        len += sizeof(em_tlv_t) + sizeof(unsigned char) + sizeof(mac_address_t);
+    }
+
+    tlv = reinterpret_cast<em_tlv_t *>(tmp);
+    tlv->type = em_tlv_type_eom;
+    tlv->len  = 0;
+    tmp += sizeof(em_tlv_t);
+    len += sizeof(em_tlv_t);
+
+    if (em_msg_t(em_msg_type_1905_ack, em_profile_type_2, buff, len).validate(errors) == 0) {
+        em_printfout("Beacon Metrics Query ACK validation failed");
+        return -1;
+    }
+
+    if (send_frame(buff, len) < 0) {
+        em_printfout("Beacon Metrics Query ACK send failed, error:%d", errno);
+        return -1;
+    }
+
+    em_printfout("Beacon Metrics Query ACK sent for msg_id=%u reason=%u", msg_id, reason);
+    return static_cast<int>(len);
 }
 
 em_metrics_t::em_metrics_t()

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -595,6 +595,8 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
         if (memcmp(first_ie + BSSID_OFFSET_IN_BEACON_RPT_IE, null_bssid, sizeof(mac_address_t)) == 0) {
             em_printfout("Beacon Metrics Response: null BSSID in report, discarding stub measurement for sta:%s",
                 util::mac_to_string(response->sta_mac_addr).c_str());
+            em_cmdu_t *cmdu = reinterpret_cast<em_cmdu_t *>(buff + sizeof(em_raw_hdr_t));
+            send_beacon_metrics_ack(ntohs(cmdu->id));
             return 0;
         }
     }
@@ -1247,18 +1249,15 @@ short em_metrics_t::send_single_beacon_metrics_query(mac_address_t sta_mac, bssi
     bool ack_gated_retry = (cmd != NULL && cmd->get_data_model() != NULL &&
         cmd->supports_retry_state());
 
-    // For assoc/beacon_report commands: retry once per second until ACK is received for the tracked MID.
-    static constexpr time_t BEACON_QUERY_RETRY_SECS = 1;
+    // For beacon_report commands, send once and wait for ACK or orchestration timeout.
     static constexpr time_t BEACON_QUERY_TIMEOUT_SECS = 10;
 
     time_t now = time(NULL);
-    if (ack_gated_retry == TRUE) {
+    if (ack_gated_retry == true) {
         time_t last_tx = cmd->get_query_tx_time();
-        int elapsed = now - last_tx;
-        if (last_tx != 0 && elapsed < BEACON_QUERY_RETRY_SECS) {
-            // em_printfout("Beacon Metrics Query retry window active for sta:%s (sent %lds ago), skipping.......",
-            //     util::mac_to_string(sta_mac).c_str(),
-            // static_cast<long>(elapsed));
+        if (last_tx != 0) {
+            em_printfout("Beacon Metrics Query already sent for sta:%s, waiting for ACK or timeout",
+                util::mac_to_string(sta_mac).c_str());
             return 0;
         }
     } else {
@@ -1274,6 +1273,8 @@ short em_metrics_t::send_single_beacon_metrics_query(mac_address_t sta_mac, bssi
     }
 
     dm = get_data_model();
+
+    em_printfout("Sending beacon metrics query for STA: %s", util::mac_to_string(sta_mac).c_str());
 
     memcpy(tmp, dm->get_agent_al_interface_mac(), sizeof(mac_address_t));
     tmp += sizeof(mac_address_t);
@@ -1391,12 +1392,11 @@ short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bss
         for (int i = 0; i < mld_info->num_affiliated_sta; i++) {
             em_printfout("For sta %s, bssid is %s and link_addr is %s", util::mac_to_string(mld_info->mac_addr).c_str(),
                 util::mac_to_string(mld_info->affiliated_sta[i].bssid).c_str(), util::mac_to_string(mld_info->affiliated_sta[i].link_addr).c_str());
-            em_printfout("Sending %d beacon metrics query for affiliated STA: %s", i, util::mac_to_string(mld_info->mac_addr).c_str());
+            em_printfout("Attempting beacon metrics query for affiliated STA[%d]: %s", i, util::mac_to_string(mld_info->mac_addr).c_str());
 
             send_single_beacon_metrics_query(sta_mac, mld_info->affiliated_sta[i].bssid);
         }
     } else {
-        em_printfout("Sending beacon metrics query for STA: %s", util::mac_to_string(sta_mac).c_str());
         send_single_beacon_metrics_query(sta_mac, bssid);
     }
 
@@ -2301,7 +2301,6 @@ int em_metrics_t::handle_1905_ack(unsigned char *buff, unsigned int len)
     std::vector<em_t *> em_radios;
     em_t *matched_em = nullptr;
     mac_address_t src_mac;
-    bool is_beacon_query_ack = false;
 
     (void)len;
 
@@ -2320,6 +2319,7 @@ int em_metrics_t::handle_1905_ack(unsigned char *buff, unsigned int len)
             (response_msg_id == em->get_unassoc_sta_query_msg_id())) {
             matched_em = em;
             em->clear_unassoc_sta_query_msg_id();
+            em_printfout("Unassociated STA Link Metrics Query Ack handled successfully");
             break;
         }
 
@@ -2333,22 +2333,15 @@ int em_metrics_t::handle_1905_ack(unsigned char *buff, unsigned int len)
             is_beacon_query_ack = true;
             cmd->get_data_model()->set_msg_id(0);
             cmd->clear_query_tx_time();
+            matched_em->set_state(em_state_beacon_report_complete);
+            em_printfout("1905 ACK received src_al_mac:%s msg_id:%u",
+                util::mac_to_string(src_mac).c_str(), response_msg_id);
             break;
         }
     }
 
-    if (matched_em != nullptr) {
-        if (is_beacon_query_ack) {
-            matched_em->set_state(em_state_beacon_report_complete);
-        }
-    }
-
     em_radios.clear();
-    if (is_beacon_query_ack) {
-        em_printfout("Beacon Metrics Query ACK handled successfully, moving beacon_report to fini");
-    } else {
-        em_printfout("Unassociated STA Link Metrics Query Ack handled successfully");
-    }
+
     return 0;
 }
 
@@ -2996,8 +2989,6 @@ void em_metrics_t::process_ctrl_state()
 
 void em_metrics_t::process_agent_state()
 {
-    em_cmd_t *cmd = get_current_cmd();
-
     switch (get_state()) {
         case em_state_agent_sta_link_metrics_pending:
             send_associated_sta_link_metrics_resp_msg();

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -414,8 +414,16 @@ int em_metrics_t::handle_beacon_metrics_query(unsigned char *buff, unsigned int 
 
     // Check if the STA is associated with any BSS on this agent
     dm_easy_mesh_t *dm = get_data_model();
-    dm_sta_t *sta = dm->get_first_sta(query_params.sta_mac_addr);
-    if (sta == NULL) {
+    bool associated = false;
+    for (dm_sta_t *sta = dm->get_first_sta(query_params.sta_mac_addr);
+            sta != NULL;
+            sta = dm->get_next_sta(query_params.sta_mac_addr, sta)) {
+        if (sta->m_sta_info.associated) {
+            associated = true;
+            break;
+        }
+    }
+    if (!associated) {
         em_printfout("STA %s not associated, sending error ACK (reason 0x02)",
             util::mac_to_string(query_params.sta_mac_addr).c_str());
         send_beacon_metrics_query_ack(query_params.sta_mac_addr, msg_id, 0x02);
@@ -1369,37 +1377,15 @@ short em_metrics_t::send_single_beacon_metrics_query(mac_address_t sta_mac, bssi
 short em_metrics_t::send_beacon_metrics_query(mac_address_t sta_mac, bssid_t bssid)
 {
     dm_easy_mesh_t *dm = get_data_model();
-    em_assoc_sta_mld_info_t *mld_info = NULL;
 
     if (dm == NULL) {
         return 0;
     }
 
-    //check if mlo, then trigger multiple query based on links
-    if (dm->is_sta_mld(sta_mac) == true) {
-        // Resolve whether this STA belongs to an MLD client.
-        for (unsigned int mld = 0; mld < dm->get_num_assoc_sta_mld(); mld++) {
-            em_assoc_sta_mld_info_t &assoc_sta_mld_info = dm->m_assoc_sta_mld[mld].m_assoc_sta_mld_info;
-            if (memcmp(assoc_sta_mld_info.mac_addr, sta_mac, sizeof(mac_address_t)) == 0) {
-                mld_info = &assoc_sta_mld_info;
-                //mld info found
-                break;
-            }
-        }
-        if (mld_info == NULL) {
-            em_printfout("No MLD info found for STA: %s", util::mac_to_string(sta_mac).c_str());
-            return -1;
-        }
-        for (int i = 0; i < mld_info->num_affiliated_sta; i++) {
-            em_printfout("For sta %s, bssid is %s and link_addr is %s", util::mac_to_string(mld_info->mac_addr).c_str(),
-                util::mac_to_string(mld_info->affiliated_sta[i].bssid).c_str(), util::mac_to_string(mld_info->affiliated_sta[i].link_addr).c_str());
-            em_printfout("Attempting beacon metrics query for affiliated STA[%d]: %s", i, util::mac_to_string(mld_info->mac_addr).c_str());
-
-            send_single_beacon_metrics_query(sta_mac, mld_info->affiliated_sta[i].bssid);
-        }
-    } else {
-        send_single_beacon_metrics_query(sta_mac, bssid);
-    }
+    /* For MLD clients, the HAL now expands a single query into per-link Beacon
+     * Requests covering every established link, so only one query is sent here
+     * to avoid sending duplicate over-the-air requests per affiliated link. */
+    send_single_beacon_metrics_query(sta_mac, bssid);
 
     return 0;
 }

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -618,6 +618,7 @@ int em_metrics_t::handle_beacon_metrics_response(unsigned char *buff, unsigned i
     sta->m_sta_info.num_beacon_meas_report = response->meas_rprt_count;
     sta->m_sta_info.beacon_report_len = report_len;
     memcpy(sta->m_sta_info.beacon_report_elem, response->meas_reports, static_cast<size_t> (report_len));
+    dm_sta_t::decode_beacon_report(sta);
 
     // Clear the timestamp so new queries can be sent immediately after a response
     sta->m_sta_info.beacon_query_sent_time = 0;
@@ -2330,7 +2331,6 @@ int em_metrics_t::handle_1905_ack(unsigned char *buff, unsigned int len)
             cmd->get_data_model() != NULL &&
             response_msg_id == cmd->get_data_model()->get_msg_id()) {
             matched_em = em;
-            is_beacon_query_ack = true;
             cmd->get_data_model()->set_msg_id(0);
             cmd->clear_query_tx_time();
             matched_em->set_state(em_state_beacon_report_complete);

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -128,7 +128,7 @@ bool em_orch_agent_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             break;
 
         case em_cmd_type_beacon_report:
-            if (em->get_state() == em_state_agent_configured) {
+            if (em->get_state() == em_state_beacon_report_complete) {
                 return true;
             }
             break;
@@ -189,8 +189,9 @@ bool em_orch_agent_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
 			return true;
 		}
 	} else if (pcmd->m_type == em_cmd_type_beacon_report) {
-        if ((em->get_state() == em_state_agent_configured) ||
-            ((em->get_state() == em_state_agent_beacon_report_pending))) {
+        if ((em->get_state() == em_state_beacon_report_pending) ||
+            (em->get_state() == em_state_agent_configured) ||
+            (em->get_state() >= em_state_agent_topo_synchronized)) {
             return true;
         }
     } else if (pcmd->m_type == em_cmd_type_get_link_quality_report) {
@@ -290,17 +291,12 @@ bool em_orch_agent_t::pre_process_orch_op(em_cmd_t *pcmd)
                     hash_map_put(dm->m_sta_map, strdup(key), new dm_sta_t(*sta));
                 }
 
-                dm_sta_t *stale_dassoc = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_dassoc_map, key));
-                if (stale_dassoc != NULL) {
-                    em_printfout("Assoc row key=%s found in live disassoc map; removing stale disassoc entry", key);
-                    delete stale_dassoc;
-                }
-
                 sta = static_cast<dm_sta_t *> (hash_map_get_next(pcmd->get_data_model()->m_sta_assoc_map, sta));
             }
 
             sta = static_cast<dm_sta_t *> (hash_map_get_first(pcmd->get_data_model()->m_sta_dassoc_map));
             while(sta != NULL) {
+                dm_sta_t *next_sta = static_cast<dm_sta_t *>(hash_map_get_next(pcmd->get_data_model()->m_sta_dassoc_map, sta));
                 dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.id, sta_mac_str);
                 dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.bssid, bss_mac_str);
                 dm_easy_mesh_t::macbytes_to_string(sta->m_sta_info.radiomac, radio_mac_str);
@@ -308,21 +304,13 @@ bool em_orch_agent_t::pre_process_orch_op(em_cmd_t *pcmd)
 
                 em_sta_info_t *em_sta = dm->get_sta_info(sta->m_sta_info.id, sta->m_sta_info.bssid, sta->m_sta_info.radiomac, em_target_sta_map_consolidated);
                 if (em_sta != NULL) {
-                    // Copy all stats from the consolidated row into the dassoc row.
-                    memcpy(&sta->m_sta_info, em_sta, sizeof(em_sta_info_t));
-                    sta->m_sta_info.associated = false;
-                    em_sta_info_t *em_sta_dassoc = dm->get_sta_info(sta->m_sta_info.id, sta->m_sta_info.bssid, sta->m_sta_info.radiomac, em_target_sta_map_disassoc);
-                    if (em_sta_dassoc != NULL) {
-                        em_printfout("Consolidated Map removed with key: %s, updating em_target_sta_map_disassoc entry", key);
-                        memcpy(em_sta_dassoc, &sta->m_sta_info, sizeof(em_sta_info_t));
-                    } else {
-                        em_printfout("Consolidated Map removed with key: %s, added em_target_sta_map_disassoc entry", key);
-                        dm->put_sta_info(&sta->m_sta_info, em_target_sta_map_disassoc);
-                    }
-                    dm_sta_t *tmp = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_map, key));
-                    delete tmp;
+                    dm_sta_t *removed_sta;
+
+                    em_printfout("Consolidated Map removed with key: %s, updating em_target_sta_map_disassoc entry", key);
+                    removed_sta = static_cast<dm_sta_t *>(hash_map_remove(dm->m_sta_map, key));
+                    delete removed_sta;
                 }
-                sta = static_cast<dm_sta_t *>(hash_map_get_next(pcmd->get_data_model()->m_sta_dassoc_map, sta));
+                sta = next_sta;
             }
             break;
         case dm_orch_type_sta_insert:
@@ -502,7 +490,7 @@ unsigned int em_orch_agent_t::build_candidates(em_cmd_t *pcmd)
                 sta = em->find_sta(mac1, mac2);
                 if (sta != NULL) {
                     queue_push(pcmd->m_em_candidates, em);
-                    printf("%s:%d Beacon report build candidate pushed\n", __func__, __LINE__);
+                    em_printfout("Beacon report build candidate pushed");
                     count++;
                 }
                 break;

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -296,8 +296,11 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             }
             break;
 
-	case em_cmd_type_unassoc_sta_query:
-            if (em->get_state() == em_state_ctrl_configured) {
+	    case em_cmd_type_unassoc_sta_query:
+            break;
+
+        case em_cmd_type_beacon_report:
+            if (em->get_state() == em_state_beacon_report_complete) {
                 return true;
             }
             break;
@@ -360,8 +363,14 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_scan_channel:
         case em_cmd_type_set_policy:
         case em_cmd_type_bsta_cap:
-	case em_cmd_type_unassoc_sta_query:
-            if (em->get_state() == em_state_ctrl_configured) {
+	    case em_cmd_type_unassoc_sta_query:
+            if (em->get_state() >= em_state_ctrl_topo_synchronized) {
+                return true;
+            }
+            break;
+        case em_cmd_type_beacon_report:
+            if ((em->get_state() >= em_state_ctrl_topo_synchronized) ||
+                (em->get_state() == em_state_beacon_report_pending)) {
                 return true;
             }
             break;
@@ -566,9 +575,8 @@ bool em_orch_ctrl_t::pre_process_orch_op(em_cmd_t *pcmd)
 unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
 {
     em_t *em;
-    std::vector<em_t *> sta_assoc_fallback_ems;
     dm_easy_mesh_t *dm;
-    mac_address_t	bss_mac, rad_mac, dev_mac;
+    mac_address_t   rad_mac, dev_mac;
     unsigned int count = 0, i;
     em_disassoc_params_t *disassoc_param;
     dm_sta_t *sta;
@@ -645,21 +653,15 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
             case em_cmd_type_sta_assoc:
                 dm = em->get_data_model();
                 dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[0], dev_mac);
-                dm_easy_mesh_t::string_to_macbytes(pcmd->m_param.u.args.args[1], bss_mac);
-                //em_printfout("BSS for this STA %s is %s", pcmd->m_param.u.args.args[2], pcmd->m_param.u.args.args[1]);
-                for (i = 0; i < dm->m_num_bss; i++) {
-                    if ((memcmp(dm->m_bss[i].m_bss_info.bssid.mac, bss_mac, sizeof(mac_address_t)) == 0) &&
-                        (em->is_al_interface_em() == false)) {
-                        queue_push(pcmd->m_em_candidates, em);
-                        count++;
-                        //em_printfout("Found em this STA, candidate count: %d", count);
-                        break;
-                    }
-                }
-
                 if ((em->is_al_interface_em() == false) &&
-                    (memcmp(dm->get_agent_al_interface_mac(), dev_mac, sizeof(mac_address_t)) == 0)) {
-                    sta_assoc_fallback_ems.push_back(em);
+                    (memcmp(dm->get_agent_al_interface_mac(), dev_mac, sizeof(mac_address_t)) == 0) &&
+                    (count == 0)) {
+                    em_printfout("sta_assoc: using radio %s for dev %s orch_op: %s",
+                        util::mac_to_string(em->get_radio_interface_mac()).c_str(),
+                        pcmd->m_param.u.args.args[0],
+                        em_cmd_t::get_orch_op_str(pcmd->get_orch_op()));
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
                 }
                 break;
 
@@ -776,15 +778,6 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
 		break;
 	}
         em = static_cast<em_t *>(hash_map_get_next(m_mgr->m_em_map, em));
-    }
-
-    if ((pcmd->m_type == em_cmd_type_sta_assoc) && (count == 0) && (!sta_assoc_fallback_ems.empty())) {
-        em_printfout("No per-link BSS match for %s, using %zu fallback radios",
-                pcmd->m_param.u.args.args[1], sta_assoc_fallback_ems.size());
-        for (auto *fallback_em : sta_assoc_fallback_ems) {
-            queue_push(pcmd->m_em_candidates, fallback_em);
-            count++;
-        }
     }
 
     pthread_mutex_unlock(&m_mgr->m_mutex);

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -364,7 +364,7 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_set_policy:
         case em_cmd_type_bsta_cap:
 	    case em_cmd_type_unassoc_sta_query:
-            if (em->get_state() >= em_state_ctrl_topo_synchronized) {
+            if (em->get_state() >= em_state_ctrl_configured) {
                 return true;
             }
             break;
@@ -768,15 +768,15 @@ unsigned int em_orch_ctrl_t::build_candidates(em_cmd_t *pcmd)
                 }
                 break;
             case em_cmd_type_unassoc_sta_query:
-		if (count == 0 && memcmp(em->get_data_model()->get_agent_al_interface_mac(),
-					pcmd->m_param.u.unassoc_sta_query_params.al_mac, sizeof(mac_address_t)) == 0) {
-		    queue_push(pcmd->m_em_candidates, em);
-		    count++;
-		}		
-		break;
-	    default:
-		break;
-	}
+                if (count == 0 && memcmp(em->get_data_model()->get_agent_al_interface_mac(),
+                    pcmd->m_param.u.unassoc_sta_query_params.al_mac, sizeof(mac_address_t)) == 0) {
+                    queue_push(pcmd->m_em_candidates, em);
+                    count++;
+                }
+		        break;
+            default:
+                break;
+	    }
         em = static_cast<em_t *>(hash_map_get_next(m_mgr->m_em_map, em));
     }
 

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -297,6 +297,9 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_fini(em_cmd_t *pcmd, em_t *em)
             break;
 
 	    case em_cmd_type_unassoc_sta_query:
+            if (em->get_state() == em_state_ctrl_configured) {
+                return true;
+            }
             break;
 
         case em_cmd_type_beacon_report:
@@ -364,7 +367,7 @@ bool em_orch_ctrl_t::is_em_ready_for_orch_exec(em_cmd_t *pcmd, em_t *em)
         case em_cmd_type_set_policy:
         case em_cmd_type_bsta_cap:
 	    case em_cmd_type_unassoc_sta_query:
-            if (em->get_state() >= em_state_ctrl_configured) {
+            if (em->get_state() == em_state_ctrl_configured) {
                 return true;
             }
             break;

--- a/tests/test_l1_dm_assoc_sta_mld.cpp
+++ b/tests/test_l1_dm_assoc_sta_mld.cpp
@@ -1008,9 +1008,9 @@ TEST(dm_assoc_sta_mld_t_Test, ValidAPMLDInformation) {
     ap_mld_info.emlmr = true;
     ap_mld_info.num_affiliated_sta = 2;
     memcpy(ap_mld_info.affiliated_sta[0].bssid, bssid1, 6);
-    memcpy(ap_mld_info.affiliated_sta[0].mac_addr, sta_mac1, 6);
+    memcpy(ap_mld_info.affiliated_sta[0].link_addr, sta_mac1, 6);
     memcpy(ap_mld_info.affiliated_sta[1].bssid, bssid2, 6);
-    memcpy(ap_mld_info.affiliated_sta[1].mac_addr, sta_mac2, 6);
+    memcpy(ap_mld_info.affiliated_sta[1].link_addr, sta_mac2, 6);
     // Create instance with initialized data
     dm_assoc_sta_mld_t assoc_sta_mld(&ap_mld_info);
     std::cout << "Exiting ValidAPMLDInformation test";


### PR DESCRIPTION
Beacon metrics query/response support and refactor MLO clients handling
Core Changes:
- Implement Beacon metrics query and response handling

Client Assoc/Disassoc Updates:
- For MLO clients, requent topo query to get latest new mld links info on a re-assoc as the links may differ
- If non-MLO client, do not re-request client cap. Also ensure to not delete caps on a disassoc.
- handle_assoc_sta_mld_topology_update() to reset m_sta_map entries before marking active links, replacing stale scan logic.
- Ensure DB disassoc sync: Write per-link associated=false entries to m_sta_assoc_map on disassociation events.
- Force re-assoc topo sync: Always trigger topo_sync for MLO STAs in analyze_sta_assoc_event() even if sta_exists=true.

Capability Updates:
- Consolidate per-link cap writes into dm_easy_mesh_t::apply_sta_cap_to_maps() to update m_sta_assoc_map and
  m_sta_map together for immediate datamodel update.
- Support 6GHz HE/EHT tags: Add decoding for extended tags (HE) and (EHT) in decode_sta_capability() to properly capture 6GHz capabilities.