### PR TITLE
RDKBDEV-3495: Fix resource leak in encode_config_reset

### DIFF
--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -414,11 +414,13 @@ int dm_easy_mesh_t::encode_config_reset(em_subdoc_info_t *subdoc, const char *ke
 
 	if ((interfaces_obj = cJSON_AddObjectToObject(net_obj, "Interfaces")) == NULL) {
 		printf("%s:%d: Could not create interface object\n", __func__, __LINE__);
+        cJSON_Delete(parent_obj);
         return -1;
 	}
 
 	if ((interface_arr_obj = cJSON_AddArrayToObject(interfaces_obj, "List")) == NULL) {
         printf("%s:%d: Could not create interface array object\n", __func__, __LINE__);
+        cJSON_Delete(parent_obj);
         return -1;
     }
 

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -412,13 +412,13 @@ int dm_easy_mesh_t::encode_config_reset(em_subdoc_info_t *subdoc, const char *ke
         return -1;
     }
 
-	if ((interfaces_obj = cJSON_AddObjectToObject(net_obj, "Interfaces")) == NULL) {
-	printf("%s:%d: Could not create interface object\n", __func__, __LINE__);
+    if ((interfaces_obj = cJSON_AddObjectToObject(net_obj, "Interfaces")) == NULL) {
+        printf("%s:%d: Could not create interface object\n", __func__, __LINE__);
         cJSON_Delete(parent_obj);
         return -1;
-	}
+    }
 
-	if ((interface_arr_obj = cJSON_AddArrayToObject(interfaces_obj, "List")) == NULL) {
+    if ((interface_arr_obj = cJSON_AddArrayToObject(interfaces_obj, "List")) == NULL) {
         printf("%s:%d: Could not create interface array object\n", __func__, __LINE__);
         cJSON_Delete(parent_obj);
         return -1;

--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -413,7 +413,7 @@ int dm_easy_mesh_t::encode_config_reset(em_subdoc_info_t *subdoc, const char *ke
     }
 
 	if ((interfaces_obj = cJSON_AddObjectToObject(net_obj, "Interfaces")) == NULL) {
-		printf("%s:%d: Could not create interface object\n", __func__, __LINE__);
+	printf("%s:%d: Could not create interface object\n", __func__, __LINE__);
         cJSON_Delete(parent_obj);
         return -1;
 	}


### PR DESCRIPTION
**Issue:**
In dm_easy_mesh_t::encode_config_reset(), parent_obj is allocated using cJSON_CreateObject(). However, parent_obj is not deleted when creation of the Interfaces object or List array fails.

**Steps to Reproduce:**
1. Execute dm_easy_mesh_t::encode_config_reset().
2. Observe the error paths when Interfaces object or List array creation fails.
3. Observe that parent_obj is not released before returning.

**Expected Behavior:**
parent_obj should be released before returning on all error paths to prevent resource leaks.

**Fix:**
Add cJSON_Delete(parent_obj) before returning -1 in the affected error paths.

**Acceptance Criteria:**
1.parent_obj is properly deleted when Interfaces object creation fails.
2.parent_obj is properly deleted when List array creation fails.
3.No resource/memory leak occurs on the affected error paths.
4.Existing successful execution and error handling behavior remains unchanged.