### PR TITLE
[RDKB-66805] Optimize anonymous memory usage caused by em_cmd_t

### DIFF
--- a/inc/em_cmd_agent.h
+++ b/inc/em_cmd_agent.h
@@ -28,9 +28,8 @@ class em_cmd_agent_t : public em_cmd_exec_t {
     em_agent_t& m_agent = g_agent;
     int m_dsock;
 public:
-    static em_cmd_t m_client_cmd_spec[];
-public:
     
+
 	/**!
 	 * @brief Executes a command and stores the result.
 	 *
@@ -61,35 +60,7 @@ public:
 	 */
 	int send_result(em_cmd_out_status_t status);
 
-    
-	/**!
-	 * @brief Creates an event from the given buffer.
-	 *
-	 * This function takes a character buffer as input and creates an event of type `em_event_t`.
-	 *
-	 * @param[in] buff A character buffer containing the event data.
-	 *
-	 * @returns A pointer to the created `em_event_t` event.
-	 * @retval NULL if the event creation fails.
-	 *
-	 * @note Ensure that the buffer is properly formatted to create a valid event.
-	 */
-	static em_event_t *create_event(char *buff);
-    
-    
-	/**!
-	 * @brief 
-	 *
-	 * Initializes a command agent with the specified command type.
-	 *
-	 * @param[in] type The type of command to initialize the agent with.
-	 *
-	 * @returns A new instance of em_cmd_agent_t initialized with the given command type.
-	 *
-	 * @note Ensure that the command type is valid and supported by the system.
-	 */
-	em_cmd_agent_t(em_cmd_type_t type);
-    
+
 	/**!
 	 * @brief Constructor for em_cmd_agent_t class.
 	 *

--- a/src/agent/em_cmd_agent.cpp
+++ b/src/agent/em_cmd_agent.cpp
@@ -37,19 +37,8 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include <pthread.h>
-#include <cjson/cJSON.h>
 #include "em_agent.h"
 #include "em_cmd_agent.h"
-
-em_cmd_t em_cmd_agent_t::m_client_cmd_spec[] = {
-    em_cmd_t(em_cmd_type_none,em_cmd_params_t{0, {"", "", "", "", ""}, "none", nullptr}),
-    em_cmd_t(em_cmd_type_dev_init,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Network", nullptr}),
-    em_cmd_t(em_cmd_type_cfg_renew, em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:Renew", nullptr}),
-    em_cmd_t(em_cmd_type_vap_config,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:BssConfig", nullptr}),
-    em_cmd_t(em_cmd_type_sta_list,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:StaList", nullptr}),
-    em_cmd_t(em_cmd_type_ap_cap_query,em_cmd_params_t{1, {"", "", "", "", ""}, "wfa-dataelements:CapReport", nullptr}),
-    em_cmd_t(em_cmd_type_max,em_cmd_params_t{0, {"", "", "", "", ""}, "max", nullptr}),
-};
 
 int em_cmd_agent_t::execute(em_long_string_t result)
 {
@@ -124,95 +113,9 @@ int em_cmd_agent_t::send_result(em_cmd_out_status_t status)
     return 0;
 }
 
-em_event_t *em_cmd_agent_t::create_event(char *buff)
-{
-    // here is the entry point of RBUS subdocuments
-    em_cmd_type_t   type = em_cmd_type_none;
-    cJSON *obj, *child_obj;
-    const char *tmp;
-    em_cmd_t    *cmd;
-    unsigned int idx;
-    em_event_t *evt;
-    em_bus_event_t *bevt;
-
-    if ((obj = cJSON_Parse(buff)) == NULL) {
-        printf("%s:%d: Failed to parse JSON object\n", __func__, __LINE__);
-        return NULL;
-    }
-
-    idx = 0; type = em_cmd_agent_t::m_client_cmd_spec[idx].get_type();
-    cmd = &em_cmd_agent_t::m_client_cmd_spec[idx];
-    while (type != em_cmd_type_max) {
-        //cmd = &em_cmd_agent_t::m_client_cmd_spec[idx];
-
-        if (cmd->get_svc() != em_service_type_agent) {
-            idx++;
-            cmd = &em_cmd_agent_t::m_client_cmd_spec[idx];
-            type = em_cmd_agent_t::m_client_cmd_spec[idx].get_type(); continue;
-        }
-
-        tmp = cmd->get_arg();
-
-        if ((child_obj = cJSON_GetObjectItem(obj, tmp)) != NULL) {
-            break;
-        }
-
-        idx++;
-        type = em_cmd_agent_t::m_client_cmd_spec[idx].get_type();
-        cmd = &em_cmd_agent_t::m_client_cmd_spec[idx];
-    }
-
-    cJSON_Delete(obj);
-
-    if ((type == em_cmd_type_none) || (type >= em_cmd_type_max)) {
-        printf("%s:%d: type invalid=%d\n", __func__, __LINE__,type);
-        return NULL;
-    }
-
-    unsigned int buff_len = static_cast<unsigned int>(strlen(buff)) + 1;
-    evt = reinterpret_cast<em_event_t *>(malloc(sizeof(em_event_t) + buff_len));
-    evt->type = em_event_type_bus;
-    bevt = &evt->u.bevt;
-
-    switch (type) {
-        case em_cmd_type_dev_init:  
-            bevt->type = em_bus_event_type_dev_init;
-            break;
-
-        case em_cmd_type_sta_list:
-            bevt->type = em_bus_event_type_sta_list;
-            break;
-
-        case em_cmd_type_ap_cap_query:
-            bevt->type = em_bus_event_type_ap_cap_query;
-            break;
-
-	    case em_cmd_type_client_cap_query:
-	        bevt->type = em_bus_event_type_client_cap_query;
-	        break;
-
-        case em_cmd_type_cfg_renew:
-            bevt->type = em_bus_event_type_cfg_renew;
-            break;
-       
-         default:
-            break;
-    }
-
-    memcpy(&bevt->params, &cmd->m_param, sizeof(em_cmd_params_t));
-    memcpy(&bevt->u.subdoc.buff, buff, buff_len);
-    bevt->data_len = buff_len;
-    return evt;
-}
-
 em_cmd_agent_t::em_cmd_agent_t(em_cmd_t& obj) : m_dsock(-1)
 {
     memcpy(&m_cmd.m_param, &obj.m_param, sizeof(em_cmd_params_t));
-}
-
-em_cmd_agent_t::em_cmd_agent_t(em_cmd_type_t type) : m_dsock(-1)
-{
-    memcpy(&m_cmd.m_param, &em_cmd_agent_t::m_client_cmd_spec[type].m_param, sizeof(em_cmd_params_t));
 }
 
 em_cmd_agent_t::em_cmd_agent_t() : m_dsock(-1)


### PR DESCRIPTION
Remove unused static command and event handling code from the EasyMesh Agent to reduce unnecessary memory usage
Fix:
A static command specification array m_client_cmd_spec[] was present in em_cmd_agent_t, resulting in unnecessary memory being allocated for command definitions.
The Agent also contained unused create_event() logic and associated JSON parsing code that was no longer required.
These static and unused components contributed to the memory footprint of the EasyMesh Agent.
Removed the unused static command specification, event creation logic, and associated cJSON dependency.
This reduces the unnecessary memory/code footprint while retaining the required Agent command functionality.
Result:
Around 3 MB of memory got reduced from em_agent vmrss.