### PR TITLE
RDKBWIFI-538: Unblock onboarding recovery via Autoconfig Renew

### DIFF
--- a/src/agent/em_agent.cpp
+++ b/src/agent/em_agent.cpp
@@ -1970,7 +1970,9 @@ em_t *em_agent_t::find_em_for_msg_type(unsigned char *data, unsigned int len, em
 					}
 				}
 				if (em->is_matching_freq_band(&band) == true) {
-					if ((em->get_state() != em_state_agent_autoconfig_renew_pending) && (em->get_state() !=em_state_agent_wsc_m2_pending) && (em->get_state() != em_state_agent_owconfig_pending) ) {
+					/* Accept renew in owconfig_pending too: the apply confirmation
+					 * never arrived and renew is the mechanism to recover that. */
+					if ((em->get_state() != em_state_agent_autoconfig_renew_pending) && (em->get_state() !=em_state_agent_wsc_m2_pending)) {
 						em_printfout("Found matching band %d for autoconfig renew request, received controller AL MAC is %s", band, al_mac_str);
 						found = true;
 						break;

--- a/src/orch/em_orch_ctrl.cpp
+++ b/src/orch/em_orch_ctrl.cpp
@@ -79,6 +79,16 @@ void em_orch_ctrl_t::orch_transient(em_cmd_t *pcmd, em_t *em)
                     dm->set_ssid_mismatch_check_time(0);
                     dm->set_last_topo_query_sent_time(0);
                     cancel_command(pcmd->get_type(), all_em_radios);
+                    /* Escalate like the SSID-mismatch path so a stuck agent redoes WSC;
+                     * the renew tx budget re-arms at the threshold, keeping this bounded. */
+                    em_printfout("Topology sync did not complete within TTL, sending Autoconfig Renew on all radios and transitioning to misconfigured state");
+                    for (em_t *radio : all_em_radios) {
+                        em_configuration_t *cfg = static_cast<em_configuration_t *>(radio);
+                        radio->set_state(em_state_ctrl_misconfigured);
+                        if (cfg->send_autoconfig_renew_msg() < 0) {
+                            em_printfout("Autoconfig Renew send failed for radio:%s", util::mac_to_string(radio->get_radio_interface_mac()).c_str());
+                        }
+                    }
                     return;
                 }
 


### PR DESCRIPTION
Boot-time race: the agent's post M2 Vap subdocs can be lost before OneWifi's webconfig handler is ready, leaving every radio below em_state_agent_onewifi_bssconfig_ind forever (topology queries ignored, the controller never converges). Two recovery fixes using existing mechanisms:

1) agent: accept em_msg_type_autoconf_renew while a radio is in
   em_state_agent_owconfig_pending, that state means the apply confirmation
   never arrived, and Renew is exactly the mechanism meant to recover it.

2) ctrl: when Topology Sync does not complete within the TTL,
   reuse the SSID mismatch escalation, transition radios to
   em_state_ctrl_misconfigured and send Autoconfig Renew instead of only
   cancelling silently. The renew tx budget re-arms at the threshold, so
   each recovery cycle stays bounded.