### PR TITLE
Fixed CI issue with ucode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,17 @@ jobs:
         # Steps for ucode installation required for hostapd compilation
         git clone https://github.com/jow-/ucode.git ucode
         cd ucode
-        git checkout 3f64c808
+        # Pin ucode: PR#398 (LibFFI module) merged to master 2026-08-27 and broke the bpi
+        # build (ucode's unconditional `#define unused __attribute__((unused))` re-expands
+        # the `unused` identifier where libhostap (hostapd/wpa_supplicant) uses it as a
+        # plain parameter/variable name, producing a parse error; libhostap's own helper
+        # for this is the properly namespaced `__maybe_unused`, which doesn't collide).
+        # 655ca6d = a0ca7b1^1 = last master BEFORE the FFI merge = last known-good state
+        # (it is literally what the last green build cloned). The colliding `unused` macro
+        # was added by abb80c6 ON the PR#398 branch, so any commit on that branch -- incl.
+        # 19ffa8a, the earlier (wrong) pin -- still ships the poisoned util.h. Use first-
+        # parent (a0ca7b1^1), NOT plain `git log`, when moving this pin; bump deliberately.
+        git checkout 655ca6d
         mkdir build && cd build
         cmake -DUBUS_SUPPORT=OFF -DUCI_SUPPORT=OFF -DULOOP_SUPPORT=OFF ..
         make -j$(nproc)


### PR DESCRIPTION
Reason for change: pin ucode to `655ca6d`  to unbreak `rdk-wifi-libhostap` build during CI test
taken as a reference from OneWifi [PR #1355](https://github.com/rdkcentral/OneWifi/pull/1355/changes#diff-ab2f63759f09e4a4c7d039b6831fe49d10a7b39c9ea91d86ee5e516c84966003)

Test procedure: check build logs, there should be no errors like [this](https://github.com/rdkcentral/unified-wifi-mesh/actions/runs/33177121824/job/99579344028) in Build - OneWifi section
```
/__w/unified-wifi-mesh/unified-wifi-mesh/easymesh_project/OneWifi/../rdk-wifi-libhostap/source/hostap-2.11/src/ap/ieee802_11.c: In function 'handle_action':
/__w/unified-wifi-mesh/unified-wifi-mesh/easymesh_project/OneWifi/../rdk-wifi-libhostap/source/hostap-2.11/src/utils/common.h:499:39: error: expected ')' before '__attribute__'
  499 | #define __maybe_unused __attribute__((unused))
      |                                       ^~~~~~
/__w/unified-wifi-mesh/unified-wifi-mesh/easymesh_project/OneWifi/../rdk-wifi-libhostap/source/hostap-2.11/src/ap/ieee802_11.c:6841:13: note: in expansion of macro '__maybe_unused'
 6841 |  u8 *action __maybe_unused;
      |             ^~~~~~~~~~~~~~
In file included from /__w/unified-wifi-mesh/unified-wifi-mesh/easymesh_project/OneWifi/../rdk-wifi-libhostap/source/hostap-2.11/src/ap/ieee802_11.c:13:
/__w/unified-wifi-mesh/unified-wifi-mesh/easymesh_project/OneWifi/../rdk-wifi-libhostap/source/hostap-2.11/src/utils/common.h:499:46: error: expected ',' or ';' before ')' token
  499 | #define __maybe_unused __attribute__((unused))
      |                                              ^
/__w/unified-wifi-mesh/unified-wifi-mesh/easymesh_project/OneWifi/../rdk-wifi-libhostap/source/hostap-2.11/src/ap/ieee802_11.c:6841:13: note: in expansion of macro '__maybe_unused'
 6841 |  u8 *action __maybe_unused;
      |             ^~~~~~~~~~~~~~
```

Priority: P1
Risks: Low