### PR TITLE
RDKCOM-5635: RDKBWIFI-571 Use CLOCK_MONOTONIC for elapsed time and timeout logic

### DIFF
--- a/inc/em_cmd.h
+++ b/inc/em_cmd.h
@@ -26,6 +26,10 @@
 #include <type_traits>
 #include "dm_easy_mesh.h"
 
+namespace util {
+	void monotonic_now(struct timeval *tv);
+}
+
 class em_cmd_t {
 public:
     em_cmd_type_t   m_type;
@@ -492,14 +496,14 @@ public:
 
     
 	/**!
-	 * @brief Sets the start time using the current time of day.
+	 * @brief Sets the command start time from the monotonic clock.
 	 *
-	 * This function initializes the start time by retrieving the current time
-	 * of day and storing it in the member variable `m_start_time`.
+	 * This function initializes the start time by reading CLOCK_MONOTONIC
+	 * and storing it in the member variable `m_start_time`.
 	 *
 	 * @note This function does not take any parameters and does not return any value.
 	 */
-	void set_start_time() { gettimeofday(&m_start_time, NULL);}
+	void set_start_time() { util::monotonic_now(&m_start_time); }
 
     
 	/**!

--- a/inc/util.h
+++ b/inc/util.h
@@ -26,6 +26,8 @@
 #include <stdint.h>
 #include "wifi_hal.h"
 #include <pthread.h>
+#include <time.h>
+#include <sys/time.h>
 #include <string>
 #include <memory>
 #include <vector>
@@ -103,6 +105,37 @@ namespace util {
 	 * @note The function modifies the input timespec structure directly.
 	 */
 	void add_milliseconds(struct timespec *ts, long milliseconds);
+
+	/**!
+	 * @brief Reads the current CLOCK_MONOTONIC time into a timespec.
+	 *
+	 * Use for all elapsed-time / timeout computations: unlike the wall clock,
+	 * CLOCK_MONOTONIC is immune to NTP time steps. The wall clock remains the
+	 * right choice only for calendar data (log stamps, DataElements TimeStamp).
+	 *
+	 * @param[out] ts Pointer to the timespec structure to fill.
+	 */
+	void monotonic_now(struct timespec *ts);
+
+	/**!
+	 * @brief Reads the current CLOCK_MONOTONIC time into a timeval.
+	 *
+	 * @param[out] tv Pointer to the timeval structure to fill.
+	 */
+	void monotonic_now(struct timeval *tv);
+
+	/**!
+	 * @brief Initializes a condition variable on CLOCK_MONOTONIC.
+	 *
+	 * pthread_cond_timedwait() deadlines built from monotonic_now() are then
+	 * interpreted on the same clock.
+	 *
+	 * @param[in,out] cond Pointer to the condition variable to initialize.
+	 *
+	 * @returns 0 on success, otherwise a pthread error code; on failure the
+	 * condition variable is not initialized.
+	 */
+	int monotonic_cond_init(pthread_cond_t *cond);
 
 	/**!
 	 * @brief Retrieves the current date and time in RFC 3399 format.

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -74,7 +74,9 @@ static bool allow_failed_conn_report(unsigned short max_reports_per_min)
 
     std::lock_guard<std::mutex> lock(g_failed_conn_report_mutex);
 
-    time_t now = time(NULL);
+    struct timespec ts_now;
+    util::monotonic_now(&ts_now);
+    time_t now = ts_now.tv_sec;
     while (!g_failed_conn_report_timestamps.empty() &&
            (now - g_failed_conn_report_timestamps.front()) >= 60) {
         g_failed_conn_report_timestamps.pop_front();

--- a/src/em/em.cpp
+++ b/src/em/em.cpp
@@ -617,15 +617,13 @@ void em_t::proto_run()
     int rc;
     em_event_t *evt;
     struct timespec time_to_wait;
-    struct timeval tm;
 
     pthread_mutex_lock(&m_iq.lock);
     while (m_exit == false) {
         rc = 0;
 
-        gettimeofday(&tm, NULL);
-        time_to_wait.tv_sec = tm.tv_sec;
-        time_to_wait.tv_nsec = tm.tv_usec * 1000;
+        /* m_iq.cond is CLOCK_MONOTONIC (util::monotonic_cond_init) */
+        util::monotonic_now(&time_to_wait);
         time_to_wait.tv_sec += m_iq.timeout;
 
         if (queue_count(m_iq.queue) == 0) {
@@ -2840,7 +2838,16 @@ int em_t::init()
     // initialize the ingress queue
     m_iq.queue = queue_create();
     pthread_mutex_init(&m_iq.lock, NULL);
-    pthread_cond_init(&m_iq.cond, NULL);
+    int rc = util::monotonic_cond_init(&m_iq.cond);
+    if (rc != 0) {
+        em_printfout("Failed to initialize ingress queue condition variable, err:%d", rc);
+        pthread_mutex_destroy(&m_iq.lock);
+        queue_destroy(m_iq.queue);
+        if (is_al_interface_em()) {
+            close(m_fd);
+        }
+        return -1;
+    }
     m_iq.timeout = EM_PROTO_TOUT;
 
     // initialize the crypto

--- a/src/em/em_mgr.cpp
+++ b/src/em/em_mgr.cpp
@@ -536,7 +536,6 @@ int em_mgr_t::start()
     int rc;
     em_event_t *evt;;
     struct timespec time_to_wait;
-    struct timeval tm;
 	bool started = false;
     input_listen();
     nodes_listen();
@@ -544,9 +543,8 @@ int em_mgr_t::start()
     while (m_exit == false) {
         rc = 0;
 
-        gettimeofday(&tm, NULL);
-        time_to_wait.tv_sec = tm.tv_sec;
-       	time_to_wait.tv_nsec = tm.tv_usec * 1000;
+        /* m_queue.cond is CLOCK_MONOTONIC (util::monotonic_cond_init) */
+        util::monotonic_now(&time_to_wait);
 		util::add_milliseconds(&time_to_wait, m_queue.timeout);
 
         if (queue_count(m_queue.queue) == 0) {
@@ -615,7 +613,14 @@ int em_mgr_t::init(const char *data_model_path)
     // initialize the egress queue
     m_queue.queue = queue_create();
     pthread_mutex_init(&m_queue.lock, NULL);
-    pthread_cond_init(&m_queue.cond, NULL);
+    int rc = util::monotonic_cond_init(&m_queue.cond);
+    if (rc != 0) {
+        em_printfout("Failed to initialize egress queue condition variable, err:%d", rc);
+        pthread_mutex_destroy(&m_queue.lock);
+        queue_destroy(m_queue.queue);
+        hash_map_destroy(m_em_map);
+        return -1;
+    }
 
     m_queue.timeout = EM_MGR_TOUT;
     m_msg_id = 0;

--- a/src/em/metrics/em_metrics.cpp
+++ b/src/em/metrics/em_metrics.cpp
@@ -1261,7 +1261,9 @@ short em_metrics_t::send_single_beacon_metrics_query(mac_address_t sta_mac, bssi
     // For beacon_report commands, send once and wait for ACK or orchestration timeout.
     static constexpr time_t BEACON_QUERY_TIMEOUT_SECS = 10;
 
-    time_t now = time(NULL);
+    struct timespec ts;
+    util::monotonic_now(&ts);
+    time_t now = ts.tv_sec;
     if (ack_gated_retry == true) {
         time_t last_tx = cmd->get_query_tx_time();
         if (last_tx != 0) {

--- a/src/orch/em_orch.cpp
+++ b/src/orch/em_orch.cpp
@@ -78,7 +78,8 @@ void em_orch_t::update_stats(em_cmd_t *pcmd)
 
     snprintf(key, sizeof(em_short_string_t), "%d", pcmd->get_type());
 
-    gettimeofday(&time_now, NULL);
+    /* Same clock as em_cmd_t::set_start_time() */
+    util::monotonic_now(&time_now);
     stats = static_cast<em_cmd_stats_t *>(hash_map_get(m_cmd_map, key));
     assert(stats != NULL);
     time = static_cast<unsigned int>(time_now.tv_sec - pcmd->m_start_time.tv_sec);

--- a/src/orch/em_orch_agent.cpp
+++ b/src/orch/em_orch_agent.cpp
@@ -56,7 +56,7 @@ void em_orch_agent_t::orch_transient(em_cmd_t *pcmd, em_t *em)
         if (al_node != NULL && al_node->m_ec_manager && al_node->get_is_dpp_onboarding()) {
             // If the enrollee is still onboarding, we need to wait for it to finish before timing out
             // Lets reset the timeout
-            gettimeofday(&pcmd->m_start_time, NULL);
+            pcmd->set_start_time();
             stats->time = 0;
         }
     }

--- a/src/utils/util.cpp
+++ b/src/utils/util.cpp
@@ -39,6 +39,8 @@
 
 
 #include "util.h"
+#include <errno.h>
+#include <time.h>
 #include <netinet/in.h>
 
 extern "C" {
@@ -93,16 +95,51 @@ void util::add_milliseconds(struct timespec *ts, long milliseconds)
 
 }
 
+void util::monotonic_now(struct timespec *ts)
+{
+    clock_gettime(CLOCK_MONOTONIC, ts);
+}
+
+void util::monotonic_now(struct timeval *tv)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    tv->tv_sec = ts.tv_sec;
+    tv->tv_usec = static_cast<suseconds_t>(ts.tv_nsec / 1000);
+}
+
+int util::monotonic_cond_init(pthread_cond_t *cond)
+{
+    pthread_condattr_t attr;
+    int rc;
+
+    rc = pthread_condattr_init(&attr);
+    if (rc != 0) {
+        return rc;
+    }
+    rc = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (rc == 0) {
+        rc = pthread_cond_init(cond, &attr);
+    }
+    pthread_condattr_destroy(&attr);
+    return rc;
+}
+
 void util::delay(int seconds) {
-    time_t start_time, current_time;
+    struct timespec deadline;
+    int rc;
 
-    // Get current time
-    time(&start_time);
-
-    do {
-        // Update current time
-        time(&current_time);
-    } while ((current_time - start_time) < seconds); // Loop until desired delay is achieved
+    monotonic_now(&deadline);
+    deadline.tv_sec += seconds;
+    while ((rc = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &deadline, NULL)) == EINTR) {
+        /* interrupted by a signal: keep sleeping until the deadline */
+    }
+    if (rc != 0) {
+        /* clock_nanosleep not usable here: fall back to a relative sleep */
+        struct timespec req = { seconds, 0 };
+        while (nanosleep(&req, &req) == -1 && errno == EINTR) {
+        }
+    }
 }
 
 char *get_formatted_time_em(char *time)

--- a/tests/test_l1_em_cmd.cpp
+++ b/tests/test_l1_em_cmd.cpp
@@ -4374,7 +4374,7 @@ TEST(em_cmd_t, get_rd_channel_max_unsigned_int_value)
 /**
  * @brief Verify that calling set_start_time() correctly updates the object's start timestamp.
  *
- * This test case validates that the set_start_time() method of the em_cmd_t class updates the internal m_start_time member variable to a value that falls between the system time captured immediately before and after the method invocation. The test ensures that no exceptions are thrown during the operation and that the recorded timestamp is within an acceptable range (with a tolerance of 1 second).
+ * This test case validates that the set_start_time() method of the em_cmd_t class updates the internal m_start_time member variable to a value that falls between the monotonic time captured immediately before and after the method invocation. The test ensures that no exceptions are thrown during the operation and that the recorded timestamp is within an acceptable range (with a tolerance of 1 second).
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 104@n
@@ -4387,32 +4387,32 @@ TEST(em_cmd_t, get_rd_channel_max_unsigned_int_value)
  * **Test Procedure:**
  * | Variation / Step | Description                                                                     | Test Data                                                                                               | Expected Result                                                                                          | Notes            |
  * | :--------------: | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------- |
- * | 01               | Capture the system time before invoking set_start_time()                        | system_time_before: captured current system time                                                        | system_time_before is successfully captured with current system time                                     | Should be successful |
+ * | 01               | Capture the monotonic time before invoking set_start_time()                        | monotonic_time_before: captured current monotonic time                                                        | monotonic_time_before is successfully captured with current monotonic time                                     | Should be successful |
  * | 02               | Invoke the set_start_time() method on the cmd_obj instance                        | cmd_obj instance, API: set_start_time()                                                                  | Method executes without throwing any exception                                                           | Should Pass      |
- * | 03               | Capture the system time after calling set_start_time()                           | system_time_after: captured current system time                                                          | system_time_after is successfully captured with current system time                                      | Should be successful |
- * | 04               | Retrieve m_start_time from cmd_obj and verify it falls within the captured range   | obj_time = cmd_obj.m_start_time, system_time_before, system_time_after (with tolerance of +1 second)       | m_start_time is set such that system_time_before <= m_start_time <= system_time_after + 1 (tolerance)      | Should Pass      |
+ * | 03               | Capture the monotonic time after calling set_start_time()                           | monotonic_time_after: captured current monotonic time                                                          | monotonic_time_after is successfully captured with current monotonic time                                      | Should be successful |
+ * | 04               | Retrieve m_start_time from cmd_obj and verify it falls within the captured range   | obj_time = cmd_obj.m_start_time, monotonic_time_before, monotonic_time_after (with tolerance of +1 second)       | m_start_time is set such that monotonic_time_before <= m_start_time <= monotonic_time_after + 1 (tolerance)      | Should Pass      |
  */
 TEST(em_cmd_t, set_start_time_VerifyTimestampUpdated)
 {
     std::cout << "Entering set_start_time_VerifyTimestampUpdated test" << std::endl;
     em_cmd_t cmd_obj;
-    // Capture system time before invoking set_start_time()
-    struct timeval system_time_before {0, 0};
-    gettimeofday(&system_time_before, nullptr);
-    std::cout << "Before invocation, system time (tv_sec): " << system_time_before.tv_sec << ", (tv_usec): " << system_time_before.tv_usec << std::endl;
+    // Capture monotonic time before invoking set_start_time()
+    struct timeval monotonic_time_before {0, 0};
+    util::monotonic_now(&monotonic_time_before);
+    std::cout << "Before invocation, monotonic time (tv_sec): " << monotonic_time_before.tv_sec << ", (tv_usec): " << monotonic_time_before.tv_usec << std::endl;
     std::cout << "Invoking set_start_time()" << std::endl;
     EXPECT_NO_THROW(cmd_obj.set_start_time());
-    // Capture system time after the call
-    struct timeval system_time_after {0, 0};
-    gettimeofday(&system_time_after, nullptr);
-    std::cout << "After invocation, system time (tv_sec): " << system_time_after.tv_sec << ", (tv_usec): " << system_time_after.tv_usec << std::endl;
+    // Capture monotonic time after the call
+    struct timeval monotonic_time_after {0, 0};
+    util::monotonic_now(&monotonic_time_after);
+    std::cout << "After invocation, monotonic time (tv_sec): " << monotonic_time_after.tv_sec << ", (tv_usec): " << monotonic_time_after.tv_usec << std::endl;
     // Retrieve the object's m_start_time
     struct timeval obj_time = cmd_obj.m_start_time;
     std::cout << "Command object start time (tv_sec): " << obj_time.tv_sec << ", (tv_usec): " << obj_time.tv_usec << std::endl;
-    // Check that the object's start time is within the system times captured
+    // Check that the object's start time is within the monotonic times captured
     // Allow a tolerance of 1 second
     bool time_within_range = false;
-    if ((obj_time.tv_sec >= system_time_before.tv_sec) && (obj_time.tv_sec <= system_time_after.tv_sec + 1)) {
+    if ((obj_time.tv_sec >= monotonic_time_before.tv_sec) && (obj_time.tv_sec <= monotonic_time_after.tv_sec + 1)) {
         time_within_range = true;
     }
     EXPECT_TRUE(time_within_range);

--- a/tests/test_l1_util.cpp
+++ b/tests/test_l1_util.cpp
@@ -4,6 +4,9 @@
 #include <vector>
 #include <arpa/inet.h>
 #include <cstring>
+#include <cerrno>
+#include <ctime>
+#include <pthread.h>
 #include "util.h"
 
 using namespace util;
@@ -587,4 +590,55 @@ TEST(UtilTest, set_net_uint16_from_host_negative_nullptr) {
     EXPECT_FALSE(ok);
     std::cout << "Returned bool=" << ok << std::endl;
     std::cout << "Exiting set_net_uint16_from_host_negative_nullptr test" << std::endl;
+}
+
+/**
+ * @brief Verify that a condition variable from monotonic_cond_init() waits against a CLOCK_MONOTONIC deadline.
+ *
+ * pthread_cond_timedwait() reads the deadline on the clock the condition variable was created with. If the
+ * clock attribute is lost, a deadline built from monotonic_now() (seconds since boot) is already in the past
+ * on CLOCK_REALTIME and the wait returns at once. The test builds a 200 ms deadline with monotonic_now() and
+ * checks that the wait ends with ETIMEDOUT no earlier than that; only the lower bound is checked so a slow
+ * host cannot fail it.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 021@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description                                                              | Test Data                           | Expected Result                                          | Notes       |
+ * | :--------------: | ------------------------------------------------------------------------ | ----------------------------------- | -------------------------------------------------------- | ----------- |
+ * | 01               | Create the condition variable with monotonic_cond_init                   | cond                                | Returns 0                                                | Should Pass |
+ * | 02               | Wait on it with a deadline of monotonic_now() + 200 ms                   | deadline = now + 200 ms             | pthread_cond_timedwait returns ETIMEDOUT                 | Should Pass |
+ * | 03               | Measure the elapsed CLOCK_MONOTONIC time                                 | start, end                          | elapsed >= 200 ms                                        | Should Pass |
+ */
+TEST(UtilTest, monotonic_cond_init_timedwait_uses_monotonic_clock) {
+    std::cout << "Entering monotonic_cond_init_timedwait_uses_monotonic_clock test" << std::endl;
+    pthread_cond_t cond;
+    pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+    ASSERT_EQ(monotonic_cond_init(&cond), 0);
+
+    struct timespec start, deadline, end;
+    monotonic_now(&start);
+    deadline = start;
+    add_milliseconds(&deadline, 200);
+
+    std::cout << "Invoking pthread_cond_timedwait(...) with a 200 ms CLOCK_MONOTONIC deadline" << std::endl;
+    pthread_mutex_lock(&lock);
+    int rc = pthread_cond_timedwait(&cond, &lock, &deadline);
+    pthread_mutex_unlock(&lock);
+    monotonic_now(&end);
+
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 + (end.tv_nsec - start.tv_nsec) / 1000000;
+    EXPECT_EQ(rc, ETIMEDOUT);
+    EXPECT_GE(elapsed_ms, 200);
+    std::cout << "Returned rc=" << rc << " elapsed_ms=" << elapsed_ms << std::endl;
+
+    pthread_cond_destroy(&cond);
+    pthread_mutex_destroy(&lock);
+    std::cout << "Exiting monotonic_cond_init_timedwait_uses_monotonic_clock test" << std::endl;
 }


### PR DESCRIPTION
Gateways boot with the clock at 1970 and ntpd steps it mid-onboarding. Elapsed time computations used the wall clock, so the step appeared as ~1.7e9 s elapsed: em_orch cancelled every pending command on both sides and onboarding never completed until the services were restarted.

Add util::monotonic_now() / util::monotonic_cond_init() and move all elapsed time logic to CLOCK_MONOTONIC:

- command TTLs: em_cmd_t::set_start_time(), em_orch_t::update_stats(), DPP timeout reset in em_orch_agent_t::orch_transient()
- queue waits in em_t::proto_run() and em_mgr_t::start(), with the condition variables created on CLOCK_MONOTONIC
- failed-connection report rate-limit window
- beacon metrics query retry window in em_metrics.cpp
- util::delay(): busy-wait replaced with clock_nanosleep()
- test: condvar from monotonic_cond_init() times out on a CLOCK_MONOTONIC deadline

Wall clock is kept where calendar time is intended (log timestamps, DataElements TimeStamp, DPP connector expiry).