### PR TITLE
RDKBWIFI-545: Emit instance-less names in WiFi6/7APRole bulk get

### DIFF
--- a/inc/tr_181.h
+++ b/inc/tr_181.h
@@ -530,8 +530,13 @@ public:
     bus_error_t raw_data_set(raw_data_t *p_data, bus_data_prop_t *property);
     template <typename T> 
     bus_data_prop_t *property_init_value(const char *root, unsigned int idx, const char *param, T value);
-    template <typename T> 
+    template <typename T>
     void property_append_tail(bus_data_prop_t **property, const char *root, unsigned int idx, const char *param, T value);
+    /* Instance-less variants (name = root + param) for object nodes that are not tables. */
+    template <typename T>
+    bus_data_prop_t *property_init_value(const char *root, const char *param, T value);
+    template <typename T>
+    void property_append_tail(bus_data_prop_t **property, const char *root, const char *param, T value);
 
     virtual bus_error_t bus_get_cb_fwd(char *event_name, raw_data_t *p_data, bus_get_handler_t cb) = 0;
     
@@ -941,6 +946,47 @@ template <typename T> void tr_181_t::property_append_tail(bus_data_prop_t **prop
     } else {
         tail = static_cast<bus_data_prop_t *>(calloc(1, sizeof(bus_data_prop_t)));
         snprintf(tail->name, sizeof(bus_name_string_t), "%s%d.%s", root, idx, param);
+        raw_data_set(&tail->value, value);
+        tail->name_len = static_cast<uint32_t>(strlen(tail->name));
+        tail->is_data_set = true;
+
+        last = *property;
+        while (last->next_data) {
+            last = last->next_data;
+        }
+        last->next_data = tail;
+    }
+}
+
+template <typename T> bus_data_prop_t *tr_181_t::property_init_value(const char *root, const char *param, T value)
+{
+    bus_data_prop_t *property = static_cast<bus_data_prop_t *>(calloc(1, sizeof(bus_data_prop_t)));
+
+    if (property == NULL) {
+        return NULL;
+    }
+
+    snprintf(property->name, sizeof(bus_name_string_t), "%s%s", root, param);
+    raw_data_set(&property->value, value);
+    property->name_len = static_cast<uint32_t>(strlen(property->name));
+    property->is_data_set = true;
+
+    return property;
+}
+
+template <typename T> void tr_181_t::property_append_tail(bus_data_prop_t **property, const char *root, const char *param, T value)
+{
+    bus_data_prop_t *tail;
+    bus_data_prop_t *last;
+
+    if (*property == NULL) {
+        *property = property_init_value(root, param, value);
+    } else {
+        tail = static_cast<bus_data_prop_t *>(calloc(1, sizeof(bus_data_prop_t)));
+        if (tail == NULL) {
+            return;
+        }
+        snprintf(tail->name, sizeof(bus_name_string_t), "%s%s", root, param);
         raw_data_set(&tail->value, value);
         tail->name_len = static_cast<uint32_t>(strlen(tail->name));
         tail->is_data_set = true;

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -6017,7 +6017,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_get_inner(char *event_name, raw_data_t *p
     char instance[MAX_INSTANCE_LEN] = { 0 };
     bool is_num;
     int device_instance = 0, radio_instance = 0;
-    bus_error_t rc;
+    bus_error_t rc = bus_error_invalid_input;
     em_wifi6_role_wire_t role_temp;
     em_wifi6_role_wire_t *role = &role_temp;
 
@@ -6062,10 +6062,10 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_get_inner(char *event_name, raw_data_t *p
         return bus_error_invalid_input;
     }
     em_radio_cap_info_t *rci = radio_cap->get_radio_cap_info();
-    char mcsnss_str[256] = { 0 };
     unsigned int i;
 
     for (i = 0; i < rci->wifi6_cap.num_role; i++) {
+        char mcsnss_str[256] = { 0 };
         memcpy(&role_temp, &rci->wifi6_cap.roles[i], sizeof(em_wifi6_role_wire_t));
 
         if (strcmp(param, "HE160") == 0) {
@@ -6074,7 +6074,7 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_get_inner(char *event_name, raw_data_t *p
             rc = dm_ctrl->raw_data_set(p_data, static_cast<bool>(role->role_head.he_8080));
         } else if (strcmp(param, "MCSNSS") == 0) {
             int num_maps = role->role_head.mcs_nss_num / EM_MIN_HE_MCS_LEN;
-            for (int j = 0; j < num_maps && i < MAX_MCS; j++) {
+            for (int j = 0; j < num_maps && j < MAX_MCS; j++) {
                 char temp[32];
                 snprintf(temp, sizeof(temp),
                         "%x%x",
@@ -6181,9 +6181,9 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_inner(char *event_name, raw_data_t *
 
 bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_params(dm_easy_mesh_t *dm, const char *root, em_radio_info_t *ri, bus_data_prop_t **property, unsigned int idx)
 {
-    char mcsnss_str[256] = { 0 };
     bus_error_t rc = bus_error_success;
     unsigned int i;
+    (void) idx; /* WiFi6APRole is an object (not a table): no row instance under it */
     em_wifi6_role_wire_t role_temp;
     em_wifi6_role_wire_t *role = &role_temp;
 
@@ -6195,10 +6195,11 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_params(dm_easy_mesh_t *dm, const cha
     em_radio_cap_info_t *rci = radio_cap->get_radio_cap_info();
 
     for (i = 0; i < rci->wifi6_cap.num_role; i++) {
+        char mcsnss_str[256] = { 0 };
         memcpy(role, &rci->wifi6_cap.roles[i], sizeof(em_wifi6_role_wire_t));
 
         int num_maps = role->role_head.mcs_nss_num / EM_MIN_HE_MCS_LEN;
-        for (int j = 1; j < num_maps && i < MAX_MCS; j++) {
+        for (int j = 0; j < num_maps && j < MAX_MCS; j++) {
             char temp[32];
             snprintf(temp, sizeof(temp),
                     "%x%x",
@@ -6207,29 +6208,29 @@ bus_error_t dm_easy_mesh_ctrl_t::wf6ap_tget_params(dm_easy_mesh_t *dm, const cha
             strncat(mcsnss_str, temp,
                     sizeof(mcsnss_str) - strlen(mcsnss_str) - 1);
         }
-        dm_ctrl->property_append_tail(property, root, idx, "HE160", role->role_head.he_160);
-        dm_ctrl->property_append_tail(property, root, idx, "HE8080", role->role_head.he_8080);
-        dm_ctrl->property_append_tail(property, root, idx, "MCSNSS", mcsnss_str);
-        dm_ctrl->property_append_tail(property, root, idx, "SUBeamformer", role->role_tail.su_beam_former);
-        dm_ctrl->property_append_tail(property, root, idx, "SUBeamformee", role->role_tail.su_beam_formee);
-        dm_ctrl->property_append_tail(property, root, idx, "MUBeamformer", role->role_tail.mu_beam_former);
-        dm_ctrl->property_append_tail(property, root, idx, "Beamformee80orLess", role->role_tail.beam_formee_sts_l80);
-        dm_ctrl->property_append_tail(property, root, idx, "BeamformeeAbove80", role->role_tail.beam_formee_sts_g80);
-        dm_ctrl->property_append_tail(property, root, idx, "ULMUMIMO", role->role_tail.ul_mumimo);
-        dm_ctrl->property_append_tail(property, root, idx, "ULOFDMA", role->role_tail.ul_ofdma);
-        dm_ctrl->property_append_tail(property, root, idx, "DLOFDMA", role->role_tail.dl_ofdma);
-        dm_ctrl->property_append_tail(property, root, idx, "MaxDLMUMIMO", role->role_tail.max_dl_mumimo_tx);
-        dm_ctrl->property_append_tail(property, root, idx, "MaxULMUMIMO", role->role_tail.max_ul_mumimo_rx);
-        dm_ctrl->property_append_tail(property, root, idx, "MaxDLOFDMA", role->role_tail.max_dl_ofdma_tx);
-        dm_ctrl->property_append_tail(property, root, idx, "MaxULOFDMA", role->role_tail.max_ul_ofdma_rx);
-        dm_ctrl->property_append_tail(property, root, idx, "RTS", role->role_tail.rts);
-        dm_ctrl->property_append_tail(property, root, idx, "MURTS", role->role_tail.mu_rts);
-        dm_ctrl->property_append_tail(property, root, idx, "MultiBSSID", role->role_tail.multi_bssid);
-        dm_ctrl->property_append_tail(property, root, idx, "MUEDCA", role->role_tail.mu_edca);
-        dm_ctrl->property_append_tail(property, root, idx, "TWTRequestor", role->role_tail.twt_req);
-        dm_ctrl->property_append_tail(property, root, idx, "TWTResponder", role->role_tail.twt_resp);
-        dm_ctrl->property_append_tail(property, root, idx, "SpatialReuse", role->role_tail.spatial_reuse);
-        dm_ctrl->property_append_tail(property, root, idx, "AnticipatedChannelUsage", role->role_tail.anticipated_channel_usage);
+        dm_ctrl->property_append_tail(property, root, "HE160", static_cast<bool>(role->role_head.he_160));
+        dm_ctrl->property_append_tail(property, root, "HE8080", static_cast<bool>(role->role_head.he_8080));
+        dm_ctrl->property_append_tail(property, root, "MCSNSS", mcsnss_str);
+        dm_ctrl->property_append_tail(property, root, "SUBeamformer", static_cast<bool>(role->role_tail.su_beam_former));
+        dm_ctrl->property_append_tail(property, root, "SUBeamformee", static_cast<bool>(role->role_tail.su_beam_formee));
+        dm_ctrl->property_append_tail(property, root, "MUBeamformer", static_cast<bool>(role->role_tail.mu_beam_former));
+        dm_ctrl->property_append_tail(property, root, "Beamformee80orLess", static_cast<bool>(role->role_tail.beam_formee_sts_l80));
+        dm_ctrl->property_append_tail(property, root, "BeamformeeAbove80", static_cast<bool>(role->role_tail.beam_formee_sts_g80));
+        dm_ctrl->property_append_tail(property, root, "ULMUMIMO", static_cast<bool>(role->role_tail.ul_mumimo));
+        dm_ctrl->property_append_tail(property, root, "ULOFDMA", static_cast<bool>(role->role_tail.ul_ofdma));
+        dm_ctrl->property_append_tail(property, root, "DLOFDMA", static_cast<bool>(role->role_tail.dl_ofdma));
+        dm_ctrl->property_append_tail(property, root, "MaxDLMUMIMO", static_cast<unsigned int>(role->role_tail.max_dl_mumimo_tx));
+        dm_ctrl->property_append_tail(property, root, "MaxULMUMIMO", static_cast<unsigned int>(role->role_tail.max_ul_mumimo_rx));
+        dm_ctrl->property_append_tail(property, root, "MaxDLOFDMA", static_cast<unsigned int>(role->role_tail.max_dl_ofdma_tx));
+        dm_ctrl->property_append_tail(property, root, "MaxULOFDMA", static_cast<unsigned int>(role->role_tail.max_ul_ofdma_rx));
+        dm_ctrl->property_append_tail(property, root, "RTS", static_cast<bool>(role->role_tail.rts));
+        dm_ctrl->property_append_tail(property, root, "MURTS", static_cast<bool>(role->role_tail.mu_rts));
+        dm_ctrl->property_append_tail(property, root, "MultiBSSID", static_cast<bool>(role->role_tail.multi_bssid));
+        dm_ctrl->property_append_tail(property, root, "MUEDCA", static_cast<bool>(role->role_tail.mu_edca));
+        dm_ctrl->property_append_tail(property, root, "TWTRequestor", static_cast<bool>(role->role_tail.twt_req));
+        dm_ctrl->property_append_tail(property, root, "TWTResponder", static_cast<bool>(role->role_tail.twt_resp));
+        dm_ctrl->property_append_tail(property, root, "SpatialReuse", static_cast<bool>(role->role_tail.spatial_reuse));
+        dm_ctrl->property_append_tail(property, root, "AnticipatedChannelUsage", static_cast<bool>(role->role_tail.anticipated_channel_usage));
     }
 
     return rc;
@@ -6389,11 +6390,12 @@ bus_error_t dm_easy_mesh_ctrl_t::wf7ap_tget_params(dm_easy_mesh_t *dm, const cha
         return rc;
     }
 
-    dm_ctrl->property_append_tail(property, root, idx, "EMLMRSupport", wifi7_radio->ap_emlmr_support);
-    dm_ctrl->property_append_tail(property, root, idx, "EMLSRSupport", wifi7_radio->ap_emlsr_support);
-    dm_ctrl->property_append_tail(property, root, idx, "STRSupport", wifi7_radio->ap_str_support);
-    dm_ctrl->property_append_tail(property, root, idx, "NSTRSupport", wifi7_radio->ap_nstr_support);
-    dm_ctrl->property_append_tail(property, root, idx, "TIDLinkMapNegotiation", dm->m_device.m_device_info.tidlink_map);
+    (void) idx; /* WiFi7APRole is an object (not a table): no row instance under it */
+    dm_ctrl->property_append_tail(property, root, "EMLMRSupport", static_cast<bool>(wifi7_radio->ap_emlmr_support));
+    dm_ctrl->property_append_tail(property, root, "EMLSRSupport", static_cast<bool>(wifi7_radio->ap_emlsr_support));
+    dm_ctrl->property_append_tail(property, root, "STRSupport", static_cast<bool>(wifi7_radio->ap_str_support));
+    dm_ctrl->property_append_tail(property, root, "NSTRSupport", static_cast<bool>(wifi7_radio->ap_nstr_support));
+    dm_ctrl->property_append_tail(property, root, "TIDLinkMapNegotiation", static_cast<uint8_t>(dm->m_device.m_device_info.tidlink_map));
 
     return rc;
 }


### PR DESCRIPTION
wf6ap_tget_params()/wf7ap_tget_params() built parameter names through the idx inserting property helpers, producing e.g. Capabilities.WiFi6APRole.1.HE160 although the schema defines WiFi6APRole/WiFi7APRole as objects, not tables, the per-leaf getters use instance-less names, so exact-name lookups on the bulk tree missed every parameter under these objects.

Add instance-less property_init_value/property_append_tail overloads and switch the two builders to them; also start the MCSNSS builder at map index 0 (the leaf getter does) and cast values to the leaf getter types so bulk and per-leaf gets return identical names and types.