### PR TITLE
RDKBWIFI-529: Decode STA capabilities when DataElements are read

### DIFF
--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -7417,6 +7417,9 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_get_inner(char *event_name, raw_data_t *p_d
         em_printfout("sta is NULL\n");
         return bus_error_invalid_input;
     }
+    /* The capability fields are derived from the stored (re)assoc request frame
+       body, not persisted with the station record; decode before reading. */
+    dm_sta_t::decode_sta_capability(sta);
     em_sta_info_t *si = sta->get_sta_info();
 
     if (strcmp(param, "MACAddress") == 0) {
@@ -7574,6 +7577,9 @@ bus_error_t dm_easy_mesh_ctrl_t::sta_tget_params(dm_easy_mesh_t *dm, const char 
             continue;
         }
         ++idx;
+
+        /* Derived capability fields; decode before reading (see sta_get_inner). */
+        dm_sta_t::decode_sta_capability(sta);
 
         char ht_caps_str[32] = {0};
         char vht_caps_str[32] = {0};


### PR DESCRIPTION
The per-STA capability fields of em_sta_info_t (HTCapabilities, VHTCapabilities, SSID, supported rates, RM and extended capabilities, vendor IEs) are not carried on the wire and are not persisted in STAList; they are derived from the stored (Re)Association Request frame body by dm_sta_t::decode_sta_capability(). That helper is called from dm_sta_t::encode() only, so the fields exist as a side effect of producing the JSON representation, and every other write to a station record replaces em_sta_info_t as a whole, which clears them again.

The DataElements getters read the fields directly, so what a caller sees depends on whether an encode happened to run since the last station update. With a station associated and metrics arriving, a polling reader gets HTCapabilities alternating between its real value and an empty string, and consumers that derive the operating standard and short guard interval support from it intermittently report the station as 802.11g without SGI.

Decode the capabilities in both getters before the fields are read, the same way encode() does. The frame body is persisted, so the derived values are stable regardless of which update ran last.