### PR TITLE
controller-id cleanup and rdkbwifi-548 review comments fix

### DIFF
--- a/inc/dm_easy_mesh.h
+++ b/inc/dm_easy_mesh.h
@@ -776,7 +776,7 @@ public:
 	 *
 	 * @note Ensure that the network is properly initialized before calling this function.
 	 */
-	em_interface_t *get_ctrl_al_interface() { return m_network.get_controller_interface(); }
+	em_interface_t *get_ctrl_al_interface() { return m_device.get_dev_interface(); }
 
 	/**!
 	 * @brief Retrieves the MAC address of the control interface.
@@ -786,7 +786,7 @@ public:
 	 * @returns A pointer to an unsigned char array representing the MAC address.
 	 * @note Ensure that the returned MAC address is valid and properly formatted.
 	 */
-	unsigned char *get_ctrl_al_interface_mac() { return m_network.get_controller_interface_mac(); }
+	unsigned char *get_ctrl_al_interface_mac() { return m_device.get_dev_interface_mac(); }
     
 	/**!
 	 * @brief Retrieves the control AL interface name.
@@ -797,7 +797,7 @@ public:
 	 *
 	 * @note The returned string is managed internally and should not be freed by the caller.
 	 */
-	char *get_ctrl_al_interface_name() { return m_network.get_controller_interface()->name; }
+	char *get_ctrl_al_interface_name() { return m_device.get_dev_interface_name(); }
     
 	/**!
 	 * @brief Sets the control AL interface MAC address.
@@ -808,7 +808,12 @@ public:
 	 *
 	 * @note Ensure that the MAC address is valid and properly formatted before calling this function.
 	 */
-	void set_ctrl_al_interface_mac(unsigned char *mac) { m_network.set_controller_id(mac); }
+	void set_ctrl_al_interface_mac(unsigned char *mac) {
+            if(NULL != mac) {
+                m_device.set_dev_interface_mac(mac);
+                m_network.set_controller_id(mac);
+            }
+        }
     
 	/**!
 	 * @brief Sets the control AL interface name.
@@ -819,7 +824,10 @@ public:
 	 *
 	 * @note This function modifies the interface name used by the network control agent.
 	 */
-	void set_ctrl_al_interface_name(char *name) { snprintf(m_network.m_net_info.ctrl_id.name, sizeof(m_network.m_net_info.ctrl_id.name), "%s", name); }
+	void set_ctrl_al_interface_name(char *name) {
+            if(NULL != name)
+                m_device.set_dev_interface_name(name);
+        }
 	
 	/**!
 	 * @brief Sets the controller ID for the network.
@@ -830,7 +838,11 @@ public:
 	 *
 	 * @note Ensure that the MAC address is valid and correctly formatted before calling this function.
 	 */
-	void set_controller_id(unsigned char *mac) { m_network.set_controller_id(mac); }
+	void set_controller_id(unsigned char *mac) {
+            if(NULL != mac)
+                m_device.set_dev_interface_mac(mac);
+                m_network.set_controller_id(mac);
+        }
 	
 	/**!
 	 * @brief Sets the controller interface media type.

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -38,7 +38,7 @@ class em_ctrl_t : public em_mgr_t {
 
     static em_ctrl_t *s_em_ctrl;
 
-    dm_easy_mesh_ctrl_t m_data_model;
+    dm_easy_mesh_ctrl_t m_ctrl_data_model;
     em_cmd_ctrl_t   *m_ctrl_cmd;
     em_orch_ctrl_t *m_orch;
 	em_dev_test_t dev_test;
@@ -69,7 +69,7 @@ public:
 
     static em_ctrl_t *get_em_ctrl_instance();
 
-	dm_easy_mesh_ctrl_t *get_dm_ctrl() { return &m_data_model; }
+	dm_easy_mesh_ctrl_t *get_dm_ctrl() { return &m_ctrl_data_model; }
 
 	em_orch_t *get_orch() override { return m_orch; }
     
@@ -104,7 +104,7 @@ public:
 	 *
 	 * @returns True if the data model is initialized, false otherwise.
 	 */
-	bool is_data_model_initialized() { return m_data_model.is_initialized(); }
+	bool is_data_model_initialized() { return m_ctrl_data_model.is_initialized(); }
     
 	/**!
 	 * @brief Checks if the network topology is initialized.
@@ -113,7 +113,7 @@ public:
 	 *
 	 * @returns True if the network topology is initialized, false otherwise.
 	 */
-	bool is_network_topology_initialized() { return m_data_model.is_network_initialized(); }
+	bool is_network_topology_initialized() { return m_ctrl_data_model.is_network_initialized(); }
 
 	
 	/**!
@@ -505,24 +505,24 @@ public:
 	 *
 	 * @note This function does not take any parameters and does not return any value.
 	 */
-	void init_network_topology() { m_data_model.init_network_topology(); }
+	void init_network_topology() { m_ctrl_data_model.init_network_topology(); }
 	
 	/**!
 	 * @brief Updates the network topology using the data model.
 	 *
-	 * This function calls the `update_network_topology` method on the `m_data_model` object
+	 * This function calls the `update_network_topology` method on the `m_ctrl_data_model` object
 	 * to refresh or modify the current network topology.
 	 *
-	 * @note Ensure that `m_data_model` is properly initialized before calling this function.
+	 * @note Ensure that `m_ctrl_data_model` is properly initialized before calling this function.
 	 */
-	void update_network_topology() { m_data_model.update_network_topology(); }
+	void update_network_topology() { m_ctrl_data_model.update_network_topology(); }
 
 	/**!
 	 * @brief Publish the network topology using the data model.
 	 *
 	 * This function publishes the current network topology over the bus.
 	 *
-	 * @note Ensure that `m_data_model` is properly updated before calling this function.
+	 * @note Ensure that `m_ctrl_data_model` is properly updated before calling this function.
 	 */
 	void publish_network_topology();
 
@@ -531,7 +531,7 @@ public:
 	 *
 	 * @returns A pointer to the first `dm_easy_mesh_t` data model, or nullptr if no dms are available.
 	 */
-	dm_easy_mesh_t *get_first_dm() override { return m_data_model.get_first_dm(); }
+	dm_easy_mesh_t *get_first_dm() override { return m_ctrl_data_model.get_first_dm(); }
 
 	/**!
 	 * @brief Retrieves the next data model in the agent list.
@@ -540,7 +540,7 @@ public:
 	 *
 	 * @returns A pointer to the next `dm_easy_mesh_t` data model, or nullptr if there are no more dms.
 	 */
-	dm_easy_mesh_t *get_next_dm(dm_easy_mesh_t *dm) override { return m_data_model.get_next_dm(dm); }
+	dm_easy_mesh_t *get_next_dm(dm_easy_mesh_t *dm) override { return m_ctrl_data_model.get_next_dm(dm); }
 
 	/**!
 	 * @brief Retrieves the data model for a given network ID and optional AL MAC address.
@@ -554,7 +554,7 @@ public:
 	 * @returns A pointer to the `dm_easy_mesh_t` data model associated with the given network ID.
 	 * @note If the AL MAC address is not provided, the function will use a default value.
 	 */
-	dm_easy_mesh_t *get_data_model(const char *net_id, const unsigned char *al_mac = NULL) { return m_data_model.get_data_model(net_id, al_mac); }
+	dm_easy_mesh_t *get_data_model(const char *net_id, const unsigned char *al_mac = NULL) { return m_ctrl_data_model.get_data_model(net_id, al_mac); }
     
 	/**!
 	 * @brief Creates a data model for the specified network ID and interface.
@@ -570,7 +570,7 @@ public:
 	 *
 	 * @note Ensure that the network ID and interface are valid before calling this function.
 	 */
-	dm_easy_mesh_t *create_data_model(const char *net_id, const em_interface_t *al_intf, em_profile_type_t profile = em_profile_type_3) { return m_data_model.create_data_model(net_id, al_intf, profile); }
+	dm_easy_mesh_t *create_data_model(const char *net_id, const em_interface_t *al_intf, em_profile_type_t profile = em_profile_type_3) { return m_ctrl_data_model.create_data_model(net_id, al_intf, profile); }
     
 	/**!
 	 * @brief Deletes the data model associated with the given network ID and AL MAC address.
@@ -582,18 +582,18 @@ public:
 	 *
 	 * @note Ensure that the network ID and AL MAC address are valid and correspond to an existing data model entry.
 	 */
-	void delete_data_model(const char *net_id, const unsigned char *al_mac) { m_data_model.delete_data_model(net_id, al_mac); }
+	void delete_data_model(const char *net_id, const unsigned char *al_mac) { m_ctrl_data_model.delete_data_model(net_id, al_mac); }
     
 	/**!
 	 * @brief Deletes all data models.
 	 *
-	 * This function calls the delete_all_data_models method on the m_data_model object,
+	 * This function calls the delete_all_data_models method on the m_ctrl_data_model object,
 	 * effectively removing all data models managed by it.
 	 *
 	 * @note Ensure that any necessary data is backed up before calling this function,
 	 * as it will remove all data models without the possibility of recovery.
 	 */
-	void delete_all_data_models() { m_data_model.delete_all_data_models(); }
+	void delete_all_data_models() { m_ctrl_data_model.delete_all_data_models(); }
     
 	/**!
 	 * @brief Updates the tables in the data model.
@@ -608,7 +608,7 @@ public:
 	 *
 	 * @note Ensure that the dm pointer is valid and properly initialized before calling this function.
 	 */
-	int update_tables(dm_easy_mesh_t *dm) { return m_data_model.update_tables(dm); }
+	int update_tables(dm_easy_mesh_t *dm) { return m_ctrl_data_model.update_tables(dm); }
     
 	/**!
 	 * @brief Loads the network SSID table.
@@ -621,16 +621,16 @@ public:
 	 *
 	 * @note Ensure that the data model is properly initialized before calling this function.
 	 */
-	int load_net_ssid_table() { return m_data_model.load_net_ssid_table(); }
+	int load_net_ssid_table() { return m_ctrl_data_model.load_net_ssid_table(); }
     
 	/**!
 	 * @brief Debugs the probe using the data model.
 	 *
-	 * This function calls the debug_probe method on the m_data_model object.
+	 * This function calls the debug_probe method on the m_ctrl_data_model object.
 	 *
-	 * @note Ensure that m_data_model is properly initialized before calling this function.
+	 * @note Ensure that m_ctrl_data_model is properly initialized before calling this function.
 	 */
-	void debug_probe() { m_data_model.debug_probe(); }
+	void debug_probe() { m_ctrl_data_model.debug_probe(); }
 
     
 	/**!

--- a/src/cli/em_cli.cpp
+++ b/src/cli/em_cli.cpp
@@ -42,40 +42,40 @@ em_cli_t g_cli;
 
 em_network_node_t *em_cli_t::get_reset_tree(char *platform)
 {
-	unsigned int len;
+    unsigned int len;
     dm_easy_mesh_t dm; 
-	em_interface_t *intf;
+    em_interface_t *intf;
     //mac_addr_str_t  ctrl_mac, ctrl_al_mac, agent_al_mac;
-	em_subdoc_info_t *subdoc;
-	em_long_string_t	dbg_str;
-	unsigned char buff[EM_IO_BUFF_SZ];
+    em_subdoc_info_t *subdoc;
+    em_long_string_t	dbg_str;
+    unsigned char buff[EM_IO_BUFF_SZ];
 
-	subdoc = (em_subdoc_info_t *)buff;
+    subdoc = (em_subdoc_info_t *)buff;
 
-	if ((len = em_cmd_exec_t::load_params_file("Reset.json", subdoc->buff)) < 0) {
-		return NULL;
-	}
+    if ((len = em_cmd_exec_t::load_params_file("Reset.json", subdoc->buff)) < 0) {
+        return NULL;
+    }
 
     dm.init();
     dm.decode_config(subdoc, "Reset");
 
-	// Prioritize the interface list depending on platform
-	if ((intf = dm.get_prioritized_interface(platform)) == NULL) {
-		intf = dm.get_interface_by_index(0);
-	}
+    // Prioritize the interface list depending on platform
+    if ((intf = dm.get_prioritized_interface(platform)) == NULL) {
+        intf = dm.get_interface_by_index(0);
+    }
 
-	snprintf(dbg_str, sizeof(em_long_string_t), "Interface Name: %s Media: %d", intf->name, intf->media);	
+    snprintf(dbg_str, sizeof(em_long_string_t), "Interface Name: %s Media: %d", intf->name, intf->media);
     g_cli.dump_lib_dbg(dbg_str);
-    dm.set_ctrl_al_interface_mac(intf->mac);
-    dm.set_ctrl_al_interface_name(intf->name);
-	dm.set_controller_id(intf->mac);
-	dm.set_controller_intf_media(intf->media);
-            
+    /* Controller ID must come from the AL-SAP MAC only */
+    // dm.set_ctrl_al_interface_mac(intf->mac);
+    // dm.set_ctrl_al_interface_name(intf->name);
+    // dm.set_controller_intf_media(intf->media);
+
     //dm.print_config();
 
     dm.encode_config(subdoc, "Reset");
 
-	return em_net_node_t::get_network_tree(subdoc->buff);
+    return em_net_node_t::get_network_tree(subdoc->buff);
 }
 
 const char *em_cli_t::get_first_cmd_str()

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -2843,7 +2843,6 @@ int dm_easy_mesh_ctrl_t::analyze_reset(em_bus_event_t *evt, em_cmd_t *pcmd[])
 
     subdoc = &evt->u.subdoc;
 
-
     dm.decode_config(subdoc, "Reset");
     //dm.print_config();
 
@@ -2855,8 +2854,8 @@ int dm_easy_mesh_ctrl_t::analyze_reset(em_bus_event_t *evt, em_cmd_t *pcmd[])
     num++;
 
     while ((pcmd[num] = tmp->clone_for_next()) != NULL) {
-		tmp = pcmd[num];
-		num++;
+        tmp = pcmd[num];
+        num++;
     }
 
     return num;
@@ -4340,10 +4339,13 @@ int dm_easy_mesh_ctrl_t::get_wifi_reset_config(cJSON *parent, char *key)
         intf = dm.get_interface_by_index(0);//Todo: check why index 0 as it is taking brlan0
     }
 
-    dm.set_ctrl_al_interface_mac(intf->mac);
-    dm.set_ctrl_al_interface_name(intf->name);
-    dm.set_controller_id(intf->mac);//Should be set to eth0-virt-peer mac
-    dm.set_controller_intf_media(intf->media);
+    /*
+     * Keep the controller ID tied to the AL-SAP MAC only.
+     * Do not overwrite it with the interface-derived MAC from config.
+     */
+    dm.set_ctrl_al_interface_mac(m_device_info.intf.mac);
+    dm.set_ctrl_al_interface_name(m_device_info.intf.name);
+    dm.set_controller_intf_media(m_device_info.intf.media);
 
     //dm.print_config();
 

--- a/src/ctrl/em_ctrl.cpp
+++ b/src/ctrl/em_ctrl.cpp
@@ -72,7 +72,7 @@ void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
     info = &evt->u.commit;
 
     dm_easy_mesh_t::macbytes_to_string(info->mac, mac_str);
-    dm = m_data_model.get_data_model(info->net_id, info->mac);
+    dm = m_ctrl_data_model.get_data_model(info->net_id, info->mac);
     if (dm == NULL) {
         new_dm.init();
         em_printfout("data model mac: %s and info->net_id : %s\n",mac_str, info->net_id);
@@ -82,7 +82,7 @@ void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
         em_printfout("data model dev mac: %s and int.mac: %s\n", util::mac_to_string(new_dm.m_device.m_device_info.id.dev_mac).c_str(),
             util::mac_to_string(new_dm.m_device.m_device_info.intf.mac).c_str());
 
-        if ((net = m_data_model.get_network(info->net_id)) != NULL) {
+        if ((net = m_ctrl_data_model.get_network(info->net_id)) != NULL) {
             em_printfout("net id: %s", net->m_net_info.id);
             pnet = new_dm.get_network();
             *pnet = *net;
@@ -100,7 +100,7 @@ void em_ctrl_t::handle_dm_commit(em_bus_event_t *evt)
             util::mac_to_string(new_dm.m_device.m_device_info.intf.mac).c_str());
         new_dm.m_device.m_device_info.is_emplus_agent = info->is_emplus_agent;
         new_dm.set_db_cfg_param(db_cfg_type_device_list_update, "");
-        m_data_model.set_config(&new_dm);
+        m_ctrl_data_model.set_config(&new_dm);
     } else {
         dm->get_device_info()->is_emplus_agent = info->is_emplus_agent;
         dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
@@ -121,7 +121,7 @@ void em_ctrl_t::handle_client_steer(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_steer(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_command_steer(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -137,7 +137,7 @@ void em_ctrl_t::handle_client_disassoc(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_disassoc(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_command_disassoc(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -153,7 +153,7 @@ void em_ctrl_t::handle_client_btm(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_command_btm(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_command_btm(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -169,7 +169,7 @@ void em_ctrl_t::handle_start_dpp(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_dpp_start(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_dpp_start(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -186,7 +186,7 @@ void em_ctrl_t::handle_channel_select(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_channel_select(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_channel_select(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -202,7 +202,7 @@ void em_ctrl_t::handle_set_channel_list(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_channel(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_set_channel(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -219,7 +219,7 @@ void em_ctrl_t::handle_scan_channel_list(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_scan_channel(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_scan_channel(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -236,7 +236,7 @@ void em_ctrl_t::handle_set_policy(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_policy(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_set_policy(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -250,7 +250,7 @@ void em_ctrl_t::handle_config_renew(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     int num;
     
-    if ((num = m_data_model.analyze_config_renew(evt, pcmd)) > 0) {
+    if ((num = m_ctrl_data_model.analyze_config_renew(evt, pcmd)) > 0) {
         m_orch->submit_commands(pcmd, static_cast<unsigned int> (num));
     }
 }
@@ -260,7 +260,7 @@ void em_ctrl_t::handle_m2_tx(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     int num;
     
-    if ((num = m_data_model.analyze_m2_tx(evt, pcmd)) > 0) {
+    if ((num = m_ctrl_data_model.analyze_m2_tx(evt, pcmd)) > 0) {
         m_orch->submit_commands(pcmd, static_cast<unsigned int> (num));
     }
 }
@@ -270,7 +270,7 @@ void em_ctrl_t::handle_sta_assoc_event(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     int num;
     
-    if ((num = m_data_model.analyze_sta_assoc_event(evt, pcmd)) > 0) {
+    if ((num = m_ctrl_data_model.analyze_sta_assoc_event(evt, pcmd)) > 0) {
         m_orch->submit_commands(pcmd, static_cast<unsigned int> (num));
     }
 }
@@ -282,7 +282,7 @@ void em_ctrl_t::handle_set_radio(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_set_radio(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_set_radio(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -298,7 +298,7 @@ void em_ctrl_t::handle_set_ssid_list(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((ret = m_data_model.analyze_set_ssid(evt, pcmd)) <= 0) {
+    } else if ((ret = m_ctrl_data_model.analyze_set_ssid(evt, pcmd)) <= 0) {
         if (ret == EM_PARSE_ERR_NO_CHANGE) {
         	m_ctrl_cmd->send_result(em_cmd_out_status_no_change);
 		} else {
@@ -319,7 +319,7 @@ void em_ctrl_t::handle_remove_device(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_remove_device(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_remove_device(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -377,7 +377,7 @@ void em_ctrl_t::handle_get_dm_data(em_bus_event_t *evt)
         return;
     }
 
-    m_data_model.get_config(params.u.args.args[1], &evt->u.subdoc);
+    m_ctrl_data_model.get_config(params.u.args.args[1], &evt->u.subdoc);
 	evt->data_len = static_cast<unsigned int> (strlen(evt->u.subdoc.buff)) + 1;
     m_ctrl_cmd->copy_bus_event(evt);
     m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -390,7 +390,7 @@ void em_ctrl_t::handle_reset(em_bus_event_t *evt)
 	
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_reset(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_reset(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -407,7 +407,7 @@ void em_ctrl_t::handle_mld_reconfig(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_mld_reconfig(pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_mld_reconfig(pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -433,7 +433,7 @@ void em_ctrl_t::handle_unassoc_sta_metrics_query(em_bus_event_t *evt)
 
     if (m_orch->is_cmd_type_in_progress(evt) == true) {
         m_ctrl_cmd->send_result(em_cmd_out_status_prev_cmd_in_progress);
-    } else if ((num = m_data_model.analyze_unassoc_sta_metrics_query(evt, pcmd)) <= 0) {
+    } else if ((num = m_ctrl_data_model.analyze_unassoc_sta_metrics_query(evt, pcmd)) <= 0) {
         m_ctrl_cmd->send_result(status_for_noncmd(num));
     } else if (m_orch->submit_commands(pcmd, static_cast<unsigned int> (num)) > 0) {
         m_ctrl_cmd->send_result(em_cmd_out_status_success);
@@ -447,7 +447,7 @@ void em_ctrl_t::handle_client_metrics_req()
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     int num;
 
-    if ((num = m_data_model.analyze_sta_link_metrics(pcmd)) > 0) {
+    if ((num = m_ctrl_data_model.analyze_sta_link_metrics(pcmd)) > 0) {
         m_orch->submit_commands(pcmd, static_cast<unsigned int> (num));
     }
 }
@@ -457,7 +457,7 @@ void em_ctrl_t::handle_bsta_cap_req(em_bus_event_t *evt)
     em_cmd_t *pcmd[EM_MAX_CMD] = {NULL};
     int num;
 
-    if ((num = m_data_model.analyze_bsta_cap_req(evt, pcmd)) > 0) {
+    if ((num = m_ctrl_data_model.analyze_bsta_cap_req(evt, pcmd)) > 0) {
         m_orch->submit_commands(pcmd, static_cast<unsigned int> (num));
     }
 }
@@ -473,7 +473,7 @@ void em_ctrl_t::handle_link_stats_alarm_report(em_bus_event_t *evt)
 
     cJSON *parent = cJSON_CreateObject();
     em_printfout("Getting STAList for alarm report\n");
-    m_data_model.get_sta_config(parent, const_cast<char*>(GLOBAL_NET_ID), em_get_sta_list_reason_alarm_report, info->buff);
+    m_ctrl_data_model.get_sta_config(parent, const_cast<char*>(GLOBAL_NET_ID), em_get_sta_list_reason_alarm_report, info->buff);
 
     //publish to orch
     if((desc = get_bus_descriptor()) == NULL) {
@@ -494,7 +494,7 @@ void em_ctrl_t::handle_link_stats_alarm_report(em_bus_event_t *evt)
     raw.raw_data.bytes = reinterpret_cast<unsigned char *> (str);
     raw.raw_data_len = static_cast<unsigned int> (strlen(str));
 
-    if (desc->bus_event_publish_fn(m_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_LINKSTATS_ALARM, &raw)== 0) {
+    if (desc->bus_event_publish_fn(m_ctrl_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_LINKSTATS_ALARM, &raw)== 0) {
         em_printfout("Link Stats Alarm published successfull");
     } else {
         em_printfout("Link Stats Alarm publish fail");
@@ -619,7 +619,7 @@ void em_ctrl_t::handle_failed_conn_msg(unsigned char *data, unsigned int len)
     raw.raw_data.bytes = reinterpret_cast<unsigned char *>(str);
     raw.raw_data_len = static_cast<unsigned int>(strlen(str));
 
-    if (desc->bus_event_publish_fn(m_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_FAILED_CONNECTION, &raw) == 0) {
+    if (desc->bus_event_publish_fn(m_ctrl_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_FAILED_CONNECTION, &raw) == 0) {
         em_printfout("FailedConnectionEvent published: bssid=%s sta=%s status=%u reason=%u",
             bssid_str, sta_str, status_code, reason_code);
     } else {
@@ -632,7 +632,7 @@ void em_ctrl_t::handle_failed_conn_msg(unsigned char *data, unsigned int len)
 
 void em_ctrl_t::handle_dirty_dm()
 {
-	m_data_model.handle_dirty_dm();
+	m_ctrl_data_model.handle_dirty_dm();
 }
 
 void em_ctrl_t::handle_5s_tick()
@@ -693,7 +693,7 @@ void em_ctrl_t::handle_nb_event(em_nb_event_t *evt)
     }
 
     uintptr_t buf = reinterpret_cast<uintptr_t>(resp);
-    ssize_t len = write(m_data_model.m_nb_pipe_wr, &buf, sizeof(buf));
+    ssize_t len = write(m_ctrl_data_model.m_nb_pipe_wr, &buf, sizeof(buf));
     assert(len == sizeof(buf));
 }
 
@@ -864,7 +864,7 @@ void em_ctrl_t::publish_network_topology()
     raw.raw_data.bytes = reinterpret_cast<unsigned char *> (str);
     raw.raw_data_len = static_cast<unsigned int> (strlen(str));
 
-    if (desc->bus_event_publish_fn(m_data_model.get_bus_hdl(), const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY), &raw)== 0) {
+    if (desc->bus_event_publish_fn(m_ctrl_data_model.get_bus_hdl(), const_cast<char*>(DEVICE_WIFI_DATAELEMENTS_NETWORK_TOPOLOGY), &raw)== 0) {
         printf("%s:%d Topology published successfull\n",__func__, __LINE__);
     } else {
         printf("%s:%d Topology publish fail\n",__func__, __LINE__);
@@ -915,8 +915,8 @@ void em_ctrl_t::publish_network_topology()
                     raw.raw_data.bytes = reinterpret_cast<unsigned char*>(buf);
                     raw.raw_data_len = static_cast<unsigned int>(read);
 
-                    if (desc->bus_event_publish_fn(m_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, &raw) == 0) {
-                    //if (desc->bus_set_fn(m_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, &raw) == 0) {
+                    if (desc->bus_event_publish_fn(m_ctrl_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, &raw) == 0) {
+                    //if (desc->bus_set_fn(m_ctrl_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, &raw) == 0) {
                         printf("%s:%d Policy published successfully\n", __func__, __LINE__);
                     } else {
                         printf("%s:%d Policy publish failed\n", __func__, __LINE__);
@@ -943,12 +943,12 @@ int em_ctrl_t::data_model_init(const char *data_model_path)
         return 0;
     }
     
-    if (m_data_model.init(data_model_path, this) != 0) {
+    if (m_ctrl_data_model.init(data_model_path, this) != 0) {
         printf("%s:%d: data model init failed\n", __func__, __LINE__);
         return 0;
     }
 
-    intf = m_data_model.get_ctrl_al_interface(const_cast<char*>(GLOBAL_NET_ID));
+    intf = m_ctrl_data_model.get_ctrl_al_interface(const_cast<char*>(GLOBAL_NET_ID));
 	if (intf == NULL) {
 		printf("%s:%d: data model init failed could not find netid\n", __func__, __LINE__);
 		return 0;
@@ -1372,7 +1372,7 @@ void em_ctrl_t::start_complete()
             { bus_data_type_property, false, 0, 0, 0, NULL } }
         };
 
-	if (m_data_model.is_initialized() == false) {
+	if (m_ctrl_data_model.is_initialized() == false) {
 		printf("%s:%d: Database not initialized ... needs reset\n", __func__, __LINE__);
 		return;
 	}
@@ -1380,13 +1380,13 @@ void em_ctrl_t::start_complete()
 	// build initial network topology
 	init_network_topology();
 
-    dm = m_data_model.get_first_dm();
+    dm = m_ctrl_data_model.get_first_dm();
     while (dm != NULL) {
 		dm->set_db_cfg_param(db_cfg_type_scan_result_list_delete, "");
 		dm->set_db_cfg_param(db_cfg_type_sta_list_delete, "");
 		dm->set_db_cfg_param(db_cfg_type_op_class_list_delete, "");
 		dm->set_db_cfg_param(db_cfg_type_bss_list_delete, "");
-        dm = m_data_model.get_next_dm(dm);
+        dm = m_ctrl_data_model.get_next_dm(dm);
     }
 	memcpy(&ac_config_raw.radio, &null_mac, sizeof(mac_address_t));
 	io_process(em_bus_event_type_cfg_renew, reinterpret_cast<unsigned char *> (&ac_config_raw), sizeof(em_bus_event_type_cfg_renew_params_t));
@@ -1408,15 +1408,15 @@ void em_ctrl_t::start_complete()
     }
 
     num_elements = (sizeof(dataElements) / sizeof(bus_data_element_t));
-    bus_error_val = desc->bus_reg_data_element_fn(m_data_model.get_bus_hdl(), dataElements, num_elements);
+    bus_error_val = desc->bus_reg_data_element_fn(m_ctrl_data_model.get_bus_hdl(), dataElements, num_elements);
     if (bus_error_val != bus_error_success) {
         printf("%s:%d bus: bus_regDataElements failed\n", __func__, __LINE__);
         return;
     }
 
-    dm = m_data_model.get_first_dm();
+    dm = m_ctrl_data_model.get_first_dm();
     while (dm != NULL && dm->is_controller() == false) {
-        dm = m_data_model.get_next_dm(dm);
+        dm = m_ctrl_data_model.get_next_dm(dm);
     }
 
     if (dm) {
@@ -1428,7 +1428,7 @@ void em_ctrl_t::start_complete()
         raw.raw_data.bytes   = al_mac_str;
         raw.raw_data_len = static_cast<unsigned int> (strlen(al_mac_str));
 
-        if (desc->bus_set_fn(m_data_model.get_bus_hdl(), "Device.WiFi.DataElements.Network.ControllerID", &raw) == 0) {
+        if (desc->bus_set_fn(m_ctrl_data_model.get_bus_hdl(), "Device.WiFi.DataElements.Network.ControllerID", &raw) == 0) {
             em_printfout("Controller ID: %s publish successful.", al_mac_str);
         }
         else {
@@ -1438,7 +1438,7 @@ void em_ctrl_t::start_complete()
             em_printfout("Could not find data model with controller role");
     }
 
-    if (desc->bus_event_subs_fn(m_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, reinterpret_cast<void *> (&tr_181_t::subs_policy_config), NULL, 0) != 0) {
+    if (desc->bus_event_subs_fn(m_ctrl_data_model.get_bus_hdl(), DEVICE_WIFI_DATAELEMENTS_NETWORK_NODE_CFG_POLICY, reinterpret_cast<void *> (&tr_181_t::subs_policy_config), NULL, 0) != 0) {
         em_printfout("bus subscribe failed");
         return;
     }
@@ -1463,14 +1463,9 @@ em_ctrl_t::~em_ctrl_t()
 #ifdef AL_SAP
 AlServiceAccessPoint* em_ctrl_t::al_sap_register(const std::string& data_socket_path, const std::string& control_socket_path)
 {
-    AlServiceAccessPoint* sap = NULL;
+    AlServiceAccessPoint* sap = nullptr;
     try {
         sap = new AlServiceAccessPoint(data_socket_path.c_str(), control_socket_path.c_str());
-        if (NULL == sap) {
-            em_printfout("%s-%d: Failed to allocate AlServiceAccessPoint", __func__, __LINE__);
-            return NULL;
-        }
-
         AlServiceRegistrationRequest registrationRequest(SAPActivation::SAP_ENABLE, ServiceType::EmController);
         sap->serviceAccessPointRegistrationRequest(registrationRequest);
 
@@ -1481,12 +1476,12 @@ AlServiceAccessPoint* em_ctrl_t::al_sap_register(const std::string& data_socket_
             g_al_mac_sap = registrationResponse.getAlMacAddressLocal();
             uint8_t* al_mac_bytes = g_al_mac_sap.data();
             if (NULL == al_mac_bytes) {
-                em_printfout("%s-%d: AL SAP registration failed with invalid AL MAC: %s", util::mac_to_string(al_mac_bytes).c_str());
+                em_printfout("AL SAP registration failed with invalid AL MAC");
                 delete sap;
                 return NULL;
             }
             em_printfout("AL SAP registration successful, AL MAC: %s", util::mac_to_string(al_mac_bytes).c_str());
-            m_data_model.set_dev_interface_mac(al_mac_bytes);
+            m_ctrl_data_model.set_dev_interface_mac(al_mac_bytes);
         } else {
             std::cout << "Registration failed with error: " << static_cast<int>(result) << std::endl;
             delete sap;
@@ -1494,12 +1489,12 @@ AlServiceAccessPoint* em_ctrl_t::al_sap_register(const std::string& data_socket_
         }
     }
     catch (const AlServiceException& e) {
-        em_printfout("%s-%d: AL SAP registration exception %s", __func__, __LINE__, e.what());
+        em_printfout("AL SAP registration exception %s", e.what());
         delete sap;
         return NULL;
     }
-    catch (const std::exception e) {
-        em_printfout("%s-%d: Unknown exception %s during AL SAP registration", __func__, __LINE__, e.what());
+    catch (const std::exception&) {
+        em_printfout("Unknown exception during AL SAP registration");
         delete sap;
         return NULL;
     }
@@ -1520,15 +1515,15 @@ int main(int argc, const char *argv[])
     if(0 == access(data_socket_path, F_OK) && 0 == access(control_socket_path, F_OK)) {
         g_sap = em_ctrl->al_sap_register(data_socket_path, control_socket_path);
         if (NULL == g_sap) {
-            em_printfout("%s-%d: Error in AL SAP registration, exiting", __func__, __LINE__);
+            em_printfout("Error in AL SAP registration, exiting");
             return -1;
         }
     }
     else {
-        em_printfout("%s-%d: Data Socket: %s, Control Socket: %s", __func__, __FILE__,
+        em_printfout("Data Socket: %s, Control Socket: %s",
 	              access(data_socket_path, F_OK) == 0 ? "present" : "missing",
                       access(control_socket_path, F_OK) == 0 ? "present" : "missing");
-        em_printfout("%s-%d: Required AL SAP socket(s) not available, exiting", __func__, __LINE__);
+        em_printfout("Required AL SAP socket(s) not available, exiting");
         return -1;
     }
 #endif

--- a/src/dm/dm_easy_mesh_list.cpp
+++ b/src/dm/dm_easy_mesh_list.cpp
@@ -1628,12 +1628,11 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
     dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (al_intf->mac), mac_str);
     snprintf(key, sizeof(em_short_string_t), "%s@%s", net_id, mac_str);
 
-
     dm = new dm_easy_mesh_t();
     dm->init();
 
     if (controller == true) {
-        em_printfout("Creating data model as controller ...");
+        em_printfout("Creating minimal data model entry for controller, net_id:[%s]", net_id);
         dm->set_controller(controller);
     } else {
         em_printfout("Creating data model as agent...");
@@ -1658,23 +1657,23 @@ dm_easy_mesh_t *dm_easy_mesh_list_t::create_data_model(const char *net_id, const
             }
         }
     }
-    em_printfout("Created data model for net_id: %s mac: %s, is_colocated:%d is_controller:%d", net_id, mac_str, colocated, controller);
+    em_printfout("Created data model for net_id:[%s] mac:[%s], is_colocated:%d is_controller:%d", net_id, mac_str, colocated, controller);
 
     dev = dm->get_device();
     memcpy(dev->m_device_info.intf.mac, al_intf->mac, sizeof(mac_address_t));
     strncpy(dev->m_device_info.id.net_id, net_id, strlen(net_id) + 1);
-	if (controller == true) {
-		memcpy(dev->m_device_info.id.dev_mac, al_intf->mac, sizeof(mac_address_t));
-		dev->m_device_info.id.media = dm->m_network.m_net_info.media;
-		//TODO: Monitor Checks
-		//memcpy(dev->m_device_info.backhaul_mac.mac, al_intf->mac, sizeof(mac_address_t));
-		dev->m_device_info.backhaul_mac.media = dm->m_network.m_net_info.media;
-		em_printfout("Backhaul mac updated to :%s device media:%d backhaul media:%d",
-			util::mac_to_string(dev->m_device_info.backhaul_mac.mac).c_str(),
-			dev->m_device_info.id.media, dev->m_device_info.backhaul_mac.media);
-		//Update the easymesh configuration file to specify colocated agent as true.
-		dev->update_easymesh_json_cfg(true);
-	} else {
+
+    if (controller == true) {
+        memcpy(dev->m_device_info.id.dev_mac, al_intf->mac, sizeof(mac_address_t));
+        dev->m_device_info.id.media = dm->m_network.m_net_info.media;
+        dev->m_device_info.backhaul_mac.media = dm->m_network.m_net_info.media;
+        em_printfout("Backhaul mac updated to :%s device media:%d backhaul media:%d",
+        util::mac_to_string(dev->m_device_info.backhaul_mac.mac).c_str(),
+        dev->m_device_info.id.media, dev->m_device_info.backhaul_mac.media);
+        //Update the easymesh configuration file to specify colocated agent as true.
+        dev->update_easymesh_json_cfg(true);
+    } else {
+        em_printfout("Initializing device for data model with AL-mac: %s", util::mac_to_string(al_intf->mac).c_str());
         dm->set_id();
         em_printfout("dm->get_id():%d", dm->get_id());
     }

--- a/src/em/config/em_configuration.cpp
+++ b/src/em/config/em_configuration.cpp
@@ -6039,7 +6039,7 @@ void em_configuration_t::process_msg(unsigned char *data, unsigned int len)
                     dm->set_topo_state(true);
                     dm->set_db_cfg_param(db_cfg_type_device_list_update, "");
                 } else {
-                    printf("%s:%d em_msg_type_topo_resp handle failed \n", __func__, __LINE__);
+                    em_printfout("em_msg_type_topo_resp handle failed");
                 }
             }
             break;

--- a/src/rdkb-cli/em_cli.cpp
+++ b/src/rdkb-cli/em_cli.cpp
@@ -43,40 +43,36 @@ em_cli_t g_cli;
 
 em_network_node_t *em_cli_t::get_reset_tree(char *platform)
 {
-	unsigned int len;
+    unsigned int len;
     dm_easy_mesh_t dm; 
-	em_interface_t *intf;
+    em_interface_t *intf;
     //mac_addr_str_t  ctrl_mac, ctrl_al_mac, agent_al_mac;
-	em_subdoc_info_t *subdoc;
-	em_long_string_t	dbg_str;
-	unsigned char buff[EM_IO_BUFF_SZ];
+    em_subdoc_info_t *subdoc;
+    em_long_string_t	dbg_str;
+    unsigned char buff[EM_IO_BUFF_SZ];
 
-	subdoc = (em_subdoc_info_t *)buff;
+    subdoc = (em_subdoc_info_t *)buff;
 
-	if ((len = em_cmd_exec_t::load_params_file("Reset.json", subdoc->buff)) < 0) {
-		return NULL;
-	}
+    if ((len = em_cmd_exec_t::load_params_file("Reset.json", subdoc->buff)) < 0) {
+        return NULL;
+    }
 
     dm.init();
     dm.decode_config(subdoc, "Reset");
 
-	// Prioritize the interface list depending on platform
-	if ((intf = dm.get_prioritized_interface(platform)) == NULL) {
-		intf = dm.get_interface_by_index(0);
-	}
+    // Prioritize the interface list depending on platform
+    if ((intf = dm.get_prioritized_interface(platform)) == NULL) {
+        intf = dm.get_interface_by_index(0);
+    }
 
-	snprintf(dbg_str, sizeof(em_long_string_t), "Interface Name: %s Media: %d", intf->name, intf->media);	
+    snprintf(dbg_str, sizeof(em_long_string_t), "Interface Name: %s Media: %d", intf->name, intf->media);
     g_cli.dump_lib_dbg(dbg_str);
-    dm.set_ctrl_al_interface_mac(intf->mac);
-    dm.set_ctrl_al_interface_name(intf->name);
-	dm.set_controller_id(intf->mac);
-	dm.set_controller_intf_media(intf->media);
-            
+
     //dm.print_config();
 
     dm.encode_config(subdoc, "Reset");
 
-	return em_net_node_t::get_network_tree(subdoc->buff);
+    return em_net_node_t::get_network_tree(subdoc->buff);
 }
 
 const char *em_cli_t::get_first_cmd_str()


### PR DESCRIPTION
Reason for change:

- Addressed review comments from @vlad-safonov for onewifi_em_ctrl crash in al_sap_register()
- Integrated the changes from @Nikita-Hakai to set the controller al mac matching eth0_virt_peer mac for openwrt environment.

Test Procedure
sanity test performed in star topolgoy and star+daisy test setups (onboarding, wifi configuration updates, channel change, wifi reset) using the reference platform BPi devices

Risk: Low