### PR TITLE
RDKBWIFI-572: Do not accept a Topology Response that fails validation

### DIFF
--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -2252,10 +2252,9 @@ int em_configuration_t::handle_topology_response(unsigned char *buff, unsigned i
         al_em->set_peer_profile(m_peer_profile);
     }
     if (em_msg_t(em_msg_type_topo_resp, m_peer_profile, buff, len).validate(errors) == 0) {
-        em_printfout("topology response msg validation failed");
-            
-        //return -1;
-    }       
+        em_printfout("topology response msg validation failed, ignoring message");
+        return -1;
+    }
         
     tlv =  reinterpret_cast<em_tlv_t *> (buff + sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));
     tmp_len = len - static_cast<unsigned int> (sizeof(em_raw_hdr_t) + sizeof(em_cmdu_t));


### PR DESCRIPTION
Problem
A single malformed Topology Response ends the topology exchange for good: handle_topology_response() logs "validation failed" but the return was commented out, so the message is processed and the controller advances to topo_synchronized. Topology Queries are only re-sent in topo_sync_pending, so the agent never receives the query it needs and rejects every AP
Capability Query until the em_config (40 s) / onewifi_cnf (10 s) TTLs cancel. Onboarding then stays broken until the services restart.

How it was hit On a colocated RDK-B gateway, the ieee1905 daemon sometimes answers the controller's Topology Query on the agent's behalf (race on its per-peer convergence state). That auto-generated response carries AP Operational BSS / BSS Configuration Report TLVs but no Multi-AP Profile TLV, so the controller assumes profile 1 and validation correctly fails on the
profile-3-only TLV (17.2.75) - but the message was accepted anyway. 2 of 3 cold reboots failed this way; the sender-side issue in ieee1905-rs is a separate defect.

Fix
Honour the validation result and drop the message. The controller stays in topo_sync_pending and retries the query every second. Valid responses (agent's own, profile 3) are unaffected. Worst case for a peer whose responses never validate: the existing 40 s TTL recovery, i.e. today's behavior.