### PR TITLE
RDKBWIFI-555: Locate IEs in (re)association request frame bodies

### DIFF
--- a/inc/dm_sta.h
+++ b/inc/dm_sta.h
@@ -118,6 +118,15 @@ public:
 	 * calling this function.
 	 */
 	static void decode_sta_capability(dm_sta_t *sta);
+
+	/**!
+	 * @brief Returns the offset of the first IE in a stored (re)assoc request
+	 * frame body, which may or may not carry the 802.11 fixed fields.
+	 *
+	 * @param[in] body Frame body as stored in the sta info.
+	 * @param[in] len Length of the frame body.
+	 */
+	static unsigned int get_assoc_frame_ie_offset(const unsigned char *body, unsigned int len);
     
 	/**!
 	 * @brief Decodes the beacon report for the given station.

--- a/inc/em_base.h
+++ b/inc/em_base.h
@@ -343,7 +343,10 @@ static const mac_address_t EM_GLOBAL_MAC_ADDRESS = {0xff, 0xff, 0xff, 0xff, 0xff
 
 /* 802.11 (re)assoc request frame body and HE Capabilities element layout */
 #define EM_ASSOC_FIXED_FIELDS_LEN    4   /* capab_info(2) + listen_interval(2) */
+#define EM_REASSOC_FIXED_FIELDS_LEN  (EM_ASSOC_FIXED_FIELDS_LEN + 6)  /* + current_ap(6) */
 #define EM_IE_HDR_LEN                2   /* element id + length */
+#define EM_EID_SSID                  0
+#define EM_EID_SUPP_RATES            1
 #define EM_EID_EXTENSION             255
 #define EM_EXT_EID_HE_CAPS           35
 #define EM_HE_MAC_CAPS_LEN           6

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -5771,13 +5771,13 @@ char* dm_easy_mesh_ctrl_t::get_sta_vht_caps_str(char *vht_cap_hex, char *buf, si
 bool dm_easy_mesh_ctrl_t::find_sta_he_caps(em_sta_info_t *si, const unsigned char **mac_caps,
     const unsigned char **phy_caps)
 {
-    /* Skip the fixed fields, as decode_sta_capability() does. */
-    unsigned int offset = EM_ASSOC_FIXED_FIELDS_LEN;
+    unsigned int offset;
 
     if ((si == NULL) || (mac_caps == NULL) || (phy_caps == NULL) ||
-        (si->frame_body_len <= EM_ASSOC_FIXED_FIELDS_LEN)) {
+        (si->frame_body_len == 0)) {
         return false;
     }
+    offset = dm_sta_t::get_assoc_frame_ie_offset(si->frame_body, si->frame_body_len);
     while (offset + EM_IE_HDR_LEN <= si->frame_body_len) {
         unsigned char id = si->frame_body[offset];
         unsigned char len = si->frame_body[offset + 1];

--- a/src/dm/dm_sta.cpp
+++ b/src/dm/dm_sta.cpp
@@ -392,6 +392,60 @@ void dm_sta_t::parse_sta_bss_radio_from_key(const char *key, mac_address_t sta, 
 
 }
 
+/* A (Re)Association Request opens with the mandatory SSID element followed by
+ * the mandatory Supported Rates element, so a candidate offset has to hold that
+ * pair. Requiring the pair rather than the SSID element alone keeps a Current AP
+ * address such as 00:04:.. from passing as an SSID element. */
+static bool starts_with_ssid_and_rates(const unsigned char *body, unsigned int len, unsigned int off)
+{
+    unsigned int next;
+
+    if ((off + EM_IE_HDR_LEN > len) || (body[off] != EM_EID_SSID) ||
+        (body[off + 1] > (EM_MAX_SSID_LEN - 1))) {
+        return false;
+    }
+    next = off + EM_IE_HDR_LEN + static_cast<unsigned int>(body[off + 1]);
+
+    return ((next + EM_IE_HDR_LEN <= len) && (body[next] == EM_EID_SUPP_RATES));
+}
+
+/* The frame body may carry the 802.11 fixed fields before the IEs, or the IEs
+ * alone. The first pass takes the offset that opens with those two elements and
+ * whose element walk consumes the body exactly. A stored body may be truncated,
+ * in which case no walk ends on the length, so the second pass keeps the same
+ * candidates and drops the exact consumption requirement. Offset 0 is a valid
+ * layout in its own right, hence both a candidate and the final fallback;
+ * callers bound every element read, so an unrecognised body yields no elements
+ * rather than an overread. */
+unsigned int dm_sta_t::get_assoc_frame_ie_offset(const unsigned char *body, unsigned int len)
+{
+    const unsigned int offsets[] = { EM_ASSOC_FIXED_FIELDS_LEN, EM_REASSOC_FIXED_FIELDS_LEN, 0 };
+    unsigned int i, off;
+
+    if (body == NULL) {
+        return 0;
+    }
+    for (i = 0; i < sizeof(offsets) / sizeof(offsets[0]); i++) {
+        off = offsets[i];
+        if (starts_with_ssid_and_rates(body, len, off) == false) {
+            continue;
+        }
+        while (off + EM_IE_HDR_LEN <= len) {
+            off += EM_IE_HDR_LEN + static_cast<unsigned int>(body[off + 1]);
+        }
+        if (off == len) {
+            return offsets[i];
+        }
+    }
+    for (i = 0; i < sizeof(offsets) / sizeof(offsets[0]); i++) {
+        off = offsets[i];
+        if (starts_with_ssid_and_rates(body, len, off) == true) {
+            return off;
+        }
+    }
+    return 0;
+}
+
 void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
 {
     unsigned int offset = 0;
@@ -403,12 +457,7 @@ void dm_sta_t::decode_sta_capability(dm_sta_t *sta)
 
     sta->m_sta_info.num_vendor_infos = 0;
 
-    /* The frame_body stores the full 802.11 (Re)Association Request frame body:
-     * capab_info (2B) + listen_interval (2B) + IEs. Skip the fixed fields. */
-    if (sta->m_sta_info.frame_body_len < 4) {
-        return;
-    }
-    offset = 4;
+    offset = get_assoc_frame_ie_offset(sta->m_sta_info.frame_body, sta->m_sta_info.frame_body_len);
 
     while (offset < sta->m_sta_info.frame_body_len) {
         if (offset + 2 > sta->m_sta_info.frame_body_len) {

--- a/tests/test_l1_dm_sta.cpp
+++ b/tests/test_l1_dm_sta.cpp
@@ -1549,3 +1549,186 @@ TEST(dm_sta_t_Test, dm_sta_t_destructor_default_constructor) {
     });
     std::cout << "Exiting dm_sta_t::~dm_sta_t()_end test" << std::endl;
 }
+
+/**
+ * @brief Verify that the IE offset of an Association Request frame body is the fixed field length.
+ *
+ * This test verifies that a body carrying the capability information and listen interval ahead of the elements resolves to the association request offset.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 047@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description                                                            | Test Data                                       | Expected Result                       | Notes       |
+ * | :--------------: | ---------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------- | ----------- |
+ * | 01               | Prepare a frame body from the association fixed fields and the elements | body = capability info, listen interval, SSID and supported rates elements | Frame body is prepared | Should be successful |
+ * | 02               | Invoke get_assoc_frame_ie_offset with the frame body and its length     | body = prepared frame body, len = body length   | Offset is EM_ASSOC_FIXED_FIELDS_LEN   | Should Pass |
+ */
+TEST(dm_sta_t_Test, GetAssocFrameIeOffsetAssocLayout) {
+    std::cout << "Entering GetAssocFrameIeOffsetAssocLayout test" << std::endl;
+    unsigned char body[] = {
+        0x31, 0x04, 0x0a, 0x00,                /* capability info + listen interval */
+        0x00, 0x04, 't', 'e', 's', 't',        /* SSID */
+        0x01, 0x04, 0x02, 0x04, 0x0b, 0x16     /* supported rates */
+    };
+    EXPECT_EQ(dm_sta_t::get_assoc_frame_ie_offset(body, sizeof(body)),
+        static_cast<unsigned int>(EM_ASSOC_FIXED_FIELDS_LEN));
+    std::cout << "Exiting GetAssocFrameIeOffsetAssocLayout test" << std::endl;
+}
+
+/**
+ * @brief Verify that the Current AP address of a Reassociation Request is not taken for an SSID element.
+ *
+ * This test verifies that a reassociation request body whose Current AP address starts with 0x00 resolves to the reassociation request offset rather than the association one.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 048@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description                                                        | Test Data                                     | Expected Result                       | Notes       |
+ * | :--------------: | ------------------------------------------------------------------ | --------------------------------------------- | ------------------------------------- | ----------- |
+ * | 01               | Prepare a frame body whose Current AP address starts with 0x00      | body = association fixed fields, Current AP address, SSID and supported rates elements | Frame body is prepared | Should be successful |
+ * | 02               | Invoke get_assoc_frame_ie_offset with the frame body and its length | body = prepared frame body, len = body length | Offset is EM_REASSOC_FIXED_FIELDS_LEN | Should Pass |
+ */
+TEST(dm_sta_t_Test, GetAssocFrameIeOffsetReassocLayout) {
+    std::cout << "Entering GetAssocFrameIeOffsetReassocLayout test" << std::endl;
+    unsigned char body[] = {
+        0x31, 0x04, 0x0a, 0x00,                      /* capability info + listen interval */
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55,          /* Current AP address, first octet 0x00 */
+        0x00, 0x04, 't', 'e', 's', 't',              /* SSID */
+        0x01, 0x04, 0x02, 0x04, 0x0b, 0x16           /* supported rates */
+    };
+    EXPECT_EQ(dm_sta_t::get_assoc_frame_ie_offset(body, sizeof(body)),
+        static_cast<unsigned int>(EM_REASSOC_FIXED_FIELDS_LEN));
+    std::cout << "Exiting GetAssocFrameIeOffsetReassocLayout test" << std::endl;
+}
+
+/**
+ * @brief Verify that a Current AP address that looks like an SSID element is not taken for one.
+ *
+ * This test verifies that a reassociation request body whose Current AP address starts with 00:04, i.e. an element id of zero and a length that consumes the rest of the address, still resolves to the reassociation request offset.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 049@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description                                                        | Test Data                                     | Expected Result                       | Notes       |
+ * | :--------------: | ------------------------------------------------------------------ | --------------------------------------------- | ------------------------------------- | ----------- |
+ * | 01               | Prepare a frame body whose Current AP address starts with 00:04     | body = association fixed fields, Current AP address, SSID and supported rates elements | Frame body is prepared | Should be successful |
+ * | 02               | Invoke get_assoc_frame_ie_offset with the frame body and its length | body = prepared frame body, len = body length | Offset is EM_REASSOC_FIXED_FIELDS_LEN | Should Pass |
+ */
+TEST(dm_sta_t_Test, GetAssocFrameIeOffsetApAddressLooksLikeSsid) {
+    std::cout << "Entering GetAssocFrameIeOffsetApAddressLooksLikeSsid test" << std::endl;
+    unsigned char body[] = {
+        0x31, 0x04, 0x0a, 0x00,                      /* capability info + listen interval */
+        0x00, 0x04, 0x22, 0x33, 0x44, 0x55,          /* Current AP address, reads as element 0 of length 4 */
+        0x00, 0x04, 't', 'e', 's', 't',              /* SSID */
+        0x01, 0x04, 0x02, 0x04, 0x0b, 0x16           /* supported rates */
+    };
+    EXPECT_EQ(dm_sta_t::get_assoc_frame_ie_offset(body, sizeof(body)),
+        static_cast<unsigned int>(EM_REASSOC_FIXED_FIELDS_LEN));
+    std::cout << "Exiting GetAssocFrameIeOffsetApAddressLooksLikeSsid test" << std::endl;
+}
+
+/**
+ * @brief Verify that a frame body carrying the elements alone resolves to offset zero.
+ *
+ * This test verifies that a body stored without any fixed fields is parsed from its first octet.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 050@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description                                                       | Test Data                                     | Expected Result | Notes       |
+ * | :--------------: | ----------------------------------------------------------------- | --------------------------------------------- | --------------- | ----------- |
+ * | 01               | Invoke get_assoc_frame_ie_offset with a body holding only elements | body = SSID and supported rates elements, len = body length | Offset is 0 | Should Pass |
+ */
+TEST(dm_sta_t_Test, GetAssocFrameIeOffsetIeOnlyLayout) {
+    std::cout << "Entering GetAssocFrameIeOffsetIeOnlyLayout test" << std::endl;
+    unsigned char body[] = {
+        0x00, 0x04, 't', 'e', 's', 't',        /* SSID */
+        0x01, 0x04, 0x02, 0x04, 0x0b, 0x16     /* supported rates */
+    };
+    EXPECT_EQ(dm_sta_t::get_assoc_frame_ie_offset(body, sizeof(body)), 0u);
+    std::cout << "Exiting GetAssocFrameIeOffsetIeOnlyLayout test" << std::endl;
+}
+
+/**
+ * @brief Verify that a truncated frame body still resolves to its own offset.
+ *
+ * This test verifies that a body whose last element is cut short resolves to the reassociation request offset instead of falling back to zero.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 051@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description                                                        | Test Data                                     | Expected Result                       | Notes       |
+ * | :--------------: | ------------------------------------------------------------------ | --------------------------------------------- | ------------------------------------- | ----------- |
+ * | 01               | Prepare a reassociation frame body whose last element is cut short  | last element declares four octets and carries two | Frame body is prepared            | Should be successful |
+ * | 02               | Invoke get_assoc_frame_ie_offset with the frame body and its length | body = prepared frame body, len = body length | Offset is EM_REASSOC_FIXED_FIELDS_LEN | Should Pass |
+ */
+TEST(dm_sta_t_Test, GetAssocFrameIeOffsetTruncatedBody) {
+    std::cout << "Entering GetAssocFrameIeOffsetTruncatedBody test" << std::endl;
+    unsigned char body[] = {
+        0x31, 0x04, 0x0a, 0x00,                      /* capability info + listen interval */
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55,          /* Current AP address, first octet 0x00 */
+        0x00, 0x04, 't', 'e', 's', 't',              /* SSID */
+        0x01, 0x04, 0x02, 0x04                       /* supported rates, two of four octets */
+    };
+    EXPECT_EQ(dm_sta_t::get_assoc_frame_ie_offset(body, sizeof(body)),
+        static_cast<unsigned int>(EM_REASSOC_FIXED_FIELDS_LEN));
+    std::cout << "Exiting GetAssocFrameIeOffsetTruncatedBody test" << std::endl;
+}
+
+/**
+ * @brief Verify that frame bodies matching no layout resolve to offset zero.
+ *
+ * This test verifies that a body holding no valid element, and a null body, are both reported as starting at offset zero.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 052@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description                                                      | Test Data                   | Expected Result | Notes       |
+ * | :--------------: | ---------------------------------------------------------------- | --------------------------- | --------------- | ----------- |
+ * | 01               | Invoke get_assoc_frame_ie_offset with a body holding no element   | body = 0xff filled, len = 8 | Offset is 0     | Should Pass |
+ * | 02               | Invoke get_assoc_frame_ie_offset with a null body                 | body = nullptr, len = 32    | Offset is 0     | Should Pass |
+ */
+TEST(dm_sta_t_Test, GetAssocFrameIeOffsetUnrecognisedBody) {
+    std::cout << "Entering GetAssocFrameIeOffsetUnrecognisedBody test" << std::endl;
+    unsigned char body[8];
+    memset(body, 0xff, sizeof(body));
+    EXPECT_EQ(dm_sta_t::get_assoc_frame_ie_offset(body, sizeof(body)), 0u);
+    EXPECT_EQ(dm_sta_t::get_assoc_frame_ie_offset(nullptr, 32), 0u);
+    std::cout << "Exiting GetAssocFrameIeOffsetUnrecognisedBody test" << std::endl;
+}


### PR DESCRIPTION
decode_sta_capability() and find_sta_he_caps() reach the IEs of the STA's stored (Re)Association Request by skipping a fixed 4 octets, the capability information and listen interval fields. That holds for an association request only.

A reassociation request carries the Current AP address as well, so its IEs start 6 octets further in. For a reassociating STA the walk therefore begins inside that address and every element after it is read out of alignment, which leaves the parsed capabilities and the WiFi6Capabilities HE lookup working on misparsed elements. A producer that stores the IEs without the fixed fields shifts the walk the other way.

Probe the association, reassociation and IEs only layouts instead, preferring the offset that opens with the mandatory SSID and Supported Rates elements and whose element walk consumes the body exactly, so that a Current AP address beginning with 0x00 cannot pass for an SSID element, and use that offset in both parsers.

Cover the association, reassociation with a Current AP address that starts with 0x00, IEs only, truncated and unrecognised layouts with unit tests.