### PR TITLE
RDKBWIFI-583: Parse ChannelSelectionRequest() Channel as the TR-181 list it is

### DIFF
--- a/docs/TR181-ChannelSelectionRequest-usage-and-testing.md
+++ b/docs/TR181-ChannelSelectionRequest-usage-and-testing.md
@@ -25,9 +25,11 @@ The payload uses nested Class.N and Channel.M objects, for example:
 ```text
 method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()"
   Class.1.OpClass uint32 81
-  Class.1.Channel.1.Channel uint32 1
+  Class.1.Channel.1.Channel string 1,6,11
   Class.1.Channel.1.Preference uint32 14
 ```
+
+Class.N.Channel.M.Channel is a TR-181 list of unsignedInt, carried as a comma-separated string. Every channel in a Channel.M row takes that row's Preference; channels that need a different preference go in another Channel.M row.
 
 ### Validation rules
 
@@ -37,6 +39,8 @@ The implementation now rejects requests when:
 - Channel indices are not valid positive integers starting at 1, or are not contiguous from 1 within each Class.N
 - OpClass is missing or invalid for the selected radio
 - OpClass band does not match the radio band
+- Channel is not a comma-separated list of channel numbers in 1..255 (empty list, empty item or trailing comma)
+- A Class.N lists more than 64 channels in total
 - Requested channels are not valid for the selected OpClass
 - Preference values are invalid for the implementation range
 - A preference is supplied without a matching channel entry
@@ -47,113 +51,113 @@ The implementation now rejects requests when:
 ### 2.4 GHz (Radio.1) - Positive
 
 ```text
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 6 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 11 Class.1.Channel.3.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 1,6,11 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 82 Class.1.Channel.1.Channel uint32 14 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 82 Class.1.Channel.1.Channel string 14 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 83 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 5 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 9 Class.1.Channel.3.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 83 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 5 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel string 9 Class.1.Channel.3.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 84 Class.1.Channel.1.Channel uint32 5 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 9 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 13 Class.1.Channel.3.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 84 Class.1.Channel.1.Channel string 5 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 9 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel string 13 Class.1.Channel.3.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 83 Class.2.Channel.1.Channel uint32 5 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 84 Class.3.Channel.1.Channel uint32 9 Class.3.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 83 Class.2.Channel.1.Channel string 5 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 84 Class.3.Channel.1.Channel string 9 Class.3.Channel.1.Preference uint32 14
 ```
 
 ### 2.4 GHz (Radio.1) - Negative
 
 ```text
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 14 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 14 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 82 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 82 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 83 Class.1.Channel.1.Channel uint32 13 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 83 Class.1.Channel.1.Channel string 13 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel string 36 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 100 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 100 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 6 Class.1.Channel.1.Preference uint32 255
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 6 Class.1.Channel.1.Preference uint32 255
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 6 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 6 Class.1.Channel.2.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 6 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 6 Class.1.Channel.2.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 6
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.1.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 6
 ```
 
 ### 5 GHz (Radio.2) - Positive
 
 ```text
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 40 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 44 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel uint32 48 Class.1.Channel.4.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel string 36,40,44,48 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 116 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 44 Class.1.Channel.2.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 116 Class.1.Channel.1.Channel string 36 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 44 Class.1.Channel.2.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 118 Class.1.Channel.1.Channel uint32 52 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 56 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 60 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel uint32 64 Class.1.Channel.4.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 118 Class.1.Channel.1.Channel string 52 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 56 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel string 60 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel string 64 Class.1.Channel.4.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 121 Class.1.Channel.1.Channel uint32 100 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 104 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 108 Class.1.Channel.3.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 121 Class.1.Channel.1.Channel string 100 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 104 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel string 108 Class.1.Channel.3.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 124 Class.1.Channel.1.Channel uint32 149 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 153 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 157 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel uint32 161 Class.1.Channel.4.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 124 Class.1.Channel.1.Channel string 149 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 153 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel string 157 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel string 161 Class.1.Channel.4.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 128 Class.1.Channel.1.Channel uint32 42 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 58 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 106 Class.1.Channel.3.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 128 Class.1.Channel.1.Channel string 42 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 58 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel string 106 Class.1.Channel.3.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 129 Class.1.Channel.1.Channel uint32 50 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 114 Class.1.Channel.2.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 129 Class.1.Channel.1.Channel string 50 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 114 Class.1.Channel.2.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 118 Class.2.Channel.1.Channel uint32 52 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 121 Class.3.Channel.1.Channel uint32 100 Class.3.Channel.1.Preference uint32 14 Class.4.OpClass uint32 124 Class.4.Channel.1.Channel uint32 149 Class.4.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel string 36 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 118 Class.2.Channel.1.Channel string 52 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 121 Class.3.Channel.1.Channel string 100 Class.3.Channel.1.Preference uint32 14 Class.4.OpClass uint32 124 Class.4.Channel.1.Channel string 149 Class.4.Channel.1.Preference uint32 14
 ```
 
 ### 5 GHz (Radio.2) - Negative
 
 ```text
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel string 36 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 149 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel string 149 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 116 Class.1.Channel.1.Channel uint32 40 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 116 Class.1.Channel.1.Channel string 40 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 128 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 128 Class.1.Channel.1.Channel string 36 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 129 Class.1.Channel.1.Channel uint32 100 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 129 Class.1.Channel.1.Channel string 100 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 500 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.2.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel string 500 Class.1.Channel.1.Preference uint32 14
 ```
 
 ### 6 GHz (Radio.3) - Positive
 
 ```text
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 5 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 9 Class.1.Channel.3.Preference uint32 14 Class.1.Channel.4.Channel uint32 13 Class.1.Channel.4.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 1,5,9,13 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 132 Class.1.Channel.1.Channel uint32 3 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 11 Class.1.Channel.2.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 132 Class.1.Channel.1.Channel string 3 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 11 Class.1.Channel.2.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 133 Class.1.Channel.1.Channel uint32 7 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 23 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 39 Class.1.Channel.3.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 133 Class.1.Channel.1.Channel string 7 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 23 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel string 39 Class.1.Channel.3.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 134 Class.1.Channel.1.Channel uint32 15 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 47 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel uint32 79 Class.1.Channel.3.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 134 Class.1.Channel.1.Channel string 15 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 47 Class.1.Channel.2.Preference uint32 14 Class.1.Channel.3.Channel string 79 Class.1.Channel.3.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 132 Class.2.Channel.1.Channel uint32 3 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 133 Class.3.Channel.1.Channel uint32 7 Class.3.Channel.1.Preference uint32 14 Class.4.OpClass uint32 134 Class.4.Channel.1.Channel uint32 15 Class.4.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14 Class.2.OpClass uint32 132 Class.2.Channel.1.Channel string 3 Class.2.Channel.1.Preference uint32 14 Class.3.OpClass uint32 133 Class.3.Channel.1.Channel string 7 Class.3.Channel.1.Preference uint32 14 Class.4.OpClass uint32 134 Class.4.Channel.1.Channel string 15 Class.4.Channel.1.Preference uint32 14
 ```
 
 ### 6 GHz (Radio.3) - Negative
 
 ```text
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 999 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 81 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel uint32 36 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 115 Class.1.Channel.1.Channel string 36 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 250 Class.1.Channel.1.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 250 Class.1.Channel.1.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 255
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 255
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 1 Class.1.Channel.2.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 1 Class.1.Channel.2.Preference uint32 14
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 1
 
-method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel uint32 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel uint32 999 Class.1.Channel.2.Preference uint32 14
+method_values "Device.WiFi.DataElements.Network.Device.2.Radio.3.ChannelSelectionRequest()" Class.1.OpClass uint32 131 Class.1.Channel.1.Channel string 1 Class.1.Channel.1.Preference uint32 14 Class.1.Channel.2.Channel string 999 Class.1.Channel.2.Preference uint32 14
 ```
 
 ## Testing done

--- a/inc/em_ctrl.h
+++ b/inc/em_ctrl.h
@@ -770,6 +770,9 @@ public:
 	// Constants for channel selection request parsing
 	static const int MAX_CHANSEL_CLASSES = 32;
 	static const int MAX_CHANSEL_CHANNELS = 64;
+	// Channel.{i}.Channel list: up to EM_MAX_CHANNELS_IN_LIST entries of at
+	// most three digits, comma-separated
+	static const int MAX_CHANSEL_LIST_LEN = EM_MAX_CHANNELS_IN_LIST * 4 - 1;
 
 	/**!
 	 * @brief Handles the bus ChannelSelectionRequest method request.

--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -1238,9 +1238,9 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
     // Data structures used to collect nested Class.N.* channel preference input.
     // The instance number is represented by the array slot itself, so the
     // incoming values must be contiguous and start at 1.
-    // Each channel entry stores the parsed channel number and preference value.
+    // Each Channel.M entry is a group of channel numbers sharing one preference.
     struct channel_info {
-        int channel;
+        std::vector<int> channels;
         int preference;
     };
 
@@ -1252,8 +1252,9 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
         channel_info channels[MAX_CHANSEL_CHANNELS];
     };
 
-    // Store parsed classes in slot-based arrays keyed by their 1-based instance number.
-    class_info classes[MAX_CHANSEL_CLASSES];
+    // Parsed classes keyed by their 1-based instance number; heap-allocated,
+    // the channel group vectors are too heavy for the stack.
+    std::vector<class_info> classes(MAX_CHANSEL_CLASSES);
     int highest_class_instance = 0;
 
     // Reset a class slot so it can be reused for a newly parsed instance.
@@ -1262,14 +1263,14 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
         cls.num_channels = 0;
         cls.highest_channel_instance = 0;
         for (int i = 0; i < MAX_CHANSEL_CHANNELS; i++) {
-            cls.channels[i].channel = -1;
+            cls.channels[i].channels.clear();
             cls.channels[i].preference = -1;
         }
     };
 
     // Initialize every slot so the emptiness checks are always well-defined.
-    for (int i = 0; i < MAX_CHANSEL_CLASSES; i++) {
-        clear_class(classes[i]);
+    for (class_info &cls : classes) {
+        clear_class(cls);
     }
 
     // Locate the storage slot for a given Class.N instance, creating it when needed.
@@ -1278,7 +1279,7 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
             return NULL;
         }
 
-        int slot = instance_index - 1;
+        size_t slot = static_cast<size_t>(instance_index - 1);
         if (classes[slot].op_class == -1 && classes[slot].num_channels == 0 && classes[slot].highest_channel_instance == 0) {
             clear_class(classes[slot]);
             if (instance_index > highest_class_instance) {
@@ -1295,13 +1296,13 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
         }
 
         int slot = channel_instance - 1;
-        bool slot_is_empty = (cls->channels[slot].channel == -1 && cls->channels[slot].preference == -1);
+        bool slot_is_empty = (cls->channels[slot].channels.empty() && cls->channels[slot].preference == -1);
         if (cls->num_channels == 0 || slot_is_empty) {
             cls->num_channels++;
             if (channel_instance > cls->highest_channel_instance) {
                 cls->highest_channel_instance = channel_instance;
             }
-            cls->channels[slot].channel = -1;
+            cls->channels[slot].channels.clear();
             cls->channels[slot].preference = -1;
         }
         return slot;
@@ -1386,7 +1387,50 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
                     goto finish;
                 }
                 if (strcmp(tokens[TR181_CHANNEL_ATTR_TOKEN], TR181_CHANNEL_STR) == 0) {
-                    if (!tr_181_t::tr181_get_prop_int(prop, &cls->channels[channel_slot].channel)) {
+                    // TR-181 models Channel as a list of unsignedInt, carried
+                    // as a comma-separated string per TR-106 list syntax.
+                    char list_str[MAX_CHANSEL_LIST_LEN + 1] = { 0 };
+                    if (!tr_181_t::tr181_copy_prop_string(prop, list_str, sizeof(list_str))) {
+                        em_printfout("Channel in '%s' must be a comma-separated list string", prop->name);
+                        rc = bus_error_invalid_input;
+                        goto finish;
+                    }
+                    // tr181_copy_prop_string() truncates silently and stops at an
+                    // embedded NUL; the copy must be the whole property value.
+                    const char *list_src = static_cast<const char *>(prop->value.raw_data.bytes);
+                    size_t list_len = prop->value.raw_data_len;
+                    if (list_len > 0 && list_src[list_len - 1] == '\0') {
+                        list_len--;
+                    } else if (list_len == 0) {
+                        list_len = strnlen(list_src, sizeof(list_str));
+                    }
+                    if (strlen(list_str) != list_len) {
+                        em_printfout("Channel list in '%s' is too long or not a plain string", prop->name);
+                        rc = bus_error_invalid_input;
+                        goto finish;
+                    }
+                    cls->channels[channel_slot].channels.clear();
+                    const char *cursor = list_str;
+                    while (*cursor != '\0') {
+                        char *chan_end = NULL;
+                        errno = 0;
+                        long channel_l = strtol(cursor, &chan_end, 10);
+                        while (isspace(static_cast<unsigned char>(*chan_end))) {
+                            ++chan_end;
+                        }
+                        if (chan_end == cursor || errno == ERANGE ||
+                            channel_l < 1 || channel_l > 255 ||
+                            (*chan_end != ',' && *chan_end != '\0') ||
+                            (*chan_end == ',' && *(chan_end + 1) == '\0')) {
+                            em_printfout("Invalid channel list '%s' in '%s'", list_str, prop->name);
+                            rc = bus_error_invalid_input;
+                            goto finish;
+                        }
+                        cls->channels[channel_slot].channels.push_back(static_cast<int>(channel_l));
+                        cursor = (*chan_end == ',') ? chan_end + 1 : chan_end;
+                    }
+                    if (cls->channels[channel_slot].channels.empty()) {
+                        em_printfout("Empty channel list in '%s'", prop->name);
                         rc = bus_error_invalid_input;
                         goto finish;
                     }
@@ -1428,7 +1472,8 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
 
     // Validate that all requested class instances have an OpClass and at least one channel entry.
     for (int class_index = 1; class_index <= highest_class_instance; class_index++) {
-        if (classes[class_index - 1].op_class == -1 && classes[class_index - 1].num_channels == 0 && classes[class_index - 1].highest_channel_instance == 0) {
+        const class_info &cls = classes[static_cast<size_t>(class_index - 1)];
+        if (cls.op_class == -1 && cls.num_channels == 0 && cls.highest_channel_instance == 0) {
             em_printfout("Missing Class.%d instance", class_index);
             rc = bus_error_invalid_input;
             goto finish;
@@ -1437,7 +1482,7 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
 
     // Validate each parsed class entry against the radio band and operating-class rules.
     for (int class_index = 1; class_index <= highest_class_instance; class_index++) {
-        class_info &cls = classes[class_index - 1];
+        class_info &cls = classes[static_cast<size_t>(class_index - 1)];
         if (cls.op_class == -1) {
             em_printfout("Missing OpClass for Class.%d", class_index);
             rc = bus_error_invalid_input;
@@ -1449,11 +1494,19 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
             goto finish;
         }
         
-        // Validate that every requested channel entry has both values populated.
+        // Reject numbering gaps and entries missing one of Channel/Preference.
         for (int channel_index = 1; channel_index <= cls.highest_channel_instance; channel_index++) {
             int channel_slot = channel_index - 1;
-            if (cls.channels[channel_slot].channel == -1 && cls.channels[channel_slot].preference == -1) {
+            bool has_channel = !cls.channels[channel_slot].channels.empty();
+            bool has_preference = (cls.channels[channel_slot].preference != -1);
+            if (!has_channel && !has_preference) {
                 em_printfout("Missing Channel.%d instance for Class.%d", channel_index, class_index);
+                rc = bus_error_invalid_input;
+                goto finish;
+            }
+            if (has_channel != has_preference) {
+                em_printfout("Class.%d.Channel.%d must set both Channel and Preference",
+                              class_index, channel_index);
                 rc = bus_error_invalid_input;
                 goto finish;
             }
@@ -1478,47 +1531,47 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
             goto finish;
         }
 
+        std::vector<int> seen_channels;
         for (int channel_index = 1; channel_index <= cls.highest_channel_instance; channel_index++) {
             int channel_slot = channel_index - 1;
-            if (cls.channels[channel_slot].channel == -1) {
-                if (cls.channels[channel_slot].preference != -1) {
-                    em_printfout("Missing Channel for Class.%d.Channel.%d", class_index, channel_index);
-                    rc = bus_error_invalid_input;
-                    goto finish;
-                }
+            channel_info &group = cls.channels[channel_slot];
+            if (group.channels.empty()) {
                 continue;
             }
-            if (cls.channels[channel_slot].channel < 1) {
-                em_printfout("Invalid channel value %d in Class.%d.Channel.%d",
-                              cls.channels[channel_slot].channel, class_index, channel_index);
-                rc = bus_error_invalid_input;
-                goto finish;
-            }
 
-            // Reject duplicate channel values within the same Class
-            for (int prev = 0; prev < channel_slot; prev++) {
-                if (cls.channels[channel_slot].channel != -1 &&
-                    cls.channels[prev].channel == cls.channels[channel_slot].channel) {
-                    em_printfout("Duplicate Channel %d in Class.%d",
-                                   cls.channels[channel_slot].channel, class_index);
+            for (int channel : group.channels) {
+                // Reject duplicate channel values within the same Class
+                for (int prev : seen_channels) {
+                    if (prev == channel) {
+                        em_printfout("Duplicate Channel %d in Class.%d", channel, class_index);
+                        rc = bus_error_invalid_input;
+                        goto finish;
+                    }
+                }
+                seen_channels.push_back(channel);
+
+                bool channel_matches_opclass = false;
+                for (int valid_channel : valid_channels) {
+                    if (valid_channel == channel) {
+                        channel_matches_opclass = true;
+                        break;
+                    }
+                }
+                if (!channel_matches_opclass) {
+                    em_printfout("Channel %d not allowed for OpClass %d in Class.%d",
+                                  channel, cls.op_class, class_index);
                     rc = bus_error_invalid_input;
                     goto finish;
                 }
             }
-
-            bool channel_matches_opclass = false;
-            for (int valid_channel : valid_channels) {
-                if (valid_channel == cls.channels[channel_slot].channel) {
-                    channel_matches_opclass = true;
-                    break;
-                }
-            }
-            if (!channel_matches_opclass) {
-                em_printfout("Channel %d not allowed for OpClass %d in Class.%d",
-                              cls.channels[channel_slot].channel, cls.op_class, class_index);
-                rc = bus_error_invalid_input;
-                goto finish;
-            }
+        }
+        // The decoded ChannelList holds EM_MAX_CHANNELS_IN_LIST entries; reject
+        // a class that would be truncated silently.
+        if (seen_channels.size() > EM_MAX_CHANNELS_IN_LIST) {
+            em_printfout("Class.%d lists %zu channels, at most %d allowed",
+                          class_index, seen_channels.size(), EM_MAX_CHANNELS_IN_LIST);
+            rc = bus_error_invalid_input;
+            goto finish;
         }
     }
 
@@ -1617,7 +1670,7 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
     if (highest_class_instance > 0) {
         // Convert each validated class entry into JSON with ChannelList and ChannelPrefList.
         for (int class_index = 1; class_index <= highest_class_instance; class_index++) {
-            class_info &cls = classes[class_index - 1];
+            class_info &cls = classes[static_cast<size_t>(class_index - 1)];
             if (cls.op_class == -1 || cls.num_channels == 0) {
                 em_printfout("Incomplete class entry");
                 rc = bus_error_invalid_input;
@@ -1652,13 +1705,20 @@ bus_error_t em_ctrl_t::cmd_channelselect(const char *method_name, const bus_data
 
             for (int channel_index = 1; channel_index <= cls.highest_channel_instance; channel_index++) {
                 int channel_slot = channel_index - 1;
-                if (cls.channels[channel_slot].channel == -1 || cls.channels[channel_slot].preference == -1) {
+                channel_info &group = cls.channels[channel_slot];
+                if (group.channels.empty() || group.preference == -1) {
                     em_printfout("Missing Channel or Preference for channel instance %d", channel_index);
                     rc = bus_error_invalid_input;
                     goto finish;
                 }
-                cJSON_AddItemToArray(channel_list_obj, cJSON_CreateNumber(cls.channels[channel_slot].channel));
-                cJSON_AddItemToArray(channel_pref_obj, cJSON_CreateNumber(cls.channels[channel_slot].preference));
+                for (int channel : group.channels) {
+                    if (!cJSON_AddItemToArray(channel_list_obj, cJSON_CreateNumber(channel)) ||
+                        !cJSON_AddItemToArray(channel_pref_obj, cJSON_CreateNumber(group.preference))) {
+                        em_printfout("Add channel entry failed");
+                        rc = bus_error_out_of_resources;
+                        goto finish;
+                    }
+                }
             }
         }
     }
@@ -5177,20 +5237,19 @@ dm_radio_t *dm_easy_mesh_ctrl_t::get_dm_radio(dm_easy_mesh_t *dm, char *instance
     }
 
     for (unsigned int i = 0; i < dm->get_num_radios(); i++) {
-        char mac_str[18];
         radio = dm->get_radio(i);
         if (radio == NULL) {
             continue;
         }
         em_radio_info_t *ri = radio->get_radio_info();
-        dm_easy_mesh_t::macbytes_to_string(const_cast<unsigned char *> (ri->id.ruid), mac_str);
-        /* Probably wrong, we need base64 */
-        if (strcmp(instance, mac_str) == 0) {
+        /* Radio.{i} aliases are published as base64(RUID), see radio_get_inner(). */
+        std::string id_b64 = em_crypto_t::base64_encode(ri->id.ruid, sizeof(ri->id.ruid));
+        if (strcmp(instance, id_b64.c_str()) == 0) {
             return radio;
         }
     }
 
-    return radio;
+    return NULL;
 }
 
 dm_sta_t *dm_easy_mesh_ctrl_t::get_dm_bh_sta(dm_easy_mesh_t *dm, dm_radio_t *radio)

--- a/tests/test_l1_em_ctrl.cpp
+++ b/tests/test_l1_em_ctrl.cpp
@@ -20,7 +20,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <stdio.h>
+#include <cstring>
 #include "em_ctrl.h"
+#include "em_crypto.h"
 
 class em_ctrl_t_Test : public ::testing::Test {
 protected:
@@ -3929,4 +3931,55 @@ TEST_F(em_ctrl_t_Test, io_process_invalid_event_type)
     EXPECT_FALSE(ret);
     free(evt);
     std::cout << "Exiting io_process_invalid_event_type test" << std::endl;
+}
+
+/**
+ * @brief Verify that get_dm_radio() resolves a Radio.{i} alias as base64(RUID) and returns NULL otherwise.
+ *
+ * Radio.{i} aliases are published as base64(RUID) by radio_get_inner(). The lookup must select the radio
+ * whose RUID encodes to the alias, must not match the MAC-string form of the RUID that the old comparison
+ * used, and must return NULL instead of another radio when nothing matches. The numeric instance path
+ * is checked as well.
+ *
+ * **Test Group ID:** Basic: 01@n
+ * **Test Case ID:** 010@n
+ * **Priority:** High@n
+ *
+ * **Pre-Conditions:** None@n
+ * **Dependencies:** None@n
+ * **User Interaction:** None@n
+ *
+ * **Test Procedure:**
+ * | Variation / Step | Description                                                    | Test Data                              | Expected Result                     | Notes       |
+ * | :--------------: | -------------------------------------------------------------- | -------------------------------------- | ----------------------------------- | ----------- |
+ * | 01               | Look up the second radio by its base64(RUID) alias             | alias = base64(ruid1), is_num = false  | Returns dm.get_radio(1)             | Should Pass |
+ * | 02               | Look up with the MAC string of the same RUID                   | "02:11:22:33:44:66", is_num = false    | Returns NULL                        | Should Pass |
+ * | 03               | Look up with an alias that matches no radio                    | "AAAAAAAA", is_num = false             | Returns NULL                        | Should Pass |
+ * | 04               | Look up by numeric instance                                    | "1", is_num = true                     | Returns dm.get_radio(0)             | Should Pass |
+ */
+TEST(dm_easy_mesh_ctrl_t, get_dm_radio_alias_is_base64_ruid) {
+    std::cout << "Entering get_dm_radio_alias_is_base64_ruid test" << std::endl;
+    dm_easy_mesh_ctrl_t dm_ctrl;
+    dm_easy_mesh_t dm;
+    const unsigned char ruid0[6] = { 0x02, 0x11, 0x22, 0x33, 0x44, 0x55 };
+    const unsigned char ruid1[6] = { 0x02, 0x11, 0x22, 0x33, 0x44, 0x66 };
+    memcpy(dm.get_radio_by_ref(0).get_radio_info()->id.ruid, ruid0, sizeof(ruid0));
+    memcpy(dm.get_radio_by_ref(1).get_radio_info()->id.ruid, ruid1, sizeof(ruid1));
+    dm.set_num_radios(2);
+
+    std::string alias = em_crypto_t::base64_encode(ruid1, sizeof(ruid1));
+    char instance[64];
+    snprintf(instance, sizeof(instance), "%s", alias.c_str());
+    std::cout << "Invoking get_dm_radio(...) with alias " << instance << std::endl;
+    EXPECT_EQ(dm_ctrl.get_dm_radio(&dm, instance, false), dm.get_radio(1u));
+
+    char mac_str[] = "02:11:22:33:44:66";
+    EXPECT_EQ(dm_ctrl.get_dm_radio(&dm, mac_str, false), nullptr);
+
+    char unknown[] = "AAAAAAAA";
+    EXPECT_EQ(dm_ctrl.get_dm_radio(&dm, unknown, false), nullptr);
+
+    char index[] = "1";
+    EXPECT_EQ(dm_ctrl.get_dm_radio(&dm, index, true), dm.get_radio(0u));
+    std::cout << "Exiting get_dm_radio_alias_is_base64_ruid test" << std::endl;
 }


### PR DESCRIPTION
Device.WiFi.DataElements...ChannelSelectionRequest() accepted the Channel input only as a single integer. TR-181 defines Class.{i}.Channel.{i}.Channel as a list of unsignedInt, carried on the wire as a comma-separated string per TR-106 list syntax, and each Channel.{i} row is a group of channels sharing one Preference, so spec-conformant callers were rejected with "invalid input" before reaching the channel selection logic.

Parse the list form: split on commas, validate each entry as a 1..255 channel, reject an empty list, and expand each group into the ChannelList/ChannelPrefList emission with the existing per-class duplicate and opclass-membership validation. The integer form was never part of the data model, so it is not kept.

get_dm_radio()'s alias branch compared the instance against the radio MAC string, which can never match the published ID, and fell back to the last radio on no match, silently targeting the wrong radio. Radio.{i} aliases are published as base64(RUID) (radio_get_inner), so compare against that and return NULL when nothing matches. The numeric instance path is unchanged.

Verified on device: a northbound CHANNEL_SELECT with grouped CSV channel lists is parsed into the correct per-opclass preferences and the Channel Selection Request / Operating Channel Report exchange completes end to end.