### PR TITLE
RDKBWIFI-585: Query capabilities again when a non-MLD client reconnects

### DIFF
--- a/src/ctrl/dm_easy_mesh_ctrl.cpp
+++ b/src/ctrl/dm_easy_mesh_ctrl.cpp
@@ -2756,9 +2756,10 @@ int dm_easy_mesh_ctrl_t::analyze_sta_assoc_event(em_bus_event_t *evt, em_cmd_t *
                 // MLD STA is "known" only if we already have its capability data
                 sta_exists = (iter->m_sta_info.frame_body_len > 0);
             } else {
-                // Legacy STA: verify BSSID matches and we have capability data
+                // Legacy STA: verify BSSID matches and we have capability data from a
+                // still-active association; a reconnect after a disassoc is queried again.
                 if (memcmp(iter->m_sta_info.bssid, params->assoc.bssid, sizeof(mac_address_t)) == 0) {
-                    sta_exists = (iter->m_sta_info.frame_body_len > 0);
+                    sta_exists = (iter->m_sta_info.frame_body_len > 0) && iter->m_sta_info.associated;
                 }
             }
             em_printfout("sta found in m_sta_map %s, sta_exists=%d", sta_mac_str, sta_exists);


### PR DESCRIPTION
A non-MLD client that disassociates and associates again with the same BSS is treated as already known: the Topology Notification disassoc path keeps the stored association frame and the assoc path skips the Client Capability Query when a row with that frame exists. Nothing then marks the row associated again, so DataElements keeps hiding the station, and the capabilities derived from the frame (standards, SGI, spatial streams, bandwidth) stay those of the first association.

Only treat the client as known while its row is still associated. A reconnect after a disassoc carries a new (Re)Association frame, so it goes through the Client Capability Query like a new client; a repeated assoc notification for an active client is still not re-queried and the stored capabilities are still kept across a disassoc.