### PR TITLE
RDKCOM-5641: RDKBDEV-3496 Fix resource leak in decode_ap_cap_config()

### DIFF
--- a/src/dm/dm_easy_mesh.cpp
+++ b/src/dm/dm_easy_mesh.cpp
@@ -1785,6 +1785,7 @@ int dm_easy_mesh_t::decode_ap_cap_config(em_subdoc_info_t *subdoc, const char *s
              msg_id = static_cast<short unsigned int> (id->valuedouble);
         printf("%s:%d: msg id %d\n", __func__, __LINE__,msg_id);
     }
+    cJSON_Delete(parent_obj);
     return 0;
 }
 


### PR DESCRIPTION
**Issue:**
In dm_easy_mesh_t::decode_ap_cap_config(), parent_obj is allocated using cJSON_Parse(), but it is not released before the final successful return, resulting in a cJSON memory/resource leak.

**Steps to Reproduce:**
    1.Execute dm_easy_mesh_t::decode_ap_cap_config().
    2.Allow the function to complete successfully.
    3.Observe that parent_obj is not released before returning.

**Expected Behavior:**
parent_obj should be released before returning from the function to prevent a resource leak.

**Fix:**
Add cJSON_Delete(parent_obj) before the final successful return.

**Acceptance Criteria:**
1.parent_obj is deleted before the successful return.
2.No cJSON memory/resource leak occurs.
3.Existing error-path cleanup remains unchanged.
4.Existing functionality and return behavior remain unchanged.