### PR TITLE
RDKBWIFI-560: Disable Controller AL MAC override via Select AL MAC Ad…

### DIFF
--- a/src/rdkb-cli/main.go
+++ b/src/rdkb-cli/main.go
@@ -88,7 +88,6 @@ type HaulTypeVisual struct {
 
 //structure of the incoming wifireset payload
 type WifiResetPayload struct {
-    SelectedMac string       `json:"selectedMac"`
     HaulTypes   []HaulConfig `json:"haulTypes"`
 }
 
@@ -3431,27 +3430,19 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
     switch r.Method {
         case http.MethodGet:
             log.Println("Received GET request for wifireset")
-            controllerValue := getTreeValue(resetTree, "ControllerID")
-
-            // Interface MACs
-            interfacesList := C.get_network_tree_by_key(resetTree, C.CString("List"))
-            macOptions := getInterfacePrefence(interfacesList)
 
             // Parse NetworkSSIDList
             ssidHaulConfig := getConfiguredHauls(resetTree)
 
-            type MacResponse struct {
-                Options         []string `json:"options"`
-                SelectedOption  string   `json:"selectedOption"`
+            type WiFiResetResponse struct {
                 SSIDHaulConfig  []HaulConfig `json:"ssidHaulConfig"`
             }
 
-            response := MacResponse{
-                Options:        macOptions,
-                SelectedOption: controllerValue,
+            response := WiFiResetResponse{
                 SSIDHaulConfig: ssidHaulConfig,
             }
 
+            w.Header().Set("Content-Type", "application/json")
             json.NewEncoder(w).Encode(response)
 
         case http.MethodPost:
@@ -3463,19 +3454,6 @@ func WifiResetHandler(w http.ResponseWriter, r *http.Request) {
             if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
                 http.Error(w, "Invalid request payload", http.StatusBadRequest)
                 return
-            }
-
-            if payload.SelectedMac != "" {
-                selectedMac := strings.Split(payload.SelectedMac, " ")[0]
-
-                // update the ControllerID in reset tree
-                if err := updateControllerID(resetTree, selectedMac); err != nil {
-                    msg := fmt.Sprintf("Update failed for AL_MAC Interface: %v", err)
-                    errorsList = append(errorsList, msg)
-                }
-            } else {
-                msg := fmt.Sprintf("Received empty value for AL MAC")
-                errorsList = append(errorsList, msg)
             }
 
             for _, haul := range payload.HaulTypes {
@@ -3626,7 +3604,7 @@ func unassocStaQueryHandler(w http.ResponseWriter, r *http.Request) {
  * Returns: Array of HaulConfig
  */
 func getConfiguredHauls(tree *C.em_network_node_t) []HaulConfig {
-    var haulConfigs []HaulConfig
+    haulConfigs := []HaulConfig{}
     networkssidListNode := C.get_network_tree_by_key(tree, C.CString("NetworkSSIDList"))
     if networkssidListNode == nil {
         return haulConfigs
@@ -3683,37 +3661,6 @@ func getConfiguredHauls(tree *C.em_network_node_t) []HaulConfig {
     }
 
     return haulConfigs
-}
-
-/* func: updateControllerID
- * Description:
- * updates the ControllerID value in the given reset configuration tree
- * based on the selected or manually entered MAC address, validates its format,
- * and executes the reset command to apply the updated configuration.
- * Return: true or false
- */
-func updateControllerID(resetTree *C.em_network_node_t, selectedMac string) error {
-    if !isValidMac(selectedMac) {
-        return fmt.Errorf("invalid MAC address: %s", selectedMac)
-    }
-
-    cMac := C.CString(selectedMac)
-    cKey := C.CString("ControllerID")
-    defer C.free(unsafe.Pointer(cMac))
-    defer C.free(unsafe.Pointer(cKey))
-
-    node := C.get_network_tree_by_key(resetTree, cKey)
-    if node == nil {
-        return fmt.Errorf("ControllerID node not found in reset tree")
-    }
-
-    buf := (*[256]byte)(unsafe.Pointer(&node.value_str[0]))
-    for i := range buf {
-        buf[i] = 0
-    }
-    copy(buf[:], selectedMac)
-
-    return nil
 }
 
 /* func: updateNetworkSSIDList()

--- a/src/rdkb-cli/static/index.html
+++ b/src/rdkb-cli/static/index.html
@@ -1824,20 +1824,6 @@
                     </div>
                     <div class="wifi-reset-section">
                         <h2>Wi-Fi Reset</h2>
-                        <div class="almac-section">
-                            <div class="almac-row">
-                                <label for="almac-select">Select AL MAC Address</label>
-                                <select id="almac-select">
-                                    <option value="">Choose AL MAC Address</option>
-                                </select>
-                            </div>
-                            <!-- Hidden input for manual MAC entry -->
-                            <div id="manual-almac-container" style="display: none; margin-top: 10px;">
-                                <div class="almac-row">
-                                    <label for="manual-almac">Enter AL MAC Address</label>
-                                    <input type="text" id="manual-almac" placeholder="e.g. d8:3a:dd:0d:ff:99" />
-                                </div>
-                        </div>
                         <!-- Haul Type Checkboxes -->
                         <div class="haultype-section" style="margin-top: 20px;">
                             <h2 class="haul-heading">Select Haul Types</h2>

--- a/src/rdkb-cli/static/script.js
+++ b/src/rdkb-cli/static/script.js
@@ -3565,48 +3565,9 @@ async handleWebSocketMessage(data) {
       }
 
       const data = await res.json();
-      if (!Array.isArray(data?.options) || !Array.isArray(data?.ssidHaulConfig)) {
-        this.showNotification("Could not received the wifi reset tree from controller, \nPlease check the controller or try again after sometime.");
+      if (!Array.isArray(data?.ssidHaulConfig)) {
+        this.showNotification("Could not receive the wifi reset tree from controller, \nPlease check the controller or try again after sometime.");
         return;
-      }
-
-      const select = document.getElementById("almac-select");
-      select.innerHTML = '<option value="">Choose AL MAC Address</option>';
-
-      data.options.forEach(mac => {
-        const option = document.createElement("option");
-        option.value = mac;
-        option.textContent = mac;
-        // parse only the AL MAC
-        const alMac = mac.split(" ")[0];
-        if (alMac === data.selectedOption) {
-          option.selected = true;
-        }
-        select.appendChild(option);
-      });
-
-      // Add "Other" option
-      const otherOption = document.createElement("option");
-      otherOption.value = "Other";
-      otherOption.textContent = "Other (Enter manually)";
-      select.appendChild(otherOption);
-
-      // Manual MAC input toggle
-      const manualMacContainer = document.getElementById("manual-almac-container");
-      if (select && manualMacContainer) {
-        select.addEventListener("change", function () {
-          const isOtherSelected = this.value === "Other";
-          manualMacContainer.style.display = isOtherSelected ? "block" : "none";
-
-          const manualInput = document.getElementById("manual-almac");
-          if (!isOtherSelected && manualInput) {
-            manualInput.value = "";
-          }
-        });
-
-        // Trigger change event in case "Other" is pre-selected
-        const event = new Event("change");
-        select.dispatchEvent(event);
       }
 
       // Populate HaulType dropdown
@@ -4418,20 +4379,6 @@ function getMacList(tbodySelector) {
 
 
   function collectResetPayload() {
-    const select = document.getElementById("almac-select");
-    const manualInput = document.getElementById("manual-almac");
-
-    let selectedMac = select.value;
-
-    if (selectedMac === "Other") {
-      selectedMac = manualInput.value.trim();
-      if (!selectedMac) {
-        alert("Please enter a valid AL MAC address.");
-        throw new Error("Manual AL MAC address is required.");
-      }
-    }
-
-
     const haulTypes = Array.from(document.querySelectorAll("input[name='haulType']:checked")).map(checkbox => {
       const haulType = checkbox.value;
       const ssid = document.getElementById(`ssid-${haulType}`)?.value || "";
@@ -4444,7 +4391,7 @@ function getMacList(tbodySelector) {
       };
     });
 
-    return { selectedMac, haulTypes };
+    return { haulTypes };
   }
 
   async function sendResetPayload(payload) {


### PR DESCRIPTION
Removed the"Select AL MAC Address" option in the EM WebUI WiFi Reset page to eliminate the backend logic that allows Controller AL MAC override. This will simplify the user experience, prevents invalid Controller AL MAC configurations/overrides, avoids AL MAC inconsistencies with unifiied-wifi-mesh and the underlying ieee1905 layers.