### PR TITLE
Pin ucode revision in GitHub build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
         # Steps for ucode installation required for hostapd compilation
         git clone https://github.com/jow-/ucode.git ucode
         cd ucode
+        git checkout 3f64c808
         mkdir build && cd build
         cmake -DUBUS_SUPPORT=OFF -DUCI_SUPPORT=OFF -DULOOP_SUPPORT=OFF ..
         make -j$(nproc)


### PR DESCRIPTION
Pins the ucode checkout to revision 3f64c808 before building.

This prevents GitHub Actions from picking up incompatible upstream ucode changes that cause the workflow build to fail.