### PR TITLE
RDKCOM-5634: RDKBWIFI-456 Fix NULL data model in put_radio() for existing radios

### DIFF
--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -358,14 +358,14 @@ void dm_easy_mesh_list_t::put_radio(const char *key, const dm_radio_t *radio)
 
     //em_printfout("Radio: %s", key);
 
-    if ((pradio = get_radio(key)) == NULL) {
-        dm = get_data_model(radio->m_radio_info.id.net_id, radio->m_radio_info.id.dev_mac);
-        //em_printfout("dm: %p net: %s device: %s", dm, radio->m_radio_info.id.net_id,
-        //      util::mac_to_string(radio->m_radio_info.id.dev_mac).c_str());
-        if (dm == NULL) {
-            return;
-        }
+    dm = get_data_model(radio->m_radio_info.id.net_id, radio->m_radio_info.id.dev_mac);
+    //em_printfout("dm: %p net: %s device: %s", dm, radio->m_radio_info.id.net_id,
+    //      util::mac_to_string(radio->m_radio_info.id.dev_mac).c_str());
+    if (dm == NULL) {
+        return;
+    }
 
+    if ((pradio = get_radio(key)) == NULL) {
         //em_printfout("Current Number of Radios: %d", dm->get_num_radios());
         dm->set_num_radios(dm->get_num_radios() + 1);
         pradio = dm->get_radio(dm->get_num_radios() - 1);

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -361,9 +361,13 @@ void dm_easy_mesh_list_t::put_radio(const char *key, const dm_radio_t *radio)
     dm = get_data_model(radio->m_radio_info.id.net_id, radio->m_radio_info.id.dev_mac);
     //em_printfout("dm: %p net: %s device: %s", dm, radio->m_radio_info.id.net_id,
     //      util::mac_to_string(radio->m_radio_info.id.dev_mac).c_str());
-    if (dm == NULL) {
-        return;
-    }
+if (dm == NULL) {
+    em_printfout("Could not find data model for radio key: %s (net: %s dev: %s)",
+        (key != NULL) ? key : "<null>",
+        radio->m_radio_info.id.net_id,
+        util::mac_to_string(radio->m_radio_info.id.dev_mac).c_str());
+    return;
+}
 
     if ((pradio = get_radio(key)) == NULL) {
         //em_printfout("Current Number of Radios: %d", dm->get_num_radios());


### PR DESCRIPTION
Issue:
During MESH ethernet onboarding, the onewifi_em_ctrl process crashed. The em_ctrl.log showed that the crash was a SIGSEGV inside em_mgr_t::create_node() while creating a new em_t node for the second radio of the onboarding agent.

Root Cause:
In dm_easy_mesh_list_t::put_radio(), the data model pointer dm was only assigned inside the if (pradio == NULL) branch. When the radio already existed, get_data_model() was never called, so dm remained NULL. This NULL pointer was then passed to create_node() and later to em_t::init(), where m_data_model->set_em(this) caused the SIGSEGV.

Solution:
Move get_data_model(radio->m_radio_info.id.net_id, radio->m_radio_info.id.dev_mac) before the existing-radio check and return early if it fails. This ensures dm is always valid before any radio insertion or update logic runs.